### PR TITLE
"--self" for self update bootstrapper

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -306,6 +306,28 @@ Target "Release" (fun _ ->
     |> Async.RunSynchronously
 )
 
+Target "DetectBootstrapperChanges" (fun _ -> 
+    let test = 1
+    let allTags = getGitResult "" "tag -l \"*\""
+    let latestVersion = allTags
+                        |> Seq.map (fun x -> try 
+                                                let ver = SemVerHelper.parse(x)
+                                                Some ver
+                                             with
+                                              | :? Exception -> None)
+                        |> Seq.filter (fun x -> match x with | Some _ -> true| None -> false)
+                        |> Seq.map (fun x -> match x with | Some y -> y | None -> failwith "Should never happen")
+                        |> Seq.filter (fun x -> match x.PreRelease with | Some _ -> false | None -> true)
+                        |> Seq.sort
+                        |> Seq.toList
+                        |> List.rev
+                        |> List.head
+
+    let res = runSimpleGitCommand "" (String.Format("diff --shortstat {0} src/Paket.Bootstrapper/", latestVersion))
+    if not (String.IsNullOrWhiteSpace(res)) then
+        DeleteFile "./bin/paket.bootstrapper.exe"
+)
+
 Target "BuildPackage" DoNothing
 
 // --------------------------------------------------------------------------------------

--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -12,6 +12,8 @@ Options:
   `version`: Downloads the given version of paket.exe from github.com.
 
   `--prefer-nuget`: Downloads the given version of paket.exe from nuget.org instead of github.com.
+  
+  `--self`: Self updating the paket.bootstrapper.exe. When this option is used the download of paket.exe will be skipped.
 
 Environment Variables:
 

--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+
+namespace Paket.Bootstrapper
+{
+    internal static class BootstrapperHelper
+    {
+        const string PaketBootstrapperUserAgent = "Paket.Bootstrapper";
+
+        internal static string GetLocalFileVersion(string target)
+        {
+            var localVersion = "";
+
+            if (File.Exists(target))
+            {
+                try
+                {
+                    FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(target);
+                    if (fvi.FileVersion != null)
+                        localVersion = fvi.FileVersion;
+                }
+                catch (Exception)
+                {
+                }
+            }
+            return localVersion;
+        }
+
+        internal static void PrepareWebClient(WebClient client, string url)
+        {
+            client.Headers.Add("user-agent", PaketBootstrapperUserAgent);
+            client.UseDefaultCredentials = true;
+            client.Proxy = GetDefaultWebProxyFor(url);
+        }
+
+        internal static HttpWebRequest PrepareWebRequest(string url)
+        {
+            var request = (HttpWebRequest)HttpWebRequest.Create(url);
+            request.UserAgent = PaketBootstrapperUserAgent;
+            request.UseDefaultCredentials = true;
+            request.Proxy = GetDefaultWebProxyFor(url);
+            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            return request;
+        }
+
+        internal static void WriteConsoleError(string message)
+        {
+            WriteConsole(message, ConsoleColor.Red);
+        }
+
+        internal static void WriteConsoleInfo(string message)
+        {
+            WriteConsole(message, ConsoleColor.Yellow);
+        }
+
+        private static void WriteConsole(string message, ConsoleColor consoleColor)
+        {
+            var oldColor = Console.ForegroundColor;
+            Console.ForegroundColor = consoleColor;
+            Console.WriteLine(message);
+            Console.ForegroundColor = oldColor;
+        }
+
+        internal static IWebProxy GetDefaultWebProxyFor(String url)
+        {
+            IWebProxy result = WebRequest.GetSystemWebProxy();
+            Uri uri = new Uri(url);
+            Uri address = result.GetProxy(uri);
+
+            if (address == uri)
+                return null;
+
+            return new WebProxy(address)
+            {
+                Credentials = CredentialCache.DefaultCredentials,
+                BypassProxyOnLocal = true
+            };
+        }
+    }
+}

