### PR TITLE
Automatic License restore

### DIFF
--- a/src/Paket.Core/Environment.fs
+++ b/src/Paket.Core/Environment.fs
@@ -63,8 +63,8 @@ module PaketEnv =
 
     let ensureNotExists (directory : DirectoryInfo) =
         match fromRootDirectory directory with
-        | Ok(_) -> fail (PaketEnvAlreadyExistsInDirectory directory)
-        | Fail(msgs) -> 
+        | Result.Ok(_) -> fail (PaketEnvAlreadyExistsInDirectory directory)
+        | Result.Fail(msgs) -> 
             let filtered = 
                 msgs
                 |> List.filter (function

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -336,7 +336,7 @@ let inline isExtracted fileName =
 /// Extracts the given package to the ./packages folder
 let ExtractPackage(fileName:string, targetFolder, name, version:SemVerInfo) =    
     async {
-        if  isExtracted fileName then
+        if isExtracted fileName then
              verbosefn "%s %A already extracted" name version
         else
             use zip = ZipFile.Read(fileName)
@@ -367,8 +367,24 @@ let ExtractPackage(fileName:string, targetFolder, name, version:SemVerInfo) =
         return targetFolder
     }
 
+let CopyLicenseFromCache(root, cacheFileName, name, version:SemVerInfo, force) = 
+    async {
+        try
+            if String.IsNullOrWhiteSpace cacheFileName then return () else
+            let cacheFile = FileInfo cacheFileName
+            if cacheFile.Exists then
+                let targetFolder = DirectoryInfo(Path.Combine(root, Constants.PackagesFolderName, name)).FullName
+                let targetFile = FileInfo(Path.Combine(targetFolder, "license.html"))
+                if not force && targetFile.Exists then
+                    verbosefn "License %s %A already copied" name version        
+                else                    
+                    File.Copy(cacheFile.FullName, targetFile.FullName, true)
+        with
+        | exn -> traceWarnfn "Could not copy license for %s %A from %s.%s    %s" name version cacheFileName Environment.NewLine exn.Message
+    }
+
 /// Extracts the given package to the ./packages folder
-let CopyFromCache(root, cacheFileName, name, version:SemVerInfo, force) = 
+let CopyFromCache(root, cacheFileName, licenseCacheFile, name, version:SemVerInfo, force) = 
     async { 
         let targetFolder = DirectoryInfo(Path.Combine(root, Constants.PackagesFolderName, name)).FullName
         let fi = FileInfo(cacheFileName)
@@ -378,8 +394,10 @@ let CopyFromCache(root, cacheFileName, name, version:SemVerInfo, force) =
         else
             CleanDir targetFolder
             File.Copy(cacheFileName, targetFile.FullName)            
-        try
-            return! ExtractPackage(targetFile.FullName,targetFolder,name,version)            
+        try 
+            let! extracted = ExtractPackage(targetFile.FullName,targetFolder,name,version)
+            do! CopyLicenseFromCache(root, licenseCacheFile, name, version, force)
+            return extracted
         with
         | exn -> 
             File.Delete targetFile.FullName
@@ -387,11 +405,47 @@ let CopyFromCache(root, cacheFileName, name, version:SemVerInfo, force) =
             return! raise exn
     }
 
+let DownloadLicense(root,force,name,version:SemVerInfo,licenseUrl,targetFileName) =
+    async { 
+        if String.IsNullOrWhiteSpace licenseUrl then return () else
+        
+        let targetFile = FileInfo targetFileName
+        if not force && targetFile.Exists && targetFile.Length > 0L then 
+            verbosefn "License for %s %A already downloaded" name version
+        else             
+            try
+                verbosefn "Downloading license for %s %A to %s" name version targetFileName
+
+                let request = HttpWebRequest.Create(Uri licenseUrl) :?> HttpWebRequest
+                request.AutomaticDecompression <- DecompressionMethods.GZip ||| DecompressionMethods.Deflate
+                request.UserAgent <- "Paket"
+                request.UseDefaultCredentials <- true
+                request.Proxy <- Utils.getDefaultProxyFor licenseUrl
+                use! httpResponse = request.AsyncGetResponse()
+            
+                use httpResponseStream = httpResponse.GetResponseStream()
+            
+                let bufferSize = 4096
+                let buffer : byte [] = Array.zeroCreate bufferSize
+                let bytesRead = ref -1
+
+                use fileStream = File.Create(targetFileName)
+            
+                while !bytesRead <> 0 do
+                    let! bytes = httpResponseStream.AsyncRead(buffer, 0, bufferSize)
+                    bytesRead := bytes
+                    do! fileStream.AsyncWrite(buffer, 0, !bytesRead)
+
+            with
+            | exn -> traceWarnfn "Could not download license for %s %A from %s.%s    %s" name version licenseUrl Environment.NewLine exn.Message
+    }
+
 /// Downloads the given package to the NuGet Cache folder
 let DownloadPackage(root, auth, url, name, version:SemVerInfo, force) = 
     async { 
         let targetFileName = Path.Combine(CacheFolder, name + "." + version.Normalize() + ".nupkg")
         let targetFile = FileInfo targetFileName
+        let licenseFileName = Path.Combine(CacheFolder, name + "." + version.Normalize() + ".license.html")
         if not force && targetFile.Exists && targetFile.Length > 0L then 
             verbosefn "%s %A already downloaded" name version            
         else 
@@ -432,10 +486,12 @@ let DownloadPackage(root, auth, url, name, version:SemVerInfo, force) =
                     let! bytes = httpResponseStream.AsyncRead(buffer, 0, bufferSize)
                     bytesRead := bytes
                     do! fileStream.AsyncWrite(buffer, 0, !bytesRead)
-
+                                
+                do! DownloadLicense(root,force,name,version,nugetPackage.LicenseUrl,licenseFileName)
             with
             | exn -> failwithf "Could not download %s %A.%s    %s" name version Environment.NewLine exn.Message
-        return! CopyFromCache(root, targetFile.FullName, name, version, force)
+                
+        return! CopyFromCache(root, targetFile.FullName, licenseFileName, name, version, force)
     }
 
 /// Finds all libraries in a nuget package.

--- a/src/Paket.Core/Nuspec.fs
+++ b/src/Paket.Core/Nuspec.fs
@@ -22,10 +22,11 @@ type Nuspec =
     { References : NuspecReferences 
       Dependencies : (PackageName * VersionRequirement * FrameworkRestrictions) list
       OfficialName : string
+      LicenseUrl : string
       FrameworkAssemblyReferences : FrameworkAssemblyReference list }
 
-    static member All = { References = NuspecReferences.All; Dependencies = []; FrameworkAssemblyReferences = []; OfficialName = "" }
-    static member Explicit references = { References = NuspecReferences.Explicit references; Dependencies = []; FrameworkAssemblyReferences = []; OfficialName = "" }
+    static member All = { References = NuspecReferences.All; Dependencies = []; FrameworkAssemblyReferences = []; OfficialName = ""; LicenseUrl = "" }
+    static member Explicit references = { References = NuspecReferences.Explicit references; Dependencies = []; FrameworkAssemblyReferences = []; OfficialName = ""; LicenseUrl = "" }
     static member Load(fileName : string) = 
         let fi = FileInfo(fileName)
         if not fi.Exists then Nuspec.All
@@ -76,6 +77,11 @@ type Nuspec =
                 |> List.map dependency
                 |> List.append frameworks
                 |> Requirements.optimizeRestrictions 
+
+            let licenseUrl =                 
+                match doc |> getNode "package" |> optGetNode "metadata" |> optGetNode "licenseUrl" with
+                | Some link -> link.InnerText
+                | None -> ""     
             
             let references = 
                 doc
@@ -114,4 +120,5 @@ type Nuspec =
             { References = if references = [] then NuspecReferences.All else NuspecReferences.Explicit references
               Dependencies = dependencies
               OfficialName = officialName
+              LicenseUrl = licenseUrl
               FrameworkAssemblyReferences = frameworkAssemblyReferences }

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -54,7 +54,7 @@ type ResolvedPackage =
     { Name : PackageName
       Version : SemVerInfo
       Dependencies : DependencySet
-      Unlisted : bool 
+      Unlisted : bool
       Settings : InstallSettings
       Source : PackageSource }
 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -45,6 +45,7 @@ type PackageDetails =
     { Name : PackageName
       Source : PackageSource
       DownloadLink : string
+      LicenseUrl : string
       Unlisted : bool
       DirectDependencies : DependencySet }
 

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -31,7 +31,7 @@ let ExtractPackage(root, sources, force, package : ResolvedPackage) =
         | LocalNuget path ->         
             let path = Utils.normalizeLocalPath path
             let packageFile = Path.Combine(root, path, sprintf "%s.%A.nupkg" name v)
-            let! folder = NuGetV2.CopyFromCache(root, packageFile, name, v, force)
+            let! folder = NuGetV2.CopyFromCache(root, packageFile, "", name, v, force) // TODO: Restore license
             return package, NuGetV2.GetLibFiles folder, NuGetV2.GetTargetsFiles folder
     }
 

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -27,7 +27,7 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
-    <StartArguments>update</StartArguments>
+    <StartArguments>restore -f</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>D:\code\Paketkopie</StartWorkingDirectory>

