### PR TITLE
Boostrapper download without nuget exe and switch bootstrapper to .net 4.5

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -3,10 +3,12 @@
 Downloads the latest stable paket.exe from github.com.
 
     [lang=batchfile]
-    $ paket.bootstrapper.exe [prerelease|version]
+    $ paket.bootstrapper.exe [prerelease|version] [--prefer-nuget]
 
 Options:
 
   `prerelease`: Downloads the latest paket.exe from github.com and includes prerelease versions.
 
   `version`: Downloads the given version of paket.exe from github.com.
+
+  `--prefer-nuget`: Downloads the given version of paket.exe from nuget.org instead of github.com.

--- a/src/Paket.Bootstrapper/DownloadArguments.cs
+++ b/src/Paket.Bootstrapper/DownloadArguments.cs
@@ -1,0 +1,18 @@
+﻿namespace Paket.Bootstrapper
+{
+    internal class DownloadArguments
+    {
+        public string Folder { get; private set; }
+        public string Target { get; private set; }
+        public string LatestVersion { get; private set; }
+        public bool IgnorePrerelease { get; private set; }
+
+        public DownloadArguments(string latestVersion, bool ignorePrerelease, string folder, string target)
+        {
+            LatestVersion = latestVersion;
+            IgnorePrerelease = ignorePrerelease;
+            Folder = folder;
+            Target = target;
+        }
+    }
+}

