### PR TITLE
Implemented paket.config

### DIFF
--- a/src/Paket.Core/Config.fs
+++ b/src/Paket.Core/Config.fs
@@ -1,0 +1,33 @@
+﻿module Paket.Config
+
+open System.IO
+open System.Xml
+
+let rootElement = "configuration"
+
+let getConfigNode (nodeName : string) =
+    let rootNode = 
+        if File.Exists Constants.PaketConfigFile then 
+            let doc = new XmlDocument()
+            doc.Load Constants.PaketConfigFile
+            doc.DocumentElement
+        else 
+            if not (Directory.Exists Constants.PaketConfigFile) then 
+                Directory.CreateDirectory Constants.PaketConfigFolder |> ignore
+
+            let doc = new XmlDocument()
+            let el = doc.CreateElement(rootElement)
+            doc.AppendChild(el) |> ignore
+            doc.Save Constants.PaketConfigFile
+            el
+
+    let node = rootNode.SelectSingleNode(sprintf "//%s" nodeName)
+    if node <> null then
+        node
+    else
+        let node = rootNode.OwnerDocument.CreateElement(nodeName)
+        rootNode.AppendChild (node) 
+
+
+let saveConfigNode (node : XmlNode) =
+    node.OwnerDocument.Save (Constants. PaketConfigFile)

--- a/src/Paket.Core/Constants.fs
+++ b/src/Paket.Core/Constants.fs
@@ -19,5 +19,7 @@ let AppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.Applicat
 
 let PaketConfigFolder = Path.Combine(AppDataFolder, "Paket")
 
+let PaketConfigFile = Path.Combine(PaketConfigFolder, "paket.config")
+
 /// The magic unpublished date is 1900-01-01T00:00:00
 let MagicUnlistingDate = DateTimeOffset(1900, 1, 1, 0, 0, 0, TimeSpan.FromHours(-8.)).DateTime

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="ProjectFile.fs" />
     <Compile Include="SolutionFile.fs" />
     <Compile Include="Nuget.fs" />
+    <Compile Include="Config.fs" />
     <Compile Include="CredentialStore.fs" />
     <Compile Include="PackageSourceParser.fs" />
     <Compile Include="DependenciesFile.fs" />


### PR DESCRIPTION
As noted in #328 credentials.xm should be renamed to paket.config and be made a more general config file.