--- a/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
@@ -101,6 +101,7 @@ let ``should generate Xml for Rx-XAML 2.2.4 with correct framework assembly refe
                { References = NuspecReferences.All
                  OfficialName = "Reactive Extensions - XAML Support Library"
                  Dependencies = []
+                 LicenseUrl = ""
                  FrameworkAssemblyReferences =
                  [{ AssemblyName = "WindowsBase"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework FrameworkVersion.V4_5)] }
                   { AssemblyName = "WindowsBase"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework FrameworkVersion.V4)] }

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
@@ -62,6 +62,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                { References = NuspecReferences.All
                  OfficialName = "Microsoft.Net.Http"
                  Dependencies = []
+                 LicenseUrl = ""
                  FrameworkAssemblyReferences =
                  [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }
                   { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
@@ -70,6 +70,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                { References = NuspecReferences.All
                  OfficialName = "Microsoft.Net.Http"
                  Dependencies = []
+                 LicenseUrl = ""
                  FrameworkAssemblyReferences =
                  [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))] }
                   { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})

--- a/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
+++ b/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
@@ -23,6 +23,7 @@ let ``can detect explicit dependencies for Fantomas``() =
           DownloadUrl = "http://www.nuget.org/api/v2/package/Fantomas/1.6.0"
           Dependencies = [PackageName "FSharp.Compiler.Service",DependenciesFileParser.parseVersionRequirement(">= 0.0.73"), []]
           Unlisted = false
