### PR TITLE
Generate other dependency version reqs in lockfile

### DIFF
--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -11,10 +11,7 @@ open Paket.PackageSources
 module LockFileSerializer =
     /// [omit]
     let formatVersionRange (version : VersionRequirement) = 
-        match version.Range with
-        | Minimum v -> ">= " + v.ToString()
-        | Specific v -> v.ToString()
-        | Range(_, v1, v2, _) -> ">= " + v1.ToString() + ", < " + v2.ToString()
+        version.ToString()
 
     /// [omit]
     let serializePackages options (resolved : PackageResolution) = 


### PR DESCRIPTION
Fix for an issue I just raised: https://github.com/fsprojects/Paket/issues/313

I've used the existing VersionRequirement.ToString() method which appears to have all cases covered, but this does assume that we would indeed want to serialise all VersionRequirement cases for dependencies.
