### PR TITLE
Use relative path references more consistently in docs

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -12,8 +12,6 @@ Paket.HelpTexts.commands
 
 // Binaries that have XML documentation (in a corresponding generated XML file)
 let referenceBinaries = [ "Paket.Core.dll" ]
-// Web site location for the generated documentation
-let website = "."
 
 let githubLink = "http://github.com/fsprojects/Paket"
 
@@ -37,14 +35,6 @@ open System.IO
 open Fake.FileHelper
 open FSharp.Literate
 open FSharp.MetadataFormat
-
-// When called from 'build.fsx', use the public project URL as <root>
-// otherwise, use the current 'output' directory.
-#if RELEASE
-let root = website
-#else
-let root = "file://" + (__SOURCE_DIRECTORY__ @@ "../output")
-#endif
 
 // Paths with template/source/output locations
 let bin        = __SOURCE_DIRECTORY__ @@ "../../bin"
@@ -83,7 +73,7 @@ let buildReference () =
     |> List.map (fun lib-> bin @@ lib)
   MetadataFormat.Generate
     ( binaries, output @@ "reference", layoutRootsAll.["en"],
-      parameters = ("root", "../" + root)::info,
+      parameters = ("root", "../")::info,
       sourceRepo = githubLink @@ "tree/master",
       sourceFolder = __SOURCE_DIRECTORY__ @@ ".." @@ "..",
       publicOnly = true, libDirs = [bin] )
@@ -102,7 +92,7 @@ let buildDocumentation () =
         | Some lang -> layoutRootsAll.[lang]
         | None -> layoutRootsAll.["en"] // "en" is the default language
     Literate.ProcessDirectory
-      ( dir, docTemplate, output @@ sub, replacements = ("root", root)::info,
+      ( dir, docTemplate, output @@ sub, replacements = ("root", ".")::info,
         layoutRoots = layoutRoots,
         generateAnchors = true )
 


### PR DESCRIPTION
This should solve the issue here: https://github.com/tpetricek/FSharp.Formatting/issues/263#issuecomment-75116353

In ProjectScaffold (and lots of other projects), you can build the documentation in two ways:

 - Running the build, which uses the absolute website path for all references
 - Running code from `generate.fsx` in F# Interactive, which uses absolute local path

See the `#if` I deleted in this commit. This means that doing `build.sh` will generate docs with reference to the live web site.

This change deletes all of this and just uses relative references. This works for the current docs, but it is fragile - in particular, this would break if you started adding new tutorial documents into sub-folders. But then we'd probably have to track the relative paths in F# Formatting (in some clever way).