### PR TITLE
option to add/remove package for a single project

### DIFF
--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -4,25 +4,59 @@ module Paket.AddProcess
 open Paket
 open System.IO
 open Paket.Domain
+open Paket.Logging
 
-let Add(dependenciesFileName, package, version, force, hard, interactive, installAfter) =
+let private notInstalled (project : ProjectFile) package = project.HasPackageInstalled(NormalizedPackageName package) |> not
+
+let private addToProject project package =
+    ProjectFile.FindOrCreateReferencesFile(FileInfo(project.FileName))
+        .AddNuGetReference(package)
+        .Save()
+
+let private add addToProjects dependenciesFileName package version force hard installAfter =
     let existingDependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
     let dependenciesFile =
         existingDependenciesFile
-          .Add(package,version)
+            .Add(package,version)
 
     dependenciesFile.Save()
 
     let lockFile = UpdateProcess.SelectiveUpdate(dependenciesFile,Some(NormalizedPackageName package),force)
+    let projects = seq { for p in ProjectFile.FindAllProjects(Path.GetDirectoryName lockFile.FileName) -> p } // lazy sequence in case no project install required
     
-    if interactive then
-        for project in ProjectFile.FindAllProjects(Path.GetDirectoryName lockFile.FileName) do
-            let notInstalled = project.HasPackageInstalled(NormalizedPackageName package) |> not
-            if notInstalled && Utils.askYesNo(sprintf "  Install to %s?" project.Name) then
-                ProjectFile.FindOrCreateReferencesFile(FileInfo(project.FileName))
-                    .AddNuGetReference(package)
-                    .Save()
+    package |> addToProjects projects
 
     if installAfter then
         let sources = dependenciesFile.GetAllPackageSources()
         InstallProcess.Install(sources, force, hard, false, lockFile)
+
+// add a package with the option to add it to a specified project
+let AddToProject(dependenciesFileName, package, version, force, hard, projectName, installAfter) =
+    
+    let addToSpecifiedProject (projects : ProjectFile seq) package =    
+        let project = 
+            projects
+            |> Seq.tryFind (fun p -> 
+                let name = p.Name.Split('.').[0]
+                name = projectName || p.Name = projectName)
+
+        match project with
+        | Some p ->
+            if package |> notInstalled p then
+                package |> addToProject p
+            else traceWarnfn "Package %s already installed in project %s" package.Id p.Name
+        | None ->
+            traceErrorfn "Could not install package in specified project %s. Project not found" projectName
+
+    add addToSpecifiedProject dependenciesFileName package version force hard installAfter
+    
+// add a package with the option to interactively add it to multiple projects
+let Add(dependenciesFileName, package, version, force, hard, interactive, installAfter) =
+   
+    let addToProjects (projects : ProjectFile seq) package = 
+        if interactive then
+            for project in projects do
+                if package |> notInstalled project && Utils.askYesNo(sprintf "  Install to %s?" project.Name) then
+                    package |> addToProject project
+    
+    add addToProjects dependenciesFileName package version force hard installAfter

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -114,6 +114,12 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.Add(dependenciesFileName, PackageName package, version, force, hard, interactive, installAfter))
+
+    /// Adds the given package with the given version to the dependencies file.
+    member this.AddToProject(package: string,version: string,force: bool,hard: bool,projectName: string,installAfter: bool): unit =
+        Utils.RunInLockedAccessMode(
+            this.RootPath,
+            fun () -> AddProcess.AddToProject(dependenciesFileName, PackageName package, version, force, hard, projectName, installAfter))
       
     /// Adds credentials for a Nuget feed
     member this.AddCredentials(source: string, username: string) : unit =
@@ -229,6 +235,12 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> RemoveProcess.Remove(dependenciesFileName, PackageName package, force, hard, interactive, installAfter))
+
+    /// Removes the given package from the specified project
+    member this.RemoveFromProject(package: string,force: bool,hard: bool,projectName: string,installAfter: bool): unit =
+        Utils.RunInLockedAccessMode(
+            this.RootPath,
+            fun () -> RemoveProcess.RemoveFromProject(dependenciesFileName, PackageName package, force, hard, projectName, installAfter))
 
     /// Shows all references for the given packages.
     member this.ShowReferencesFor(packages: string list): unit =

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -4,17 +4,19 @@ module Paket.RemoveProcess
 open Paket
 open System.IO
 open Paket.Domain
+open Paket.Logging
 
-let Remove(dependenciesFileName, package:PackageName, force, hard, interactive, installAfter) =
+let private removePackageFromProject project package = 
+    ProjectFile.FindOrCreateReferencesFile(FileInfo(project.FileName))
+        .RemoveNuGetReference(package)
+        .Save()
+
+let private remove removeFromProjects dependenciesFileName (package: PackageName) force hard installAfter = 
     let (PackageName name) = package
     let root = Path.GetDirectoryName dependenciesFileName
     let allProjects = ProjectFile.FindAllProjects root
-    for project in allProjects do        
-        if project.HasPackageInstalled(NormalizedPackageName package) then
-            if (not interactive) || Utils.askYesNo(sprintf "  Remove from %s?" project.Name) then
-                ProjectFile.FindOrCreateReferencesFile(FileInfo(project.FileName))
-                    .RemoveNuGetReference(package)
-                    .Save()
+    
+    removeFromProjects allProjects
             
     // check we have it removed from all paket.references files
     let stillInstalled =
