### PR TITLE
Restore console color after handling exception

### DIFF
--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -122,8 +122,10 @@ namespace Paket.Bootstrapper
             {
                 if (!File.Exists(target))
                     Environment.ExitCode = 1;
+                var oldColor = Console.ForegroundColor;
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine(exn.Message);
+                Console.ForegroundColor = oldColor;
             }
         }
     }


### PR DESCRIPTION
In scenarios when the bootstrapper is run as part of build processes and an exception occurres, the console remains colored `red` and following output is erroneously seams to be an error.
