### PR TITLE
Paket should keep paket.dependencies as stable as possible

### DIFF
--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -140,9 +140,9 @@ module DependenciesFileParser =
     | CopyLocal of bool
     | Redirects of bool
 
-    let private (|Remote|Package|Comment|ParserOptions|SourceFile|) (line:string) =
+    let private (|Remote|Package|Empty|ParserOptions|SourceFile|) (line:string) =
         match line.Trim() with
-        | _ when String.IsNullOrWhiteSpace line -> Comment(line)
+        | _ when String.IsNullOrWhiteSpace line -> Empty(line)
         | String.StartsWith "source" _ as trimmed -> Remote(PackageSource.Parse(trimmed))
         | String.StartsWith "nuget" trimmed -> 
             let parts = trimmed.Trim().Replace("\"", "").Split([|' '|],StringSplitOptions.RemoveEmptyEntries) |> Seq.toList
@@ -176,24 +176,26 @@ module DependenciesFileParser =
             SourceFile(``parse git source`` trimmed SingleSourceFileOrigin.GitHubLink "github")
         | String.StartsWith "http" _ as trimmed  ->
             SourceFile(``parse http source`` trimmed)
-        | String.StartsWith "//" _ -> Comment(line)
-        | String.StartsWith "#" _ -> Comment(line)
+        | String.StartsWith "//" _ -> Empty(line)
+        | String.StartsWith "#" _ -> Empty(line)
         | _ -> failwithf "Unrecognized token: %s" line
     
-    let parseDependenciesFile fileName (lines:string seq) = 
-        ((0, InstallOptions.Default, [], [], [],[]), lines)
-        ||> Seq.fold(fun (lineNo, options, sources: PackageSource list, packages, sourceFiles: UnresolvedSourceFile list,comments) line ->
+    let parseDependenciesFile fileName (lines:string seq) =
+        let lines = lines |> Seq.toArray
+         
+        ((0, InstallOptions.Default, [], [], []), lines)
+        ||> Seq.fold(fun (lineNo, options, sources: PackageSource list, packages, sourceFiles: UnresolvedSourceFile list) line ->
             let lineNo = lineNo + 1
             try
                 match line with
-                | Remote(newSource) -> lineNo, options, sources @ [newSource], packages, sourceFiles, comments
-                | Comment(line) -> lineNo, options, sources, packages, sourceFiles, if line <> "" then (lineNo,line)::comments else comments
-                | ParserOptions(ParserOption.ReferencesMode mode) -> lineNo, { options with Strict = mode }, sources, packages, sourceFiles, comments
-                | ParserOptions(ParserOption.Redirects mode) -> lineNo, { options with Redirects = mode }, sources, packages, sourceFiles, comments
-                | ParserOptions(ParserOption.CopyLocal mode) -> lineNo, { options with Settings = { options.Settings with CopyLocal = mode }}, sources, packages, sourceFiles, comments
-                | ParserOptions(ParserOption.ImportTargets mode) -> lineNo, { options with Settings = { options.Settings with ImportTargets = mode }}, sources, packages, sourceFiles, comments
-                | ParserOptions(ParserOption.FrameworkRestrictions r) -> lineNo, { options with Settings = { options.Settings with FrameworkRestrictions = r }}, sources, packages, sourceFiles, comments
-                | ParserOptions(ParserOption.OmitContent omit) -> lineNo, { options with Settings = { options.Settings with  OmitContent = omit }}, sources, packages, sourceFiles, comments
+                | Empty(_) -> lineNo, options, sources , packages, sourceFiles
+                | Remote(newSource) -> lineNo, options, sources @ [newSource], packages, sourceFiles
+                | ParserOptions(ParserOption.ReferencesMode mode) -> lineNo, { options with Strict = mode }, sources, packages, sourceFiles
+                | ParserOptions(ParserOption.Redirects mode) -> lineNo, { options with Redirects = mode }, sources, packages, sourceFiles
+                | ParserOptions(ParserOption.CopyLocal mode) -> lineNo, { options with Settings = { options.Settings with CopyLocal = mode }}, sources, packages, sourceFiles
+                | ParserOptions(ParserOption.ImportTargets mode) -> lineNo, { options with Settings = { options.Settings with ImportTargets = mode }}, sources, packages, sourceFiles
+                | ParserOptions(ParserOption.FrameworkRestrictions r) -> lineNo, { options with Settings = { options.Settings with FrameworkRestrictions = r }}, sources, packages, sourceFiles
+                | ParserOptions(ParserOption.OmitContent omit) -> lineNo, { options with Settings = { options.Settings with  OmitContent = omit }}, sources, packages, sourceFiles
                 | Package(name,version,rest) ->
                     let prereleases,optionsText =
                         if rest.Contains ":" then
@@ -216,19 +218,20 @@ module DependenciesFileParser =
                           ResolverStrategy = parseResolverStrategy version
                           Parent = DependenciesFile fileName
                           Settings = InstallSettings.Parse(optionsText)
-                          VersionRequirement = parseVersionRequirement((version + " " + prereleases).Trim '!') } :: packages, sourceFiles, comments
+                          VersionRequirement = parseVersionRequirement((version + " " + prereleases).Trim '!') } :: packages, sourceFiles
                 | SourceFile(origin, (owner,project, commit), path) ->
