### PR TITLE
Linked source files now all go underneath a "paket-files" folder.

### DIFF
--- a/src/Paket/ProjectFile.fs
+++ b/src/Paket/ProjectFile.fs
@@ -145,7 +145,7 @@ type ProjectFile =
                     node.SetAttribute("Include", path)
                     node
                     |> addChild (this.CreateNode("Paket","True"))
-                    |> addChild (this.CreateNode("Link",sourceFile.Name))
+                    |> addChild (this.CreateNode("Link","paket-files/" + sourceFile.Name))
 
                 compileItemGroup.PrependChild(node) |> ignore                
 

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -59,7 +59,7 @@
   <ItemGroup>
     <Compile Include="..\..\paket-files\forki\FsUnit\7623fc13439f0e60bd05c1ed3b5f6dcb937fe468\FsUnit.fs">
       <Paket>True</Paket>
-      <Link>FsUnit.fs</Link>
+      <Link>paket-files/FsUnit.fs</Link>
     </Compile>
     <Compile Include="TestHelpers.fs" />
     <Compile Include="SemVerSpecs.fs" />


### PR DESCRIPTION
See #114
