### PR TITLE
Better error message for missing paket.dependencies

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -34,7 +34,7 @@ type Dependencies(dependenciesFileName: string) =
                 let parent = dir.Parent
                 if parent = null then
                     if withError then
-                        failwithf "Could not find %s" Constants.DependenciesFileName
+                        failwithf "Could not find '%s'. To use Paket with this solution, please run 'paket init' first." Constants.DependenciesFileName
                     else 
                         Constants.DependenciesFileName
                 else


### PR DESCRIPTION
I created a new project, installed Paket via NuGet (it was even up!) and then wanted to install packages via `paket add nuget ....`, which resulted in the error

    Paket failed with:
        Could not find paket.dependencies

That just leaves me hanging, which is not very user friendly. I suppose there is a good reason why it doesn't simply create `paket.dependencies` when it can't find it, but it should at least tell me what I can/need to do about that.

I have updated the error message to mention `paket init`, so the user has a way to proceed.