### PR TITLE
Revised encoded space in library filename

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -304,7 +304,7 @@ let ExtractPackage(fileName:string, targetFolder, name, version:SemVerInfo) =
                         cleanup sub
                 for file in dir.GetFiles() do
                     let newName = file.Name.Replace("%2B", "+").Replace("%20", " ")
-                    if file.Name <> newName then
+                    if file.Name <> newName && not (File.Exists <| Path.Combine(file.DirectoryName, newName)) then
                         File.Move(file.FullName, Path.Combine(file.DirectoryName, newName))
             cleanup (DirectoryInfo targetFolder)
             tracefn "%s %A unzipped to %s" name version targetFolder


### PR DESCRIPTION
0.17.7 doesn't work with Plossum.CommandLine - project file has `%2520` inside and doesn't compile

i quit on using Uri.Unescape, replacing just `%20` and `%2B` in cleanup func when extracting nupkg.

Tested with Plossum.CommandLine and Paket source

references #411 
