### PR TITLE
added missing nuspec.xsd namespace and better exception

### DIFF
--- a/src/Paket.Core/Nuspec.fs
+++ b/src/Paket.Core/Nuspec.fs
@@ -63,7 +63,8 @@ type Nuspec =
         ["ns1","http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"
          "ns2","http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"
          "ns3","http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"
-         "ns4","http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"]
+         "ns4","http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
+         "ns5","http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd"]
 
     static member All = { References = NuspecReferences.All; Dependencies = []; FrameworkAssemblyReferences = []; OfficialName = "" }
     static member Explicit references = { References = NuspecReferences.Explicit references; Dependencies = []; FrameworkAssemblyReferences = []; OfficialName = "" }
@@ -80,7 +81,9 @@ type Nuspec =
 
             let nsUri = doc.LastChild.NamespaceURI
             let ns = manager.LookupPrefix(nsUri)       
-            
+            if ns = null then
+                failwithf "unrecognized namespace of %s in %s" nsUri fileName
+
             let dependencies = 
                 doc.SelectNodes(sprintf "/%s:package/%s:metadata/%s:dependencies/%s:dependency" ns ns ns ns, manager)
                 |> Seq.cast<XmlNode>

--- a/tests/Paket.Tests/InstallModel/NuspecSpecs.fs
+++ b/tests/Paket.Tests/InstallModel/NuspecSpecs.fs
@@ -53,3 +53,10 @@ let ``can detect framework assemblies for Octokit``() =
     Nuspec.Load("TestFiles/Octokit.nuspec").FrameworkAssemblyReferences
     |> shouldEqual 
         [{ AssemblyName = "System.Net.Http"; TargetFramework = DotNetFramework(FrameworkVersion.V4_5) }]
+
+[<Test>]
+let ``can detect framework assemblies for FSharp.Data.SqlEnumProvider``() = 
+    Nuspec.Load("TestFiles/FSharp.Data.SqlEnumProvider.nuspec").FrameworkAssemblyReferences
+    |> shouldEqual 
+        [{ AssemblyName = "System.Data"; TargetFramework = DotNetFramework(FrameworkVersion.V4) }
+         { AssemblyName = "System.Xml"; TargetFramework = DotNetFramework(FrameworkVersion.V4) }]

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -64,96 +64,6 @@
   </Target>
   -->
   <Import Project="$(SolutionDir)\.paket\paket.targets" />
-  <ItemGroup>
-    <Compile Include="..\..\paket-files\forki\FsUnit\FsUnit.fs">
-      <Paket>True</Paket>
-      <Link>FsUnit.fs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="TestHelpers.fs" />
-    <Compile Include="SemVerSpecs.fs" />
-    <Compile Include="NugetVersionRangeSpecs.fs" />
-    <Compile Include="BindingRedirect.fs" />
-    <Content Include="TestFiles\FSharp.Data.nuspec">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestFiles\FSharp.Data.Prerelease.nuspec">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestFiles\Octokit.nuspec">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestFiles\Fantomas.nuspec">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestFiles\Microsoft.Net.Http.nuspec">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Compile Include="FilterVersionSpecs.fs" />
-    <Compile Include="DependenciesFile\VersionRangeSpecs.fs" />
-    <Compile Include="DependenciesFile\ParserSpecs.fs" />
-    <Compile Include="DependenciesFile\SaveSpecs.fs" />
-    <Compile Include="DependenciesFile\AddPackageSpecs.fs" />
-    <Compile Include="Resolver\DependencyGraphSpecs.fs" />
-    <Compile Include="Resolver\SimpleDependenciesSpecs.fs" />
-    <Compile Include="Resolver\CyclicGraphSpecs.fs" />
-    <Compile Include="Resolver\ConflictGraphSpecs.fs" />
-    <Compile Include="Resolver\CasingSpecs.fs" />
-    <Compile Include="Resolver\PessimisticStrategySpecs.fs" />
-    <Compile Include="LockFile\GeneratorSpecs.fs" />
-    <Compile Include="LockFile\GenerateStrictModeSpecs.fs" />
-    <Compile Include="LockFile\GenerateContentNoneOptionSpecs.fs" />
-    <Compile Include="LockFile\GenerateAuthModeSpecs.fs" />
-    <Compile Include="LockFile\GeneratorWithMutlipleSourcesSpecs.fs" />
-    <Compile Include="LockFile\ParserSpecs.fs" />
-    <Compile Include="LockFile\ParserWithMultipleSourcesSpecs.fs" />
-    <Compile Include="ReferencesFile\ReferencesFileSpecs.fs" />
-    <Compile Include="Simplifier\BasicScenarioSpecs.fs" />
-    <None Include="ProjectFile\TestData\Project1.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="ProjectFile\TestData\ProjectWithConditions.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="ProjectFile\TestData\Empty.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="ProjectFile\TestData\CustomFantomasNode.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="ProjectFile\TestData\NoCustomFantomasNode.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <Compile Include="ProjectFile\ConditionSpecs.fs" />
-    <Compile Include="ProjectFile\FileBuildActionSpecs.fs" />
-    <Compile Include="InstallModel\ProcessingSpecs.fs" />
-    <Compile Include="InstallModel\Xml\Fantomas.fs" />
-    <Compile Include="InstallModel\Xml\SystemNetHttp.fs" />
-    <Compile Include="InstallModel\Xml\SystemNetHttpWithFrameworkReferences.fs" />
-    <Compile Include="InstallModel\Xml\ManualNodes.fs" />
-    <Compile Include="InstallModel\NuspecSpecs.fs" />
-    <Compile Include="DependencyModel\ProjectDependencySpecs.fs" />
-    <None Include="paket.references" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <ProjectReference Include="..\..\src\Paket.Core\Paket.Core.fsproj">
-      <Name>Paket.Core</Name>
-      <Project>{7bab0ae2-089f-4761-b138-a717aa2f86c5}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
       <Choose>