-                    lineNo, options, sources, packages, { Owner = owner; Project = project; Commit = commit; Name = path; Origin = origin} :: sourceFiles, comments
+                    lineNo, options, sources, packages, { Owner = owner; Project = project; Commit = commit; Name = path; Origin = origin} :: sourceFiles
                     
             with
             | exn -> failwithf "Error in paket.dependencies line %d%s  %s" lineNo Environment.NewLine exn.Message)
-        |> fun (_,options,sources,packages,remoteFiles,comments) ->
+        |> fun (_,options,sources,packages,remoteFiles) ->
             fileName,
             options,
             sources,
             packages |> List.rev,
             remoteFiles |> List.rev,
-            comments
+            lines
+
 
 module DependenciesFileSerializer = 
     let formatVersionRange strategy (version : VersionRequirement) : string =          
@@ -256,23 +259,39 @@ module DependenciesFileSerializer =
         let text = prefix + version         
         if text <> "" && preReleases <> "" then text + " " + preReleases else text + preReleases
 
+    let sourceString source = "source " + source
+
+    let packageString packageName versionRequirement resolverStrategy (settings:InstallSettings) =
+        let (PackageName name) = packageName
+        let version = formatVersionRange resolverStrategy versionRequirement
+        let s = settings.ToString()
+
+        sprintf "nuget %s%s%s" name (if version <> "" then " " + version else "") (if s <> "" then " " + s else s)        
+
 /// Allows to parse and analyze paket.dependencies files.
-type DependenciesFile(fileName,options,sources,packages : PackageRequirement list, remoteFiles : UnresolvedSourceFile list, comments) = 
+type DependenciesFile(fileName,options,sources,packages : PackageRequirement list, remoteFiles : UnresolvedSourceFile list, textRepresentation:string []) = 
     let packages = packages |> Seq.toList
     let dependencyMap = Map.ofSeq (packages |> Seq.map (fun p -> p.Name, p.VersionRequirement))
+
+    let tryFindPackageLine (packageName:PackageName) =
+        let name = packageName.ToString().ToLower()
+        textRepresentation
+        |> Array.tryFindIndex (fun (l:string) -> 
+            let splitted = l.Split(' ') |> Array.map (fun s -> s.ToLower())
+            splitted |> Array.exists ((=) "nuget") && splitted |> Array.exists ((=) name))
             
     member __.DirectDependencies = dependencyMap
     member __.Packages = packages
-    member __.Comments = comments
     member __.HasPackage (name : PackageName) = packages |> List.exists (fun p -> NormalizedPackageName p.Name = NormalizedPackageName name)
     member __.RemoteFiles = remoteFiles
     member __.Options = options
     member __.FileName = fileName
