### PR TITLE
remove hard path to bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if test "$OS" = "Windows_NT"
 then
   # use .Net

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$(id -u)" != "0" ]; then
   echo "This local installation of Paket requires root privileges. Please run script as root (i.e. using 'sudo')." 1>&2
@@ -33,7 +33,7 @@ done
 rm -rf $BIN/paket
 
 cat >> $BIN/paket <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 exec mono $LIB/paket/paket.exe "\$@"
 EOF
 


### PR DESCRIPTION
On systems like OpenBSD bash is installed to /usr/local/bin/bash - this diff removes the hard coded /bin/bash in favor of pulling the path from the users environment.