### PR TITLE
Only pick up project output files that exactly match assembly filename. Fixes #750

### DIFF
--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -159,8 +159,10 @@ let findDependencies (dependencies : DependenciesFile) config (template : Templa
 
         let additionalFiles =
             fi.Directory.GetFiles(fi.Name.Replace(fi.Extension,"") + ".*")
-            |> Array.filter (fun f -> [".xml"; ".dll"; ".exe"; ".pdb"; ".mdb"] |> List.exists ((=) (f.Extension.ToLower())))
-        
+            |> Array.filter (fun f -> 
+                let sameFileName = (Path.GetFileNameWithoutExtension f.Name) = (Path.GetFileNameWithoutExtension fi.Name)
+                let validExtension = [".xml"; ".dll"; ".exe"; ".pdb"; ".mdb"] |> List.exists ((=) (f.Extension.ToLower()))
+                sameFileName && validExtension)        
         additionalFiles
         |> Array.fold (fun template file -> addFile file.FullName targetDir template) template
     


### PR DESCRIPTION
Fix for #750. Ideally a unit test around this could be added but it's a bit beyond my F# skill at the moment. PackageProcessSpecs.fs looks like a likely spot to add something...