### PR TITLE
Fixing #729 and #732

### DIFF
--- a/src/Paket.Core/NupkgWriter.fs
+++ b/src/Paket.Core/NupkgWriter.fs
@@ -10,7 +10,7 @@ open System.Xml
 
 let nuspecId = "nuspec"
 let corePropsId = "coreProp"
-let contentTypePath = "/[Content_Types].xml"
+let contentTypePath = "[Content_Types].xml"
 
 let contentTypeDoc fileList = 
     let declaration = XDeclaration("1.0", "UTF-8", "yes")
@@ -117,7 +117,7 @@ let nuspecDoc (info:CompleteInfo) =
     optional.Dependencies |> buildDependenciesNode
     XDocument(declaration, box root)
 
-let corePropsPath = sprintf "/package/services/metadata/core-properties/%s.psmdcp" corePropsId
+let corePropsPath = sprintf "package/services/metadata/core-properties/%s.psmdcp" corePropsId
 
 let corePropsDoc (core : CompleteCoreInfo) = 
     let declaration = XDeclaration("1.0", "UTF-8", "yes")
@@ -145,7 +145,7 @@ let corePropsDoc (core : CompleteCoreInfo) =
     !! ns "lastModifiedBy" "paket"
     XDocument(declaration, box root)
 
-let relsPath = "/_rels/.rels"
+let relsPath = "_rels/.rels"
 
 let relsDoc (core : CompleteCoreInfo) = 
     let declaration = XDeclaration("1.0", "UTF-8", "yes")


### PR DESCRIPTION
It seems moving to the .net 4.5 zip packaging handles paths differently. Having a leading `/` on paths added a "no-name" folder in the archive (at least it looked like that in 7 zip archive browser). Effectively putting metadata in a separate sub folder from the rest of package content.

Removing leading `/` in paths did at least produce valid package in windows, and no tests are failing on my machine.

Hopefully this will fix #729 and #732 