### PR TITLE
restore the references just for the project

### DIFF
--- a/.paket/paket.targets
+++ b/.paket/paket.targets
@@ -17,7 +17,8 @@
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 $(PaketBootStrapperExePath)</PaketBootStrapperCommand>
     <!-- Commands -->
-    <RestoreCommand>$(PaketCommand) restore</RestoreCommand>
+    <PaketReferences>$(MSBuildProjectDirectory)\paket.references</PaketReferences>
+    <RestoreCommand>$(PaketCommand) restore --references-files $(PaketReferences)</RestoreCommand>
     <DownloadPaketCommand>$(PaketBootStrapperCommand)</DownloadPaketCommand>
     <!-- We need to ensure packages are restored prior to assembly resolve -->
     <BuildDependsOn Condition="$(RestorePackages) == 'true'">RestorePackages; $(BuildDependsOn);</BuildDependsOn>
@@ -31,6 +32,6 @@
     <Exec Command="$(DownloadPaketCommand)" Condition=" '$(DownloadPaket)' == 'true' AND !Exists('$(PaketExePath)')" />
   </Target>
   <Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
-    <Exec Command="$(RestoreCommand)" WorkingDirectory="$(PaketRootPath)" />
+    <Exec Command="$(RestoreCommand)" WorkingDirectory="$(PaketRootPath)" Condition="Exists('$(PaketReferences)')" />
   </Target>
 </Project>


### PR DESCRIPTION
Thanks to #267 and the below changes, our build time decreased by only downloading required nuget packages. Our `build.cmd` now looks like:

```
.paket\paket.bootstrapper.exe
.paket\paket.exe restore --references-files paket.references
packages\FAKE\tools\FAKE.exe build.fsx %*
```
