### PR TITLE
General doc fixes

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -15,7 +15,7 @@ Paket also enables one to [reference files directly from GitHub repositories](gi
 <div id="no-version"></div>
 ## NuGet puts the package version into the path. Is Paket doing the same?
 
-No, since Paket provides a global view to your dependencies it installs only one version of a package and therefor the version number is not needed in the path.
+No, since Paket provides a global view of your dependencies it installs only one version of a package and therefore the version number is not needed in the path.
 This makes it much easier to reference files in the package and you don't have to edit these references when you update a package.
 
 ## Why does Paket add references to the libraries associated with each supported framework version within a NuGet package to my projects?
@@ -37,7 +37,7 @@ Paket tries to embrace [SemVer](http://semver.org/) while NuGet uses a pessimist
 
 No, we don't run any script or program from NuGet packages and we have no plans to do this in the future.
 We know that this might cause you some manual work for some of the currently available NuGet packages, but we think these install scripts cause more harm than good.
-In fact our current model doesn't allow to run install.ps1 script like the following from `FontAwesome.4.1.0`:
+In fact our current model would not be able to work consistently alongside an `install.ps1` script like the following from `FontAwesome.4.1.0`:
 
     [lang=batchfile]
     param($installPath, $toolsPath, $package, $project)
@@ -48,7 +48,7 @@ In fact our current model doesn't allow to run install.ps1 script like the follo
     }
     
 The reason is simply that even if we would support PowerShell on Windows we can't access the Visual Studio project system. Paket is a command line tool and doesn't run inside of Visual Studio.
-There is no way to make this work – and even NuGet.exe can't do it in command line mode. 
+There is no reasonable way to make this work – and even NuGet.exe can't do it in command line mode. 
 
 Instead we encourage the .NET community to use a declarative install process and we will help to fix this in the affected packages.
 
@@ -66,7 +66,7 @@ The process is very easy and you can read more about it in the [convert from NuG
 
 ## Does Paket allow groups like bundler does?
 
-No at the moment we don't see the requirement for something like [bundler's groups](http://bundler.io/v1.7/groups.html). Longer discussion can be found [here](https://github.com/fsprojects/Paket/issues/116).
+No at the moment we don't see the need for something like [bundler's groups](http://bundler.io/v1.7/groups.html) in the .NET environment. Longer discussion can be found [here](https://github.com/fsprojects/Paket/issues/116).
 
 ## Can I use Paket to manage npm/bower/whatever dependencies?
 

--- a/docs/content/github-dependencies.md
+++ b/docs/content/github-dependencies.md
@@ -1,6 +1,6 @@
 # GitHub dependencies
 
-Paket allows to link files from [github.com](http://www.github.com) into your projects.
+Paket allows one to automatically manage the linking of files from [github.com](http://www.github.com) into your projects.
 
 ## Referencing a single file
 
@@ -8,20 +8,20 @@ You can reference a single file from [github.com](http://www.github.com) simply 
 
     github forki/FsUnit FsUnit.fs
 
-If you run the [`paket update` command](paket-update.html), then it will add a new section to your [`paket.lock` file](lock-file.html):
+If you run the [`paket update` command](paket-update.html), it will add a new section to your [`paket.lock` file](lock-file.html):
 
     [lang=batchfile]
-	GITHUB
-	  remote: forki/FsUnit
-	  specs:
-		FsUnit.fs (7623fc13439f0e60bd05c1ed3b5f6dcb937fe468)
+    GITHUB
+      remote: forki/FsUnit
+      specs:
+        FsUnit.fs (7623fc13439f0e60bd05c1ed3b5f6dcb937fe468)
 
-As you can see the file is pinned to a concrete commit. This allows you to reliably use the same file version in succeeding builds.
+As you can see the file is pinned to a concrete commit. This allows you to reliably use the same file version in succeeding builds until you elect to perform a [`paket update` command](paket-update.html) at a time of your choosing.
 
 If you want to reference the file in one of your project files then add an entry to the project's [`paket.references` file.](references-files.html):
 
-	[lang=batchfile]
-	File:FsUnit.fs
+    [lang=batchfile]
+    File:FsUnit.fs
 
 This will reference the linked file directly into your project.
 

--- a/docs/content/lock-file.md
+++ b/docs/content/lock-file.md
@@ -46,11 +46,11 @@ The `paket.lock` file records the concrete dependency resolution of all direct *
 
 If the `paket.lock` file is not present when [paket install](paket-install.html) is requested, it will be generated. Subsequent runs of [paket install](paket-install.html) will not reanalyze the `paket.dependencies` file or touch `paket.lock`.
 
-All changes after the initial generation will be as a result of [`paket install`](paket-install.html) or [paket update](paket-update.html) commands.
+All changes after the initial generation will be as a result of [paket update](paket-update.html) commands.
 
 As a result, committing the `paket.lock` file to your version control system guarantees that other developers and/or build servers will always end up with a reliable and consistent set of packages regardless of where or when a [paket install](paket-install.html) occurs.
-When you run [`paket install`](paket-install.html) and the `paket.lock` file is not present, it will be generated. Subsequent runs of [`paket install`](paket-install.html) will not reanalyze the `paket.dependencies` file nor touch `paket.lock`.
 
-If you make changes to [`paket.dependencies`](dependencies-file.html) or you want Paket to check for newer versions of the direct and indirect dependencies as specified in [`paket.dependencies`](dependencies-file.html), run [`paket update`](paket-update.html).
+If you make changes to [`paket.dependencies`](dependencies-file.html) or you want Paket to check for newer versions of the direct and indirect dependencies as specified in [`paket.dependencies`](dependencies-file.html), run:
 
-As a result, committing the `paket.lock` file to your version control system guarantees that other developers and/or build servers will always end up with a reliable and consistent set of packages regardless of where or when [`paket install`](paket-install.html) is executed.
+  - [`paket outdated`](paket-outdated.html) to check for new versions, and report what's available.
+  - [`paket update`](paket-update.html) to check for new versions, download any that fit the criteria`, and update the references within the project files as specified by their associated [`paket.references`](references-files.html).


### PR DESCRIPTION
Just visited all docs. Most I've visited recently so just minor glaring English fixes
- lockfile seems to be a confused merge - 2 paras duplicated
- BTW standardising on redundant EOL before EOF and converting spaces to tabs in few places where I see them (more than likely my fault in first place)

More to follow...