--- a/src/Paket.Bootstrapper/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/GitHubDownloadStrategy.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.IO;
+using System.Net;
+
+namespace Paket.Bootstrapper
+{
+    internal class GitHubDownloadStrategy : IDownloadStrategy
+    {
+        private PrepareWebClientDelegate PrepareWebClient { get; set; }
+        private GetDefaultWebProxyForDelegate GetDefaultWebProxyFor { get; set; }
+        public string Name { get { return "Github"; } }
+        public IDownloadStrategy FallbackStrategy { get; set; }
+
+        public GitHubDownloadStrategy(PrepareWebClientDelegate prepareWebClient, GetDefaultWebProxyForDelegate getDefaultWebProxyFor)
+        {
+            PrepareWebClient = prepareWebClient;
+            GetDefaultWebProxyFor = getDefaultWebProxyFor;
+        }
+
+        public string GetLatestVersion(bool ignorePrerelease)
+        {
+            string latestVersion = "";
+            using (WebClient client = new WebClient())
+            {
+                const string releasesUrl = "https://github.com/fsprojects/Paket/releases";
+                PrepareWebClient(client, releasesUrl);
+
+                var data = client.DownloadString(releasesUrl);
+                var start = 0;
+                while (latestVersion == "")
+                {
+                    start = data.IndexOf("Paket/tree/", start) + 11;
+                    var end = data.IndexOf("\"", start);
+                    latestVersion = data.Substring(start, end - start);
+                    if (latestVersion.Contains("-") && ignorePrerelease)
+                        latestVersion = "";
+                }
+            }
+            return latestVersion;
+        }
+
+        public void DownloadVersion(string latestVersion, string target)
+        {
+            var url = String.Format("https://github.com/fsprojects/Paket/releases/download/{0}/paket.exe", latestVersion);
+
+            Console.WriteLine("Starting download from {0}", url);
+
+            var request = (HttpWebRequest)HttpWebRequest.Create(url);
+
+            request.UseDefaultCredentials = true;
+            request.Proxy = GetDefaultWebProxyFor(url);
+            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+
+            using (HttpWebResponse httpResponse = (HttpWebResponse)request.GetResponse())
+            {
+                using (Stream httpResponseStream = httpResponse.GetResponseStream())
+                {
+                    const int bufferSize = 4096;
+                    byte[] buffer = new byte[bufferSize];
+                    int bytesRead = 0;
+
+                    using (FileStream fileStream = File.Create(target))
+                    {
+                        while ((bytesRead = httpResponseStream.Read(buffer, 0, bufferSize)) != 0)
+                        {
+                            fileStream.Write(buffer, 0, bytesRead);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Paket.Bootstrapper/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/IDownloadStrategy.cs
@@ -1,0 +1,15 @@
+using System.Net;
+
+namespace Paket.Bootstrapper
+{
+    internal interface IDownloadStrategy
+    {
+        string Name { get; }
+        IDownloadStrategy FallbackStrategy { get; set; }
+        string GetLatestVersion(bool ignorePrerelease);
+        void DownloadVersion(string latestVersion, string target);
+    }
+
+    public delegate void PrepareWebClientDelegate(WebClient client, string url);
+    public delegate IWebProxy GetDefaultWebProxyForDelegate(string url);
+}

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 
 namespace Paket.Bootstrapper
 {
@@ -24,18 +25,14 @@ namespace Paket.Bootstrapper
             get { return "Nuget"; }
         }
 
-        public IDownloadStrategy FallbackStrategy
-        {
-            get;
-            set;
-        }
+        public IDownloadStrategy FallbackStrategy { get; set; }
 
         public string GetLatestVersion(bool ignorePrerelease)
         {
             using (WebClient client = new WebClient())
             {
                 const string getVersionsFromNugetUrl = "https://www.nuget.org/api/v2/package-versions/Paket";
-                const string withPrereleases = "?includePrereleases=true";
+                const string withPrereleases = "?includePrerelease=true";
 
                 var versionRequestUrl = getVersionsFromNugetUrl;
                 if (!ignorePrerelease)
@@ -46,9 +43,31 @@ namespace Paket.Bootstrapper
                     Trim('[', ']').
                     Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).
                     Select(x => x.Trim('"')).
-                    LastOrDefault(x => !String.IsNullOrWhiteSpace(x)) ?? String.Empty;
-                return latestVersion;
+                    Select(x => GetSemVer(x)).
+                    OrderBy(x => x).
+                    LastOrDefault(x => !String.IsNullOrWhiteSpace(x.Original));
+                return latestVersion != null ? latestVersion.Original : String.Empty;
             }
+        }
+
+        private SemVer GetSemVer(string version)
+        {
+            var dashSplitted = version.Split('-', '+');
+            var splitted = dashSplitted[0].Split('.');
+            var l = splitted.Length;
+
+            var prereleaseBuild = dashSplitted.Length > 1 && dashSplitted[1].Split('.').Length > 1 ? dashSplitted[1].Split('.')[1] : "0";
+
+            return new SemVer
+            {
+                Major = l > 0 ? Int32.Parse(splitted[0]) : 0,
+                Minor = l > 1 ? Int32.Parse(splitted[1]) : 0,
+                Patch = l > 2 ? Int32.Parse(splitted[2]) : 0,
+                PreRelease = PreRelease.TryParse(dashSplitted.Length > 1 ? dashSplitted[1].Split('.')[0] : String.Empty),
+                Build = l > 3 ? splitted[3] : "0",
+                PreReleaseBuild = prereleaseBuild,
+                Original = version
+            };
         }
 
         public void DownloadVersion(string latestVersion, string target)
@@ -82,5 +101,95 @@ namespace Paket.Bootstrapper
             }
         }
 
+        private class SemVer : IComparable
+        {
+            public int Major { get; set; }
+            public int Minor { get; set; }
+            public int Patch { get; set; }
+            public PreRelease PreRelease { get; set; }
+            public string Original { get; set; }
+            public string PreReleaseBuild { get; set; }
+            public string Build { get; set; }
+
+            public int CompareTo(object obj)
+            {
+                var y = obj as SemVer;
+                if (y == null)
+                    throw new ArgumentException("cannot compare values of different types", "obj");
+                var x = this;
+                if (x.Major != y.Major) return x.Major.CompareTo(y.Major);
+                else if (x.Minor != y.Minor) return x.Minor.CompareTo(y.Minor);
+                else if (x.Patch != y.Patch) return x.Patch.CompareTo(y.Patch);
+                else if (x.Build != y.Build)
+                {
+                    int buildx, buildy;
+                    var parseResultx = Int32.TryParse(x.Build, out buildx);
+                    var parseResulty = Int32.TryParse(y.Build, out buildy);
+                    if (parseResultx && parseResulty)
+                        return buildx.CompareTo(buildy);
+                    return x.Build.CompareTo(y.Build);
+                }
+                else if (x.PreRelease == y.PreRelease && x.PreReleaseBuild == y.PreReleaseBuild) return 0;
+                else if (x.PreRelease == null && y.PreRelease != null && x.PreReleaseBuild == "0") return 1;
+                else if (y.PreRelease == null && x.PreRelease != null && y.PreReleaseBuild == "0") return -1;
+                else if (x.PreRelease != y.PreRelease) return x.PreRelease.CompareTo(y.PreRelease);
+                else if (x.PreReleaseBuild != y.PreReleaseBuild)
+                {
+                    int prereleaseBuildx, prereleaseBuildy;
+                    var parseResultx = Int32.TryParse(x.PreReleaseBuild, out prereleaseBuildx);
+                    var parseResulty = Int32.TryParse(y.PreReleaseBuild, out prereleaseBuildy);
+                    if (parseResultx && parseResulty)
+                        return prereleaseBuildx.CompareTo(prereleaseBuildy);
+                    return x.PreReleaseBuild.CompareTo(y.PreReleaseBuild);
+                }
+                else return 0;
+            }
+
+            public override bool Equals(object obj)
+            {
+                var y = obj as SemVer;
+                if (y == null)
+                    return false;
+                return Major == y.Major && Minor == y.Minor && Patch == y.Patch && PreRelease == y.PreRelease && Build == y.Build && PreReleaseBuild == y.PreReleaseBuild;
+            }
+        }
+
+        private class PreRelease : IComparable
+        {
+            public string Origin { get; set; }
+            public string Name { get; set; }
+            public long? Number { get; set; }
+
+            public static PreRelease TryParse(string str)
+            {
+                var m = new Regex(@"^(?<name>[a-zA-Z]+)(?<number>\d*)$").Match(str);
+                if (m.Success)
+                {
+                    long? number = null;
+                    if (m.Groups["number"].Value != "")
+                        number = long.Parse(m.Groups["number"].Value);
+
+                    return new PreRelease { Origin = str, Name = m.Groups["name"].Value, Number = number };
+                }
+                return null;
+            }
+
+            public int CompareTo(object obj)
+            {
+                var yObj = obj as PreRelease;
+                if (yObj == null)
+                    throw new ArgumentException("cannot compare values of different types", "obj");
+                var x = this;
+                if (x.Name != yObj.Name) return x.Name.CompareTo(yObj.Name);
+                else if (!x.Number.HasValue && yObj.Number.HasValue)
+                    return 1;
+                else if (x.Number.HasValue && !yObj.Number.HasValue)
+                    return -1;
+                else if (!x.Number.HasValue && !yObj.Number.HasValue)
+                    return 0;
+                else
+                    return x.Number.Value.CompareTo(yObj.Number.Value);
+            }
+        }
     }
 }

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+
+namespace Paket.Bootstrapper
+{
+    internal class NugetDownloadStrategy : IDownloadStrategy
+    {
+        private PrepareWebClientDelegate PrepareWebClient { get; set; }
+        private GetDefaultWebProxyForDelegate GetDefaultWebProxyFor { get; set; }
+        private string Folder { get; set; }
+
+        public NugetDownloadStrategy(PrepareWebClientDelegate prepareWebClient, GetDefaultWebProxyForDelegate getDefaultWebProxyFor, string folder)
+        {
+            PrepareWebClient = prepareWebClient;
+            GetDefaultWebProxyFor = getDefaultWebProxyFor;
+            Folder = folder;
+        }
+
+        public string Name
+        {
+            get { return "Nuget"; }
+        }
+
+        public IDownloadStrategy FallbackStrategy
+        {
+            get;
+            set;
+        }
+
+        public string GetLatestVersion(bool ignorePrerelease)
+        {
+            using (WebClient client = new WebClient())
+            {
+                const string getVersionsFromNugetUrl = "https://www.nuget.org/api/v2/package-versions/Paket";
+                const string withPrereleases = "?includePrereleases=true";
+
+                var versionRequestUrl = getVersionsFromNugetUrl;
+                if (!ignorePrerelease)
+                    versionRequestUrl += withPrereleases;
+                PrepareWebClient(client, versionRequestUrl);
+                var versions = client.DownloadString(versionRequestUrl);
+                var latestVersion = versions.
+                    Trim('[', ']').
+                    Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).
+                    Select(x => x.Trim('"')).
+                    LastOrDefault(x => !String.IsNullOrWhiteSpace(x)) ?? String.Empty;
+                return latestVersion;
+            }
+        }
+
+        public void DownloadVersion(string latestVersion, string target)
+        {
+            using (WebClient client = new WebClient())
+            {
+                const string getLatestFromNugetUrl = "https://www.nuget.org/api/v2/package/Paket";
+                const string getSpecificFromNugetUrlTemplate = "https://www.nuget.org/api/v2/package/Paket/{0}";
+                const string paketNupkgFile = "paket.latest.nupkg";
+                const string paketNupkgFileTemplate = "paket.{0}.nupkg";
+
+                var paketDownloadUrl = getLatestFromNugetUrl;
+                var paketFile = paketNupkgFile;
+                if (latestVersion != "")
+                {
+                    paketDownloadUrl = String.Format(getSpecificFromNugetUrlTemplate, latestVersion);
+                    paketFile = String.Format(paketNupkgFileTemplate, latestVersion);
+                }
+
+                var randomFullPath = Path.Combine(Folder, Path.GetRandomFileName());
+                Directory.CreateDirectory(randomFullPath);
+                var paketPackageFile = Path.Combine(randomFullPath, paketFile);
+                Console.WriteLine("Starting download from {0}", paketDownloadUrl);
+                PrepareWebClient(client, paketDownloadUrl);
+                client.DownloadFile(paketDownloadUrl, paketPackageFile);
+
+                ZipFile.ExtractToDirectory(paketPackageFile, randomFullPath);
+                var paketSourceFile = Path.Combine(randomFullPath, "Tools", "Paket.exe");
+                File.Copy(paketSourceFile, target, true);
+                Directory.Delete(randomFullPath, true);
+            }
+        }
+
+    }
+}

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -39,6 +39,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DownloadArguments.cs" />
+    <Compile Include="GitHubDownloadStrategy.cs" />
+    <Compile Include="IDownloadStrategy.cs" />
+    <Compile Include="NugetDownloadStrategy.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Paket.Bootstrapper</RootNamespace>
     <AssemblyName>paket.bootstrapper</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -10,6 +9,9 @@ namespace Paket.Bootstrapper
 {
     class Program
     {
+        const string PreferNugetCommandArg = "--prefer-nuget";
+        const string PrereleaseCommandArg = "prerelease";
+
         static IWebProxy GetDefaultWebProxyFor(String url)
         {
             IWebProxy result = WebRequest.GetSystemWebProxy();
@@ -19,7 +21,8 @@ namespace Paket.Bootstrapper
             if (address == uri)
                 return null;
 
-            return new WebProxy(address) { 
+            return new WebProxy(address)
+            {
                 Credentials = CredentialCache.DefaultCredentials,
                 BypassProxyOnLocal = true
             };
@@ -27,163 +30,132 @@ namespace Paket.Bootstrapper
 
         static void Main(string[] args)
         {
-            var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var target = Path.Combine(folder, "paket.exe");
-            var latestVersion = "";
-            var ignorePrerelease = true;
-            
+            var commandArgs = args;
+            bool preferNuget = false;
+            if (commandArgs.Contains(PreferNugetCommandArg))
+            {
+                preferNuget = true;
+                commandArgs = args.Where(x => x != PreferNugetCommandArg).ToArray();
+            }
+            var dlArgs = EvaluateCommandArgs(commandArgs);
+
+            var effectiveStrategy = GetEffectiveDownloadStrategy(dlArgs, preferNuget);
+
+            StartPaketBootstrapping(effectiveStrategy, dlArgs);
+        }
+
+        private static void StartPaketBootstrapping(IDownloadStrategy downloadStrategy, DownloadArguments dlArgs)
+        {
+            Action<Exception> handleException = exception =>
+            {
+                if (!File.Exists(dlArgs.Target))
+                    Environment.ExitCode = 1;
+                WriteConsoleError(String.Format("{0} ({1})", exception.Message, downloadStrategy.Name));
+            };
             try
             {
-                if (args.Length >= 1)
-                {
-                    if (args[0] == "prerelease")
-                    {
-                        ignorePrerelease = false;
-                        Console.WriteLine("Prerelease requested. Looking for latest prerelease.");
-                    }
-                    else
-                    {
-                        latestVersion = args[0];
-                        Console.WriteLine("Version {0} requested.", latestVersion);
-                    }
-                }
-                else Console.WriteLine("No version specified. Downloading latest stable.");
-                var localVersion = "";
+                var localVersion = GetLocalFileVersion(dlArgs.Target);
 
-                if (File.Exists(target))
-                {
-                    try
-                    {
-                        FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(target);
-                        if (fvi.FileVersion != null)
-                            localVersion = fvi.FileVersion;
-                    }
-                    catch (Exception)
-                    {
-                    }
-                }
-
+                var latestVersion = dlArgs.LatestVersion;
                 if (latestVersion == "")
                 {
-                    using (WebClient client = new WebClient())
-                    {
-                        var releasesUrl = "https://github.com/fsprojects/Paket/releases";
-
-                        PrepareWebClient(client, releasesUrl);
-
-                        var data = client.DownloadString(releasesUrl);
-                        var start = 0;
-                        while (latestVersion == "")
-                        {
-                            start = data.IndexOf("Paket/tree/", start) + 11;
-                            var end = data.IndexOf("\"", start);
-                            latestVersion = data.Substring(start, end - start);
-                            if (latestVersion.Contains("-") && ignorePrerelease)
-                                latestVersion = "";
-                        }
-                    }
+                    latestVersion = downloadStrategy.GetLatestVersion(dlArgs.IgnorePrerelease);
                 }
 
                 if (!localVersion.StartsWith(latestVersion))
                 {
-                    var url = String.Format("https://github.com/fsprojects/Paket/releases/download/{0}/paket.exe", latestVersion);
-
-                    Console.WriteLine("Starting download from {0}", url);
-
-                    var request = (HttpWebRequest)HttpWebRequest.Create(url);
-
-                    request.UseDefaultCredentials = true;
-                    request.Proxy = GetDefaultWebProxyFor(url);
-
-                    request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-                    using (HttpWebResponse httpResponse = (HttpWebResponse)request.GetResponse())
-                    {
-                        using (Stream httpResponseStream = httpResponse.GetResponseStream())
-                        {
-                            const int bufferSize = 4096;
-                            byte[] buffer = new byte[bufferSize];
-                            int bytesRead = 0;
-
-                            using (FileStream fileStream = File.Create(target))
-                            {
-                                while ((bytesRead = httpResponseStream.Read(buffer, 0, bufferSize)) != 0)
-                                {
-                                    fileStream.Write(buffer, 0, bytesRead);
-                                }
-                            }
-                        }
-                    }
+                    downloadStrategy.DownloadVersion(latestVersion, dlArgs.Target);
                 }
                 else
                 {
                     Console.WriteLine("Paket.exe {0} is up to date.", localVersion);
                 }
             }
-            catch (WebException)
+            catch (WebException exn)
             {
-                if (!File.Exists(target))
+                var shouldHandleException = true;
+                if (!File.Exists(dlArgs.Target))
                 {
-                    Console.WriteLine("Github download failed. Try downloading Paket directly from 'nuget.org'.");
-                    NugetAlternativeDownload(folder, target, latestVersion, ignorePrerelease);
+                    if (downloadStrategy.FallbackStrategy != null)
+                    {
+                        var fallbackStrategy = downloadStrategy.FallbackStrategy;
+                        Console.WriteLine("'{0}' download failed. Try fallback download from '{1}'.", downloadStrategy.Name, fallbackStrategy.Name);
+                        StartPaketBootstrapping(fallbackStrategy, dlArgs);
+                        shouldHandleException = !File.Exists(dlArgs.Target);
+                    }
                 }
+                if (shouldHandleException)
+                    handleException(exn);
             }
             catch (Exception exn)
             {
-                if (!File.Exists(target))
-                    Environment.ExitCode = 1;
-                WriteConsoleError(exn.Message);
+                handleException(exn);
             }
         }
 
-        private static void NugetAlternativeDownload(string folder, string target, string latestVersion, bool ignorePrereleases)
+        private static IDownloadStrategy GetEffectiveDownloadStrategy(DownloadArguments dlArgs, bool preferNuget)
         {
-            try
+            var gitHubDownloadStrategy = new GitHubDownloadStrategy(PrepareWebClient, GetDefaultWebProxyFor);
+            var nugetDownloadStrategy = new NugetDownloadStrategy(PrepareWebClient, GetDefaultWebProxyFor, dlArgs.Folder);
+
+            IDownloadStrategy effectiveStrategy;
+            if (preferNuget)
             {
-                using (WebClient client = new WebClient())
+                effectiveStrategy = nugetDownloadStrategy;
+                nugetDownloadStrategy.FallbackStrategy = gitHubDownloadStrategy;
+            }
+            else
+            {
+                effectiveStrategy = gitHubDownloadStrategy;
+                gitHubDownloadStrategy.FallbackStrategy = nugetDownloadStrategy;
+            }
+            return effectiveStrategy;
+        }
+
+        private static string GetLocalFileVersion(string target)
+        {
+            var localVersion = "";
+
+            if (File.Exists(target))
+            {
+                try
                 {
-                    const string getLatestFromNugetUrl = "https://www.nuget.org/api/v2/package/Paket";
-                    const string getVersionsFromNugetUrl = "https://www.nuget.org/api/v2/package-versions/Paket?includePrereleases=true";
-                    const string getSpecificFromNugetUrlTemplate = "https://www.nuget.org/api/v2/package/Paket/{0}";
-                    const string paketNupkgFile = "paket.latest.nupkg";
-                    const string paketNupkgFileTemplate = "paket.{0}.nupkg";
-
-                    var paketDownloadUrl = getLatestFromNugetUrl;
-                    var paketFile = paketNupkgFile;
-                    if (latestVersion == "" && !ignorePrereleases)
-                    {
-                        PrepareWebClient(client, getVersionsFromNugetUrl);
-                        var versions = client.DownloadString(getVersionsFromNugetUrl);
-                        latestVersion = versions.
-                                            Trim('[', ']').
-                                            Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries).
-                                            Select(x => x.Trim('"')).
-                                            LastOrDefault(x => !String.IsNullOrWhiteSpace(x)) ?? String.Empty;
-                    }
-                    if (latestVersion != "")
-                    {
-                        paketDownloadUrl = String.Format(getSpecificFromNugetUrlTemplate, latestVersion);
-                        paketFile = String.Format(paketNupkgFileTemplate, latestVersion);
-                    }
-
-                    var randomFullPath = Path.Combine(folder, Path.GetRandomFileName());
-                    Directory.CreateDirectory(randomFullPath);
-                    var paketPackageFile = Path.Combine(randomFullPath, paketFile);
-                    Console.WriteLine("Starting download from {0}", paketDownloadUrl);
-                    PrepareWebClient(client, paketDownloadUrl);
-                    client.DownloadFile(paketDownloadUrl, paketPackageFile);
-
-                    ZipFile.ExtractToDirectory(paketPackageFile, randomFullPath);
-                    var paketSourceFile = Path.Combine(randomFullPath, "Tools", "Paket.exe");
-                    File.Copy(paketSourceFile, target);
-                    Directory.Delete(randomFullPath, true);
+                    FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(target);
+                    if (fvi.FileVersion != null)
+                        localVersion = fvi.FileVersion;
+                }
+                catch (Exception)
+                {
                 }
             }
-            catch (Exception exn)
+            return localVersion;
+        }
+
+        private static DownloadArguments EvaluateCommandArgs(string[] args)
+        {
+            var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var target = Path.Combine(folder, "paket.exe");
+
+            var latestVersion = "";
+            var ignorePrerelease = true;
+
+            if (args.Length >= 1)
             {
-                if (!File.Exists(target))
-                    Environment.ExitCode = 1;
-                WriteConsoleError(exn.Message);
+                if (args[0] == PrereleaseCommandArg)
+                {
+                    ignorePrerelease = false;
+                    Console.WriteLine("Prerelease requested. Looking for latest prerelease.");
+                }
+                else
+                {
+                    latestVersion = args[0];
+                    Console.WriteLine("Version {0} requested.", latestVersion);
+                }
             }
+            else Console.WriteLine("No version specified. Downloading latest stable.");
+
+
+            return new DownloadArguments(latestVersion, ignorePrerelease, folder, target);
         }
 
         private static void PrepareWebClient(WebClient client, string url)
@@ -201,4 +173,5 @@ namespace Paket.Bootstrapper
             Console.ForegroundColor = oldColor;
         }
     }
+
 }


### PR DESCRIPTION
The previous approach for the nuget fallback for the bootstrapper used the nuget.exe to accomplish it tasks.
I changed the fallback behaviour for the bootstrapper with the following new features
- change project version to .Net 4.5 (to unzip via Framework)
- do not use nuget.exe anymore
- download package directly via nuget API
- use evaluated parameters for prerelease or specified version

