### PR TITLE
[WIP] Property tests for dependencies file parsing

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,7 @@
 source https://nuget.org/api/v2
 
+nuget FsCheck
+nuget FsCheck.NUnit
 nuget Newtonsoft.Json
 nuget UnionArgParser
 nuget NUnit.Runners
@@ -13,5 +15,3 @@ github forki/FsUnit FsUnit.fs
 github fsharp/FAKE modules/Octokit/Octokit.fsx
 github fsharp/FAKE src/app/FakeLib/Globbing/Globbing.fs
 github fsprojects/Chessie src/Chessie/ErrorHandling.fs
-nuget FsCheck
-nuget FsCheck.NUnit

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,3 +14,4 @@ github fsharp/FAKE modules/Octokit/Octokit.fsx
 github fsharp/FAKE src/app/FakeLib/Globbing/Globbing.fs
 github fsprojects/Chessie src/Chessie/ErrorHandling.fs
 nuget FsCheck
+nuget FsCheck.NUnit

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,3 +13,4 @@ github forki/FsUnit FsUnit.fs
 github fsharp/FAKE modules/Octokit/Octokit.fsx
 github fsharp/FAKE src/app/FakeLib/Globbing/Globbing.fs
 github fsprojects/Chessie src/Chessie/ErrorHandling.fs
+nuget FsCheck

--- a/paket.lock
+++ b/paket.lock
@@ -2,6 +2,7 @@ NUGET
   remote: https://nuget.org/api/v2
   specs:
     FAKE (3.30.3)
+    FsCheck (1.0.4)
     FSharp.Compiler.Service (0.0.89)
     FSharp.Core (3.1.2.1)
     FSharp.Formatting (2.9.4)

--- a/paket.lock
+++ b/paket.lock
@@ -3,6 +3,10 @@ NUGET
   specs:
     FAKE (3.30.3)
     FsCheck (1.0.4)
+    FsCheck.Nunit (1.0.4)
+      FsCheck (>= 1.0.4)
+      NUnit (>= 2.6.3)
+      NUnit.Runners (>= 2.6.3)
     FSharp.Compiler.Service (0.0.89)
     FSharp.Core (3.1.2.1)
     FSharp.Formatting (2.9.4)

--- a/tests/Paket.Tests/App.config
+++ b/tests/Paket.Tests/App.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="nunit.core" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="nunit.core.interfaces" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
+++ b/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
@@ -1,0 +1,2 @@
+﻿module Paket.DependenciesFile.PropertyTests
+

--- a/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
+++ b/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
@@ -1,2 +1,14 @@
 ﻿module Paket.DependenciesFile.PropertyTests
 
+open System
+open FsCheck
+open NUnit.Framework
+open Paket
+
+let ``round trip`` (lines : string[]) =
+    let df = DependenciesFile(DependenciesFileParser.parseDependenciesFile "dummy" lines)
+    df.ToString() = String.concat Environment.NewLine lines 
+
+[<Test>]
+let ``round trip test``() =
+    Check.QuickThrowOnFailure(``round trip``)

--- a/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
+++ b/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
@@ -2,13 +2,16 @@
 
 open System
 open FsCheck
-open NUnit.Framework
+open FsCheck.NUnit
 open Paket
 
+type DFFileGenerator =
+    static member StringArray() = 
+        {new Arbitrary<string[]>() with
+            override x.Generator = Gen.elements [[|"nuget FsCheck"|]]
+            override x.Shrinker t = Seq.empty }
+
+[<Property(Arbitrary = [|typeof<DFFileGenerator>|])>]
 let ``round trip`` (lines : string[]) =
     let df = DependenciesFile(DependenciesFileParser.parseDependenciesFile "dummy" lines)
     df.ToString() = String.concat Environment.NewLine lines 
-
-[<Test>]
-let ``round trip test``() =
-    Check.QuickThrowOnFailure(``round trip``)

--- a/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
+++ b/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
@@ -5,13 +5,29 @@ open FsCheck
 open FsCheck.NUnit
 open Paket
 
