### PR TITLE
WIP: Separate args for each command

### DIFF
--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -2,6 +2,30 @@
 
 open Nessos.UnionArgParser
 
+type Command =
+    | [<First>][<CustomCommandLine("add")>]                 Add
+    | [<First>][<CustomCommandLine("config")>]              Config
+    | [<First>][<CustomCommandLine("convert-from-nuget")>]  ConvertFromNuget
+    | [<First>][<CustomCommandLine("find-refs")>]           FindRefs 
+    | [<First>][<CustomCommandLine("init")>]                Init
+    | [<First>][<CustomCommandLine("init-auto-restore")>]   InitAutoRestore
+    | [<First>][<CustomCommandLine("install")>]             Install
+    | [<First>][<CustomCommandLine("outdated")>]            Outdated
+    | [<First>][<CustomCommandLine("remove")>]              Remove
+    | [<First>][<CustomCommandLine("restore")>]             Restore
+    | [<First>][<CustomCommandLine("simplify")>]            Simplify
+    | [<First>][<CustomCommandLine("update")>]              Update
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+ 
+type GlobalArgs =
+    | [<AltCommandLine("-v")>] Verbose
+    | Log_File of string
+with
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
 type AddArgs =
     | [<First>][<CustomCommandLine("nuget")>][<Mandatory>] Nuget of string
     | [<CustomCommandLine("version")>] Version of string

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -1,0 +1,95 @@
+﻿module Paket.Commands
+
+open Nessos.UnionArgParser
+
+type AddArgs =
+    | [<First>][<CustomCommandLine("nuget")>][<Mandatory>] Nuget of string
+    | [<CustomCommandLine("version")>] Version of string
+    | [<AltCommandLine("-f")>] Force
+    | [<AltCommandLine("-i")>] Interactive
+    | Hard
+    | No_Install
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type ConfigArgs = 
+    | [<CustomCommandLine("add-credentials")>] AddCredentials of string
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type ConvertFromNugetArgs =
+    | [<AltCommandLine("-f")>] Force
+    | No_Install
+    | No_Auto_Restore
+    | Creds_Migration of string
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type FindRefsArgs =
+    | [<Rest>][<CustomCommandLine("nuget")>][<Mandatory>] Packages of string
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type InitArgs =
+    | [<Hidden>] NoArg
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type InitAutoRestoreArgs =
+    | [<Hidden>] NoArg
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type InstallArgs =
+    | [<AltCommandLine("-f")>] Force
+    | Hard
+    | Redirects
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type OutdatedArgs =
+    | Ignore_Constraints
+    | [<AltCommandLine("--pre")>] Include_Prereleases
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type RemoveArgs =
+    | [<First>][<CustomCommandLine("nuget")>][<Mandatory>] Nuget of string
+    | [<AltCommandLine("-f")>] Force
+    | [<AltCommandLine("-i")>] Interactive
+    | Hard
+    | No_Install
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type RestoreArgs =
+    | [<AltCommandLine("-f")>] Force
+    | [<Rest>] References_Files of string
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type SimplifyArgs =
+    | [<AltCommandLine("-i")>] Interactive
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
+
+type UpdateArgs =
+    | [<First>][<CustomCommandLine("nuget")>] Nuget of string
+    | [<CustomCommandLine("version")>] Version of string
+    | [<AltCommandLine("-f")>] Force
+    | Hard
+    | Redirects
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""

