### PR TITLE
Protect paket.exe from incomplete github downloads

### DIFF
--- a/src/Paket.Bootstrapper/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/GitHubDownloadStrategy.cs
@@ -58,14 +58,18 @@ namespace Paket.Bootstrapper
                     const int bufferSize = 4096;
                     byte[] buffer = new byte[bufferSize];
                     int bytesRead = 0;
+                    var tmpFile = Path.GetTempFileName();
 
-                    using (FileStream fileStream = File.Create(target))
+                    using (FileStream fileStream = File.Create(tmpFile))
                     {
                         while ((bytesRead = httpResponseStream.Read(buffer, 0, bufferSize)) != 0)
                         {
                             fileStream.Write(buffer, 0, bytesRead);
                         }
                     }
+
+                    File.Copy(tmpFile, target, true);
+                    File.Delete(tmpFile);
                 }
             }
         }


### PR DESCRIPTION
Currently the github HTTP response writes directly to the target paket.exe, but the the download fails until it completes it left a defect paket.exe. So lets download to a temporary file and only copy it to the target location if the download was successful.

This is the same behavior as the nuget download strategy.