### PR TITLE
Let build.cmd builds fail fast

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,6 +2,13 @@
 cls
 
 .nuget\nuget.exe install Paket -OutputDirectory packages -Prerelease -ExcludeVersion
+if errorlevel 1 (
+  exit /b %errorlevel%
+)
 
 packages\Paket\tools\paket.exe install
+if errorlevel 1 (
+  exit /b %errorlevel%
+)
+
 packages\FAKE\tools\FAKE.exe build.fsx %*


### PR DESCRIPTION
Same as with `build.sh`.
