### PR TITLE
Fix for missing content using net4.5 zip

### DIFF
--- a/src/Paket.Core/NupkgWriter.fs
+++ b/src/Paket.Core/NupkgWriter.fs
@@ -201,6 +201,11 @@ let Write (core : CompleteCoreInfo) optional workingDir outputDir =
         writerF stream
         stream.Close()
 
+    let ensureValidTargetName (target:string) =
+        match target.Replace(" ", "%20") with
+        | t when t.EndsWith("/") -> t
+        | t                      -> t + "/"
+
     // adds all files in a directory to the zipFile
     let rec addDir source target =
         for file in Directory.EnumerateFiles(source,"*.*",SearchOption.TopDirectoryOnly) do
@@ -215,7 +220,7 @@ let Write (core : CompleteCoreInfo) optional workingDir outputDir =
 
     // add files
     for fileName,targetFileName in optional.Files do
-        let targetFileName = targetFileName.Replace(" ", "%20")
+        let targetFileName = ensureValidTargetName targetFileName
         let source = Path.Combine(workingDir, fileName)
         if Directory.Exists source then
             addDir source targetFileName


### PR DESCRIPTION
The reason the project type template worked (`Paket.Core`) and the file type template (`Paket tool`) failed was that project type template yielded target paths (`lib/net45/`) with _trailing slash_. Trailing slashes from file type templates depends on template content.

For reasons beyond my understanding, treating the nupkg as a zip file had no issues, regardless of trailing slash, but nuget would fail to extract a package if trailing slash was not present.

This PR will hopefully fix the missing content issue in #742, I have tested it on Paket and som custom templates, and it seems to work