+    member __.Lines = textRepresentation
     member __.Sources = sources
     member this.Resolve(force) = 
         let getSha1 origin owner repo branch = RemoteDownload.getSHA1OfBranch origin owner repo branch |> Async.RunSynchronously
         let root = Path.GetDirectoryName this.FileName
-        this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force)
+        this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force)   
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF) =
         let resolveSourceFile(file:ResolvedSourceFile) : PackageRequirement list =
@@ -303,39 +322,53 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
         { ResolvedPackages = PackageResolver.Resolve(getVersionF, getPackageDetailsF, options.Settings.FrameworkRestrictions, remoteDependencies @ packages)
           ResolvedSourceFiles = remoteFiles }        
 
-    member __.AddAdditionalPackage(packageName:PackageName,version:string,settings) =
-        let versionRange = DependenciesFileParser.parseVersionRequirement (version.Trim '!')
-        let sources',sources = 
-            match packages |> List.rev with
-            | lastPackage::_ -> lastPackage.Sources,sources
-            | [] -> 
-                [PackageSources.DefaultNugetSource],
-                if sources |> List.exists ((=) PackageSources.DefaultNugetSource) then sources else PackageSources.DefaultNugetSource :: sources
-
-        let newPackage = 
-            { Name = packageName
-              VersionRequirement = versionRange
-              Sources = sources'
-              ResolverStrategy = DependenciesFileParser.parseResolverStrategy version
-              Settings = settings
-              Parent = PackageRequirementSource.DependenciesFile fileName }
+    member __.AddAdditionalPackage(packageName:PackageName,versionRequirement,resolverStrategy,settings) =
+        let packageString = DependenciesFileSerializer.packageString packageName versionRequirement resolverStrategy settings
 
         // Try to find alphabetical matching position to insert the package
         let smaller = Seq.takeWhile (fun (p:PackageRequirement) -> p.Name <= packageName) packages |> List.ofSeq
-        let bigger = Seq.skipWhile (fun (p:PackageRequirement) -> p.Name <= packageName) packages |> List.ofSeq
 
-        let newPackages = smaller @ [newPackage] @ bigger
+        let newLines =
+            let list = new System.Collections.Generic.List<_>()
+            list.AddRange textRepresentation
+            match smaller with
+            | [] -> 
+                match packages with
+                | [] ->
+                    if remoteFiles <> [] then
+                        list.Insert(0,"")
 
-        DependenciesFile(fileName,options,sources,newPackages, remoteFiles, comments)
+                    list.Insert(0,packageString)
+                    
+                    match sources with
+                    | [] -> 
+                        list.Insert(0,"")
+                        list.Insert(0,DependenciesFileSerializer.sourceString Constants.DefaultNugetStream)
+                    | _ -> ()
+                | _ -> list.Add packageString
 
-    member __.AddFixedPackage(packageName:PackageName,version:string,settings) =
+            | _ -> 
+                let p = Seq.last smaller
+
+                match tryFindPackageLine p.Name with
+                | None -> list.Add packageString
+                | Some pos -> list.Insert(pos + 1,packageString)
+            
+            list |> Seq.toArray
+
+        DependenciesFile(DependenciesFileParser.parseDependenciesFile fileName newLines)
+
+
+    member this.AddAdditionalPackage(packageName:PackageName,version:string,settings) =
+        let versionRequirement = DependenciesFileParser.parseVersionRequirement (version.Trim '!')
+        let resolverStrategy = DependenciesFileParser.parseResolverStrategy version
+
+        this.AddAdditionalPackage(packageName,versionRequirement,resolverStrategy,settings)
+
+    member this.AddFixedPackage(packageName:PackageName,version:string,settings) =
         let versionRange = DependenciesFileParser.parseVersionRequirement (version.Trim '!')
-        let sources = 
-            match packages |> List.rev with
-            | lastPackage::_ -> lastPackage.Sources
-            | [] -> [PackageSources.DefaultNugetSource]
 
