### PR TITLE
Integrate BindingRedirects into Paket install process.

### DIFF
--- a/src/Paket.Core/CustomAssemblyInfo.fs
+++ b/src/Paket.Core/CustomAssemblyInfo.fs
@@ -1,0 +1,5 @@
+﻿namespace System
+open System.Runtime.CompilerServices
+
+[<assembly: InternalsVisibleToAttribute("Paket.Tests")>]
+do ()

--- a/src/Paket.Core/InstallModel.fs
+++ b/src/Paket.Core/InstallModel.fs
@@ -31,6 +31,10 @@ type Reference =
             let fi = new FileInfo(normalizePath lib)
             fi.Name.Replace(fi.Extension, "")
 
+    member this.Path =
+        match this with
+        | Library path -> path
+        | FrameworkAssemblyReference path -> path
 
 type InstallFiles = 
     { References : Reference Set

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -436,7 +436,6 @@
       <Paket>True</Paket>
       <Link>Streams.fs</Link>
     </Compile>
-    <Compile Include="AssemblyInfo.fs" />
     <Content Include="..\..\packages\FSharp.Core.Microsoft.Signed\lib\net40\FSharp.Core.optdata">
       <Link>FSharp.Core.optdata</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -471,6 +470,7 @@
     <Compile Include="DependencyModel.fs" />
     <Compile Include="LockFile.fs" />
     <Compile Include="RestoreProcess.fs" />
+    <Compile Include="BindingRedirects.fs" />
     <Compile Include="InstallProcess.fs" />
     <Compile Include="UpdateProcess.fs" />
     <Compile Include="RemoveProcess.fs" />
@@ -479,10 +479,11 @@
     <Compile Include="VSIntegration.fs" />
     <Compile Include="NugetConvert.fs" />
     <Compile Include="FindOutdated.fs" />
-    <Compile Include="BindingRedirects.fs" />
     <Compile Include="FindReferences.fs" />
     <Compile Include="PublicAPI.fs" />
     <None Include="paket.references" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="CustomAssemblyInfo.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/src/Paket/App.config
+++ b/src/Paket/App.config
@@ -1,14 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="FSharp.Core"
-                          publicKeyToken="b03f5f7f11d50a3a"
-                          culture="neutral"/>
-        <bindingRedirect oldVersion="4.3.0.0"
-                         newVersion="4.3.1.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="4.3.0.0" newVersion="4.3.1.0"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
 </configuration>


### PR DESCRIPTION
This PR integrates the code for #245 into the main install process. There are a few fixes I made at the same time.

Issues: -
- Does not support removal of BRs when a dependency is removed.
- Is greedy i.e. will simply put a BR for every strong-named assembly even if not necessarily required.

Could use some feedback on this as to where it should go from here (and whether I've integrated it in the correct place).
