### PR TITLE
Add support for WinExe output type

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -456,8 +456,9 @@ type ProjectFile =
     member this.OutputType =
         seq {for outputType in this.Document |> getDescendants "OutputType" ->
                 match outputType.InnerText with
-                | "Exe" -> ProjectOutputType.Exe
-                | _     -> ProjectOutputType.Library }
+                | "Exe"    -> ProjectOutputType.Exe
+                | "WinExe" -> ProjectOutputType.Exe
+                | _        -> ProjectOutputType.Library }
         |> Seq.head
 
     member this.GetTargetFramework() =

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -194,6 +194,9 @@
     <None Include="ProjectFile\TestData\Project2.fsprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="ProjectFile\TestData\Project3.fsprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="ProjectFile\TestData\ProjectWithConditions.fsprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -15,6 +15,11 @@ let ``should detect exe output type for Project2 proj file``() =
     |> shouldEqual ProjectOutputType.Exe
 
 [<Test>]
+let ``should detect exe output type for Project3 proj file``() =
+    ProjectFile.Load("./ProjectFile/TestData/Project3.fsprojtest").Value.OutputType
+    |> shouldEqual ProjectOutputType.Exe
+
+[<Test>]
 let ``should detect target framework for Project1 proj file``() =
     ProjectFile.Load("./ProjectFile/TestData/Project1.fsprojtest").Value.GetTargetFramework()
     |> shouldEqual (DotNetFramework(FrameworkVersion.V4_5))
@@ -40,4 +45,9 @@ let ``should detect assembly name for Project1 proj file`` () =
 let ``should detect assembly name for Project2 proj file`` () =
     ProjectFile.Load("./ProjectFile/TestData/Project2.fsprojtest").Value.GetAssemblyName()
     |> shouldEqual ("Paket.Tests.exe")
+
+[<Test>]
+let ``should detect assembly name for Project3 proj file`` () =
+    ProjectFile.Load("./ProjectFile/TestData/Project3.fsprojtest").Value.GetAssemblyName()
+    |> shouldEqual ("Paket.Tests.Win.exe")
 

--- a/tests/Paket.Tests/ProjectFile/TestData/Project3.fsprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/Project3.fsprojtest
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>e789c72a-5cfd-436b-8ef1-61aa2852a89f</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Paket.Tests</RootNamespace>
+    <AssemblyName>Paket.Tests.Win</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <Name>Paket.Tests</Name>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\fsharp_project_scaffold_tests.XML</DocumentationFile>
+    <StartAction>Project</StartAction>
+    <StartProgram>
+    </StartProgram>
+    <StartArguments>
+    </StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Paket.Tests.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <ItemGroup>
+    <Compile Include="FsUnit.fs" />
+    <Compile Include="TestHelpers.fs" />
+    <Compile Include="SemVerSpecs.fs" />
+    <Compile Include="NugetVersionRangeSpecs.fs" />
+    <Compile Include="FilterVersionSpecs.fs" />
+    <Compile Include="DependencyGraphSpecs.fs" />
+    <Compile Include="CyclicGraphSpecs.fs" />
+    <Compile Include="ConflictGraphSpecs.fs" />
+    <Compile Include="ConfigVersionRangeSpecs.fs" />
+    <Compile Include="LoadConfigSpecs.fs" />
+    <Compile Include="ResolveConfigSpecs.fs" />
+    <Compile Include="LockFileGenerationSpecs.fs" />
+    <Compile Include="LockFileGenerationWithMutlipleSourcesSpecs.fs" />
+    <Compile Include="LockFileParserSpecs.fs" />
+    <Compile Include="LockFileWithMultipleSourcesParserSpecs.fs" />
+    <Content Include="TestData\Project1.fsproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="ProjectFileSpecs.fs" />
+    <None Include="packages" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+      <HintPath>..\..\lib\FSharp\FSharp.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Paket\Paket.fsproj">
+      <Name>Paket</Name>
+      <Project>{09b32f18-0c20-4489-8c83-5106d5c04c93}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Paket.Core\Paket.Core.fsproj">
+      <Name>Paket.Core</Name>
+      <Project>{7bab0ae2-089f-4761-b138-a717aa2f86c5}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Fixes #674 

From https://msdn.microsoft.com/en-us/library/bb629394.aspx 


>OutputType
 
>Specifies the file format of the output file. This parameter can have one of the following values: 

> * Library. Creates a code library. (Default value.)
> * Exe. Creates a console application.
> * Module. Creates a module.
> * Winexe. Creates a Windows-based program.
 
Now only the `module` output type is not handled by Paket, it will be treated as library output
 