-        let strategy,newVersionRange = 
+        let resolverStrategy,versionRequirement = 
             match packages |> List.tryFind (fun p -> NormalizedPackageName p.Name = NormalizedPackageName packageName) with
             | Some package -> 
                 package.ResolverStrategy,
@@ -344,25 +377,21 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
                 | _ -> versionRange
             | None -> DependenciesFileParser.parseResolverStrategy version,versionRange
 
-        let newPackage = 
-            { Name = packageName
-              VersionRequirement = newVersionRange
-              Sources = sources
-              ResolverStrategy = strategy
-              Settings = settings
-              Parent = PackageRequirementSource.DependenciesFile fileName }
-
-        DependenciesFile(fileName,options,sources,(packages |> List.filter (fun p -> NormalizedPackageName p.Name <> NormalizedPackageName packageName)) @ [newPackage], remoteFiles, comments)
+        this.AddAdditionalPackage(packageName,versionRequirement,resolverStrategy,settings)
 
     member this.AddFixedPackage(packageName:PackageName,version:string) =
         this.AddFixedPackage(packageName,version,InstallSettings.Default)
 
-    member __.RemovePackage(packageName:PackageName) =
-        let newPackages = 
-            packages
-            |> List.filter (fun p -> NormalizedPackageName p.Name <> NormalizedPackageName packageName)
+    member this.RemovePackage(packageName:PackageName) =
+        match tryFindPackageLine packageName with
+        | None -> this
+        | Some pos ->
+            let removeElementAt index myArr = // TODO: Replace this in F# 4.0
+                [|  for i = 0 to Array.length myArr - 1 do 
+                       if i <> index then yield myArr.[ i ] |]
 
-        DependenciesFile(fileName,options,sources,newPackages,remoteFiles, comments)
+            let newLines = removeElementAt pos textRepresentation
+            DependenciesFile(DependenciesFileParser.parseDependenciesFile fileName newLines)
 
     static member add (dependenciesFile : DependenciesFile) (packageName,version,installSettings) =
         dependenciesFile.Add(packageName,version,installSettings)
@@ -399,7 +428,7 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
                                      if NormalizedPackageName p.Name = NormalizedPackageName packageName then 
                                          { p with VersionRequirement = versionRequirement }
                                      else p)
-            DependenciesFile(this.FileName, this.Options, sources, packages, this.RemoteFiles, comments)
+            DependenciesFile(this.FileName, this.Options, sources, packages, this.RemoteFiles, textRepresentation)
         else
             traceWarnfn "%s doesn't contain package %s. ==> Ignored" fileName name
             this
@@ -414,71 +443,7 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
         let fi = FileInfo(fileName)
         fi.Directory.FullName
 