--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -78,5 +78,22 @@ namespace Paket.Bootstrapper
                 BypassProxyOnLocal = true
             };
         }
+
+        internal static void FileMove(string oldPath, string newPath)
+        {
+            try
+            {
+                if (File.Exists(newPath))
+                {
+                    File.Delete(newPath);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+
+            }
+
+            File.Move(oldPath, newPath);
+        }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadArguments.cs
+++ b/src/Paket.Bootstrapper/DownloadArguments.cs
@@ -4,15 +4,17 @@
     {
         public string Folder { get; private set; }
         public string Target { get; private set; }
+        public bool DoSelfUpdate { get; set; }
         public string LatestVersion { get; private set; }
         public bool IgnorePrerelease { get; private set; }
 
-        public DownloadArguments(string latestVersion, bool ignorePrerelease, string folder, string target)
+        public DownloadArguments(string latestVersion, bool ignorePrerelease, string folder, string target, bool doSelfUpdate)
         {
             LatestVersion = latestVersion;
             IgnorePrerelease = ignorePrerelease;
             Folder = folder;
             Target = target;
+            DoSelfUpdate = doSelfUpdate;
         }
     }
 }

--- a/src/Paket.Bootstrapper/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/GitHubDownloadStrategy.cs
@@ -73,16 +73,15 @@ namespace Paket.Bootstrapper
             }
         }
 
-        public bool SelfUpdate(string latestVersion)
+        public void SelfUpdate(string latestVersion)
         {
-            bool updateSuccess = false;
             var executingAssembly = Assembly.GetExecutingAssembly();
             string exePath = executingAssembly.Location;
             var localVersion = BootstrapperHelper.GetLocalFileVersion(exePath);
             if (localVersion.StartsWith(latestVersion))
             {
                 Console.WriteLine("Bootstrapper is up to date. Nothing to do.");
-                return updateSuccess;
+                return;
             }
 
             var url = String.Format("https://github.com/fsprojects/Paket/releases/download/{0}/paket.bootstrapper.exe", latestVersion);
@@ -105,7 +104,6 @@ namespace Paket.Bootstrapper
                 BootstrapperHelper.FileMove(exePath, renamedPath);
                 BootstrapperHelper.FileMove(tmpDownloadPath, exePath);
                 Console.WriteLine("Self update of bootstrapper was successful.");
-                updateSuccess = true;
             }
             catch (Exception)
             {
@@ -113,8 +111,6 @@ namespace Paket.Bootstrapper
                 BootstrapperHelper.FileMove(renamedPath, exePath);
                 throw;
             }
-
-            return updateSuccess;
         }
 
     }

--- a/src/Paket.Bootstrapper/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/IDownloadStrategy.cs
@@ -12,5 +12,6 @@ namespace Paket.Bootstrapper
     }
 
     public delegate void PrepareWebClientDelegate(WebClient client, string url);
+    public delegate HttpWebRequest PrepareWebRequestDelegate(string url);
     public delegate IWebProxy GetDefaultWebProxyForDelegate(string url);
 }

--- a/src/Paket.Bootstrapper/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/IDownloadStrategy.cs
@@ -8,6 +8,7 @@ namespace Paket.Bootstrapper
         IDownloadStrategy FallbackStrategy { get; set; }
         string GetLatestVersion(bool ignorePrerelease);
         void DownloadVersion(string latestVersion, string target);
+        bool SelfUpdate(string latestVersion);
     }
 
     public delegate void PrepareWebClientDelegate(WebClient client, string url);

--- a/src/Paket.Bootstrapper/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/IDownloadStrategy.cs
@@ -8,7 +8,7 @@ namespace Paket.Bootstrapper
         IDownloadStrategy FallbackStrategy { get; set; }
         string GetLatestVersion(bool ignorePrerelease);
         void DownloadVersion(string latestVersion, string target);
-        bool SelfUpdate(string latestVersion);
+        void SelfUpdate(string latestVersion);
     }
 
     public delegate void PrepareWebClientDelegate(WebClient client, string url);

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -101,6 +101,12 @@ namespace Paket.Bootstrapper
             }
         }
 
