### PR TITLE
fix paket add/remove with just project name

### DIFF
--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -37,7 +37,7 @@ let AddToProject(dependenciesFileName, package, version, force, hard, projectNam
         let project = 
             projects
             |> Seq.tryFind (fun p -> 
-                let name = p.Name.Split('.').[0]
+                let name = Path.GetFileNameWithoutExtension p.Name
                 name = projectName || p.Name = projectName)
 
         match project with

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -55,7 +55,7 @@ let RemoveFromProject(dependenciesFileName, package:PackageName, force, hard, pr
         let project = 
             projects
             |> Seq.tryFind (fun p -> 
-                let name = p.Name.Split('.').[0]
+                let name = Path.GetFileNameWithoutExtension p.Name
                 name = projectName || p.Name = projectName)
 
         match project with


### PR DESCRIPTION
Fix for adding by project name (without .*sproj extenstion) for projects with names containing periods (e.g. Paket.Bootstrapper.csproj). My bad.