### PR TITLE
Added a find-refs function (Issue #333)

### DIFF
--- a/docs/content/paket-find-refs.md
+++ b/docs/content/paket-find-refs.md
@@ -1,0 +1,27 @@
+# paket find-refs
+
+Finds all [`paket.references` files](references-file.html) that contain the given Nuget packages.
+
+    [lang=batchfile]
+    $ paket find-refs --packages PACKAGENAME1 PACKAGENAME1 ...
+
+## Sample
+.src/Paket/paket.references contains:
+
+	UnionArgParser
+	FSharp.Core.Microsoft.Signed
+
+.src/Paket.Core/paket.references contains:
+
+	Newtonsoft.Json
+	DotNetZip
+	FSharp.Core.Microsoft.Signed
+
+Now we run `paket find-refs --packages DotNetZip FSharp.Core.Microsoft.Signed`:
+	
+	DotNetZip
+	.src/Paket.Core/paket.references
+
+	FSharp.Core.Microsoft.Signed
+	.src/Paket.Core/paket.references
+	.src/Paket/paket.references

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -67,6 +67,7 @@
             <li><a href="@Root/paket-simplify.html">paket simplify</a></li>
             <li><a href="@Root/convert-from-nuget.html">paket convert-from-nuget</a></li>            
             <li><a href="@Root/paket-init-auto-restore.html">paket init-auto-restore</a></li>
+            <li><a href="@Root/paket-find-refs.html">paket find-refs</a></li>
             <li class="divider"></li>
             <li><a href="@Root/paket-folder.html">.paket folder</a></li>       
             <li><a href="@Root/bootstrapper.html">paket.bootstrapper.exe</a></li>            

--- a/src/Paket.Core/FindReferences.fs
+++ b/src/Paket.Core/FindReferences.fs
@@ -1,0 +1,29 @@
+﻿module Paket.FindReferences
+
+open System
+open System.IO
+open Logging
+
+let For (packages : list<string>) =
+    let refFiles =
+        Directory.GetFiles(".", "paket.references", SearchOption.AllDirectories)
+        |> Seq.map ReferencesFile.FromFile
+
+    let packagesAndTheirRefFiles =
+        packages
+        |> Seq.collect (fun p ->            
+                refFiles
+                |> Seq.filter (fun r ->
+                    r.NugetPackages
+                    |> Seq.filter (fun np -> np.Equals(p))
+                    |> Seq.isEmpty |> not)
+                |> Seq.map (fun r -> (p, r.FileName)))
+        |> Seq.groupBy fst
+        
+    packagesAndTheirRefFiles
+    |> Seq.iter (fun (k, vs) ->
+        tracefn "%s" k
+        vs |> Seq.map snd |> Seq.iter (fun v -> tracefn "%s" v)
+        
+        tracefn "")
+

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -102,6 +102,7 @@
     <Compile Include="FindOutdated.fs" />
     <Compile Include="BindingRedirects.fs" />
     <None Include="paket.references" />
+    <Compile Include="FindReferences.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Data.TypeProviders" />

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -24,6 +24,7 @@ type Command =
     | ConvertFromNuget
     | InitAutoRestore
     | Simplify
+    | FindRefs
     | Unknown
 
 type CLIArguments =
@@ -36,6 +37,7 @@ type CLIArguments =
     | [<First>][<NoAppSettings>][<CustomCommandLine("convert-from-nuget")>] ConvertFromNuget
     | [<First>][<NoAppSettings>][<CustomCommandLine("init-auto-restore")>] InitAutoRestore
     | [<First>][<NoAppSettings>][<CustomCommandLine("simplify")>] Simplify
+    | [<First>][<NoAppSettings>][<CustomCommandLine("find-refs")>] FindRefs
     | [<AltCommandLine("-v")>] Verbose
     | [<AltCommandLine("-i")>] Interactive
     | [<AltCommandLine("-f")>] Force
@@ -43,6 +45,7 @@ type CLIArguments =
     | [<CustomCommandLine("nuget")>] Nuget of string
     | [<CustomCommandLine("version")>] Version of string
     | [<Rest>]References_Files of string
+    | [<Rest>]Packages of string
     | No_Install
     | Strict
     | [<AltCommandLine("--pre")>] Include_Prereleases
@@ -57,6 +60,7 @@ with
             | Restore -> "restores all packages."
             | Update -> "updates the paket.lock file and installs all packages."
             | References_Files _ -> "allows to specify a list of references file names."
+            | Packages _ -> "allows to specify a list of Nuget package names."
             | Outdated -> "displays information about new packages."
             | ConvertFromNuget -> "converts all projects from NuGet to Paket."
             | InitAutoRestore -> "enables automatic restore for Visual Studio."
@@ -71,8 +75,9 @@ with
             | No_Auto_Restore -> "omits init-auto-restore after convert-from-nuget."
             | Nuget _ -> "allows to specify a nuget package."
             | Version _ -> "allows to specify a package version."
+            | FindRefs _ -> "finds all references to the given packages."
 
-let parser = UnionArgParser.Create<CLIArguments>("USAGE: paket [add|remove|install|update|outdated|convert-from-nuget|init-auto-restore|simplify] ... options")
+let parser = UnionArgParser.Create<CLIArguments>("USAGE: paket [add|remove|install|update|outdated|convert-from-nuget|init-auto-restore|simplify|find-refs] ... options")
  
 let results =
     try
@@ -87,6 +92,7 @@ let results =
             elif results.Contains <@ CLIArguments.ConvertFromNuget @> then Command.ConvertFromNuget
             elif results.Contains <@ CLIArguments.InitAutoRestore @> then Command.InitAutoRestore
             elif results.Contains <@ CLIArguments.Simplify @> then Command.Simplify
+            elif results.Contains <@ CLIArguments.FindRefs @> then Command.FindRefs
             else Command.Unknown
         if results.Contains <@ CLIArguments.Verbose @> then
             verbose <- true
@@ -134,6 +140,9 @@ try
         | Command.InitAutoRestore -> VSIntegration.InitAutoRestore()
         | Command.ConvertFromNuget -> NuGetConvert.ConvertFromNuget(force,noInstall |> not,noAutoRestore |> not)
         | Command.Simplify -> Simplifier.Simplify(interactive)
+        | Command.FindRefs ->
+            let packages = results.GetResults <@ CLIArguments.Packages @>
+            FindReferences.For(packages)
         | _ -> traceErrorfn "no command given.%s" (parser.Usage())
         
         let elapsedTime = Utils.TimeSpanToReadableString stopWatch.Elapsed


### PR DESCRIPTION
This PR adds a find-refs function that allows to specify a list of Nuget package names and get all the paket-references back that contain them.

you simply run `paket find-refs --packages PACKAGENAME1 PACKAGENAME1 ...`

and get a result like this:

```
DotNetZip
.src/Paket.Core/paket.references

FSharp.Core.Microsoft.Signed
.src/Paket.Core/paket.references
.src/Paket/paket.references
```

Docs are included.
