### PR TITLE
Respect case sensitivity for package paths

### DIFF
--- a/src/Paket/InstallProcess.fs
+++ b/src/Paket/InstallProcess.fs
@@ -109,12 +109,13 @@ let Install(regenerate, force, hard, dependenciesFilename) =
             |> Map.ofArray
 
         let rec addPackage (name:string) =
-            if name.ToLower().StartsWith "file:" then
+            let identity = name.ToLower()
+
+            if identity.StartsWith "file:" then
                 let sourceFile = name.Split(':').[1]
                 usedSourceFiles.Add sourceFile |> ignore
             else
-                let name = name.ToLower()
-                match allPackages |> Map.tryFind name with
+                match allPackages |> Map.tryFind identity with
                 | Some package ->
                     if usedPackages.Add name then
                         if not lockFile.Strict then


### PR DESCRIPTION
This is a very quick fix for #108. I'm sorry I didn't supply tests, but I'm too much of a novice to easily extract `addPackage` and have tests for it. I built on Win7 and tested on Linux/Mono. Seems to work fine.