+        public bool SelfUpdate(string latestVersion)
+        {
+            Console.WriteLine("self update of bootstrapper via nuget is currently not possible");
+            return false;
+        }
+
         private class SemVer : IComparable
         {
             public int Major { get; set; }

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -132,17 +132,15 @@ namespace Paket.Bootstrapper
             }
         }
 
-        public bool SelfUpdate(string latestVersion)
+        public void SelfUpdate(string latestVersion)
         {
-            bool updateSuccess = false;
-
             var executingAssembly = Assembly.GetExecutingAssembly();
             string target = executingAssembly.Location;
             var localVersion = BootstrapperHelper.GetLocalFileVersion(target);
             if (localVersion.StartsWith(latestVersion))
             {
                 Console.WriteLine("Bootstrapper is up to date. Nothing to do.");
-                return updateSuccess;
+                return;
             }
             var apiHelper = new NugetApiHelper(PaketBootstrapperNugetPackageName);
 
@@ -176,7 +174,6 @@ namespace Paket.Bootstrapper
                 BootstrapperHelper.FileMove(target, renamedPath);
                 BootstrapperHelper.FileMove(paketSourceFile, target);
                 Console.WriteLine("Self update of bootstrapper was successful.");
-                updateSuccess = true;
             }
             catch (Exception)
             {
@@ -185,7 +182,6 @@ namespace Paket.Bootstrapper
                 throw;
             }
             Directory.Delete(randomFullPath, true);
