### PR TITLE
Convert remove custom import and targets

### DIFF
--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -309,6 +309,7 @@ let convertProjects nugetEnv =
     [for project,packagesConfig in nugetEnv.NugetProjectFiles do 
         project.ReplaceNuGetPackagesFile()
         project.RemoveNuGetTargetsEntries()
+        project.RemoveImportAndTargetEntries(packagesConfig.Packages |> List.map (fun p -> p.Id, p.Version))
         yield project, convertPackagesConfigToReferences project.FileName packagesConfig]
 
 let createPaketEnv rootDirectory nugetEnv credsMirationMode = trial {

--- a/src/Paket.Core/SolutionFile.fs
+++ b/src/Paket.Core/SolutionFile.fs
@@ -59,7 +59,7 @@ type SolutionFile(fileName: string) =
     member __.FileName = fileName
 
     member __.RemoveNugetEntries() =
-        for file in ["nuget.targets";"packages.config";"nuget.exe"] do
+        for file in ["nuget.targets";"packages.config";"nuget.exe";"nuget.config"] do
             match content |> Seq.tryFindIndex (fun line -> line.ToLower().Contains(sprintf ".nuget\\%s" file)) with
             | Some(index) -> content.RemoveAt(index)
             | None -> ()            


### PR DESCRIPTION
solves #776
the issue is also mentioned ind #516 

`convert-from-nuget` will look for `Import`s with package id and version in path, and additionally will interactively ask if one wants to remove following `Target` node (if present) 

Couldn't come up with wiser heuristic for this