### PR TITLE
Fixes re-ordering problem with files

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -177,6 +177,19 @@ type ProjectFile =
                 | None  ->
                     let firstNode = fileItemsInSameDir |> Seq.head 
                     firstNode.ParentNode.InsertBefore(libReferenceNode, firstNode) |> ignore
+        
+        let paketNodes = 
+            this.FindPaketNodes("Compile")
+            @ this.FindPaketNodes("Content")
+           
+        //remove uneeded files
+        for paketNode in paketNodes do
+            match getAttribute "Include" paketNode with
+            | Some path ->
+                if not(fileItems |> List.exists (fun fi -> fi.Include = path))
+                then paketNode.ParentNode.RemoveChild(paketNode) |> ignore
+                else ()
+            | _ -> ()
 
         this.DeleteIfEmpty("PropertyGroup")
         this.DeleteIfEmpty("ItemGroup")

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -129,8 +129,6 @@ type ProjectFile =
             node.ParentNode.RemoveChild(node) |> ignore
 
     member this.UpdateFileItems(fileItems : FileItem list, hard) = 
-        this.DeletePaketNodes("Compile")
-        this.DeletePaketNodes("Content")
 
         let firstItemGroup = this.ProjectNode |> getNodes "ItemGroup" |> Seq.firstOrDefault
 
@@ -143,7 +141,6 @@ type ProjectFile =
                 ["Content", node :?> XmlElement
                  "Compile", node :?> XmlElement ] 
             |> dict
-
 
         for fileItem in fileItems |> List.rev do
             let libReferenceNode = 
@@ -161,6 +158,7 @@ type ProjectFile =
                     match node |> getAttribute "Include" with
                     | Some path when path.StartsWith(Path.GetDirectoryName(fileItem.Include)) -> true
                     | _ -> false)
+            
 
             if Seq.isEmpty fileItemsInSameDir then 
                 newItemGroups.[fileItem.BuildAction].PrependChild(libReferenceNode) |> ignore
@@ -177,9 +175,9 @@ type ProjectFile =
                         then existingNode :?> XmlElement |> addChild (this.CreateNode("Paket","True")) |> ignore
                     else verbosefn "  - custom nodes for %s in %s ==> skipping" fileItem.Include this.FileName
                 | None  ->
-                    let firstNode = fileItemsInSameDir |> Seq.head
+                    let firstNode = fileItemsInSameDir |> Seq.head 
                     firstNode.ParentNode.InsertBefore(libReferenceNode, firstNode) |> ignore
-        
+
         this.DeleteIfEmpty("PropertyGroup")
         this.DeleteIfEmpty("ItemGroup")
         this.DeleteIfEmpty("Choose")

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -30,7 +30,7 @@
     <StartArguments>update</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
-    <StartWorkingDirectory>c:\code\Paket09x</StartWorkingDirectory>
+    <StartWorkingDirectory>D:\Appdev\officeprovider\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -218,6 +218,9 @@
     <None Include="ProjectFile\TestData\NoCustomFantomasNode.fsprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="ProjectFile\TestData\MaintainsOrdering.fsprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Compile Include="ProjectFile\ConditionSpecs.fs" />
     <Compile Include="ProjectFile\FileBuildActionSpecs.fs" />
     <Compile Include="ProjectFile\InterProjectDependencySpecs.fs" />

--- a/tests/Paket.Tests/ProjectFile/TestData/MaintainsOrdering.fsprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/MaintainsOrdering.fsprojtest
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>b8134fc6-3f15-4f95-baac-e5b2c7856060</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>OfficeProvider</RootNamespace>
+    <AssemblyName>OfficeProvider</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <Name>OfficeProvider</Name>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\OfficeProvider.XML</DocumentationFile>
+    <StartArguments>D:\Appdev\officeprovider\tests\test.sln</StartArguments>
+    <StartAction>Program</StartAction>
+    <StartProgram>devenv.exe</StartProgram>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\OfficeProvider.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\..\.paket\paket.targets" />
+  <ItemGroup>
+    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\CommonRuntime\Pluralizer.fs">
+      <Paket>True</Paket>
+      <Link>fsharp_data/Pluralizer.fs</Link>
+    </Compile>
+    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\CommonRuntime\NameUtils.fs">
+      <Paket>True</Paket>
+      <Link>fsharp_data/NameUtils.fs</Link>
+    </Compile>
+    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\CommonRuntime\TextConversions.fs">
+      <Paket>True</Paket>
+      <Link>fsharp_data/TextConversions.fs</Link>
+    </Compile>
+    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\CommonRuntime\StructuralTypes.fs">
+      <Paket>True</Paket>
+      <Link>fsharp_data/StructuralTypes.fs</Link>
+    </Compile>
+    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\CommonRuntime\StructuralInference.fs">
+      <Paket>True</Paket>
+      <Link>fsharp_data/StructuralInference.fs</Link>
+    </Compile>
+    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\CommonRuntime\TextRuntime.fs">
+      <Paket>True</Paket>
+      <Link>fsharp_data/TextRuntime.fs</Link>
+    </Compile>
+    <Content Include="ProvidedTypes.fsi">
+      <Paket>True</Paket>
+    </Content>
+    <Compile Include="ProvidedTypes.fs">
+      <Paket>True</Paket>
+    </Compile>
+    <Compile Include="DebugProvidedTypes.fs">
+      <Paket>True</Paket>
+    </Compile>
+    <Compile Include="QuotationHelpers.fs" />
+    <Compile Include="CommonTypes.fs" />
+    <Compile Include="ExcelProvider.fs" />
+    <Compile Include="WordProvider.fs" />
+    <Compile Include="ProviderEntryPoint.fs" />
+    <None Include="Script.fsx" />
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="DocumentFormat.OpenXml">
+      <HintPath>..\..\packages\DocumentFormat.OpenXml\lib\DocumentFormat.OpenXml.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I have had problems in a number of projects where I have re-ordered the files in the project, for one reason or another. However when I run `paket update` there are certain situations where this order isn't maintained. For example,

Before running `paket update`
![original-ordering-officeprovider-microsoft visual studio](https://cloud.githubusercontent.com/assets/585546/6829067/18826c04-d309-11e4-85ea-3cbef38274b3.png)

After running `paket update`

![afterupdate-ordering-officeprovider-microsoft visual studio](https://cloud.githubusercontent.com/assets/585546/6829085/27caa12c-d309-11e4-8cea-5e2b3a6a4ec2.png)

This fix prevents this re-ordering from happening by retaining the paket Compile and Content elements in place when `ProjectFile.UpdateFileItems`. I'm not a 100% sure this is the correct fix, but it was the most simply thing I could see to do with out changing `UpdateFiles` significantly. 

 
