### PR TITLE
Fix for fsprojects/Paket#600 - paket.version file not generated

### DIFF
--- a/src/Paket.Core/RemoteDownload.fs
+++ b/src/Paket.Core/RemoteDownload.fs
@@ -165,7 +165,7 @@ let DownloadSourceFiles(rootPath, sourceFiles:ModuleResolver.ResolvedSourceFile 
                     })
                 |> Async.Parallel
 
-            if not <| File.ReadAllText(versionFile.FullName).Contains(version)
+            if not <| versionFile.Exists && File.ReadAllText(versionFile.FullName).Contains(version)
                 then File.AppendAllLines(versionFile.FullName, [version])
         })
     |> Async.Parallel


### PR DESCRIPTION
Check paket.version file actually exists before reading it.

See #600.