### PR TITLE
Work in progress: framework assembly references

### DIFF
--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -100,10 +100,7 @@ let private applyBindingRedirects root extractedPackages =
     extractedPackages
     |> Seq.map(fun (package, model:InstallModel) -> model.GetReferences.Force())
     |> Set.unionMany
-    |> Seq.choose(fun ref -> 
-            match ref with
-            | Reference.Library path -> Some path
-            | _-> None)
+    |> Seq.map (fun ref -> ref.Path)
     |> Seq.distinctBy (fun p -> FileInfo(p).Name)
     |> Seq.choose(fun assemblyFileName ->
         try

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
@@ -8,6 +8,18 @@ open Paket.Domain
 
 let expected = """
 <Choose xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5')">
+    <ItemGroup>
+      <Reference Include="System.Net.Http">
+        <Paket>True</Paket>
+      </Reference>
+      <Reference Include="System.Net.Http.WebRequest">
+        <Paket>True</Paket>
+      </Reference>
+    </ItemGroup>
+  </When>
+</Choose>
+<Choose xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
     <ItemGroup>
       <Reference Include="System.Net.Http.Extensions">
@@ -30,12 +42,6 @@ let expected = """
         <Private>True</Private>
         <Paket>True</Paket>
       </Reference>
-      <Reference Include="System.Net.Http">
-        <Paket>True</Paket>
-      </Reference>
-      <Reference Include="System.Net.Http.WebRequest">
-        <Paket>True</Paket>
-      </Reference>
     </ItemGroup>
   </When>
   <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
@@ -48,12 +54,6 @@ let expected = """
       <Reference Include="System.Net.Http.Primitives">
         <HintPath>..\..\..\Microsoft.Net.Http\lib\net45\System.Net.Http.Primitives.dll</HintPath>
         <Private>True</Private>
-        <Paket>True</Paket>
-      </Reference>
-      <Reference Include="System.Net.Http">
-        <Paket>True</Paket>
-      </Reference>
-      <Reference Include="System.Net.Http.WebRequest">
         <Paket>True</Paket>
       </Reference>
     </ItemGroup>
@@ -70,7 +70,10 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               @"..\Microsoft.Net.Http\lib\net40\System.Net.Http.WebRequest.dll" 
                      
               @"..\Microsoft.Net.Http\lib\net45\System.Net.Http.Extensions.dll" 
-              @"..\Microsoft.Net.Http\lib\net45\System.Net.Http.Primitives.dll"],
+              @"..\Microsoft.Net.Http\lib\net45\System.Net.Http.Primitives.dll"
+                     
+              @"..\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Extensions.dll" 
+              @"..\Microsoft.Net.Http\lib\portable-net45+win8\System.Net.Http.Primitives.dll"],
                { References = NuspecReferences.All
                  OfficialName = "Microsoft.Net.Http"
                  Dependencies = []


### PR DESCRIPTION
The current implementation of framework assembly references don't fit the new LibFolder approach. I tried to re-implement this in a new way. This is not done yet; it's creating invalid XML. I think this is what we still need to implement before we merge:
- merge FrameworkRestrictions for the same assembly path so we get one condition for every path
- group assemblies with the same condition
- handle empty conditions and put them into an "Otherwise" element
