### PR TITLE
Uses 'PAKET.VERSION' environment variable for bootstrap requests

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -12,3 +12,7 @@ Options:
   `version`: Downloads the given version of paket.exe from github.com.
 
   `--prefer-nuget`: Downloads the given version of paket.exe from nuget.org instead of github.com.
+
+Environment Variables:
+
+  `PAKET.VERSION`: The requested version can also be set using this environment variable. Above options take precedence over the environment variable 

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -145,6 +145,7 @@ namespace Paket.Bootstrapper
                 if (args[0] == PrereleaseCommandArg)
                 {
                     ignorePrerelease = false;
+                    latestVersion = "";
                     Console.WriteLine("Prerelease requested. Looking for latest prerelease.");
                 }
                 else

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -11,6 +11,7 @@ namespace Paket.Bootstrapper
     {
         const string PreferNugetCommandArg = "--prefer-nuget";
         const string PrereleaseCommandArg = "prerelease";
+        const string PaketVersionEnv = "PAKET.VERSION";
 
         static IWebProxy GetDefaultWebProxyFor(String url)
         {
@@ -136,7 +137,7 @@ namespace Paket.Bootstrapper
             var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var target = Path.Combine(folder, "paket.exe");
 
-            var latestVersion = "";
+            var latestVersion = Environment.GetEnvironmentVariable(PaketVersionEnv) ?? "";
             var ignorePrerelease = true;
 
             if (args.Length >= 1)
@@ -152,6 +153,8 @@ namespace Paket.Bootstrapper
                     Console.WriteLine("Version {0} requested.", latestVersion);
                 }
             }
+            else if (!String.IsNullOrWhiteSpace(latestVersion))
+                Console.WriteLine("Version {0} requested.", latestVersion);
             else Console.WriteLine("No version specified. Downloading latest stable.");
 
 


### PR DESCRIPTION
When the environment variable `PAKET.VERSION` exists `paket.bootstrap.exe` will download that version when no argument is given: 
```
~/Desktop env PAKET.VERSION=0.38.6 mono paket.bootstrapper.exe
Version 0.38.6 requested.
Paket.exe 0.38.6.0 is up to date.
```

When a version argument (or prerelease flag) is passed to `paket.bootstrap.exe` it will behave as always:
```
env PAKET.VERSION=0.38.6 mono paket.bootstrapper.exe 0.40.1
Version 0.40.1 requested.
Starting download from https://github.com/fsprojects/Paket/releases/download/0.40.1/paket.exe
```

This will simplify pinning the version of paket on local and CI environments. Especially for ProjectScaffold projects where you would have to edit multiple places in the build.cmd and build.sh files.