### PR TITLE
FrameworkHandling: support extracting Silverlight5.0 and NetCore4.5

### DIFF
--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -78,6 +78,7 @@ type FrameworkIdentifier =
          "3.5", "35" 
          "4.0", "40" 
          "4.5", "45" 
+         "5.0", "50" 
          "0.0", "" ]
 
     static member Extract(path:string) = 
@@ -115,10 +116,13 @@ type FrameworkIdentifier =
         | "sl4-wp71" -> Some(WindowsPhoneApp "7.1")
         | "sl4-windowsphone71" -> Some(WindowsPhoneApp "7.1")
         | "win8" -> Some(Windows "v8.0")
+        | "netcore45" -> Some(Windows "v8.0")
         | "wp8" -> Some(WindowsPhoneApp "v8.0")
         | "wpa81" -> Some(WindowsPhoneApp "v8.1")
         | "monoandroid" -> Some(MonoAndroid)
+        | "monoandroid10" -> Some(MonoAndroid)
         | "monotouch" -> Some(MonoTouch)
+        | "monotouch10" -> Some(MonoTouch)
         | _ ->                         
             if path.ToLower().StartsWith("portable-") then
                 Some(PortableFramework("7.0", path.ToLower().Replace("portable-","")))

--- a/tests/Paket.Tests/Nuspec/MathNet.Numerics.nuspec
+++ b/tests/Paket.Tests/Nuspec/MathNet.Numerics.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>MathNet.Numerics</id>
+    <version>3.2.3</version>
+    <title>Math.NET Numerics</title>
+    <authors>Christoph Ruegg, Marcus Cuda, Jurgen Van Gael</authors>
+    <owners>Christoph Ruegg, Marcus Cuda, Jurgen Van Gael</owners>
+    <licenseUrl>http://numerics.mathdotnet.com/docs/License.html</licenseUrl>
+    <projectUrl>http://numerics.mathdotnet.com/</projectUrl>
+    <iconUrl>http://www.mathdotnet.com/images/MathNet128.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Math.NET Numerics is the numerical foundation of the Math.NET project, aiming to provide methods and algorithms for numerical computations in science, engineering and every day use. Supports .Net 4.0, .Net 3.5 and Mono on Windows, Linux and Mac; Silverlight 5, WindowsPhone/SL 8, WindowsPhone 8.1 and Windows 8 with PCL Portable Profiles 47 and 328; Android/iOS with Xamarin.</description>
+    <summary>Math.NET Numerics, providing methods and algorithms for numerical computations in science, engineering and every day use.</summary>
+    <releaseNotes>Bug fix: MatrixNormal distribution: density for non-square matrices ~Evelina Gabasova</releaseNotes>
+    <tags>math numeric statistics probability integration interpolation regression solve fit linear algebra matrix fft</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework3.5">
+        <dependency id="TaskParallelLibrary" version="1.0.2856.0" />
+      </group>
+      <group targetFramework=".NETFramework4.0" />
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Numerics" targetFramework=".NETFramework4.0, .NETCore4.5, Silverlight5.0, MonoAndroid1.0, MonoTouch1.0" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
+++ b/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
@@ -92,7 +92,8 @@ let ``can detect reference files for SqlCLient``() =
 let ``can detect framework assemblies for Octokit``() = 
     Nuspec.Load("Nuspec/Octokit.nuspec").FrameworkAssemblyReferences
     |> shouldEqual 
-        [{ AssemblyName = "System.Net.Http"; TargetFramework = Some(DotNetFramework(FrameworkVersion.V4_5)) }]
+        [{ AssemblyName = "System.Net.Http"; TargetFramework = Some(DotNetFramework(FrameworkVersion.V4_5)) }
+         { AssemblyName = "System.Net.Http"; TargetFramework = Some(Windows("v8.0")) }]
 
 [<Test>]
 let ``can detect framework assemblies for FSharp.Data.SqlEnumProvider``() = 
@@ -124,3 +125,13 @@ let ``can detect explicit dependencies for ReadOnlyCollectionExtensions``() =
          "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"), Some(DotNetFramework(FrameworkVersion.V2))
          "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"), Some(DotNetFramework(FrameworkVersion.V3_5))
          "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"), Some(DotNetFramework(FrameworkVersion.V4_Client))]
+
+[<Test>]
+let ``can detect framework assemblies for MathNet.Numerics``() = 
+    Nuspec.Load("Nuspec/MathNet.Numerics.nuspec").FrameworkAssemblyReferences
+    |> shouldEqual 
+        [{ AssemblyName = "System.Numerics"; TargetFramework = Some(DotNetFramework(FrameworkVersion.V4_Client)) }
+         { AssemblyName = "System.Numerics"; TargetFramework = Some(Windows("v8.0")) }
+         { AssemblyName = "System.Numerics"; TargetFramework = Some(Silverlight("v5.0")) }
+         { AssemblyName = "System.Numerics"; TargetFramework = Some(MonoAndroid) }
+         { AssemblyName = "System.Numerics"; TargetFramework = Some(MonoTouch) }]

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -380,6 +380,9 @@
     <Content Include="Nuspec\FSharp.Data.SqlClient.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Nuspec\MathNet.Numerics.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Compile Include="Nuspec\NuspecSpecs.fs" />
     <Content Include="NuGetOData\Fantomas.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
It's small changes only, hope it doesn't clash with the recent work in the portable branch:
- Alias "5.0" to "50" (e.g. for Silverlight 5.0)
- Extract "netcore45" to Windows v8.0 ([pre-NuGet2.1 way](http://docs.nuget.org/docs/release-notes/nuget-2.1))
- Extract MonoAndroid/MonoTouch also if there is a v1.0 suffix present
- Add unit test to extract framework assembly references for MathNet.Numerics