-    override __.ToString() =        
-        let sources = 
-            packages
-            |> Seq.map (fun package -> package.Sources,package)
-            |> Seq.groupBy fst
-
-        let formatNugetSource source = 
-            "source " + String.quoted source.Url +
-                match source.Authentication with
-                | Some (PlainTextAuthentication(username,password)) -> 
-                    sprintf " username: \"%s\" password: \"%s\"" username password
-                | Some (EnvVarAuthentication(usernameVar,passwordVar)) -> 
-                    sprintf " username: \"%s\" password: \"%s\"" usernameVar.Variable passwordVar.Variable
-                | _ -> ""
-                 
-        let all =
-            let hasReportedSource = ref false
-            let hasReportedFirst = ref false
-            let hasReportedSecond = ref false
-            [ if options.Strict then yield "references: strict"
-              if options.Redirects then yield "redirects: on"
-              let optionsString = options.Settings.ToString(true)
-              if optionsString <> "" then yield optionsString
-              for sources, packages in sources do
-                  for source in sources do
-                      hasReportedSource := true
-                      match source with
-                      | Nuget source -> yield formatNugetSource source
-                      | LocalNuget source -> yield "source " + String.quoted source
-                  
-                  for _,package in packages do
-                      if (not !hasReportedFirst) && !hasReportedSource  then
-                          yield ""
-                          hasReportedFirst := true
-
-                      let (PackageName name) = package.Name
-                      let version = DependenciesFileSerializer.formatVersionRange package.ResolverStrategy package.VersionRequirement
-                      let s = package.Settings.ToString()
-
-                      yield sprintf "nuget %s%s%s" name (if version <> "" then " " + version else "") (if s <> "" then " " + s else s)
-                     
-              for remoteFile in remoteFiles do
-                  if (not !hasReportedSecond) && !hasReportedFirst then
-                      yield ""
-                      hasReportedSecond := true
-                      
-                  yield remoteFile.ToString() ]
-                  
-        let comments = comments |> dict
-
-        let withComments =
-            let lineNo = ref 1
-            [for line in all do
-                let rec checkForComment() =
-                    [match comments.TryGetValue !lineNo with
-                     | true,line -> 
-                        yield line
-                        lineNo := !lineNo + 1
-                        yield! checkForComment()
-                     | _ -> ()]
-                yield! checkForComment()
-                yield line
-                lineNo := !lineNo + 1]
-
-        String.Join(Environment.NewLine, withComments)
+    override __.ToString() = String.Join(Environment.NewLine, textRepresentation)
 
     member this.Save() =
         File.WriteAllText(fileName, this.ToString())

--- a/src/Paket.Core/Environment.fs
+++ b/src/Paket.Core/Environment.fs
@@ -90,5 +90,5 @@ module PaketEnv =
             let dependenciesFile = 
                 DependenciesFile(
                     Path.Combine(directory.FullName, Constants.DependenciesFileName), 
-                    InstallOptions.Default, [], [], [], [])
+                    InstallOptions.Default, [], [], [], [||])
             dependenciesFile.ToString() |> saveFile dependenciesFile.FileName

--- a/src/Paket.Core/FindOutdated.fs
+++ b/src/Paket.Core/FindOutdated.fs
@@ -21,7 +21,7 @@ let private adjustVersionRequirements strict includingPrereleases (dependenciesF
                 | false,false -> VersionRequirement.AllReleases, ResolverStrategy.Max
             { p with VersionRequirement = requirement; ResolverStrategy = strategy})
 