--- a/src/Paket/HelpTexts.fs
+++ b/src/Paket/HelpTexts.fs
@@ -207,7 +207,7 @@ This will add the package to the selected paket.references files and also to the
           Text = """Finds all project files that have the given NuGet packages installed.
 
     [lang=batchfile]
-    $ paket find-refs PACKAGENAME1 PACKAGENAME1 ...
+    $ paket find-refs nuget PACKAGENAME1 PACKAGENAME1 ...
 
 ## Sample
 

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -30,12 +30,14 @@
     <StartArguments>update -f</StartArguments>
     <StartArguments>remove nuget nunit -i</StartArguments>
     <StartArguments>simplify -i -v --log-file "C:\sandbox\la"</StartArguments>
+    <StartArguments>restore</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>
     </StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketkopie</StartWorkingDirectory>
     <StartWorkingDirectory>D:\skyDrive\Dev\sandbox\Solution1</StartWorkingDirectory>
+    <StartWorkingDirectory>d:\code\jsonLD.Entities\src</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -29,15 +29,11 @@
     </DocumentationFile>
     <StartArguments>update -f</StartArguments>
     <StartArguments>remove nuget nunit -i</StartArguments>
-    <StartArguments>simplify -i -v --log-file "C:\sandbox\la"</StartArguments>
-    <StartArguments>restore</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>
     </StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketkopie</StartWorkingDirectory>
-    <StartWorkingDirectory>D:\skyDrive\Dev\sandbox\Solution1</StartWorkingDirectory>
-    <StartWorkingDirectory>d:\code\jsonLD.Entities\src</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="HelpTexts.fs" />
+    <Compile Include="Commands.fs" />
     <Compile Include="Program.fs" />
     <Content Include="App.config" />
     <None Include="paket.references" />

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -29,11 +29,13 @@
     </DocumentationFile>
     <StartArguments>update -f</StartArguments>
     <StartArguments>remove nuget nunit -i</StartArguments>
+    <StartArguments>simplify -i -v --log-file "C:\sandbox\la"</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>
     </StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketkopie</StartWorkingDirectory>
+    <StartWorkingDirectory>D:\skyDrive\Dev\sandbox\Solution1</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -79,6 +79,23 @@ with
             | FindRefs _ -> "finds all references to the given packages."
             | AddCredentials _ -> "add credentials to config file for the specified source."
 
+
+type Command =
+    | [<First>][<CustomCommandLine("add")>]                 Add
+    | [<First>][<CustomCommandLine("config")>]              Config
+    | [<First>][<CustomCommandLine("convert-from-nuget")>]  ConvertFromNuget
+    | [<First>][<CustomCommandLine("find-refs")>]           FindRefs 
+    | [<First>][<CustomCommandLine("init")>]                Init
+    | [<First>][<CustomCommandLine("init-auto-restore")>]   InitAutoRestore
+    | [<First>][<CustomCommandLine("install")>]             Install
+    | [<First>][<CustomCommandLine("outdated")>]            Outdated
+    | [<First>][<CustomCommandLine("remove")>]              Remove
+    | [<First>][<CustomCommandLine("restore")>]             Restore
+    | [<First>][<CustomCommandLine("simplify")>]            Simplify
+    | [<First>][<CustomCommandLine("update")>]              Update
+with 
+    interface IArgParserTemplate with
+        member __.Usage = ""
  
 type GlobalArgs =
     | [<AltCommandLine("-v")>] Verbose
@@ -87,7 +104,22 @@ with
     interface IArgParserTemplate with
         member __.Usage = ""
 
+let (|Command|_|) args = 
+    let results = 
+        UnionArgParser.Create<Command>()
+            .Parse(inputs = args,
+                   ignoreMissing = true, 
+                   ignoreUnrecognized = true, 
+                   raiseOnUsage = false)
+
+    match results.GetAllResults() with
+    | [ command ] -> Some (command, args.[1..])
+    | [] -> None
+    | _ -> failwith "expected only one command"
+
+
 let filterGlobalArgs args = 
+
     let globalResults = 
         UnionArgParser.Create<GlobalArgs>().Parse(ignoreMissing = true, ignoreUnrecognized = true, raiseOnUsage = false)
     let verbose = globalResults.Contains <@ GlobalArgs.Verbose @>
@@ -95,184 +127,184 @@ let filterGlobalArgs args =
 
     let rest = 
         match logFile with
-        | Some file -> args |> List.filter (fun a -> a <> "--log-file" && a <> file)
+        | Some file -> args |> Array.filter (fun a -> a <> "--log-file" && a <> file)
         | None -> args
 
     let rest = 
-        if verbose then rest |> List.filter (fun a -> a <> "-v" && a <> "--verbose")
+        if verbose then rest |> Array.filter (fun a -> a <> "-v" && a <> "--verbose")
         else rest
 
     verbose, logFile, rest
+
+    
+let commandArgs<'T when 'T :> IArgParserTemplate> args = 
+    UnionArgParser
+        .Create<'T>()
+        .Parse(inputs = args, raiseOnUsage = false, errorHandler = ProcessExiter())
+
 
 let showHelp (helpTopic:HelpTexts.CommandHelpTopic) = 
                         tracefn "%s" helpTopic.Title
                         tracefn "%s" helpTopic.Text
 
-let v, logFile, args = filterGlobalArgs (Environment.GetCommandLineArgs() |> Seq.skip 1 |> Seq.toList)
-
-let commandArgs<'T when 'T :> IArgParserTemplate> args = 
-    UnionArgParser
-        .Create<'T>()
-        .Parse(inputs = Array.ofList args, raiseOnUsage = false, errorHandler = ProcessExiter())
+let v, logFile, args = filterGlobalArgs (Environment.GetCommandLineArgs().[1..])
 
 Logging.verbose <- v
 Option.iter setLogFile logFile
 
 try
     match args with
-        | "add" :: args ->
-            let results = commandArgs<AddArgs> args
+    | Command(Add, args) ->
+        let results = commandArgs<AddArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["add"]
-            else
-                let packageName = results.GetResult <@ AddArgs.Nuget @>
-                let version = defaultArg (results.TryGetResult <@ AddArgs.Version @>) ""
-                let force = results.Contains <@ AddArgs.Force @>
-                let hard = results.Contains <@ AddArgs.Hard @>
-                let interactive = results.Contains <@ AddArgs.Interactive @>
-                let noInstall = results.Contains <@ AddArgs.No_Install @>
-                Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["add"]
+        else
+            let packageName = results.GetResult <@ AddArgs.Nuget @>
+            let version = defaultArg (results.TryGetResult <@ AddArgs.Version @>) ""
+            let force = results.Contains <@ AddArgs.Force @>
+            let hard = results.Contains <@ AddArgs.Hard @>
+            let interactive = results.Contains <@ AddArgs.Interactive @>
+            let noInstall = results.Contains <@ AddArgs.No_Install @>
+            Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
         
-        | "config" :: args ->
-            let results = commandArgs<ConfigArgs> args
+    | Command(Config, args) ->
+        let results = commandArgs<ConfigArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["config"]
-            else
-                let args = results.GetResults <@ ConfigArgs.AddCredentials @> 
-                let source = args.Item 0
-                let username = 
-                    if(args.Length > 1) then
-                        args.Item 1
-                    else
-                        ""
-                Paket.ConfigFile.askAndAddAuth(source)(username)
+        if results.IsUsageRequested then
+            trace <| results.Usage("paket config")
+        else
+            let args = results.GetResults <@ ConfigArgs.AddCredentials @> 
+            let source = args.Item 0
+            let username = 
+                if(args.Length > 1) then
+                    args.Item 1
+                else
+                    ""
+            Paket.ConfigFile.askAndAddAuth(source)(username)
 
-        | "convert-from-nuget" :: args ->
-            let results = commandArgs<ConvertFromNugetArgs> args
+    | Command(ConvertFromNuget, args) ->
+        let results = commandArgs<ConvertFromNugetArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["convert-from-nuget"]
-            else
-                let force = results.Contains <@ ConvertFromNugetArgs.Force @>
-                let noInstall = results.Contains <@ ConvertFromNugetArgs.No_Install @>
-                let noAutoRestore = results.Contains <@ ConvertFromNugetArgs.No_Install @>
-                let credsMigrationMode = results.TryGetResult <@ ConvertFromNugetArgs.Creds_Migration @>
-                Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["convert-from-nuget"]
+        else
+            let force = results.Contains <@ ConvertFromNugetArgs.Force @>
+            let noInstall = results.Contains <@ ConvertFromNugetArgs.No_Install @>
+            let noAutoRestore = results.Contains <@ ConvertFromNugetArgs.No_Install @>
+            let credsMigrationMode = results.TryGetResult <@ ConvertFromNugetArgs.Creds_Migration @>
+            Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
     
-        | "find-refs" :: args ->
-            let results = commandArgs<FindRefsArgs> args
+    | Command(FindRefs, args) ->
+        let results = commandArgs<FindRefsArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["find-refs"]
-            else
-                let packages = results.GetResults <@ FindRefsArgs.Packages @>
-                Dependencies.Locate().ShowReferencesFor(packages)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["find-refs"]
+        else
+            let packages = results.GetResults <@ FindRefsArgs.Packages @>
+            Dependencies.Locate().ShowReferencesFor(packages)
         
-        | "init" :: args ->
-            let results = commandArgs<InitArgs> args
+    | Command(Init, args) ->
+        let results = commandArgs<InitArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["init"]
-            else
-                Dependencies.Init()
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["init"]
+        else
+            Dependencies.Init()
 
-        | "init-auto-restore" :: args ->
-            let results = commandArgs<InitAutoRestoreArgs> args
+    | Command(InitAutoRestore, args) ->
+        let results = commandArgs<InitAutoRestoreArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["init-auto-restore"]
-            else
-                Dependencies.Locate().InitAutoRestore()
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["init-auto-restore"]
+        else
+            Dependencies.Locate().InitAutoRestore()
 
-        | "install" :: args ->
-            let results = commandArgs<InstallArgs> args
+    | Command(Install, args) ->
+        let results = commandArgs<InstallArgs> args
             
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["install"]
-            else
-                let force = results.Contains <@ InstallArgs.Force @>
-                let hard = results.Contains <@ InstallArgs.Hard @>
-                let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
-                Dependencies.Locate().Install(force,hard,withBindingRedirects)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["install"]
+        else
+            let force = results.Contains <@ InstallArgs.Force @>
+            let hard = results.Contains <@ InstallArgs.Hard @>
+            let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
+            Dependencies.Locate().Install(force,hard,withBindingRedirects)
 
-        | "outdated" :: args ->
-            let results = commandArgs<OutdatedArgs> args
+    | Command(Outdated, args) ->
+        let results = commandArgs<OutdatedArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["outdated"]
-            else
-                let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
-                let includePrereleases = results.Contains <@ OutdatedArgs.Include_Prereleases @>
-                Dependencies.Locate().ShowOutdated(strict,includePrereleases)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["outdated"]
+        else
+            let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
+            let includePrereleases = results.Contains <@ OutdatedArgs.Include_Prereleases @>
+            Dependencies.Locate().ShowOutdated(strict,includePrereleases)
 
-        | "remove" :: args ->
-            let results = commandArgs<RemoveArgs> args
+    | Command(Remove, args) ->
+        let results = commandArgs<RemoveArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["remove"]
-            else 
-                let packageName = results.GetResult <@ RemoveArgs.Nuget @>
-                let force = results.Contains <@ RemoveArgs.Force @>
-                let hard = results.Contains <@ RemoveArgs.Hard @>
-                let interactive = results.Contains <@ RemoveArgs.Interactive @>
-                let noInstall = results.Contains <@ RemoveArgs.No_Install @>
-                Dependencies.Locate().Remove(packageName, force, hard, interactive, noInstall |> not)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["remove"]
+        else 
+            let packageName = results.GetResult <@ RemoveArgs.Nuget @>
+            let force = results.Contains <@ RemoveArgs.Force @>
+            let hard = results.Contains <@ RemoveArgs.Hard @>
+            let interactive = results.Contains <@ RemoveArgs.Interactive @>
+            let noInstall = results.Contains <@ RemoveArgs.No_Install @>
+            Dependencies.Locate().Remove(packageName, force, hard, interactive, noInstall |> not)
 
-        | "restore" :: args ->
-            let results = commandArgs<RestoreArgs> args
+    | Command(Restore, args) ->
+        let results = commandArgs<RestoreArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["restore"]
-            else 
-                let force = results.Contains <@ RestoreArgs.Force @>
-                let files = results.GetResults <@ RestoreArgs.References_Files @> 
-                Dependencies.Locate().Restore(force,files)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["restore"]
+        else 
+            let force = results.Contains <@ RestoreArgs.Force @>
+            let files = results.GetResults <@ RestoreArgs.References_Files @> 
+            Dependencies.Locate().Restore(force,files)
 
-        | "simplify" :: args ->
-            let results = commandArgs<SimplifyArgs> args
+    | Command(Simplify, args) ->
+        let results = commandArgs<SimplifyArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["simplify"]
-            else 
-                let interactive = results.Contains <@ SimplifyArgs.Interactive @>
-                Dependencies.Simplify(interactive)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["simplify"]
+        else 
+            let interactive = results.Contains <@ SimplifyArgs.Interactive @>
+            Dependencies.Simplify(interactive)
 
-        | "update" :: args ->
-            let results = commandArgs<UpdateArgs> args
+    | Command(Update, args) ->
+        let results = commandArgs<UpdateArgs> args
 
-            if results.IsUsageRequested then
-                showHelp HelpTexts.commands.["update"]
-            else 
-                let hard = results.Contains <@ UpdateArgs.Hard @>
-                let force = results.Contains <@ UpdateArgs.Force @>
-                match results.TryGetResult <@ UpdateArgs.Nuget @> with
-                | Some packageName -> 
-                    let version = results.TryGetResult <@ UpdateArgs.Version @>
-                    Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
-                | _ -> 
-                    let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
-                    Dependencies.Locate().Update(force,hard,withBindingRedirects)
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["update"]
+        else 
+            let hard = results.Contains <@ UpdateArgs.Hard @>
+            let force = results.Contains <@ UpdateArgs.Force @>
+            match results.TryGetResult <@ UpdateArgs.Nuget @> with
+            | Some packageName -> 
+                let version = results.TryGetResult <@ UpdateArgs.Version @>
+                Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
+            | _ -> 
+                let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
+                Dependencies.Locate().Update(force,hard,withBindingRedirects)
 
-        | _ ->
+    | _ ->
+        let allCommands = 
+            Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<Command>)
+            |> Array.map (fun command -> 
+                   let attr = 
+                       command.GetCustomAttributes(typeof<CustomCommandLineAttribute>)
+                       |> Seq.cast<CustomCommandLineAttribute>
+                       |> Seq.head
+                   attr.Name)
+            |> String.concat Environment.NewLine
 
-            let toCommandLine (commandArgsType : string) =
-                commandArgsType.Replace("Args", "")
-                |> Seq.mapi (fun i c -> if i > 0 && Char.IsUpper c then [|'-';c|] else [|c|])
-                |> Array.concat
-                |> (fun array -> String(array).ToLowerInvariant())
-                
-            let allCommands =
-                typeof<AddArgs>.DeclaringType.GetNestedTypes() 
-                |> Array.map (fun argsType -> toCommandLine argsType.Name)
-                |> String.concat Environment.NewLine
-
-            tracefn "available commands: %s%s%s%s" 
-                Environment.NewLine
-                Environment.NewLine
-                allCommands
-                Environment.NewLine
+        tracefn "available commands: %s%s%s%s" 
+            Environment.NewLine
+            Environment.NewLine
+            allCommands
+            Environment.NewLine
 
     let elapsedTime = Utils.TimeSpanToReadableString stopWatch.Elapsed
     tracefn "%s - ready." elapsedTime

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -18,30 +18,6 @@ let assembly = Assembly.GetExecutingAssembly()
 let fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
 tracefn "Paket version %s" fvi.FileVersion
 
-type Command =
-    | [<First>][<CustomCommandLine("add")>]                 Add
-    | [<First>][<CustomCommandLine("config")>]              Config
-    | [<First>][<CustomCommandLine("convert-from-nuget")>]  ConvertFromNuget
-    | [<First>][<CustomCommandLine("find-refs")>]           FindRefs 
-    | [<First>][<CustomCommandLine("init")>]                Init
-    | [<First>][<CustomCommandLine("init-auto-restore")>]   InitAutoRestore
-    | [<First>][<CustomCommandLine("install")>]             Install
-    | [<First>][<CustomCommandLine("outdated")>]            Outdated
-    | [<First>][<CustomCommandLine("remove")>]              Remove
-    | [<First>][<CustomCommandLine("restore")>]             Restore
-    | [<First>][<CustomCommandLine("simplify")>]            Simplify
-    | [<First>][<CustomCommandLine("update")>]              Update
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
- 
-type GlobalArgs =
-    | [<AltCommandLine("-v")>] Verbose
-    | Log_File of string
-with
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
 let (|Command|_|) args = 
     let results = 
         UnionArgParser.Create<Command>()

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -15,6 +15,7 @@ let assembly = Assembly.GetExecutingAssembly()
 let fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
 tracefn "Paket version %s" fvi.FileVersion
 
+
 type Command =
     | Init
     | Add
@@ -93,121 +94,176 @@ with
 
 let parser = UnionArgParser.Create<CLIArguments>("USAGE: paket [add|remove|install|update|outdated|convert-from-nuget|init-auto-restore|simplify|find-refs|config] ... options")
  
-let results =
-    try
-        let results = parser.Parse(raiseOnUsage=false)
-        let command = 
-            if results.Contains <@ CLIArguments.Init @> then Command.Init
-            elif results.Contains <@ CLIArguments.Add @> then Command.Add
-            elif results.Contains <@ CLIArguments.Remove @> then Command.Remove
-            elif results.Contains <@ CLIArguments.Install @> then Command.Install
-            elif results.Contains <@ CLIArguments.Restore @> then Command.Restore
-            elif results.Contains <@ CLIArguments.Update @> then Command.Update
-            elif results.Contains <@ CLIArguments.Outdated @> then Command.Outdated
-            elif results.Contains <@ CLIArguments.ConvertFromNuget @> then Command.ConvertFromNuget
-            elif results.Contains <@ CLIArguments.InitAutoRestore @> then Command.InitAutoRestore
-            elif results.Contains <@ CLIArguments.Simplify @> then Command.Simplify
-            elif results.Contains <@ CLIArguments.Config @> then Command.Config
-            elif results.Contains <@ CLIArguments.FindRefs @> then Command.FindRefs
-            else Command.Unknown
-        if results.Contains <@ CLIArguments.Verbose @> then
-            verbose <- true
 
-        if results.Contains <@ CLIArguments.Log_File @> then
-            setLogFile <| results.GetResult <@ CLIArguments.Log_File @> 
-
-        Some(command,results)
-    with
-    | _ ->
-        tracefn "%s %s%s" (String.Join(" ",Environment.GetCommandLineArgs())) Environment.NewLine (parser.Usage())
-        None
-
-try
-    match results with
-    | Some(command,results) ->
-        let force = results.Contains <@ CLIArguments.Force @> 
-        let interactive = results.Contains <@ CLIArguments.Interactive @> 
-        let hard = results.Contains <@ CLIArguments.Hard @> 
-        let noInstall = results.Contains <@ CLIArguments.No_Install @>
-        let noAutoRestore = results.Contains <@ CLIArguments.No_Auto_Restore @>
-        let includePrereleases = results.Contains <@ CLIArguments.Include_Prereleases @> 
-        let withBindingRedirects = results.Contains <@ CLIArguments.Redirects @>
-
-        if results.IsUsageRequested then 
-            let showHelp (helpTopic:HelpTexts.CommandHelpTopic) = 
-                tracefn "%s" helpTopic.Title
-                tracefn "%s" helpTopic.Text
-
-            match command with
-            | Command.Init -> showHelp HelpTexts.commands.["init"]
-            | Command.Add -> showHelp HelpTexts.commands.["add"]
-            | Command.Remove -> showHelp HelpTexts.commands.["remove"]
-            | Command.Install -> showHelp HelpTexts.commands.["install"]
-            | Command.Restore -> showHelp HelpTexts.commands.["restore"]
-            | Command.Update -> showHelp HelpTexts.commands.["update"]
-            | Command.Outdated -> showHelp HelpTexts.commands.["outdated"]
-            | Command.InitAutoRestore -> showHelp HelpTexts.commands.["init-auto-restore"]
-            | Command.ConvertFromNuget -> showHelp HelpTexts.commands.["convert-from-nuget"]
-            | Command.Simplify -> showHelp HelpTexts.commands.["simplify"]
-            | Command.FindRefs -> showHelp HelpTexts.commands.["find-refs"]
-            | Command.Config -> showHelp HelpTexts.commands.["config"]
-            | Command.Unknown -> traceErrorfn "no command given.%s" (parser.Usage())
-
-        else
-            match command with
-            | Command.Init -> Dependencies.Init()
-            | Command.Add -> 
-                let packageName = results.GetResult <@ CLIArguments.Nuget @>
-                let version = 
-                    match results.TryGetResult <@ CLIArguments.Version @> with
-                    | Some x -> x
-                    | _ -> ""
-
-                Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
-            | Command.Remove -> 
-                let packageName = results.GetResult <@ CLIArguments.Nuget @>            
-                Dependencies.Locate().Remove(packageName,force,hard,interactive,noInstall |> not)
-            | Command.Install -> Dependencies.Locate().Install(force,hard,withBindingRedirects)
-            | Command.Restore -> 
-                let files = results.GetResults <@ CLIArguments.References_Files @> 
-                Dependencies.Locate().Restore(force,files)
-            | Command.Update -> 
-                match results.TryGetResult <@ CLIArguments.Nuget @> with
-                | Some packageName -> 
-                    let version = results.TryGetResult <@ CLIArguments.Version @>
-                    Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
-                | _ -> Dependencies.Locate().Update(force,hard,withBindingRedirects)
-            | Command.Outdated ->         
-                let strict = results.Contains <@ CLIArguments.Ignore_Constraints @> |> not
-                Dependencies.Locate().ShowOutdated(strict,includePrereleases)
-            | Command.InitAutoRestore -> Dependencies.Locate().InitAutoRestore()
-            | Command.ConvertFromNuget -> 
-                let credsMigrationMode = results.TryGetResult <@ CLIArguments.Creds_Migration @>
-                Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
-            | Command.Simplify -> Dependencies.Simplify(interactive)
-            | Command.FindRefs ->
-                let packages = results.GetResults <@ CLIArguments.FindRefs @>
-                Dependencies.Locate().ShowReferencesFor(packages)
-            | Command.Config -> 
-                let args = results.GetResults <@ CLIArguments.AddCredentials @> 
-                let source = args.Item 0
-                let username = 
-                    if(args.Length > 1) then
-                        args.Item 1
-                    else
-                        ""
-                Paket.ConfigFile.askAndAddAuth(source)(username)
-
-            | Command.Unknown -> traceErrorfn "no command given.%s" (parser.Usage())
-        
-            let elapsedTime = Utils.TimeSpanToReadableString stopWatch.Elapsed
-
-            tracefn "%s - ready." elapsedTime
-    | None -> ()
+type GlobalArgs =
+    | [<AltCommandLine("-v")>] Verbose
+    | Log_File of string
 with
-| exn when not (exn :? System.NullReferenceException) -> 
-    Environment.ExitCode <- 1
-    traceErrorfn "Paket failed with:%s\t%s" Environment.NewLine exn.Message
+    interface IArgParserTemplate with
+        member __.Usage = ""
 
-    if verbose then
-        traceErrorfn "StackTrace:%s  %s" Environment.NewLine exn.StackTrace
+let filterGlobalArgs args = 
+    let globalResults = 
+        UnionArgParser.Create<GlobalArgs>().Parse(ignoreMissing = true, ignoreUnrecognized = true, raiseOnUsage = false)
+    let verbose = globalResults.Contains <@ GlobalArgs.Verbose @>
+    let logFile = globalResults.TryGetResult <@ GlobalArgs.Log_File @> 
+
+    let rest = 
+        match logFile with
+        | Some file -> args |> List.filter (fun a -> a <> "--log-file" && a <> file)
+        | None -> args
+
+    let rest = 
+        if verbose then rest |> List.filter (fun a -> a <> "-v" && a <> "--verbose")
+        else rest
+
+    verbose, logFile, rest
+
+type SimplifyArgs =
+    | [<AltCommandLine("-i")>] Interactive
+with 
+    interface IArgParserTemplate with
+        member x.Usage = 
+            match x with
+            | Interactive -> ""
+
+
+let showHelp (helpTopic:HelpTexts.CommandHelpTopic) = 
+                        tracefn "%s" helpTopic.Title
+                        tracefn "%s" helpTopic.Text
+
+let v, logFile, args = filterGlobalArgs (Environment.GetCommandLineArgs() |> Seq.skip 1 |> Seq.toList)
+
+Logging.verbose <- v
+Option.iter setLogFile logFile
+
+match args with
+    | "simplify" :: args ->
+        let results = 
+            UnionArgParser
+                .Create<SimplifyArgs>()
+                .Parse(inputs = Array.ofList args, raiseOnUsage = false, errorHandler = ProcessExiter())
+        
+        if results.IsUsageRequested then
+            showHelp HelpTexts.commands.["simplify"]
+        else 
+            let interactive = results.Contains <@ SimplifyArgs.Interactive @>
+            Dependencies.Simplify(interactive)
+
+    | _ ->
+
+        let results =
+            try
+        
+                    let results = parser.Parse(raiseOnUsage=false)
+                    let command = 
+                        if results.Contains <@ CLIArguments.Init @> then Command.Init
+                        elif results.Contains <@ CLIArguments.Add @> then Command.Add
+                        elif results.Contains <@ CLIArguments.Remove @> then Command.Remove
+                        elif results.Contains <@ CLIArguments.Install @> then Command.Install
+                        elif results.Contains <@ CLIArguments.Restore @> then Command.Restore
+                        elif results.Contains <@ CLIArguments.Update @> then Command.Update
+                        elif results.Contains <@ CLIArguments.Outdated @> then Command.Outdated
+                        elif results.Contains <@ CLIArguments.ConvertFromNuget @> then Command.ConvertFromNuget
+                        elif results.Contains <@ CLIArguments.InitAutoRestore @> then Command.InitAutoRestore
+                        elif results.Contains <@ CLIArguments.Simplify @> then Command.Simplify
+                        elif results.Contains <@ CLIArguments.Config @> then Command.Config
+                        elif results.Contains <@ CLIArguments.FindRefs @> then Command.FindRefs
+                        else Command.Unknown
+                    if results.Contains <@ CLIArguments.Verbose @> then
+                        verbose <- true
+
+                    if results.Contains <@ CLIArguments.Log_File @> then
+                        setLogFile <| results.GetResult <@ CLIArguments.Log_File @> 
+
+                    Some(command,results)
+            with
+            | _ ->
+                tracefn "%s %s%s" (String.Join(" ",Environment.GetCommandLineArgs())) Environment.NewLine (parser.Usage())
+                None
+
+        try
+            match results with
+            | Some(command,results) ->
+                let force = results.Contains <@ CLIArguments.Force @> 
+                let interactive = results.Contains <@ CLIArguments.Interactive @> 
+                let hard = results.Contains <@ CLIArguments.Hard @> 
+                let noInstall = results.Contains <@ CLIArguments.No_Install @>
+                let noAutoRestore = results.Contains <@ CLIArguments.No_Auto_Restore @>
+                let includePrereleases = results.Contains <@ CLIArguments.Include_Prereleases @> 
+                let withBindingRedirects = results.Contains <@ CLIArguments.Redirects @>
+
+                if results.IsUsageRequested then 
+                    match command with
+                    | Command.Init -> showHelp HelpTexts.commands.["init"]
+                    | Command.Add -> showHelp HelpTexts.commands.["add"]
+                    | Command.Remove -> showHelp HelpTexts.commands.["remove"]
+                    | Command.Install -> showHelp HelpTexts.commands.["install"]
+                    | Command.Restore -> showHelp HelpTexts.commands.["restore"]
+                    | Command.Update -> showHelp HelpTexts.commands.["update"]
+                    | Command.Outdated -> showHelp HelpTexts.commands.["outdated"]
+                    | Command.InitAutoRestore -> showHelp HelpTexts.commands.["init-auto-restore"]
+                    | Command.ConvertFromNuget -> showHelp HelpTexts.commands.["convert-from-nuget"]
+                    | Command.Simplify -> showHelp HelpTexts.commands.["simplify"]
+                    | Command.FindRefs -> showHelp HelpTexts.commands.["find-refs"]
+                    | Command.Config -> showHelp HelpTexts.commands.["config"]
+                    | Command.Unknown -> traceErrorfn "no command given.%s" (parser.Usage())
+
+                else
+                    match command with
+                    | Command.Init -> Dependencies.Init()
+                    | Command.Add -> 
+                        let packageName = results.GetResult <@ CLIArguments.Nuget @>
+                        let version = 
+                            match results.TryGetResult <@ CLIArguments.Version @> with
+                            | Some x -> x
+                            | _ -> ""
+
+                        Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
+                    | Command.Remove -> 
+                        let packageName = results.GetResult <@ CLIArguments.Nuget @>            
+                        Dependencies.Locate().Remove(packageName,force,hard,interactive,noInstall |> not)
+                    | Command.Install -> Dependencies.Locate().Install(force,hard,withBindingRedirects)
+                    | Command.Restore -> 
+                        let files = results.GetResults <@ CLIArguments.References_Files @> 
+                        Dependencies.Locate().Restore(force,files)
+                    | Command.Update -> 
+                        match results.TryGetResult <@ CLIArguments.Nuget @> with
+                        | Some packageName -> 
+                            let version = results.TryGetResult <@ CLIArguments.Version @>
+                            Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
+                        | _ -> Dependencies.Locate().Update(force,hard,withBindingRedirects)
+                    | Command.Outdated ->         
+                        let strict = results.Contains <@ CLIArguments.Ignore_Constraints @> |> not
+                        Dependencies.Locate().ShowOutdated(strict,includePrereleases)
+                    | Command.InitAutoRestore -> Dependencies.Locate().InitAutoRestore()
+                    | Command.ConvertFromNuget -> 
+                        let credsMigrationMode = results.TryGetResult <@ CLIArguments.Creds_Migration @>
+                        Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
+                    | Command.Simplify -> Dependencies.Simplify(interactive)
+                    | Command.FindRefs ->
+                        let packages = results.GetResults <@ CLIArguments.FindRefs @>
+                        Dependencies.Locate().ShowReferencesFor(packages)
+                    | Command.Config -> 
+                        let args = results.GetResults <@ CLIArguments.AddCredentials @> 
+                        let source = args.Item 0
+                        let username = 
+                            if(args.Length > 1) then
+                                args.Item 1
+                            else
+                                ""
+                        Paket.ConfigFile.askAndAddAuth(source)(username)
+
+                    | Command.Unknown -> traceErrorfn "no command given.%s" (parser.Usage())
+        
+                    let elapsedTime = Utils.TimeSpanToReadableString stopWatch.Elapsed
+
+                    tracefn "%s - ready." elapsedTime
+            | None -> ()
+        with
+        | exn when not (exn :? System.NullReferenceException) -> 
+            Environment.ExitCode <- 1
+            traceErrorfn "Paket failed with:%s\t%s" Environment.NewLine exn.Message
+
+            if verbose then
+                traceErrorfn "StackTrace:%s  %s" Environment.NewLine exn.StackTrace

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -273,6 +273,9 @@ try
                 Environment.NewLine
                 allCommands
                 Environment.NewLine
+
+    let elapsedTime = Utils.TimeSpanToReadableString stopWatch.Elapsed
+    tracefn "%s - ready." elapsedTime
 with
 | exn when not (exn :? System.NullReferenceException) -> 
     Environment.ExitCode <- 1

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -2,11 +2,14 @@
 module Paket.Program
 
 open System
-open Nessos.UnionArgParser
-open Paket.Logging
 open System.Diagnostics
 open System.Reflection
 open System.IO
+
+open Paket.Logging
+open Paket.Commands
+
+open Nessos.UnionArgParser
 
 let private stopWatch = new Stopwatch()
 stopWatch.Start()
@@ -15,21 +18,6 @@ let assembly = Assembly.GetExecutingAssembly()
 let fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
 tracefn "Paket version %s" fvi.FileVersion
 
-
-type Command =
-    | Init
-    | Add
-    | Remove
-    | Install
-    | Restore
-    | Update
-    | Outdated
-    | ConvertFromNuget
-    | InitAutoRestore
-    | Simplify
-    | FindRefs
-    | Config
-    | Unknown
 
 type CLIArguments =
     | [<First>][<NoAppSettings>][<CustomCommandLine("init")>] Init
@@ -91,10 +79,7 @@ with
             | FindRefs _ -> "finds all references to the given packages."
             | AddCredentials _ -> "add credentials to config file for the specified source."
 
-
-let parser = UnionArgParser.Create<CLIArguments>("USAGE: paket [add|remove|install|update|outdated|convert-from-nuget|init-auto-restore|simplify|find-refs|config] ... options")
  
-
 type GlobalArgs =
     | [<AltCommandLine("-v")>] Verbose
     | Log_File of string
@@ -119,87 +104,6 @@ let filterGlobalArgs args =
 
     verbose, logFile, rest
 
-type AddArgs =
-    | [<First>][<CustomCommandLine("nuget")>][<Mandatory>] Nuget of string
-    | [<CustomCommandLine("version")>] Version of string
-    | [<AltCommandLine("-f")>] Force
-    | [<AltCommandLine("-i")>] Interactive
-    | Hard
-    | No_Install
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type ConvertFromNugetArgs =
-    | [<AltCommandLine("-f")>] Force
-    | No_Install
-    | No_Auto_Restore
-    | Creds_Migration of string
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type FindRefsArgs =
-    | [<Rest>][<CustomCommandLine("nuget")>][<Mandatory>] Packages of string
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type InitArgs =
-    | [<Hidden>] NoArg
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type InstallArgs =
-    | [<AltCommandLine("-f")>] Force
-    | Hard
-    | Redirects
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type OutdatedArgs =
-    | Ignore_Constraints
-    | [<AltCommandLine("--pre")>] Include_Prereleases
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type RemoveArgs =
-    | [<First>][<CustomCommandLine("nuget")>][<Mandatory>] Nuget of string
-    | [<AltCommandLine("-f")>] Force
-    | [<AltCommandLine("-i")>] Interactive
-    | Hard
-    | No_Install
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type RestoreArgs =
-    | [<AltCommandLine("-f")>] Force
-    | [<Rest>] References_Files of string
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type SimplifyArgs =
-    | [<AltCommandLine("-i")>] Interactive
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-type UpdateArgs =
-    | [<First>][<CustomCommandLine("nuget")>] Nuget of string
-    | [<CustomCommandLine("version")>] Version of string
-    | [<AltCommandLine("-f")>] Force
-    | Hard
-    | Redirects
-with 
-    interface IArgParserTemplate with
-        member __.Usage = ""
-
-
 let showHelp (helpTopic:HelpTexts.CommandHelpTopic) = 
                         tracefn "%s" helpTopic.Title
                         tracefn "%s" helpTopic.Text
@@ -214,233 +118,165 @@ let commandArgs<'T when 'T :> IArgParserTemplate> args =
 Logging.verbose <- v
 Option.iter setLogFile logFile
 
-match args with
-    | "add" :: args ->
-        let results = commandArgs<AddArgs> args
+try
+    match args with
+        | "add" :: args ->
+            let results = commandArgs<AddArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["add"]
-        else
-            let packageName = results.GetResult <@ AddArgs.Nuget @>
-            let version = defaultArg (results.TryGetResult <@ AddArgs.Version @>) ""
-            let force = results.Contains <@ AddArgs.Force @>
-            let hard = results.Contains <@ AddArgs.Hard @>
-            let interactive = results.Contains <@ AddArgs.Interactive @>
-            let noInstall = results.Contains <@ AddArgs.No_Install @>
-            Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["add"]
+            else
+                let packageName = results.GetResult <@ AddArgs.Nuget @>
+                let version = defaultArg (results.TryGetResult <@ AddArgs.Version @>) ""
+                let force = results.Contains <@ AddArgs.Force @>
+                let hard = results.Contains <@ AddArgs.Hard @>
+                let interactive = results.Contains <@ AddArgs.Interactive @>
+                let noInstall = results.Contains <@ AddArgs.No_Install @>
+                Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
         
-    | "convert-from-nuget" :: args ->
-        let results = commandArgs<ConvertFromNugetArgs> args
+        | "config" :: args ->
+            let results = commandArgs<ConfigArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["convert-from-nuget"]
-        else
-            let force = results.Contains <@ ConvertFromNugetArgs.Force @>
-            let noInstall = results.Contains <@ ConvertFromNugetArgs.No_Install @>
-            let noAutoRestore = results.Contains <@ ConvertFromNugetArgs.No_Install @>
-            let credsMigrationMode = results.TryGetResult <@ ConvertFromNugetArgs.Creds_Migration @>
-            Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["config"]
+            else
+                let args = results.GetResults <@ ConfigArgs.AddCredentials @> 
+                let source = args.Item 0
+                let username = 
+                    if(args.Length > 1) then
+                        args.Item 1
+                    else
+                        ""
+                Paket.ConfigFile.askAndAddAuth(source)(username)
+
+        | "convert-from-nuget" :: args ->
+            let results = commandArgs<ConvertFromNugetArgs> args
+
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["convert-from-nuget"]
+            else
+                let force = results.Contains <@ ConvertFromNugetArgs.Force @>
+                let noInstall = results.Contains <@ ConvertFromNugetArgs.No_Install @>
+                let noAutoRestore = results.Contains <@ ConvertFromNugetArgs.No_Install @>
+                let credsMigrationMode = results.TryGetResult <@ ConvertFromNugetArgs.Creds_Migration @>
+                Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
     
-    | "find-refs" :: args ->
-        let results = commandArgs<FindRefsArgs> args
+        | "find-refs" :: args ->
+            let results = commandArgs<FindRefsArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["find-refs"]
-        else
-            let packages = results.GetResults <@ FindRefsArgs.Packages @>
-            Dependencies.Locate().ShowReferencesFor(packages)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["find-refs"]
+            else
+                let packages = results.GetResults <@ FindRefsArgs.Packages @>
+                Dependencies.Locate().ShowReferencesFor(packages)
         
-    | "init" :: args ->
-        let results = commandArgs<InitArgs> args
+        | "init" :: args ->
+            let results = commandArgs<InitArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["init"]
-        else
-            Dependencies.Init()
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["init"]
+            else
+                Dependencies.Init()
 
-    | "install" :: args ->
-        let results = commandArgs<InstallArgs> args
+        | "init-auto-restore" :: args ->
+            let results = commandArgs<InitAutoRestoreArgs> args
+
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["init-auto-restore"]
+            else
+                Dependencies.Locate().InitAutoRestore()
+
+        | "install" :: args ->
+            let results = commandArgs<InstallArgs> args
             
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["install"]
-        else
-            let force = results.Contains <@ InstallArgs.Force @>
-            let hard = results.Contains <@ InstallArgs.Hard @>
-            let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
-            Dependencies.Locate().Install(force,hard,withBindingRedirects)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["install"]
+            else
+                let force = results.Contains <@ InstallArgs.Force @>
+                let hard = results.Contains <@ InstallArgs.Hard @>
+                let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
+                Dependencies.Locate().Install(force,hard,withBindingRedirects)
 
-    | "outdated" :: args ->
-        let results = commandArgs<OutdatedArgs> args
+        | "outdated" :: args ->
+            let results = commandArgs<OutdatedArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["outdated"]
-        else
-            let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
-            let includePrereleases = results.Contains <@ OutdatedArgs.Include_Prereleases @>
-            Dependencies.Locate().ShowOutdated(strict,includePrereleases)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["outdated"]
+            else
+                let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
+                let includePrereleases = results.Contains <@ OutdatedArgs.Include_Prereleases @>
+                Dependencies.Locate().ShowOutdated(strict,includePrereleases)
 
-    | "remove" :: args ->
-        let results = commandArgs<RemoveArgs> args
+        | "remove" :: args ->
+            let results = commandArgs<RemoveArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["remove"]
-        else 
-            let packageName = results.GetResult <@ RemoveArgs.Nuget @>
-            let force = results.Contains <@ RemoveArgs.Force @>
-            let hard = results.Contains <@ RemoveArgs.Hard @>
-            let interactive = results.Contains <@ RemoveArgs.Interactive @>
-            let noInstall = results.Contains <@ RemoveArgs.No_Install @>
-            Dependencies.Locate().Remove(packageName, force, hard, interactive, noInstall |> not)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["remove"]
+            else 
+                let packageName = results.GetResult <@ RemoveArgs.Nuget @>
+                let force = results.Contains <@ RemoveArgs.Force @>
+                let hard = results.Contains <@ RemoveArgs.Hard @>
+                let interactive = results.Contains <@ RemoveArgs.Interactive @>
+                let noInstall = results.Contains <@ RemoveArgs.No_Install @>
+                Dependencies.Locate().Remove(packageName, force, hard, interactive, noInstall |> not)
 
-    | "restore" :: args ->
-        let results = commandArgs<RestoreArgs> args
+        | "restore" :: args ->
+            let results = commandArgs<RestoreArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["restore"]
-        else 
-            let force = results.Contains <@ RestoreArgs.Force @>
-            let files = results.GetResults <@ RestoreArgs.References_Files @> 
-            Dependencies.Locate().Restore(force,files)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["restore"]
+            else 
+                let force = results.Contains <@ RestoreArgs.Force @>
+                let files = results.GetResults <@ RestoreArgs.References_Files @> 
+                Dependencies.Locate().Restore(force,files)
 
-    | "simplify" :: args ->
-        let results = commandArgs<SimplifyArgs> args
+        | "simplify" :: args ->
+            let results = commandArgs<SimplifyArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["simplify"]
-        else 
-            let interactive = results.Contains <@ SimplifyArgs.Interactive @>
-            Dependencies.Simplify(interactive)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["simplify"]
+            else 
+                let interactive = results.Contains <@ SimplifyArgs.Interactive @>
+                Dependencies.Simplify(interactive)
 
-    | "update" :: args ->
-        let results = commandArgs<UpdateArgs> args
+        | "update" :: args ->
+            let results = commandArgs<UpdateArgs> args
 
-        if results.IsUsageRequested then
-            showHelp HelpTexts.commands.["update"]
-        else 
-            let hard = results.Contains <@ UpdateArgs.Hard @>
-            let force = results.Contains <@ UpdateArgs.Force @>
-            match results.TryGetResult <@ UpdateArgs.Nuget @> with
-            | Some packageName -> 
-                let version = results.TryGetResult <@ UpdateArgs.Version @>
-                Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
-            | _ -> 
-                let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
-                Dependencies.Locate().Update(force,hard,withBindingRedirects)
+            if results.IsUsageRequested then
+                showHelp HelpTexts.commands.["update"]
+            else 
+                let hard = results.Contains <@ UpdateArgs.Hard @>
+                let force = results.Contains <@ UpdateArgs.Force @>
+                match results.TryGetResult <@ UpdateArgs.Nuget @> with
+                | Some packageName -> 
+                    let version = results.TryGetResult <@ UpdateArgs.Version @>
+                    Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
+                | _ -> 
+                    let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
+                    Dependencies.Locate().Update(force,hard,withBindingRedirects)
 
-    | _ ->
+        | _ ->
 
-        let results =
-            try
-        
-                    let results = parser.Parse(raiseOnUsage=false)
-                    let command = 
-                        if results.Contains <@ CLIArguments.Init @> then Command.Init
-                        elif results.Contains <@ CLIArguments.Add @> then Command.Add
-                        elif results.Contains <@ CLIArguments.Remove @> then Command.Remove
-                        elif results.Contains <@ CLIArguments.Install @> then Command.Install
-                        elif results.Contains <@ CLIArguments.Restore @> then Command.Restore
-                        elif results.Contains <@ CLIArguments.Update @> then Command.Update
-                        elif results.Contains <@ CLIArguments.Outdated @> then Command.Outdated
-                        elif results.Contains <@ CLIArguments.ConvertFromNuget @> then Command.ConvertFromNuget
-                        elif results.Contains <@ CLIArguments.InitAutoRestore @> then Command.InitAutoRestore
-                        elif results.Contains <@ CLIArguments.Simplify @> then Command.Simplify
-                        elif results.Contains <@ CLIArguments.Config @> then Command.Config
-                        elif results.Contains <@ CLIArguments.FindRefs @> then Command.FindRefs
-                        else Command.Unknown
-                    if results.Contains <@ CLIArguments.Verbose @> then
-                        verbose <- true
+            let toCommandLine (commandArgsType : string) =
+                commandArgsType.Replace("Args", "")
+                |> Seq.mapi (fun i c -> if i > 0 && Char.IsUpper c then [|'-';c|] else [|c|])
+                |> Array.concat
+                |> (fun array -> String(array).ToLowerInvariant())
+                
+            let allCommands =
+                typeof<AddArgs>.DeclaringType.GetNestedTypes() 
+                |> Array.map (fun argsType -> toCommandLine argsType.Name)
+                |> String.concat Environment.NewLine
 
-                    if results.Contains <@ CLIArguments.Log_File @> then
-                        setLogFile <| results.GetResult <@ CLIArguments.Log_File @> 
+            tracefn "available commands: %s%s%s%s" 
+                Environment.NewLine
+                Environment.NewLine
+                allCommands
+                Environment.NewLine
+with
+| exn when not (exn :? System.NullReferenceException) -> 
+    Environment.ExitCode <- 1
+    traceErrorfn "Paket failed with:%s\t%s" Environment.NewLine exn.Message
 
-                    Some(command,results)
-            with
-            | _ ->
-                tracefn "%s %s%s" (String.Join(" ",Environment.GetCommandLineArgs())) Environment.NewLine (parser.Usage())
-                None
-
-        try
-            match results with
-            | Some(command,results) ->
-                let force = results.Contains <@ CLIArguments.Force @> 
-                let interactive = results.Contains <@ CLIArguments.Interactive @> 
-                let hard = results.Contains <@ CLIArguments.Hard @> 
-                let noInstall = results.Contains <@ CLIArguments.No_Install @>
-                let noAutoRestore = results.Contains <@ CLIArguments.No_Auto_Restore @>
-                let includePrereleases = results.Contains <@ CLIArguments.Include_Prereleases @> 
-                let withBindingRedirects = results.Contains <@ CLIArguments.Redirects @>
-
-                if results.IsUsageRequested then 
-                    match command with
-                    | Command.Init -> showHelp HelpTexts.commands.["init"]
-                    | Command.Add -> showHelp HelpTexts.commands.["add"]
-                    | Command.Remove -> showHelp HelpTexts.commands.["remove"]
-                    | Command.Install -> showHelp HelpTexts.commands.["install"]
-                    | Command.Restore -> showHelp HelpTexts.commands.["restore"]
-                    | Command.Update -> showHelp HelpTexts.commands.["update"]
-                    | Command.Outdated -> showHelp HelpTexts.commands.["outdated"]
-                    | Command.InitAutoRestore -> showHelp HelpTexts.commands.["init-auto-restore"]
-                    | Command.ConvertFromNuget -> showHelp HelpTexts.commands.["convert-from-nuget"]
-                    | Command.Simplify -> showHelp HelpTexts.commands.["simplify"]
-                    | Command.FindRefs -> showHelp HelpTexts.commands.["find-refs"]
-                    | Command.Config -> showHelp HelpTexts.commands.["config"]
-                    | Command.Unknown -> traceErrorfn "no command given.%s" (parser.Usage())
-
-                else
-                    match command with
-                    | Command.Init -> Dependencies.Init()
-                    | Command.Add -> 
-                        let packageName = results.GetResult <@ CLIArguments.Nuget @>
-                        let version = 
-                            match results.TryGetResult <@ CLIArguments.Version @> with
-                            | Some x -> x
-                            | _ -> ""
-
-                        Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
-                    | Command.Remove -> 
-                        let packageName = results.GetResult <@ CLIArguments.Nuget @>            
-                        Dependencies.Locate().Remove(packageName,force,hard,interactive,noInstall |> not)
-                    | Command.Install -> Dependencies.Locate().Install(force,hard,withBindingRedirects)
-                    | Command.Restore -> 
-                        let files = results.GetResults <@ CLIArguments.References_Files @> 
-                        Dependencies.Locate().Restore(force,files)
-                    | Command.Update -> 
-                        match results.TryGetResult <@ CLIArguments.Nuget @> with
-                        | Some packageName -> 
-                            let version = results.TryGetResult <@ CLIArguments.Version @>
-                            Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
-                        | _ -> Dependencies.Locate().Update(force,hard,withBindingRedirects)
-                    | Command.Outdated ->         
-                        let strict = results.Contains <@ CLIArguments.Ignore_Constraints @> |> not
-                        Dependencies.Locate().ShowOutdated(strict,includePrereleases)
-                    | Command.InitAutoRestore -> Dependencies.Locate().InitAutoRestore()
-                    | Command.ConvertFromNuget -> 
-                        let credsMigrationMode = results.TryGetResult <@ CLIArguments.Creds_Migration @>
-                        Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
-                    | Command.Simplify -> Dependencies.Simplify(interactive)
-                    | Command.FindRefs ->
-                        let packages = results.GetResults <@ CLIArguments.FindRefs @>
-                        Dependencies.Locate().ShowReferencesFor(packages)
-                    | Command.Config -> 
-                        let args = results.GetResults <@ CLIArguments.AddCredentials @> 
-                        let source = args.Item 0
-                        let username = 
-                            if(args.Length > 1) then
-                                args.Item 1
-                            else
-                                ""
-                        Paket.ConfigFile.askAndAddAuth(source)(username)
-
-                    | Command.Unknown -> traceErrorfn "no command given.%s" (parser.Usage())
-        
-                    let elapsedTime = Utils.TimeSpanToReadableString stopWatch.Elapsed
-
-                    tracefn "%s - ready." elapsedTime
-            | None -> ()
-        with
-        | exn when not (exn :? System.NullReferenceException) -> 
-            Environment.ExitCode <- 1
-            traceErrorfn "Paket failed with:%s\t%s" Environment.NewLine exn.Message
-
-            if verbose then
-                traceErrorfn "StackTrace:%s  %s" Environment.NewLine exn.StackTrace
+    if verbose then
+        traceErrorfn "StackTrace:%s  %s" Environment.NewLine exn.StackTrace


### PR DESCRIPTION
Because Paket.exe is always to be invoked with a given command, I thought it would be nice to separate arguments for each of the commands.

 - clearer view of which command uses what arguments
 - easier to express the syntax of commands (see f.e issue in #511)
 - good way to maintain the command line help (will need to fill in the usage for arguments)
 - potential for automated (build process) command syntax in markdown docs

Tell me what you think, if you give green light I'll proceed with filling up the usages, and what else gives.