### PR TITLE
Minor fix for when the Paket project directory is not directly off the root filesystem

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -78,7 +78,7 @@ let stable =
 
 let genFSAssemblyInfo (projectPath) =
     let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)
-    let folderName = System.IO.Path.GetDirectoryName(projectPath)
+    let folderName = System.IO.Path.GetFileName(System.IO.Path.GetDirectoryName(projectPath))
     let basePath = "src" @@ folderName
     let fileName = basePath @@ "AssemblyInfo.fs"
     CreateFSharpAssemblyInfo fileName


### PR DESCRIPTION
Example:
If I clone the repo here -> /home/devuser/data/Paket
and then run ./build.sh it will generate the files
/home/devuser/data/Paket/src/home/devuser/data/Paket/src/Paket.Core/AssemblyInfo.fs
/home/devuser/data/Paket/src/home/devuser/data/Paket/src/Paket/AssemblyInfo.fs

Because the Path.GetDirectoryName method returns the entire path:
'/home/devuser/data/Paket/src/Paket.Core' instead of just 'Paket.Core'

This fix wraps that piece in a Path.GetFileName call so it will cut it down to that 'Paket.Core' string that looks like was intended.