+let source = Gen.constant "source https://nuget.org/api/v2"
+
+let nuget = Gen.constant "nuget FsCheck"
+
+let github = Gen.constant "github forki/FsUnit FsUnit.fs"
+
+let gist = Gen.constant "gist Thorium/1972349 timestamp.fs"
+
+let http = Gen.constant "http http://www.fssnip.net/1n decrypt.fs"
+
+let depLine = Gen.oneof [source; nuget; github; gist; http]
+
 type DFFileGenerator =
     static member StringArray() = 
         {new Arbitrary<string[]>() with
-            override x.Generator = Gen.elements [[|"nuget FsCheck"|]]
+            override x.Generator = Gen.arrayOf depLine
             override x.Shrinker t = Seq.empty }
 
-[<Property(Arbitrary = [|typeof<DFFileGenerator>|])>]
+let _ = PropertyAttribute(Verbose = true)
+
+[<Property(
+    Arbitrary = [|typeof<DFFileGenerator>|],
+    Verbose = true)>]
 let ``round trip`` (lines : string[]) =
     let df = DependenciesFile(DependenciesFileParser.parseDependenciesFile "dummy" lines)
     df.ToString() = String.concat Environment.NewLine lines 

--- a/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
+++ b/tests/Paket.Tests/DependenciesFile/PropertyTests.fs
@@ -4,6 +4,10 @@ open System
 open FsCheck
 open FsCheck.NUnit
 open Paket
+open TestHelpers
+
+let nl = Environment.NewLine
+let linesToString s = String.concat nl s
 
 let source = Gen.constant "source https://nuget.org/api/v2"
 
@@ -15,19 +19,53 @@ let gist = Gen.constant "gist Thorium/1972349 timestamp.fs"
 
 let http = Gen.constant "http http://www.fssnip.net/1n decrypt.fs"
 
-let depLine = Gen.oneof [source; nuget; github; gist; http]
+let empty = Gen.constant ""
+
+let line = Gen.oneof [source; nuget; github; gist; http; empty]
+
+let slashComment = Gen.constant "//comment"
+let lineWComment = 
+    let line = Gen.oneof [source; nuget; empty]
+    (line, slashComment)
+    ||> Gen.map2 (fun l c -> l + " " + c)
+
+let hashComment = Gen.constant "#comment"
+let comment = Gen.oneof [slashComment; hashComment]
+
+let depLine = Gen.frequency [80, line; 10, lineWComment; 10, comment]
+
+let globalOpts = 
+    Gen.elements 
+        [ "references: strict"; "framework: net35, net40"; "content: none"; "import_targets: false"; "copy_local: false" ]
+    |> Gen.arrayOf
+    |> Gen.map (Seq.distinct >> Array.ofSeq)
+
+let generator = 
+    (Gen.arrayOf depLine, globalOpts)
+    ||> Gen.map2 (fun lines globalOpts -> Array.append globalOpts lines)
+    |> Gen.map linesToString
+
+let shrinker s =
+    let lines = s |> toLines
+    seq { 
+        for i in [0 .. lines.Length - 1] do
+            yield seq { 
+                for j in [0 .. lines.Length - 1] do
+                    if i <> j then yield lines.[j] }
+                |> linesToString}
 
 type DFFileGenerator =
     static member StringArray() = 
-        {new Arbitrary<string[]>() with
-            override x.Generator = Gen.arrayOf depLine
-            override x.Shrinker t = Seq.empty }
+        {new Arbitrary<string>() with
+            override x.Generator = generator
+            override x.Shrinker t = shrinker t }
 
 let _ = PropertyAttribute(Verbose = true)
 
 [<Property(
     Arbitrary = [|typeof<DFFileGenerator>|],
     Verbose = true)>]
-let ``round trip`` (lines : string[]) =
+let ``round trip`` (contents : string) =
+    let lines = toLines contents
     let df = DependenciesFile(DependenciesFileParser.parseDependenciesFile "dummy" lines)
     df.ToString() = String.concat Environment.NewLine lines 

