### PR TITLE
Release note + LocateOrCreate for NugetConvert

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * New `paket find-refs` command - http://fsprojects.github.io/Paket/paket-find-refs.html
 * If `paket add` doesn't change the dependencies file then the resolver will be skipped
 * BUGFIX: Trailing whitespace is ignored in `paket.references`
+* Migration of NuGet source credentials on convert-from-nuget - http://fsprojects.github.io/Paket/convert-from-nuget.html#Migrating-NuGet-source-credentials
 
 #### 0.12.2 - 07.11.2014
 * Adding --ignore-constraints to `paket outdated` - https://github.com/fsprojects/Paket/issues/308 

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -31,8 +31,12 @@ type Dependencies(dependenciesFileName) =
         tracefn "found: %s" dependenciesFileName
         Dependencies(dependenciesFileName)
 
-    /// Tries to create a paket.dependencies file in the current folder.
-    static member Create() = Dependencies.Create(Environment.CurrentDirectory)
+    /// Tries to locate the paket.dependencies file in the current folder, and if fails then creates one.
+    static member LocateOrCreate() = 
+        try
+            Dependencies.Locate()
+        with _ ->
+            Dependencies.Create(Environment.CurrentDirectory)
 
     /// Tries to create a paket.dependencies file in the given folder.
     static member Create(path) = 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -147,7 +147,7 @@ try
             let credsMigrationMode = 
                 results.TryGetResult <@ CLIArguments.Creds_Migration @>
                 |> Option.map NuGetConvert.CredsMigrationMode.Parse
-            Dependencies.Create().ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
+            Dependencies.LocateOrCreate().ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
         | Command.Simplify -> Dependencies.Locate().Simplify(interactive)
         | Command.FindRefs ->
             let packages = results.GetResults <@ CLIArguments.Packages @>


### PR DESCRIPTION
Convert-from-nuget can be also invoked with `--force` if there's already a paket.dependencies, so I changed the Create member to LocateOrCreate. 
