### PR TITLE
Remove parsing of invalid child element of ProjectReference

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -16,8 +16,7 @@ type FileItem =
 type ProjectReference = 
     { Path : string
       Name : string
-      GUID : Guid
-      Private : bool }
+      GUID : Guid }
 
 [<RequireQualifiedAccess>]
 type ProjectOutputType =
@@ -265,8 +264,7 @@ type ProjectFile =
         [for n in this.Document |> getDescendants "ProjectReference" -> 
             { Path = n.Attributes.["Include"].Value
               Name = forceGetInnerText n "Name"
-              GUID =  forceGetInnerText n "Project" |> Guid.Parse
-              Private =  forceGetInnerText n "Private" |> bool.Parse }]
+              GUID =  forceGetInnerText n "Project" |> Guid.Parse }]
 
     member this.ReplaceNuGetPackagesFile() =
         let noneNodes = this.Document |> getDescendants "None"


### PR DESCRIPTION
Fixes issue #452.
According to http://msdn.microsoft.com/en-us/library/bb629388.aspx the Private element in question is not
a child element of ProjectReference item.
(Also it was not used anywhere at all)
