### PR TITLE
Replace illegal <Import> attr 'Paket' with Label="Paket"

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -43,7 +43,7 @@ type ProjectFile =
             [for node in node.ChildNodes do
                 if node.Name.Contains("__paket__") || 
                     (node.Name = "Import" && node.Attributes.["Project"].Value.Contains("__paket__")) ||
-                    (node |> hasAttribute "Paket") 
+                    ((node |> getAttribute "Label") = Some("Paket"))
                 then
                     yield node
                 yield! subNodes node]
@@ -341,7 +341,7 @@ type ProjectFile =
                 this.CreateNode("Import")
                 |> addAttribute "Project" fileName
                 |> addAttribute "Condition" (sprintf "Exists('%s')" fileName)
-                |> addAttribute "Paket" "true")
+                |> addAttribute "Label" "Paket")
             |> Seq.toList
 
         propertyNameNodes,chooseNode,propertyChooseNode

--- a/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
@@ -14,7 +14,7 @@ let emptyPropertyDefinitionNodes = """<?xml version="1.0" encoding="utf-16"?>
 <Choose xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 let expectedPropertyNodes = """<?xml version="1.0" encoding="utf-16"?>
-<Import Project="..\..\..\GitInfoPlanter\build\GitInfoPlanter.targets" Condition="Exists('..\..\..\GitInfoPlanter\build\GitInfoPlanter.targets')" Paket="true" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
+<Import Project="..\..\..\GitInfoPlanter\build\GitInfoPlanter.targets" Condition="Exists('..\..\..\GitInfoPlanter\build\GitInfoPlanter.targets')" Label="Paket" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 [<Test>]
 let ``should generate Xml for GitInfoPlanter2.0.0``() = 

--- a/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
@@ -30,7 +30,7 @@ let expectedPropertyDefinitionNodes = """<?xml version="1.0" encoding="utf-16"?>
 </Choose>"""
 
 let expectedPropertyNodes = """<?xml version="1.0" encoding="utf-16"?>
-<Import Project="..\..\..\LibGit2Sharp\build\$(__paket__LibGit2Sharp_props).props" Condition="Exists('..\..\..\LibGit2Sharp\build\$(__paket__LibGit2Sharp_props).props')" Paket="true" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
+<Import Project="..\..\..\LibGit2Sharp\build\$(__paket__LibGit2Sharp_props).props" Condition="Exists('..\..\..\LibGit2Sharp\build\$(__paket__LibGit2Sharp_props).props')" Label="Paket" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 [<Test>]
 let ``should generate Xml for LibGit2Sharp 2.0.0``() = 

--- a/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
@@ -73,7 +73,7 @@ let expectedPropertyDefinitionNodes = """<?xml version="1.0" encoding="utf-16"?>
 </Choose>"""
 
 let expectedPropertyNodes = """<?xml version="1.0" encoding="utf-16"?>
-<Import Project="..\..\..\System.Data.SQLite.Core\build\$(__paket__System_Data_SQLite_Core_targets).targets" Condition="Exists('..\..\..\System.Data.SQLite.Core\build\$(__paket__System_Data_SQLite_Core_targets).targets')" Paket="true" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
+<Import Project="..\..\..\System.Data.SQLite.Core\build\$(__paket__System_Data_SQLite_Core_targets).targets" Condition="Exists('..\..\..\System.Data.SQLite.Core\build\$(__paket__System_Data_SQLite_Core_targets).targets')" Label="Paket" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 [<Test>]
 let ``should generate Xml for SQLite``() = 

--- a/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
@@ -11,7 +11,7 @@ let emptyPropertyNameNodes = """<?xml version="1.0" encoding="utf-16"?>
 <Choose xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 let expectedPropertyNodes = """<?xml version="1.0" encoding="utf-16"?>
-<Import Project="..\..\..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets')" Paket="true" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
+<Import Project="..\..\..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets')" Label="Paket" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 [<Test>]
 let ``should generate Xml for StyleCop.MSBuild``() = 

--- a/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
@@ -11,7 +11,7 @@ let emptyReferenceNodes = """<?xml version="1.0" encoding="utf-16"?>
 <Choose xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 let expectedPropertyNodes = """<?xml version="1.0" encoding="utf-16"?>
-<Import Project="..\..\..\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props" Condition="Exists('..\..\..\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props')" Paket="true" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
+<Import Project="..\..\..\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props" Condition="Exists('..\..\..\xunit.runner.visualstudio\build\$(__paket__xunit_runner_visualstudio_props).props')" Label="Paket" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
 
 let expectedPropertyDefinitionNodes = """<?xml version="1.0" encoding="utf-16"?>
 <Choose xmlns="http://schemas.microsoft.com/developer/msbuild/2003">


### PR DESCRIPTION
This replaces the Paket attribute used to identify paket-controlled `<Import>` elements a `Label` attribute that doesn't make VS b0rk