--- a/tests/Paket.Tests/FsCheckAddin.fs
+++ b/tests/Paket.Tests/FsCheckAddin.fs
@@ -1,0 +1,14 @@
+namespace FsCheck.NUnit.Examples
+
+open NUnit.Core.Extensibility
+
+open FsCheck.NUnit
+open FsCheck.NUnit.Addin
+
+[<NUnitAddin(Description = "FsCheck addin")>]
+type FsCheckAddin() =        
+    interface IAddin with
+        override x.Install host = 
+            let tcBuilder = new FsCheckTestCaseBuider()
+            host.GetExtensionPoint("TestCaseBuilders").Install(tcBuilder)
+            true

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -123,7 +123,7 @@
     </Content>
     <Content Include="Nuspec\WindowsAzure.Storage.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>  
+    </Content>
     <Content Include="Nuspec\LiteGuard.Source.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -178,6 +178,7 @@
     <Compile Include="DependenciesFile\AddPackageSpecs.fs" />
     <Compile Include="DependenciesFile\RemovePackageSpecs.fs" />
     <Compile Include="DependenciesFile\DependencyChangesSpecs.fs" />
+    <Compile Include="DependenciesFile\PropertyTests.fs" />
     <Compile Include="Resolver\DependencyGraphSpecs.fs" />
     <Compile Include="Resolver\SimpleDependenciesSpecs.fs" />
     <Compile Include="Resolver\CyclicGraphSpecs.fs" />
@@ -224,10 +225,10 @@
     </None>
     <None Include="ProjectFile\TestData\MaintainsOrdering.fsprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>                              
+    </None>
     <None Include="ProjectFile\TestData\NewSilverlightClassLibrary.csprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>                              
+    </None>
     <None Include="ProjectFile\TestData\FSharp.Core.Fluent-3.1.fsprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -276,6 +277,17 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Import Project="Paket.Tests.paket.targets" Condition="Exists('Paket.Tests.paket.targets')" />
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="FsCheck">
+          <HintPath>..\..\packages\FsCheck\lib\net45\FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -65,6 +65,9 @@
   -->
   <Import Project="$(SolutionDir)\.paket\paket.targets" />
   <ItemGroup>
+    <Compile Include="FsCheckAddin.fs">
+      <Paket>True</Paket>
+    </Compile>
     <Compile Include="..\..\paket-files\forki\FsUnit\FsUnit.fs">
       <Paket>True</Paket>
       <Link>FsUnit.fs</Link>
@@ -262,9 +265,16 @@
     <Compile Include="InstallModel\Penalty\FrameworkConditionsSpecs.fs" />
     <Compile Include="DependencyModel\ProjectDependencySpecs.fs" />
     <None Include="paket.references" />
+    <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
+    <Reference Include="nunit.core">
+      <HintPath>..\..\packages\NUnit.Runners\tools\lib\nunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.core.interfaces">
+      <HintPath>..\..\packages\NUnit.Runners\tools\lib\nunit.core.interfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Security" />
@@ -282,6 +292,22 @@
       <ItemGroup>
         <Reference Include="FsCheck">
           <HintPath>..\..\packages\FsCheck\lib\net45\FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="FsCheck.NUnit.Addin">
+          <HintPath>..\..\packages\FsCheck.Nunit\lib\net45\FsCheck.NUnit.Addin.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="FsCheck.NUnit">
+          <HintPath>..\..\packages\FsCheck.Nunit\lib\net45\FsCheck.NUnit.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/Paket.Tests/paket.references
+++ b/tests/Paket.Tests/paket.references
@@ -2,4 +2,5 @@ NUnit
 NUnit.Runners
 FSharp.Core
 FsCheck
+FsCheck.NUnit
 File:FsUnit.fs .

--- a/tests/Paket.Tests/paket.references
+++ b/tests/Paket.Tests/paket.references
@@ -1,4 +1,5 @@
 NUnit
 NUnit.Runners
-File:FsUnit.fs .
 FSharp.Core
+FsCheck
+File:FsUnit.fs .


### PR DESCRIPTION
As per #802 the dependencies file caches all lines for later serializing, so this round-test may not be that useful, however it can surely serve as a safety net for future refactorings.

The test doesn't yet generate all valid dependencies files, but it could already find some pitfalls:
- can have comment line starting with `#`,
 but can't have a hash-comment inline such as `nuget FsCheck #fscheck is cool`
- can not have comments after: github, gist, http dependencies

Didn't fix those for now, instead made a workaround in generating test data