### PR TITLE
A simple install script for Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ rm -rf $BIN/paket
 
 cat >> $BIN/paket <<EOF
 #!/bin/bash
-exec mono $LIB/paket/Paket.exe "$@"
+exec mono $LIB/paket/Paket.exe "\$@"
 EOF
 
 chmod a+x $BIN/paket


### PR DESCRIPTION
This is a first drop of a simple bash installer for Linux. It basically mimics `nuget install` (in a somewhat half-bakery way) and installs to `/usr/local/`, following FHS guidelines. That's why it requires root privileges.

I hacked this quite quickly, so testing with different settings would be a must. A typical installation one-liner would be:

```
wget -qO - https://raw.githubusercontent.com/fsprojects/Paket/master/install.sh | sudo bash
```

_Note for testers:_ 
You can test the installer easily by referring to `install.sh` of this PR

```
wget -qO - https://raw.githubusercontent.com/ilkerde/Paket/master/install.sh | sudo bash
```

The script is somewhat idempotentish, you can safely run it multiple times. It serves as an updater as well. That is, if there's a more recent version of Paket on nuget, it will happily install the new version (clearing the existing install).

In a "production" scenario, we would most probably want to expose the script on a more "friendly" URL (maybe docs). Right now it only contains the fundamental checks, but it's fairly good to use I guess.

Ref: #42
