### PR TITLE
Rewrite template file parsing

### DIFF
--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -67,7 +67,7 @@ let Pack(dependencies : DependenciesFile, packageOutputPath, buildConfig, versio
                                 let missing =
                                     [ if merged.Id = None then yield "Id"
                                       if merged.Version = None then yield "Version"
-                                      if merged.Authors = None then yield "Authors"
+                                      if merged.Authors = None || merged.Authors = Some [] then yield "Authors"
                                       if merged.Description = None then yield "Description" ]
                                     |> fun xs -> String.Join(", ",xs)
 

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -27,10 +27,10 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
-    <StartArguments>update</StartArguments>
+    <StartArguments>pack output temp version 1.0.0.0</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
-    <StartWorkingDirectory>d:\code\Paket09x</StartWorkingDirectory>
+    <StartWorkingDirectory>c:\rip\FSharpx.Async</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/TemplateFileParsing.fs
@@ -20,7 +20,7 @@ let FileBasedLongDesc = """type file
 id My.Thing
 version 1.0
 authors Bob McBob
-description
+description  
     A longer description
     on two lines.
 """
@@ -115,24 +115,26 @@ description A short description
 
 [<Literal>]
 let DescriptionTest = """type project
-id
-    15below.TravelStatus.CommonMessages
-title
-    15below.TravelStatus.CommonMessages
-authors
-    15below
 owners
-    15below
+    Thomas Petricek, David Thomas, Ryan Riley, Steffen Forkmann
+authors 
+    Thomas Petricek, David Thomas, Ryan Riley, Steffen Forkmann
+projectUrl
+    http://fsprojects.github.io/FSharpx.Async/
+iconUrl
+    http://fsprojects.github.io/FSharpx.Async/img/logo.png
+licenseUrl
+    http://fsprojects.github.io/FSharpx.Async/license.html
 requireLicenseAcceptance
     false
-description
-    Common messages for Travel Status
-projectUrl
-    https://github.com/15below/Pasngr.TravelStatus/tree/master/src/15below.TravelStatus.CommonMessages
-iconUrl
-    https://si0.twimg.com/profile_images/3046082295/a10bd2175096bd5faebbd8285e319d54_bigger.png
 copyright
-    Copyright 2013
+    Copyright 2015
+tags
+    F#, async, fsharpx
+summary
+    Async extensions for F#
+description
+    Async extensions for F#
 
 """
 


### PR DESCRIPTION
Closes #625 and tests for #659 

Before:

![before](https://cloud.githubusercontent.com/assets/309312/6393506/923cbe70-bdc2-11e4-9856-46c60e5c52e6.PNG)

After:

![after](https://cloud.githubusercontent.com/assets/309312/6393510/97b198c6-bdc2-11e4-9a0d-0b947dd79084.PNG)

It would be easier to smug about the two order of magnitude improvement if I hadn't written the original :)
