### PR TITLE
Observable.OfAsync now fires OnCompleted

### DIFF
--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -399,22 +399,28 @@ module ObservableExtensions =
             evt.Publish |> guard (fun o ->
                 for n in s do evt.Trigger(n))
 
-        let ofAsync a: IObservable<'a> =
-            { new IObservable<'a> with 
-                member __.Subscribe obs =
-                    let token = new CancellationTokenSource()
-                    Async.StartWithContinuations(a, obs.OnNext, obs.OnError, obs.OnError, token.Token)
-                    { new IDisposable with
-                        member __.Dispose() = 
-                            token.Cancel |> ignore
-                            token.Dispose() }}
-    
-        let ofAsyncWithToken (token:CancellationToken) a: IObservable<'a> =
-            { new IObservable<'a> with 
-                member __.Subscribe obs =
-                    Async.StartWithContinuations(a, obs.OnNext, obs.OnError, obs.OnError, token)
-                    { new IDisposable with
-                        member __.Dispose() = () }}
+        let private oneAndDone (obs : IObserver<_>) value =
+            obs.OnNext value
+            obs.OnCompleted() 
+
+        let ofAsync a : IObservable<'a> = 
+            { new IObservable<'a> with
+                  member __.Subscribe obs = 
+                      let oneAndDone' = oneAndDone obs
+                      let token = new CancellationTokenSource()
+                      Async.StartWithContinuations(a,oneAndDone',obs.OnError,obs.OnError,token.Token)
+                      { new IDisposable with
+                            member __.Dispose() = 
+                                token.Cancel |> ignore
+                                token.Dispose() } }
+        
+        let ofAsyncWithToken (token : CancellationToken) a : IObservable<'a> = 
+            { new IObservable<'a> with
+                  member __.Subscribe obs = 
+                      let oneAndDone' = oneAndDone obs
+                      Async.StartWithContinuations(a,oneAndDone',obs.OnError,obs.OnError,token)
+                      { new IDisposable with
+                            member __.Dispose() = () } }
 
         let flatten (a: IObservable<#seq<'a>>): IObservable<'a> =
             { new IObservable<'a> with


### PR DESCRIPTION
The ``Observable.OfAsync`` operations never fired the OnCompleted event of the observer.  This could cause issues where Observers are waiting for Async events to finish. This change fixes that.  