### PR TITLE
Fixed home path detection

### DIFF
--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -36,12 +36,12 @@ let GetHomeDirectory() =
     else
         Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%")
 
-let normalizeLocalPath(path:string) =
+let normalizeLocalPath(path:string)=
     if path.StartsWith("~/") then
-        Path.Combine(GetHomeDirectory(),path.Substring(1))
-    else
+        Path.Combine(GetHomeDirectory(), path.Substring(2))
+    else 
         path
-
+        
 /// Creates a directory if it does not exist.
 let createDir path = 
     try

--- a/tests/Paket.Tests/UtilsSpecs.fs
+++ b/tests/Paket.Tests/UtilsSpecs.fs
@@ -1,5 +1,6 @@
 ﻿module Paket.UtilsSpecs
 
+open System.IO
 open Paket
 open NUnit.Framework
 open FsUnit
@@ -9,3 +10,10 @@ let ``createRelativePath should handle spaces``() =
     "C:/some file" 
     |> createRelativePath "C:/a/b" 
     |> shouldEqual "..\\some file"
+
+    
+[<Test>]
+let ``normalize path with home directory``() =
+    "~/data" 
+    |> Utils.normalizeLocalPath
+    |> shouldEqual (GetHomeDirectory() + Path.DirectorySeparatorChar.ToString()  +  "data")


### PR DESCRIPTION
I discovered a bug when normalizing local nuget path the second parameter is always "rooted" means that it got a leading slash. Therefore we get back a rooted home instead of replacing "~" with the home dir.