### PR TITLE
Try to use "First" attribute to parse commands

### DIFF
--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -25,7 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>..\..\bin\Paket.xml</DocumentationFile>
-    <StartArguments>update</StartArguments>
+    <StartArguments>--command update</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>Paket.exe</StartProgram>
     <StartWorkingDirectory>D:\code\paket</StartWorkingDirectory>


### PR DESCRIPTION
It would be nice to parse the command with UnionArgParser, but
- Paket.exe --command update ==> works
- Paket.exe update ==> doesn't work