@@ -326,4 +236,93 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
+  <ItemGroup>
+    <Compile Include="..\..\paket-files\forki\FsUnit\FsUnit.fs">
+      <Paket>True</Paket>
+      <Link>FsUnit.fs</Link>
+    </Compile>
+    <Compile Include="TestHelpers.fs" />
+    <Compile Include="SemVerSpecs.fs" />
+    <Compile Include="NugetVersionRangeSpecs.fs" />
+    <Compile Include="BindingRedirect.fs" />
+    <Content Include="TestFiles\FSharp.Data.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\FSharp.Data.Prerelease.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\Octokit.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\Fantomas.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\Microsoft.Net.Http.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\FSharp.Data.SqlEnumProvider.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="FilterVersionSpecs.fs" />
+    <Compile Include="DependenciesFile\VersionRangeSpecs.fs" />
+    <Compile Include="DependenciesFile\ParserSpecs.fs" />
+    <Compile Include="DependenciesFile\SaveSpecs.fs" />
+    <Compile Include="DependenciesFile\AddPackageSpecs.fs" />
+    <Compile Include="Resolver\DependencyGraphSpecs.fs" />
+    <Compile Include="Resolver\SimpleDependenciesSpecs.fs" />
+    <Compile Include="Resolver\CyclicGraphSpecs.fs" />
+    <Compile Include="Resolver\ConflictGraphSpecs.fs" />
+    <Compile Include="Resolver\CasingSpecs.fs" />
+    <Compile Include="Resolver\PessimisticStrategySpecs.fs" />
+    <Compile Include="LockFile\GeneratorSpecs.fs" />
+    <Compile Include="LockFile\GenerateStrictModeSpecs.fs" />
+    <Compile Include="LockFile\GenerateContentNoneOptionSpecs.fs" />
+    <Compile Include="LockFile\GenerateAuthModeSpecs.fs" />
+    <Compile Include="LockFile\GeneratorWithMutlipleSourcesSpecs.fs" />
+    <Compile Include="LockFile\ParserSpecs.fs" />
+    <Compile Include="LockFile\ParserWithMultipleSourcesSpecs.fs" />
+    <Compile Include="ReferencesFile\ReferencesFileSpecs.fs" />
+    <Compile Include="Simplifier\BasicScenarioSpecs.fs" />
+    <None Include="ProjectFile\TestData\Project1.fsprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\ProjectWithConditions.fsprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\Empty.fsprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\CustomFantomasNode.fsprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\NoCustomFantomasNode.fsprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <Compile Include="ProjectFile\ConditionSpecs.fs" />
+    <Compile Include="ProjectFile\FileBuildActionSpecs.fs" />
+    <Compile Include="InstallModel\ProcessingSpecs.fs" />
+    <Compile Include="InstallModel\Xml\Fantomas.fs" />
+    <Compile Include="InstallModel\Xml\SystemNetHttp.fs" />
+    <Compile Include="InstallModel\Xml\SystemNetHttpWithFrameworkReferences.fs" />
+    <Compile Include="InstallModel\Xml\ManualNodes.fs" />
+    <Compile Include="InstallModel\NuspecSpecs.fs" />
+    <Compile Include="DependencyModel\ProjectDependencySpecs.fs" />
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\..\src\Paket.Core\Paket.Core.fsproj">
+      <Name>Paket.Core</Name>
+      <Project>{7bab0ae2-089f-4761-b138-a717aa2f86c5}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/tests/Paket.Tests/TestFiles/FSharp.Data.SqlEnumProvider.nuspec
+++ b/tests/Paket.Tests/TestFiles/FSharp.Data.SqlEnumProvider.nuspec
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+    <metadata>
+        <id>FSharp.Data.SqlEnumProvider</id>
+        <version>0.9.0-aplha</version>
+        <authors>Dmitry Morozov</authors>
+        <owners>Dmitry Morozov</owners>
+        <licenseUrl>http://github.com/fsprojects/FSharp.Data.SqlEnumProvider/blob/master/LICENSE.md</licenseUrl>
+        <projectUrl>http://github.com/fsprojects/FSharp.Data.SqlEnumProvider/</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Database enumeration types</description>
+        <summary>Converts lookup data into enumeration type.</summary>
+        <releaseNotes>TryFindName method was added.</releaseNotes>
+        <copyright>Copyright 2014</copyright>
+        <tags>F# fsharp data typeprovider sql</tags>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System.Data" targetFramework=".NETFramework4.0" />
+            <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.0" />
+        </frameworkAssemblies>
+    </metadata>
+</package>


### PR DESCRIPTION
This is a bug found when using `0.9.1.` It is missing `http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd`. I also added an better message if another xsd is missing.

In Paket.Tests.fsproj below, the only change to the files is adding this:

```
    <Content Include="TestFiles\FSharp.Data.SqlEnumProvider.nuspec">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </Content>
```

I'm not sure what is up with the rest Visual Studio 2013 switching the Choose & ItemGroup order. I tried twice with the same result.
