### PR TITLE
Fixed travis build from #318

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq mono-complete nuget mono-vbnc fsharp libgdiplus=2.10-3
   - mozroots --import --sync --quiet
+  - mkdir ~/.config/.mono/keypairs
+  - chmod 700 ~/.config/.mono/keypairs
 
-script: 
+script:
   - ./build.sh All


### PR DESCRIPTION
After merging #318, the tests were failing on travis due a mono bug, which doesn't set the correct permissions on the keystore. When manually creating the keystore and setting the correct permission the build will pass.