@@ -45,3 +47,34 @@ let Remove(dependenciesFileName, package:PackageName, force, hard, interactive, 
     if installAfter then
         let sources = DependenciesFile.ReadFromFile(dependenciesFileName).GetAllPackageSources()
         InstallProcess.Install(sources, force, hard, false, lockFile)
+
+// remove a package with the option to remove it from a specified project
+let RemoveFromProject(dependenciesFileName, package:PackageName, force, hard, projectName, installAfter) =
+    
+    let removeFromSpecifiedProject (projects : ProjectFile seq) =    
+        let project = 
+            projects
+            |> Seq.tryFind (fun p -> 
+                let name = p.Name.Split('.').[0]
+                name = projectName || p.Name = projectName)
+
+        match project with
+        | Some p ->
+            if p.HasPackageInstalled(NormalizedPackageName package) then
+                package |> removePackageFromProject p
+            else traceWarnfn "Package %s was not installed in project %s" package.Id p.Name
+        | None ->
+            traceErrorfn "Could not install package in specified project %s. Project not found" projectName
+
+    remove removeFromSpecifiedProject dependenciesFileName package force hard installAfter
+
+// remove a package with the option to interactively remove it from multiple projects
+let Remove(dependenciesFileName, package:PackageName, force, hard, interactive, installAfter) =
+    
+    let removeFromProjects (projects: ProjectFile seq) =
+        for project in projects do        
+            if project.HasPackageInstalled(NormalizedPackageName package) then
+                if (not interactive) || Utils.askYesNo(sprintf "  Remove from %s?" project.Name) then
+                    package |> removePackageFromProject project
+
+    remove removeFromProjects dependenciesFileName package force hard installAfter

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -29,6 +29,7 @@ with
 type AddArgs =
     | [<CustomCommandLine("nuget")>][<Mandatory>] Nuget of string
     | [<CustomCommandLine("version")>] Version of string
+    | [<CustomCommandLine("project")>] Project of string
     | [<AltCommandLine("-f")>] Force
     | [<AltCommandLine("-i")>] Interactive
     | Hard
@@ -88,6 +89,7 @@ with
 
 type RemoveArgs =
     | [<CustomCommandLine("nuget")>][<Mandatory>] Nuget of string
+    | [<CustomCommandLine("project")>] Project of string
     | [<AltCommandLine("-f")>] Force
     | [<AltCommandLine("-i")>] Interactive
     | Hard

--- a/src/Paket/HelpTexts.fs
+++ b/src/Paket/HelpTexts.fs
@@ -186,7 +186,14 @@ Options:
 
   `--hard`: Replaces package references within project files even if they are not yet adhering to to Paket's conventions (and hence considered manually managed). See [convert from NuGet](paket-convert-from-nuget.html).
 
-  See also [paket remove](paket-remove.html).
+## Adding to a single project
+
+It's also possible to add a package to a specified project only: 
+
+    [lang=batchfile]
+    $ paket add nuget PACKAGENAME [version VERSION] [project PROJECT] [--force] [--hard]
+
+See also [paket remove](paket-remove.html).
 
 ## Sample
 
@@ -317,6 +324,13 @@ Options:
   `--force`: Forces the download and reinstallation of all packages.
 
   `--hard`: Replaces package references within project files even if they are not yet adhering to to Paket's conventions (and hence considered manually managed). See [convert from NuGet](paket-convert-from-nuget.html).
+
+## Removing from a single project
+
+It's also possible to remove a package from a specified project only: 
+
+    [lang=batchfile]
+    $ paket remove nuget PACKAGENAME [project PROJECT] [--force] [--hard]
 
 See also [paket add](paket-add.html)."""}
 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -82,9 +82,13 @@ try
             let version = defaultArg (results.TryGetResult <@ AddArgs.Version @>) ""
             let force = results.Contains <@ AddArgs.Force @>
             let hard = results.Contains <@ AddArgs.Hard @>
-            let interactive = results.Contains <@ AddArgs.Interactive @>
             let noInstall = results.Contains <@ AddArgs.No_Install @>
-            Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
+            match results.TryGetResult <@ AddArgs.Project @> with
+            | Some projectName ->
+                Dependencies.Locate().AddToProject(packageName, version, force, hard, projectName, noInstall |> not)
+            | None ->
+                let interactive = results.Contains <@ AddArgs.Interactive @>
+                Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
         
     | Command(Config, args) ->
         let results = commandArgs<ConfigArgs> args
@@ -174,9 +178,13 @@ try
             let packageName = results.GetResult <@ RemoveArgs.Nuget @>
             let force = results.Contains <@ RemoveArgs.Force @>
             let hard = results.Contains <@ RemoveArgs.Hard @>
-            let interactive = results.Contains <@ RemoveArgs.Interactive @>
             let noInstall = results.Contains <@ RemoveArgs.No_Install @>
-            Dependencies.Locate().Remove(packageName, force, hard, interactive, noInstall |> not)
+            match results.TryGetResult <@ RemoveArgs.Project @> with
+            | Some projectName ->
+                Dependencies.Locate().RemoveFromProject(packageName, force, hard, projectName, noInstall |> not)
+            | None ->
+                let interactive = results.Contains <@ RemoveArgs.Interactive @>
+                Dependencies.Locate().Remove(packageName, force, hard, interactive, noInstall |> not)
 
     | Command(Restore, args) ->
         let results = commandArgs<RestoreArgs> args


### PR DESCRIPTION
As per https://github.com/fsprojects/Paket/issues/583

Added a `project` option to both add and remove commands so you can specify an individual project to add/remove a package. This is especially useful in some of our large solutions where using the interactive option is a bit unwieldy.