### PR TITLE
fixed: cannot install nuget packages from local TeamCity feeds 

### DIFF
--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -71,6 +71,7 @@ let defaultProxy =
     if address = irrelevantDestination then null else
     let proxy = new WebProxy(address)
     proxy.Credentials <- CredentialCache.DefaultCredentials
+    proxy.BypassProxyOnLocal <- true
     proxy
 
 let inline createWebClient(auth:Auth option) =


### PR DESCRIPTION
in presence of default proxy (set defaultProxy.BypassProxyOnLocal <- true)
