### PR TITLE
Fix 2 for fsprojects/Paket#600 - paket.version file not generated

### DIFF
--- a/src/Paket.Core/RemoteDownload.fs
+++ b/src/Paket.Core/RemoteDownload.fs
@@ -165,7 +165,7 @@ let DownloadSourceFiles(rootPath, sourceFiles:ModuleResolver.ResolvedSourceFile 
                     })
                 |> Async.Parallel
 
-            if not <| versionFile.Exists && File.ReadAllText(versionFile.FullName).Contains(version)
+            if not <| (versionFile.Exists && File.ReadAllText(versionFile.FullName).Contains(version))
                 then File.AppendAllLines(versionFile.FullName, [version])
         })
     |> Async.Parallel


### PR DESCRIPTION
Second trial, this time considering the operator precedence - sorry for the extra work