### PR TITLE
Find the references file in upper directories

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -55,6 +55,7 @@ type ProjectFile =
             let rec findInDir (currentDir:DirectoryInfo) = 
                 let generalReferencesFile = FileInfo(Path.Combine(currentDir.FullName, Constants.ReferencesFile))
                 if generalReferencesFile.Exists then Some generalReferencesFile.FullName
+                elif (FileInfo(Path.Combine(currentDir.FullName, Constants.DependenciesFileName))).Exists then None
                 elif currentDir.Parent = null then None
                 else findInDir currentDir.Parent 
                     


### PR DESCRIPTION
@hmemcpy would like to put a paket.references file in a folder and let it work for all projects in subfolders.