+          LicenseUrl = "http://github.com/dungpa/fantomas/blob/master/LICENSE.md"
           CacheVersion = NugetPackageCache.CurrentCacheVersion
           SourceUrl = fakeUrl }
 
@@ -36,6 +37,7 @@ let ``can detect explicit dependencies for Rx-PlaformServices``() =
                 [PackageName "Rx-Interfaces",DependenciesFileParser.parseVersionRequirement(">= 2.2"), []
                  PackageName "Rx-Core",DependenciesFileParser.parseVersionRequirement(">= 2.2"), []]
           Unlisted = true
+          LicenseUrl = "http://go.microsoft.com/fwlink/?LinkID=261272"
           CacheVersion = NugetPackageCache.CurrentCacheVersion
           SourceUrl = fakeUrl }
 
@@ -48,6 +50,7 @@ let ``can detect explicit dependencies for EasyNetQ``() =
           Dependencies = 
                 [PackageName "RabbitMQ.Client",DependenciesFileParser.parseVersionRequirement(">= 3.4.3"), []]
           Unlisted = false
+          LicenseUrl = "https://github.com/mikehadlow/EasyNetQ/blob/master/licence.txt"
           CacheVersion = NugetPackageCache.CurrentCacheVersion
           SourceUrl = fakeUrl }
 
