### PR TITLE
Make the file search for app.config and web.config case insensitive

### DIFF
--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -57,7 +57,7 @@ let private applyBindingRedirects bindingRedirects (configFilePath:string) =
 /// Applies a set of binding redirects to all .config files in a specific folder.
 let applyBindingRedirectsToFolder rootPath bindingRedirects =
     Directory.GetFiles(rootPath, "*.config", SearchOption.AllDirectories) 
-    |> Seq.filter (fun x -> x.EndsWith(Path.DirectorySeparatorChar.ToString() + "web.config") || x.EndsWith(Path.DirectorySeparatorChar.ToString() + "app.config"))
+    |> Seq.filter (fun x -> x.EndsWith(Path.DirectorySeparatorChar.ToString() + "web.config", StringComparison.CurrentCultureIgnoreCase) || x.EndsWith(Path.DirectorySeparatorChar.ToString() + "app.config", StringComparison.CurrentCultureIgnoreCase))
     |> Seq.iter (applyBindingRedirects bindingRedirects)
 
 /// Calculates the short form of the public key token for use with binding redirects, if it exists.


### PR DESCRIPTION
--redirects flag writes appropriate binding redirects to all app.config and web.config files. VS generates capitalized .config files (i.e. App.config), but the file search was case-sensitive, so nothing was written. This had me stumped for a long while.
