### PR TITLE
Convert Outdated command to ROP

### DIFF
--- a/src/Paket.Core/FindOutdated.fs
+++ b/src/Paket.Core/FindOutdated.fs
@@ -46,24 +46,16 @@ let FindOutdated strict includingPrereleases environment = rop {
     return detectOutdated lockFile.ResolvedPackages resolvedPackages
 }
 
-/// Finds all outdated packages.
-let FindOutdatedOld(dependenciesFileName,strict,includingPrereleases) =
-    let dependenciesFile =
-        DependenciesFile.ReadFromFile dependenciesFileName
-        |> adjustVersionRequirements strict includingPrereleases
-
-    let resolution = dependenciesFile.Resolve(true)
-    let resolvedPackages = resolution.ResolvedPackages.GetModelOrFail()
-    let lockFile = LockFile.LoadFrom(dependenciesFile.FindLockfile().FullName)
-
-    detectOutdated lockFile.ResolvedPackages resolvedPackages
-
-/// Prints all outdated packages.
-let ShowOutdated(dependenciesFileName,strict,includingPrereleases) =
-    let allOutdated = FindOutdatedOld(dependenciesFileName,strict,includingPrereleases)
-    if allOutdated = [] then
+let private printOutdated packages =
+    if packages = [] then
         tracefn "No outdated packages found."
     else
         tracefn "Outdated packages found:"
-        for (PackageName name),oldVersion,newVersion in allOutdated do
+        for (PackageName name),oldVersion,newVersion in packages do
             tracefn "  * %s %s -> %s" name (oldVersion.ToString()) (newVersion.ToString())
+
+/// Prints all outdated packages.
+let ShowOutdated strict includingPrereleases environment = rop {
+    let! allOutdated = FindOutdated strict includingPrereleases environment
+    printOutdated allOutdated
+}

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -155,9 +155,10 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Finds all outdated packages.
     member this.FindOutdated(strict: bool,includePrereleases: bool): (string * SemVerInfo) list =
-        FindOutdated.FindOutdated(dependenciesFileName,strict,includePrereleases)
+        FindOutdated.FindOutdated strict includePrereleases
+        |> this.Process
         |> List.map (fun (PackageName p,_,newVersion) -> p,newVersion)
-    
+
     /// Pulls new paket.targets and bootstrapper and puts them into .paket folder.
     member this.InitAutoRestore(): unit = 
         Utils.RunInLockedAccessMode(

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -151,7 +151,7 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Lists outdated packages.
     member this.ShowOutdated(strict: bool,includePrereleases: bool): unit =
-        FindOutdated.ShowOutdated(dependenciesFileName,strict,includePrereleases)
+        FindOutdated.ShowOutdated strict includePrereleases |> this.Process
 
     /// Finds all outdated packages.
     member this.FindOutdated(strict: bool,includePrereleases: bool): (string * SemVerInfo) list =


### PR DESCRIPTION
Actually not completed.
Used functions `DependenciesFile.Resolve` and `ResolvedPackages.GetModelOrFail` still need to be converted.
related to #464 