### PR TITLE
Fix for #670, inter project dependencies without matching package id

### DIFF
--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -35,10 +35,7 @@ let AddToProject(dependenciesFileName, package, version, force, hard, projectNam
     
     let addToSpecifiedProject (projects : ProjectFile seq) package =    
         let project = 
-            projects
-            |> Seq.tryFind (fun p -> 
-                let name = Path.GetFileNameWithoutExtension p.Name
-                name = projectName || p.Name = projectName)
+            projects |> Seq.tryFind (fun p -> p.NameWithoutExtension = projectName || p.Name = projectName)
 
         match project with
         | Some p ->

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -83,7 +83,7 @@ let Pack(dependencies : DependenciesFile, packageOutputPath, buildConfig, versio
 
             let id = 
                 match merged.Contents with
-                | CompleteInfo (c, _) -> c.Id 
+                | CompleteInfo _ -> projectFile.NameWithoutExtension
                 | x -> failwithf "unexpected failure while merging meta data: %A" x
 
             id,(merged,projectFile))

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -43,6 +43,8 @@ type ProjectFile =
 
     member this.Name = FileInfo(this.FileName).Name
 
+    member this.NameWithoutExtension = Path.GetFileNameWithoutExtension this.Name
+
     member this.GetCustomReferenceAndFrameworkNodes() = this.FindNodes false "Reference"
 
     /// Finds all project files

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -53,10 +53,7 @@ let RemoveFromProject(dependenciesFileName, package:PackageName, force, hard, pr
     
     let removeFromSpecifiedProject (projects : ProjectFile seq) =    
         let project = 
-            projects
-            |> Seq.tryFind (fun p -> 
-                let name = Path.GetFileNameWithoutExtension p.Name
-                name = projectName || p.Name = projectName)
+            projects |> Seq.tryFind (fun p -> p.NameWithoutExtension = projectName || p.Name = projectName)
 
         match project with
         | Some p ->


### PR DESCRIPTION
Fix for https://github.com/fsprojects/Paket/issues/670

Use the project name (without extension) to uniquely identify projects when determining inter project dependencies.

For this I added a new property on the ProjectFile for getting the project name without extension, so I've also used this in a couple of other places from some previous work I did.