-            return updateSuccess;
         }
 
         private class SemVer : IComparable

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -3,15 +3,51 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Paket.Bootstrapper
 {
     internal class NugetDownloadStrategy : IDownloadStrategy
     {
+        internal class NugetApiHelper
+        {
+            private readonly string packageName;
+            const string GetPackageVersionTemplate = "https://www.nuget.org/api/v2/package-versions/{0}";
+            const string GetLatestFromNugetUrlTemplate = "https://www.nuget.org/api/v2/package/{0}";
+            const string GetSpecificFromNugetUrlTemplate = "https://www.nuget.org/api/v2/package/{0}/{1}";
+
+            public NugetApiHelper(string packageName)
+            {
+                this.packageName = packageName;
+            }
+
+            internal string GetAllPackageVersions(bool includePrerelease)
+            {
+                var request = String.Format(GetPackageVersionTemplate, packageName);
+                const string withPrereleases = "?includePrerelease=true";
+                if (includePrerelease)
+                    request += withPrereleases;
+                return request;
+            }
+
+            internal string GetLatestPackage()
+            {
+                return String.Format(GetLatestFromNugetUrlTemplate, packageName);
+            }
+
+            internal string GetSpecificPackageVersion(string version)
+            {
+                return String.Format(GetSpecificFromNugetUrlTemplate, packageName, version);
+            }
+        }
+
+
         private PrepareWebClientDelegate PrepareWebClient { get; set; }
         private GetDefaultWebProxyForDelegate GetDefaultWebProxyFor { get; set; }
         private string Folder { get; set; }
+        private const string PaketNugetPackageName = "Paket";
+        private const string PaketBootstrapperNugetPackageName = "Paket.Bootstrapper";
 
         public NugetDownloadStrategy(PrepareWebClientDelegate prepareWebClient, GetDefaultWebProxyForDelegate getDefaultWebProxyFor, string folder)
         {
@@ -29,14 +65,10 @@ namespace Paket.Bootstrapper
 
         public string GetLatestVersion(bool ignorePrerelease)
         {
-            using (WebClient client = new WebClient())
+            var apiHelper = new NugetApiHelper(PaketNugetPackageName);
+            using (var client = new WebClient())
             {
-                const string getVersionsFromNugetUrl = "https://www.nuget.org/api/v2/package-versions/Paket";
-                const string withPrereleases = "?includePrerelease=true";
-
-                var versionRequestUrl = getVersionsFromNugetUrl;
-                if (!ignorePrerelease)
-                    versionRequestUrl += withPrereleases;
+                var versionRequestUrl = apiHelper.GetAllPackageVersions(!ignorePrerelease);
                 PrepareWebClient(client, versionRequestUrl);
                 var versions = client.DownloadString(versionRequestUrl);
                 var latestVersion = versions.
@@ -72,18 +104,17 @@ namespace Paket.Bootstrapper
 
         public void DownloadVersion(string latestVersion, string target)
         {
+            var apiHelper = new NugetApiHelper(PaketNugetPackageName);
             using (WebClient client = new WebClient())
             {
-                const string getLatestFromNugetUrl = "https://www.nuget.org/api/v2/package/Paket";
-                const string getSpecificFromNugetUrlTemplate = "https://www.nuget.org/api/v2/package/Paket/{0}";
                 const string paketNupkgFile = "paket.latest.nupkg";
                 const string paketNupkgFileTemplate = "paket.{0}.nupkg";
 
-                var paketDownloadUrl = getLatestFromNugetUrl;
+                var paketDownloadUrl = apiHelper.GetLatestPackage();
                 var paketFile = paketNupkgFile;
-                if (latestVersion != "")
+                if (latestVersion != String.Empty)
                 {
-                    paketDownloadUrl = String.Format(getSpecificFromNugetUrlTemplate, latestVersion);
+                    paketDownloadUrl = apiHelper.GetSpecificPackageVersion(latestVersion);
                     paketFile = String.Format(paketNupkgFileTemplate, latestVersion);
                 }
 
@@ -103,8 +134,58 @@ namespace Paket.Bootstrapper
 
         public bool SelfUpdate(string latestVersion)
         {
-            BootstrapperHelper.WriteConsoleInfo("self update of bootstrapper via nuget is currently not possible");
-            return false;
+            bool updateSuccess = false;
+
+            var executingAssembly = Assembly.GetExecutingAssembly();
+            string target = executingAssembly.Location;
+            var localVersion = BootstrapperHelper.GetLocalFileVersion(target);
+            if (localVersion.StartsWith(latestVersion))
+            {
+                Console.WriteLine("Bootstrapper is up to date. Nothing to do.");
+                return updateSuccess;
+            }
+            var apiHelper = new NugetApiHelper(PaketBootstrapperNugetPackageName);
+
+            const string paketNupkgFile = "paket.bootstrapper.latest.nupkg";
+            const string paketNupkgFileTemplate = "paket.bootstrapper.{0}.nupkg";
+            var getLatestFromNugetUrl = apiHelper.GetLatestPackage();
+
+            var paketDownloadUrl = getLatestFromNugetUrl;
+            var paketFile = paketNupkgFile;
+            if (latestVersion != String.Empty)
+            {
+                paketDownloadUrl = apiHelper.GetSpecificPackageVersion(latestVersion);
+                paketFile = String.Format(paketNupkgFileTemplate, latestVersion);
+            }
+
+            var randomFullPath = Path.Combine(Folder, Path.GetRandomFileName());
+            Directory.CreateDirectory(randomFullPath);
+            var paketPackageFile = Path.Combine(randomFullPath, paketFile);
+            Console.WriteLine("Starting download from {0}", paketDownloadUrl);
+            using (var client = new WebClient())
+            {
+                PrepareWebClient(client, paketDownloadUrl);
+                client.DownloadFile(paketDownloadUrl, paketPackageFile);
+            }
+            ZipFile.ExtractToDirectory(paketPackageFile, randomFullPath);
+
+            var paketSourceFile = Path.Combine(randomFullPath, "Tools", "Paket.Bootstrapper.exe");
+            var renamedPath = Path.GetTempFileName();
+            try
+            {
+                BootstrapperHelper.FileMove(target, renamedPath);
+                BootstrapperHelper.FileMove(paketSourceFile, target);
+                Console.WriteLine("Self update of bootstrapper was successful.");
+                updateSuccess = true;
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Self update failed. Resetting bootstrapper.");
+                BootstrapperHelper.FileMove(renamedPath, target);
+                throw;
+            }
+            Directory.Delete(randomFullPath, true);
+            return updateSuccess;
         }
 
         private class SemVer : IComparable

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -103,7 +103,7 @@ namespace Paket.Bootstrapper
 
         public bool SelfUpdate(string latestVersion)
         {
-            Console.WriteLine("self update of bootstrapper via nuget is currently not possible");
+            BootstrapperHelper.WriteConsoleInfo("self update of bootstrapper via nuget is currently not possible");
             return false;
         }
 

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -46,7 +46,6 @@
     <Compile Include="NugetDownloadStrategy.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RestartException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BootstrapperHelper.cs" />
     <Compile Include="DownloadArguments.cs" />
     <Compile Include="GitHubDownloadStrategy.cs" />
     <Compile Include="IDownloadStrategy.cs" />

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -45,6 +45,7 @@
     <Compile Include="NugetDownloadStrategy.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RestartException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -127,10 +127,16 @@ namespace Paket.Bootstrapper
             var latestVersion = Environment.GetEnvironmentVariable(PaketVersionEnv) ?? "";
             var ignorePrerelease = true;
             bool doSelfUpdate = false;
+            var commandArgs = args;
 
-            if (args.Length >= 1)
+            if (commandArgs.Contains(SelfUpdateCommandArg))
             {
-                if (args[0] == PrereleaseCommandArg)
+                commandArgs = commandArgs.Where(x => x != SelfUpdateCommandArg).ToArray();
+                doSelfUpdate = true;
+            }
+            if (commandArgs.Length >= 1)
+            {
+                if (commandArgs[0] == PrereleaseCommandArg)
                 {
                     ignorePrerelease = false;
                     latestVersion = "";
@@ -138,12 +144,8 @@ namespace Paket.Bootstrapper
                 }
                 else
                 {
-                    latestVersion = args[0];
+                    latestVersion = commandArgs[0];
                     Console.WriteLine("Version {0} requested.", latestVersion);
-                }
-                if (args.Contains(SelfUpdateCommandArg))
-                {
-                    doSelfUpdate = true;
                 }
             }
             else if (!String.IsNullOrWhiteSpace(latestVersion))

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -102,7 +102,7 @@ namespace Paket.Bootstrapper
 
         private static IDownloadStrategy GetEffectiveDownloadStrategy(DownloadArguments dlArgs, bool preferNuget)
         {
-            var gitHubDownloadStrategy = new GitHubDownloadStrategy(BootstrapperHelper.PrepareWebClient, BootstrapperHelper.GetDefaultWebProxyFor);
+            var gitHubDownloadStrategy = new GitHubDownloadStrategy(BootstrapperHelper.PrepareWebClient, BootstrapperHelper.PrepareWebRequest,  BootstrapperHelper.GetDefaultWebProxyFor);
             var nugetDownloadStrategy = new NugetDownloadStrategy(BootstrapperHelper.PrepareWebClient, BootstrapperHelper.GetDefaultWebProxyFor, dlArgs.Folder);
 
             IDownloadStrategy effectiveStrategy;

--- a/src/Paket.Bootstrapper/RestartException.cs
+++ b/src/Paket.Bootstrapper/RestartException.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Paket.Bootstrapper
-{
-    internal class RestartException : Exception
-    {
-    }
-}

--- a/src/Paket.Bootstrapper/RestartException.cs
+++ b/src/Paket.Bootstrapper/RestartException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Paket.Bootstrapper
+{
+    internal class RestartException : Exception
+    {
+    }
+}


### PR DESCRIPTION
Like suggested by @dnauck in #790 I have created a self update a while ago. This adds an option --self that updates the bootstrapper in place for the github downloads. The nuget download can't currently support the self update because in the nuget package does not contain the bootstrapper.

The current behaviour updates the bootstrapper always, also with the version argument.
After the self-update was successful the bootstrapper gets restarted with the original parameters, but not "--self"