-    DependenciesFile(dependenciesFile.FileName, dependenciesFile.Options, dependenciesFile.Sources, newPackages, dependenciesFile.RemoteFiles, dependenciesFile.Comments)
+    DependenciesFile(dependenciesFile.FileName, dependenciesFile.Options, dependenciesFile.Sources, newPackages, dependenciesFile.RemoteFiles, dependenciesFile.Lines) // TODO: fix me
 
 let private detectOutdated (oldResolution: PackageResolver.PackageResolution) (newResolution: PackageResolver.PackageResolution) =
     [for kv in oldResolution do

--- a/src/Paket.Core/Simplifier.fs
+++ b/src/Paket.Core/Simplifier.fs
@@ -31,11 +31,12 @@ let simplifyDependenciesFile (dependenciesFile : DependenciesFile, flatLookup, i
     let packages = dependenciesFile.Packages |> List.map (fun p -> p.Name)
     let! transitive = findTransitive(packages, flatLookup, DependencyNotFoundInLockFile)
 
-    let newPackages = 
+    return
         dependenciesFile.Packages
-        |> List.filter (fun package -> not <| removePackage(package.Name, transitive, dependenciesFile.FileName, interactive))
-    let d = dependenciesFile
-    return DependenciesFile(d.FileName, d.Options, d.Sources, newPackages, d.RemoteFiles, d.Comments)
+        |> List.fold  (fun (d:DependenciesFile) package ->
+                if removePackage(package.Name, transitive, dependenciesFile.FileName, interactive) then
+                    d.Remove(package.Name)
+                else d) dependenciesFile
 }
 
 let simplifyReferencesFile (refFile, flatLookup, interactive) = trial {

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -32,7 +32,7 @@
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>D:\code\Pakettest</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\Paketkopie</StartWorkingDirectory>
-    <StartArguments>add nuget fake</StartArguments>
+    <StartArguments>add nuget FSharp.Core</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>D:\code\Pakettest</StartWorkingDirectory>

--- a/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
@@ -21,8 +21,8 @@ nuget SignalR = 3.3.2"""
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
-nuget FAKE 1.1
-nuget SignalR 3.3.2
+nuget FAKE = 1.1
+nuget SignalR = 3.3.2
 nuget xunit"""
 
     cfg.ToString()
@@ -42,10 +42,10 @@ nuget SignalR = 3.3.2"""
     let expected = """source http://nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
-nuget FAKE 1.1
+nuget FAKE = 1.1
 nuget Rx-Main ~> 2.0
 nuget Rz
-nuget SignalR 3.3.2"""
+nuget SignalR = 3.3.2"""
 
     cfg.ToString()
     |> shouldEqual (normalizeLineEndings expected)
@@ -67,7 +67,7 @@ github forki/FsUnit FsUnit.fs"""
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
-nuget FAKE 1.1
+nuget FAKE = 1.1
 nuget NuGet.CommandLine
 nuget xunit
 
@@ -105,7 +105,6 @@ nuget Castle.Windsor-log4net ~> 3.2"""
     let cfg = DependenciesFile.FromCode(config).Add(PackageName "FAKE","1.2")
     
     let expected = """source http://nuget.org/api/v2
-
 nuget Castle.Windsor-log4net ~> 3.2
 nuget FAKE 1.2"""
 
@@ -129,13 +128,14 @@ github forki/FsUnit FsUnit.fs"""
 
 [<Test>]
 let ``should add new packages with nuget package resolution strategy``() = 
-    let config = """"""
+    let config = ""
 
     let cfg = DependenciesFile.FromCode(config).Add(PackageName "FAKE","!~> 1.2")
     
     let expected = """source https://nuget.org/api/v2
 
-nuget FAKE !~> 1.2"""
+nuget FAKE !~> 1.2
+"""
 
     cfg.ToString()
     |> shouldEqual (normalizeLineEndings expected)
@@ -162,3 +162,29 @@ nuget FAKE = 1.1
 nuget SignalR = 3.3.2"""
 
     DependenciesFile.FromCode(config).Add(PackageName "fAKe","") |> ignore
+
+[<Test>]
+let ``should keep sources stable``() = 
+    let before = """source https://www.nuget.org/api/v2
+
+nuget quicksilver
+nuget FsCheck
+
+source https://www.nuget.org/api/v3
+
+nuget NUnit"""
+
+    let expected = """source https://www.nuget.org/api/v2
+
+nuget quicksilver
+nuget FsCheck
+
+source https://www.nuget.org/api/v3
+
+nuget NUnit
+nuget FAKE"""
+
+    DependenciesFile.FromCode(before)
+      .Add(PackageName "FAKE","")
+      .ToString()
+    |> shouldEqual (normalizeLineEndings expected)

--- a/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
@@ -188,3 +188,37 @@ nuget FAKE"""
       .Add(PackageName "FAKE","")
       .ToString()
     |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should update packages with new version``() = 
+    let config = """source https://nuget.org/api/v2
+
+nuget FAKE 1.1
+"""
+
+    let cfg = DependenciesFile.FromCode(config).UpdatePackageVersion(PackageName "FAKE","1.2")
+    
+    let expected = """source https://nuget.org/api/v2
+
+nuget FAKE 1.2
+"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should update packages with nuget package resolution strategy``() = 
+    let config = """source https://nuget.org/api/v2
+
+nuget FAKE ~> 1.1
+"""
+
+    let cfg = DependenciesFile.FromCode(config).UpdatePackageVersion(PackageName "FAKE","!~> 1.2")
+    
+    let expected = """source https://nuget.org/api/v2
+
+nuget FAKE !~> 1.2
+"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)

--- a/tests/Paket.Tests/DependenciesFile/RemovePackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/RemovePackageSpecs.fs
@@ -1,0 +1,58 @@
+module paket.dependenciesFile.RemovePackageSpecs
+
+open Paket
+open NUnit.Framework
+open FsUnit
+open TestHelpers
+open Paket.Domain
+
+[<Test>]
+let ``should remove the right package``() = 
+    let config = """source http://nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2
+nuget Rx-Main ~> 2.0
+nuget FAKE = 1.1
+nuget SignalR = 3.3.2"""
+
+    let cfg = DependenciesFile.FromCode(config).Remove(PackageName "FAKE")
+    
+    let expected = """source http://nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2
+nuget Rx-Main ~> 2.0
+nuget SignalR = 3.3.2"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should remove only the correct package``() = 
+    let config = """source http://nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2
+nuget Castle.Windsor ~> 3.2"""
+
+    let cfg = DependenciesFile.FromCode(config).Remove(PackageName "Castle.Windsor")
+    
+    let expected = """source http://nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should keep stable if package doesn't exist``() = 
+    let config = """source http://nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2"""
+
+    let cfg = DependenciesFile.FromCode(config).Remove(PackageName "Castle.Windsor")
+    
+    let expected = """source http://nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)

--- a/tests/Paket.Tests/DependenciesFile/SaveSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/SaveSpecs.fs
@@ -35,22 +35,6 @@ let ``should serialize strict config``() =
     |> shouldEqual (normalizeLineEndings strictConfig)
 
 
-let configWithNoRestriction = """source http://nuget.org/api/v2
-
-nuget FAKE >= 0"""
-
-let configWithNoRestriction2 = """source http://nuget.org/api/v2
-
-nuget FAKE"""
-
-
-[<Test>]
-let ``should remove >= 0 from config``() = 
-    let cfg = DependenciesFile.FromCode(configWithNoRestriction)
-    
-    cfg.ToString()
-    |> shouldEqual (normalizeLineEndings configWithNoRestriction2)
-
 let contentNoneConfig = """redirects: on
 content: none
 source http://nuget.org/api/v2

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -176,6 +176,7 @@
     <Compile Include="DependenciesFile\ParserSpecs.fs" />
     <Compile Include="DependenciesFile\SaveSpecs.fs" />
     <Compile Include="DependenciesFile\AddPackageSpecs.fs" />
+    <Compile Include="DependenciesFile\RemovePackageSpecs.fs" />
     <Compile Include="DependenciesFile\DependencyChangesSpecs.fs" />
     <Compile Include="Resolver\DependencyGraphSpecs.fs" />
     <Compile Include="Resolver\SimpleDependenciesSpecs.fs" />

--- a/tests/Paket.Tests/Simplifier/BasicScenarioSpecs.fs
+++ b/tests/Paket.Tests/Simplifier/BasicScenarioSpecs.fs
@@ -95,3 +95,12 @@ let ``should remove all transitive dependencies from dep file recursively``() =
         depFile.Packages |> List.map (fun p -> p.Name) |> shouldEqual [PackageName"A";PackageName"C"]
         refFiles.Head.NugetPackages |>  shouldEqual [PackageInstallSettings.Default("A"); PackageInstallSettings.Default("C")]
         refFiles.Tail.Head.NugetPackages |>  shouldEqual [PackageInstallSettings.Default("C"); PackageInstallSettings.Default("D")]
+
+        let expected = """
+source http://nuget.org/api/v2
+
+nuget A 1.0
+nuget C 1.0"""
+
+        depFile.ToString()
+        |> shouldEqual (normalizeLineEndings expected)


### PR DESCRIPTION
Idea:

Instead of serializing the Dependencies file from the already parsed information we always modify the text and reparse it. Maybe not the best style, but it keep comments and everything in place.

fixes #780, #731

This needs a lot of testing. Especially the convert-from-nuget stuff (cc @theimowski)

/cc @matthid, @cjbhaines, @mexx, @inosik , @haf