@@ -59,6 +62,7 @@ let ``can detect explicit dependencies for Fleece``() =
           DownloadUrl = "http://www.nuget.org/api/v2/package/Fleece/0.4.0"
           Unlisted = false
           CacheVersion = NugetPackageCache.CurrentCacheVersion
+          LicenseUrl = "https://raw.github.com/mausch/Fleece/master/LICENSE"
           Dependencies = 
             [PackageName "FSharpPlus",DependenciesFileParser.parseVersionRequirement(">= 0.0.4"), []
              PackageName "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"), []
@@ -74,6 +78,7 @@ let ``can detect explicit dependencies for ReadOnlyCollectionExtensions``() =
           DownloadUrl = "http://www.nuget.org/api/v2/package/ReadOnlyCollectionExtensions/1.2.0"
           Unlisted = false
           CacheVersion = NugetPackageCache.CurrentCacheVersion
+          LicenseUrl = "https://github.com/mausch/ReadOnlyCollections/blob/master/license.txt"
           Dependencies = 
             [PackageName "LinqBridge",DependenciesFileParser.parseVersionRequirement(">= 1.3.0"), 
                [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V3_5))]
@@ -90,6 +95,7 @@ let ``can detect explicit dependencies for Math.Numerics``() =
         { PackageName = "MathNet.Numerics"
           DownloadUrl = "http://www.nuget.org/api/v2/package/MathNet.Numerics/3.3.0"
           Unlisted = false
+          LicenseUrl = "http://numerics.mathdotnet.com/docs/License.html"
           CacheVersion = NugetPackageCache.CurrentCacheVersion
           Dependencies = 
             [PackageName "TaskParallelLibrary",DependenciesFileParser.parseVersionRequirement(">= 1.0.2856"), 

--- a/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
+++ b/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
@@ -84,7 +84,7 @@ let ``can detect framework assemblies for SqlCLient``() =
          { AssemblyName = "System.Xml"; FrameworkRestrictions = [] } ]
 
 [<Test>]
-let ``can detect ´license for SqlCLient``() = 
+let ``can detect license for SqlCLient``() = 
     Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec").LicenseUrl
     |> shouldEqual "http://github.com/fsprojects/FSharp.Data.SqlClient/blob/master/LICENSE.md"
 

--- a/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
+++ b/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
@@ -84,6 +84,11 @@ let ``can detect framework assemblies for SqlCLient``() =
          { AssemblyName = "System.Xml"; FrameworkRestrictions = [] } ]
 
 [<Test>]
+let ``can detect ´license for SqlCLient``() = 
+    Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec").LicenseUrl
+    |> shouldEqual "http://github.com/fsprojects/FSharp.Data.SqlClient/blob/master/LICENSE.md"
+
+[<Test>]
 let ``can detect dependencies for SqlCLient``() = 
     Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec").Dependencies
     |> shouldEqual 

--- a/tests/Paket.Tests/TestHelpers.fs
+++ b/tests/Paket.Tests/TestHelpers.fs
@@ -19,6 +19,7 @@ let PackageDetailsFromGraph (graph : seq<string * string * (string * VersionRequ
     { Name = name
       Source = Seq.head sources
       DownloadLink = ""
+      LicenseUrl = ""
       Unlisted = false
       DirectDependencies = Set.ofList dependencies }
 


### PR DESCRIPTION
with this change we restore all licenses to `packages/[PACKAGENAME]/license.html` and therefore implements #735

/cc @sergey-tihon  @haacked 