### PR TITLE
Load assembly from path - fixes #827

### DIFF
--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -91,16 +91,19 @@ let loadAssemblyId buildConfig (projectFile : ProjectFile) =
     let bytes = File.ReadAllBytes fileName
     let assembly = Assembly.Load bytes
 
-    assembly,assembly.GetName().Name
+    assembly,assembly.GetName().Name,fileName
 
-let loadAssemblyAttributes (assembly:Assembly) = 
+let loadAssemblyAttributes fileName (assembly:Assembly) = 
     try
         assembly.GetCustomAttributes(true)
     with
-    | exn -> 
-        traceWarnfn "Loading custom attributes failed for %s.%sMessage: %s" assembly.FullName Environment.NewLine exn.Message
+    | :? FileNotFoundException -> 
+        // retrieving via path
+        let assembly = Assembly.LoadFrom fileName            
+        assembly.GetCustomAttributes(true)
+    | exn ->
+        traceWarnfn "Loading custom attributes failed for %s.%sMessage: %s" fileName Environment.NewLine exn.Message
         assembly.GetCustomAttributes(false)
-
 
 let (|Valid|Invalid|) md = 
     match md with

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -52,13 +52,13 @@ let Pack(dependencies : DependenciesFile, packageOutputPath, buildConfig, versio
                     match md with
                     | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, opt) }
                     | _ ->
-                        let assembly,id = loadAssemblyId buildConfig projectFile
+                        let assembly,id,assemblyFileName = loadAssemblyId buildConfig projectFile
                         let md = { md with Id = md.Id ++ Some id }
 
                         match md with
                         | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, opt) }
                         | _ ->
-                            let attribs = loadAssemblyAttributes assembly
+                            let attribs = loadAssemblyAttributes assemblyFileName assembly
 
                             let merged = 
                                 { Id = md.Id

--- a/tests/Paket.Tests/PackageProcessSpecs.fs
+++ b/tests/Paket.Tests/PackageProcessSpecs.fs
@@ -41,10 +41,10 @@ let ``Loading assembly metadata works``() =
         if workingDir.Contains "Debug" then "Debug"
         else "Release"
 
-    let assembly,id = PackageMetaData.loadAssemblyId config projFile.Value
+    let assembly,id,fileName = PackageMetaData.loadAssemblyId config projFile.Value
     id |> shouldEqual "Paket.Tests"
     
-    let attribs = PackageMetaData.loadAssemblyAttributes assembly
+    let attribs = PackageMetaData.loadAssemblyAttributes fileName assembly
     PackageMetaData.getVersion assembly attribs |> shouldEqual <| Some(SemVer.Parse "1.0.0.0")
     PackageMetaData.getAuthors attribs |> shouldEqual <| Some([ "Two"; "Authors" ])
     PackageMetaData.getDescription attribs |> shouldEqual <| Some("A description")


### PR DESCRIPTION
I'm not completely sure why we loaded the assembly via bytes. IIRC there was a bug with loadfrom. I now work around the bug in #827 via reloading if needed.