### PR TITLE
Pull request/refactor update process

### DIFF
--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -33,7 +33,7 @@ let private add installToProjects addToProjectsF dependenciesFileName package ve
 
         if installAfter then
             let sources = dependenciesFile.GetAllPackageSources()
-            InstallProcess.Install(sources, options, lockFile)
+            InstallProcess.Install(sources, { SmartInstallOptions.Default with Common = options }, lockFile)
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, package, version, options : InstallerOptions, projectName, installAfter) =

--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -33,7 +33,7 @@ let private add installToProjects addToProjectsF dependenciesFileName package ve
 
         if installAfter then
             let sources = dependenciesFile.GetAllPackageSources()
-            InstallProcess.Install(sources, force, hard, false, lockFile)
+            InstallProcess.Install(sources, { CommonOptions.Default with Force = force; Hard = hard; Redirects = false }, lockFile)
 
 // add a package with the option to add it to a specified project
 let AddToProject(dependenciesFileName, package, version, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -17,19 +17,18 @@ let private addToProject (project : ProjectFile) package =
 let private add installToProjects addToProjectsF dependenciesFileName package version options installAfter =
     let existingDependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
     let (PackageName name) = package
-    if (not installToProjects) && existingDependenciesFile.HasPackage package && String.IsNullOrWhiteSpace version then 
+    if (not installToProjects) && existingDependenciesFile.HasPackage package && String.IsNullOrWhiteSpace version then
         traceWarnfn "%s contains package %s already." dependenciesFileName name
     else
         let dependenciesFile =
             existingDependenciesFile
                 .Add(package,version)
-    
 
         let lockFile = UpdateProcess.SelectiveUpdate(dependenciesFile, Some(NormalizedPackageName package), options.Force)
         let projects = seq { for p in ProjectFile.FindAllProjects(Path.GetDirectoryName lockFile.FileName) -> p } // lazy sequence in case no project install required
 
         dependenciesFile.Save()
-    
+
         package |> addToProjectsF projects
 
         if installAfter then
@@ -38,8 +37,8 @@ let private add installToProjects addToProjectsF dependenciesFileName package ve
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, package, version, options : CommonOptions, projectName, installAfter) =
-    
-    let addToSpecifiedProject (projects : ProjectFile seq) package =    
+
+    let addToSpecifiedProject (projects : ProjectFile seq) package =
         match ProjectFile.TryFindProject(projects,projectName) with
         | Some p ->
             if package |> notInstalled p then
@@ -49,11 +48,11 @@ let AddToProject(dependenciesFileName, package, version, options : CommonOptions
             traceErrorfn "Could not install package in specified project %s. Project not found" projectName
 
     add true addToSpecifiedProject dependenciesFileName package version options installAfter
-    
+
 // Add a package with the option to interactively add it to multiple projects.
 let Add(dependenciesFileName, package, version, options : CommonOptions, interactive, installAfter) =
-   
-    let addToProjects (projects : ProjectFile seq) package = 
+
+    let addToProjects (projects : ProjectFile seq) package =
         if interactive then
             for project in projects do
                 if package |> notInstalled project && Utils.askYesNo(sprintf "  Install to %s?" project.Name) then

--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -36,7 +36,7 @@ let private add installToProjects addToProjectsF dependenciesFileName package ve
             InstallProcess.Install(sources, options, lockFile)
 
 // Add a package with the option to add it to a specified project.
-let AddToProject(dependenciesFileName, package, version, options : CommonOptions, projectName, installAfter) =
+let AddToProject(dependenciesFileName, package, version, options : InstallerOptions, projectName, installAfter) =
 
     let addToSpecifiedProject (projects : ProjectFile seq) package =
         match ProjectFile.TryFindProject(projects,projectName) with
@@ -50,7 +50,7 @@ let AddToProject(dependenciesFileName, package, version, options : CommonOptions
     add true addToSpecifiedProject dependenciesFileName package version options installAfter
 
 // Add a package with the option to interactively add it to multiple projects.
-let Add(dependenciesFileName, package, version, options : CommonOptions, interactive, installAfter) =
+let Add(dependenciesFileName, package, version, options : InstallerOptions, interactive, installAfter) =
 
     let addToProjects (projects : ProjectFile seq) package =
         if interactive then

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -276,7 +276,7 @@ let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile
         applyBindingRedirects root extractedPackages
 
 /// Installs all packages from the lock file.
-let InstallNew(sources, options : CommonOptions, lockFile:LockFile) =
+let Install(sources, options : CommonOptions, lockFile : LockFile) =
     let root = FileInfo(lockFile.FileName).Directory.FullName
     let projects = findAllReferencesFiles root |> returnOrFail
     InstallIntoProjectsNew(sources, options, lockFile, projects)
@@ -284,7 +284,3 @@ let InstallNew(sources, options : CommonOptions, lockFile:LockFile) =
 /// Installs all packages from the lock file (compatibility version).
 let InstallIntoProjects(sources, force, hard, withBindingRedirects, lockFile : LockFile, projects) =
     InstallIntoProjectsNew(sources, CommonOptions.createLegacyOptions(force, hard, withBindingRedirects), lockFile, projects)
-
-/// Installs all packages from the lock file (compatibility version).
-let Install(sources, force, hard, withBindingRedirects, lockFile:LockFile) =
-    InstallNew(sources, CommonOptions.createLegacyOptions(force, hard, withBindingRedirects), lockFile)

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -23,17 +23,17 @@ let findPackageFolder root (PackageName name) =
     | Some x -> x
     | None -> failwithf "Package directory for package %s was not found." name
 
-let private findPackagesWithContent (root,usedPackages:Map<PackageName,PackageInstallSettings>) = 
+let private findPackagesWithContent (root,usedPackages:Map<PackageName,PackageInstallSettings>) =
     usedPackages
     |> Seq.filter (fun kv -> defaultArg kv.Value.Settings.OmitContent false |> not)
     |> Seq.map (fun kv -> findPackageFolder root kv.Key)
-    |> Seq.choose (fun packageDir -> 
-            packageDir.GetDirectories("Content") 
+    |> Seq.choose (fun packageDir ->
+            packageDir.GetDirectories("Content")
             |> Array.append (packageDir.GetDirectories("content"))
             |> Array.tryFind (fun _ -> true))
     |> Seq.toList
 
-let private copyContentFiles (project : ProjectFile, packagesWithContent) = 
+let private copyContentFiles (project : ProjectFile, packagesWithContent) =
 
     let rules : list<(FileInfo -> bool)> = [
             fun f -> f.Name = "_._"
@@ -49,7 +49,7 @@ let private copyContentFiles (project : ProjectFile, packagesWithContent) =
         fromDir.GetDirectories() |> Array.toList
         |> List.collect (fun subDir -> copyDirContents(subDir, lazy toDir.Force().CreateSubdirectory(subDir.Name)))
         |> List.append
-            (fromDir.GetFiles() 
+            (fromDir.GetFiles()
                 |> Array.toList
                 |> List.filter (onBlackList >> not)
                 |> List.map (fun file -> file.CopyTo(Path.Combine(toDir.Force().FullName, file.Name), true)))
@@ -64,28 +64,28 @@ let private removeCopiedFiles (project: ProjectFile) =
             removeEmptyDirHierarchy dir.Parent
 
     let removeFilesAndTrimDirs (files: FileInfo list) =
-        for f in files do 
-            if f.Exists then 
+        for f in files do
+            if f.Exists then
                 f.Delete()
 
-        let dirsPathsDeepestFirst = 
+        let dirsPathsDeepestFirst =
             files
             |> Seq.map (fun f -> f.Directory.FullName)
             |> Seq.distinct
             |> List.ofSeq
             |> List.rev
-        
+
         for dirPath in dirsPathsDeepestFirst do
             removeEmptyDirHierarchy (DirectoryInfo dirPath)
 
-    project.GetPaketFileItems() 
+    project.GetPaketFileItems()
     |> List.filter (fun fi -> not <| fi.FullName.Contains(Constants.PaketFilesFolderName))
     |> removeFilesAndTrimDirs
 
-let CreateInstallModel(root, sources, force, package) = 
-    async { 
+let CreateInstallModel(root, sources, force, package) =
+    async {
         let! (package, files, targetsFiles) = RestoreProcess.ExtractPackage(root, sources, force, package)
-        let (PackageName name) = package.Name        
+        let (PackageName name) = package.Name
         let nuspec = Nuspec.Load(root,package.Name)
         let files = files |> Array.map (fun fi -> fi.FullName)
         let targetsFiles = targetsFiles |> Array.map (fun fi -> fi.FullName)
@@ -93,10 +93,10 @@ let CreateInstallModel(root, sources, force, package) =
     }
 
 /// Restores the given packages from the lock file.
-let createModel(root, sources,force, lockFile:LockFile) = 
+let createModel(root, sources, force, lockFile : LockFile) =
     let sourceFileDownloads = RemoteDownload.DownloadSourceFiles(root, lockFile.SourceFiles)
-        
-    let packageDownloads = 
+
+    let packageDownloads =
         lockFile.ResolvedPackages
         |> Seq.map (fun kv -> CreateInstallModel(root,sources,force,kv.Value))
         |> Async.Parallel
@@ -139,17 +139,17 @@ let findAllReferencesFiles root =
     |> ProjectFile.FindAllProjects
     |> Array.choose (fun p -> ProjectFile.FindReferencesFile(FileInfo(p.FileName))
                                 |> Option.map (fun r -> p, r))
-    |> Array.map (fun (project,file) -> 
-        try 
+    |> Array.map (fun (project,file) ->
+        try
             ok <| (project, ReferencesFile.FromFile(file))
-        with _ -> 
+        with _ ->
             fail <| ReferencesFileParseError (FileInfo(file)))
     |> collect
 
 /// Installs all packages from the lock file.
 let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile, projects) =
     let root = Path.GetDirectoryName lockFile.FileName
-    let extractedPackages = createModel(root,sources,force, lockFile)
+    let extractedPackages = createModel(root, sources, options.Force, lockFile)
 
     let model =
         extractedPackages
@@ -161,29 +161,29 @@ let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile
         |> Array.map (fun (p,m) -> NormalizedPackageName p.Name,p)
         |> Map.ofArray
 
-    for project : ProjectFile, referenceFile in projects do    
+    for project : ProjectFile, referenceFile in projects do
         verbosefn "Installing to %s" project.FileName
-        
+
         let usedPackages =
             lockFile.GetPackageHull(referenceFile)
-            |> Seq.map (fun u -> 
+            |> Seq.map (fun u ->
                 let package = packages.[NormalizedPackageName u.Key]
-                let referenceFileSettings = 
+                let referenceFileSettings =
                     referenceFile.NugetPackages
                     |> List.tryFind (fun x -> NormalizedPackageName x.Name = NormalizedPackageName u.Key)
-                let copyLocal =                
+                let copyLocal =
                     match referenceFileSettings with
                     | Some s -> s.Settings.CopyLocal
                     | None -> None
-                let omitContent =                
+                let omitContent =
                     match referenceFileSettings with
                     | Some s -> s.Settings.OmitContent
                     | None -> None
-                let importTargets =                
+                let importTargets =
                     match referenceFileSettings with
                     | Some s -> s.Settings.ImportTargets
                     | None -> None
-                let restriktions =                
+                let restriktions =
                     match referenceFileSettings with
                     | Some s -> s.Settings.FrameworkRestrictions
                     | None -> []
@@ -192,12 +192,12 @@ let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile
                 u.Key,
                     { u.Value with
                         Settings =
-                            { u.Value.Settings with 
-                                FrameworkRestrictions = 
+                            { u.Value.Settings with
+                                FrameworkRestrictions =
                                     // TODO: This should filter
                                     restriktions @
-                                      u.Value.Settings.FrameworkRestrictions @ 
-                                      lockFile.Options.Settings.FrameworkRestrictions @ 
+                                      u.Value.Settings.FrameworkRestrictions @
+                                      lockFile.Options.Settings.FrameworkRestrictions @
                                       package.Settings.FrameworkRestrictions
 
                                 ImportTargets =
@@ -245,7 +245,7 @@ let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile
 
         removeCopiedFiles project
 
-        let getSingleRemoteFilePath name = 
+        let getSingleRemoteFilePath name =
             traceVerbose <| sprintf "Filename %s " name
             lockFile.SourceFiles |> List.iter (fun i -> traceVerbose <| sprintf " %s %s " i.Name (i.FilePath root))
             let sourceFile = lockFile.SourceFiles |> List.tryFind (fun f -> Path.GetFileName(f.Name) = name)
@@ -255,15 +255,15 @@ let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile
 
         let gitRemoteItems =
             referenceFile.RemoteFiles
-            |> List.map (fun file -> 
-                             { BuildAction = project.DetermineBuildAction file.Name 
+            |> List.map (fun file ->
+                             { BuildAction = project.DetermineBuildAction file.Name
                                Include = createRelativePath project.FileName (getSingleRemoteFilePath file.Name)
                                Link = Some(if file.Link = "." then Path.GetFileName(file.Name)
                                            else Path.Combine(file.Link, Path.GetFileName(file.Name))) })
-        
+
         let nuGetFileItems =
             copyContentFiles(project, findPackagesWithContent(root,usedPackages))
-            |> List.map (fun file -> 
+            |> List.map (fun file ->
                                 { BuildAction = project.DetermineBuildAction file.Name
                                   Include = createRelativePath project.FileName file.FullName
                                   Link = None })

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -147,7 +147,7 @@ let findAllReferencesFiles root =
     |> collect
 
 /// Installs all packages from the lock file.
-let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile, projects) =
+let InstallIntoProjects(sources, options : CommonOptions, lockFile : LockFile, projects) =
     let root = Path.GetDirectoryName lockFile.FileName
     let extractedPackages = createModel(root, sources, options.Force, lockFile)
 
@@ -279,8 +279,4 @@ let InstallIntoProjectsNew(sources, options : CommonOptions, lockFile : LockFile
 let Install(sources, options : CommonOptions, lockFile : LockFile) =
     let root = FileInfo(lockFile.FileName).Directory.FullName
     let projects = findAllReferencesFiles root |> returnOrFail
-    InstallIntoProjectsNew(sources, options, lockFile, projects)
-
-/// Installs all packages from the lock file (compatibility version).
-let InstallIntoProjects(sources, force, hard, withBindingRedirects, lockFile : LockFile, projects) =
-    InstallIntoProjectsNew(sources, CommonOptions.createLegacyOptions(force, hard, withBindingRedirects), lockFile, projects)
+    InstallIntoProjects(sources, options, lockFile, projects)

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -147,7 +147,7 @@ let findAllReferencesFiles root =
     |> collect
 
 /// Installs all packages from the lock file.
-let InstallIntoProjects(sources, options : CommonOptions, lockFile : LockFile, projects) =
+let InstallIntoProjects(sources, options : InstallerOptions, lockFile : LockFile, projects) =
     let root = Path.GetDirectoryName lockFile.FileName
     let extractedPackages = createModel(root, sources, options.Force, lockFile)
 
@@ -276,7 +276,7 @@ let InstallIntoProjects(sources, options : CommonOptions, lockFile : LockFile, p
         applyBindingRedirects root extractedPackages
 
 /// Installs all packages from the lock file.
-let Install(sources, options : CommonOptions, lockFile : LockFile) =
+let Install(sources, options : InstallerOptions, lockFile : LockFile) =
     let root = FileInfo(lockFile.FileName).Directory.FullName
     let projects = findAllReferencesFiles root |> returnOrFail
     InstallIntoProjects(sources, options, lockFile, projects)

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -405,4 +405,6 @@ let replaceNugetWithPaket initAutoRestore installAfter result =
         VSIntegration.TurnOnAutoRestore result.PaketEnv |> returnOrFail
 
     if installAfter then
-        UpdateProcess.Update(result.PaketEnv.DependenciesFile.FileName,true,true,true)
+        UpdateProcess.Update(
+            result.PaketEnv.DependenciesFile.FileName,
+            { CommonOptions.Default with Force = true; Hard = true; Redirects = true })

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -407,4 +407,4 @@ let replaceNugetWithPaket initAutoRestore installAfter result =
     if installAfter then
         UpdateProcess.Update(
             result.PaketEnv.DependenciesFile.FileName,
-            { CommonOptions.Default with Force = true; Hard = true; Redirects = true })
+            { InstallerOptions.Default with Force = true; Hard = true; Redirects = true })

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -109,6 +109,7 @@
     <Compile Include="BindingRedirects.fs" />
     <Compile Include="TemplateFile.fs" />
     <Compile Include="NupkgWriter.fs" />
+    <Compile Include="ProcessOptions.fs" />
     <Compile Include="InstallProcess.fs" />
     <Compile Include="UpdateProcess.fs" />
     <Compile Include="RemoveProcess.fs" />

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -20,3 +20,11 @@ type InstallerOptions =
             Force = force
             Hard = hard
             Redirects = redirects }
+
+type SmartInstallOptions =
+    { Common : InstallerOptions
+      OnlyReferenced : bool }
+
+    static member Default =
+        { Common = InstallerOptions.Default
+          OnlyReferenced = false }

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -5,7 +5,7 @@ namespace Paket
 /// Hard      - Replace package references within project files even if they are not yet adhering
 ///             to the Paket's conventions (and hence considered manually managed)
 /// Redirects - Create binding redirects for the NuGet packages
-type CommonOptions =
+type InstallerOptions =
     { Force : bool
       Hard : bool
       Redirects : bool }
@@ -16,7 +16,7 @@ type CommonOptions =
           Redirects = false }
 
     static member createLegacyOptions(force, hard, redirects) =
-        { CommonOptions.Default with
+        { InstallerOptions.Default with
             Force = force
             Hard = hard
             Redirects = redirects }

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -1,0 +1,22 @@
+namespace Paket
+
+// Options for UpdateProcess and InstallProcess.
+/// Force     - Force the download and reinstallation of all packages
+/// Hard      - Replace package references within project files even if they are not yet adhering
+///             to the Paket's conventions (and hence considered manually managed)
+/// Redirects - Create binding redirects for the NuGet packages
+type CommonOptions =
+    { Force : bool
+      Hard : bool
+      Redirects : bool }
+
+    static member Default =
+        { Force = false
+          Hard = false
+          Redirects = false }
+
+    static member createLegacyOptions(force, hard, redirects) =
+        { CommonOptions.Default with
+            Force = force
+            Hard = hard
+            Redirects = redirects }

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -151,13 +151,14 @@ type Dependencies(dependenciesFileName: string) =
             fun () -> UpdateProcess.Update(dependenciesFileName,force,hard,withBindingRedirects))
 
     /// Updates all dependencies.
-    member this.Update(force: bool,hard: bool): unit = this.Update(force,hard,false)
+    member this.Update(force: bool, hard: bool): unit = this.Update(force, hard, false)
 
     /// Updates the given package.
-    member this.UpdatePackage(package: string,version: string option,force: bool,hard: bool): unit =
+    member this.UpdatePackage(package: string, version: string option, force: bool, hard: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> UpdateProcess.UpdatePackage(dependenciesFileName,PackageName package,version,force,hard,false))
+            fun () -> UpdateProcess.UpdatePackage(dependenciesFileName, PackageName package, version,
+                                                  CommonOptions.createLegacyOptions(force, hard, false)))
 
     /// Restores all dependencies.
     member this.Restore(): unit = this.Restore(false,[])

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -105,22 +105,31 @@ type Dependencies(dependenciesFileName: string) =
     member this.Add(package: string): unit = this.Add(package,"")
 
     /// Adds the given package with the given version to the dependencies file.
-    member this.Add(package: string,version: string): unit = this.Add(package, version, false, false, false, true)
+    member this.Add(package: string,version: string): unit =
+        this.Add(package, version, force = false, hard = false, redirects = false, interactive = false, installAfter = true)
 
     /// Adds the given package with the given version to the dependencies file.
     member this.Add(package: string,version: string,force: bool,hard: bool,interactive: bool,installAfter: bool): unit =
+        this.Add(package, version, force, hard, false, interactive, installAfter)
+
+    /// Adds the given package with the given version to the dependencies file.
+    member this.Add(package: string,version: string,force: bool,hard: bool,redirects: bool,interactive: bool,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.Add(dependenciesFileName, PackageName(package.Trim()), version,
-                                     InstallerOptions.createLegacyOptions(force, hard, false),
+                                     InstallerOptions.createLegacyOptions(force, hard, redirects),
                                      interactive, installAfter))
 
     /// Adds the given package with the given version to the dependencies file.
     member this.AddToProject(package: string,version: string,force: bool,hard: bool,projectName: string,installAfter: bool): unit =
+        this.AddToProject(package, version, force, hard, false, projectName, installAfter)
+
+   /// Adds the given package with the given version to the dependencies file.
+    member this.AddToProject(package: string,version: string,force: bool,hard: bool,redirects: bool,projectName: string,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.AddToProject(dependenciesFileName, PackageName package, version,
-                                              InstallerOptions.createLegacyOptions(force, hard, false),
+                                              InstallerOptions.createLegacyOptions(force, hard, redirects),
                                               projectName, installAfter))
 
     /// Adds credentials for a Nuget feed

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -110,13 +110,17 @@ type Dependencies(dependenciesFileName: string) =
     member this.Add(package: string,version: string,force: bool,hard: bool,interactive: bool,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> AddProcess.Add(dependenciesFileName, PackageName(package.Trim()), version, force, hard, interactive, installAfter))
+            fun () -> AddProcess.Add(dependenciesFileName, PackageName(package.Trim()), version,
+                                     CommonOptions.createLegacyOptions(force, hard, false),
+                                     interactive, installAfter))
 
     /// Adds the given package with the given version to the dependencies file.
     member this.AddToProject(package: string,version: string,force: bool,hard: bool,projectName: string,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> AddProcess.AddToProject(dependenciesFileName, PackageName package, version, force, hard, projectName, installAfter))
+            fun () -> AddProcess.AddToProject(dependenciesFileName, PackageName package, version,
+                                              CommonOptions.createLegacyOptions(force, hard, false),
+                                              projectName, installAfter))
       
     /// Adds credentials for a Nuget feed
     member this.AddCredentials(source: string, username: string) : unit =

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -148,7 +148,7 @@ type Dependencies(dependenciesFileName: string) =
     member this.Update(force: bool,hard: bool,withBindingRedirects:bool): unit = 
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> UpdateProcess.Update(dependenciesFileName,force,hard,withBindingRedirects))
+            fun () -> UpdateProcess.Update(dependenciesFileName, CommonOptions.createLegacyOptions(force, hard, withBindingRedirects)))
 
     /// Updates all dependencies.
     member this.Update(force: bool, hard: bool): unit = this.Update(force, hard, false)

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -111,7 +111,7 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.Add(dependenciesFileName, PackageName(package.Trim()), version,
-                                     CommonOptions.createLegacyOptions(force, hard, false),
+                                     InstallerOptions.createLegacyOptions(force, hard, false),
                                      interactive, installAfter))
 
     /// Adds the given package with the given version to the dependencies file.
@@ -119,7 +119,7 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.AddToProject(dependenciesFileName, PackageName package, version,
-                                              CommonOptions.createLegacyOptions(force, hard, false),
+                                              InstallerOptions.createLegacyOptions(force, hard, false),
                                               projectName, installAfter))
       
     /// Adds credentials for a Nuget feed
@@ -132,7 +132,7 @@ type Dependencies(dependenciesFileName: string) =
     member this.Install(force: bool, hard: bool, withBindingRedirects:bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> UpdateProcess.SmartInstall(dependenciesFileName, None, CommonOptions.createLegacyOptions(force,hard,withBindingRedirects)))
+            fun () -> UpdateProcess.SmartInstall(dependenciesFileName, None, InstallerOptions.createLegacyOptions(force,hard,withBindingRedirects)))
 
     /// Creates a paket.dependencies file with the given text in the current directory and installs it.
     static member Install(dependencies, ?path: string, ?force, ?hard, ?withBindingRedirects) = 
@@ -152,7 +152,7 @@ type Dependencies(dependenciesFileName: string) =
     member this.Update(force: bool,hard: bool,withBindingRedirects:bool): unit = 
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> UpdateProcess.Update(dependenciesFileName, CommonOptions.createLegacyOptions(force, hard, withBindingRedirects)))
+            fun () -> UpdateProcess.Update(dependenciesFileName, InstallerOptions.createLegacyOptions(force, hard, withBindingRedirects)))
 
     /// Updates all dependencies.
     member this.Update(force: bool, hard: bool): unit = this.Update(force, hard, false)
@@ -162,7 +162,7 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> UpdateProcess.UpdatePackage(dependenciesFileName, PackageName package, version,
-                                                  CommonOptions.createLegacyOptions(force, hard, false)))
+                                                  InstallerOptions.createLegacyOptions(force, hard, false)))
 
     /// Restores all dependencies.
     member this.Restore(): unit = this.Restore(false,[])

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -123,12 +123,12 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> ConfigFile.askAndAddAuth source username |> returnOrFail )
-        
+
     /// Installs all dependencies.
-    member this.Install(force: bool,hard: bool,withBindingRedirects:bool): unit = 
+    member this.Install(force: bool, hard: bool, withBindingRedirects:bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> UpdateProcess.SmartInstall(dependenciesFileName,None,force,hard,withBindingRedirects))
+            fun () -> UpdateProcess.SmartInstall(dependenciesFileName, None, CommonOptions.createLegacyOptions(force,hard,withBindingRedirects)))
 
     /// Creates a paket.dependencies file with the given text in the current directory and installs it.
     static member Install(dependencies, ?path: string, ?force, ?hard, ?withBindingRedirects) = 

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -46,7 +46,7 @@ let private remove removeFromProjects dependenciesFileName (package: PackageName
     
     if installAfter then
         let sources = DependenciesFile.ReadFromFile(dependenciesFileName).GetAllPackageSources()
-        InstallProcess.Install(sources, force, hard, false, lockFile)
+        InstallProcess.Install(sources, { CommonOptions.Default with Force = force; Hard = hard; Redirects = false }, lockFile)
 
 // remove a package with the option to remove it from a specified project
 let RemoveFromProject(dependenciesFileName, package:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -46,7 +46,7 @@ let private remove removeFromProjects dependenciesFileName (package: PackageName
     
     if installAfter then
         let sources = DependenciesFile.ReadFromFile(dependenciesFileName).GetAllPackageSources()
-        InstallProcess.Install(sources, { CommonOptions.Default with Force = force; Hard = hard; Redirects = false }, lockFile)
+        InstallProcess.Install(sources, { InstallerOptions.Default with Force = force; Hard = hard; Redirects = false }, lockFile)
 
 // remove a package with the option to remove it from a specified project
 let RemoveFromProject(dependenciesFileName, package:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -46,7 +46,7 @@ let private remove removeFromProjects dependenciesFileName (package: PackageName
     
     if installAfter then
         let sources = DependenciesFile.ReadFromFile(dependenciesFileName).GetAllPackageSources()
-        InstallProcess.Install(sources, { InstallerOptions.Default with Force = force; Hard = hard; Redirects = false }, lockFile)
+        InstallProcess.Install(sources, { SmartInstallOptions.Default with Common = { InstallerOptions.Default with Force = force; Hard = hard; Redirects = false }}, lockFile )
 
 // remove a package with the option to remove it from a specified project
 let RemoveFromProject(dependenciesFileName, package:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -67,7 +67,7 @@ let SelectiveUpdate(dependenciesFile : DependenciesFile, exclude, force) =
     LockFile.Create(lockFileName.FullName, dependenciesFile.Options, resolution.ResolvedPackages, resolution.ResolvedSourceFiles)
 
 /// Smart install command
-let SmartInstall(dependenciesFileName, exclude, options : CommonOptions) =
+let SmartInstall(dependenciesFileName, exclude, options : InstallerOptions) =
     let root = Path.GetDirectoryName dependenciesFileName
     let projects = InstallProcess.findAllReferencesFiles root |> returnOrFail
     let dependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
@@ -81,7 +81,7 @@ let SmartInstall(dependenciesFileName, exclude, options : CommonOptions) =
         projects)
 
 /// Update a single package command
-let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, options : CommonOptions) =
+let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, options : InstallerOptions) =
     match newVersion with
     | Some v ->
         DependenciesFile.ReadFromFile(dependenciesFileName)
@@ -92,7 +92,7 @@ let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, o
     SmartInstall(dependenciesFileName, Some(NormalizedPackageName packageName), options)
 
 /// Update command
-let Update(dependenciesFileName, options : CommonOptions) =
+let Update(dependenciesFileName, options : InstallerOptions) =
     let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
     if lockFileName.Exists then lockFileName.Delete()
     SmartInstall(dependenciesFileName, None, options)

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -92,12 +92,7 @@ let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, o
     SmartInstall(dependenciesFileName, Some(NormalizedPackageName packageName), options)
 
 /// Update command
-let UpdateNew(dependenciesFileName, options : CommonOptions) =
+let Update(dependenciesFileName, options : CommonOptions) =
     let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
     if lockFileName.Exists then lockFileName.Delete()
     SmartInstall(dependenciesFileName, None, options)
-
-/// Update command (compatibility version)
-let Update(dependenciesFileName, force, hard, withBindingRedirects) =
-    let options = CommonOptions.createLegacyOptions(force, hard, withBindingRedirects)
-    UpdateNew(dependenciesFileName, options)

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -74,11 +74,9 @@ let SmartInstallNew(dependenciesFileName, exclude, options : CommonOptions) =
 
     let lockFile = SelectiveUpdate(dependenciesFile,exclude,options.Force)
 
-    InstallProcess.InstallIntoProjects(
+    InstallProcess.InstallIntoProjectsNew(
         dependenciesFile.GetAllPackageSources(),
-        options.Force,
-        options.Hard,
-        options.Redirects,
+        options,
         lockFile,
         projects)
 

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -67,7 +67,7 @@ let SelectiveUpdate(dependenciesFile : DependenciesFile, exclude, force) =
     LockFile.Create(lockFileName.FullName, dependenciesFile.Options, resolution.ResolvedPackages, resolution.ResolvedSourceFiles)
 
 /// Smart install command
-let SmartInstallNew(dependenciesFileName, exclude, options : CommonOptions) =
+let SmartInstall(dependenciesFileName, exclude, options : CommonOptions) =
     let root = Path.GetDirectoryName dependenciesFileName
     let projects = InstallProcess.findAllReferencesFiles root |> returnOrFail
     let dependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
@@ -89,18 +89,13 @@ let UpdatePackageNew(dependenciesFileName, packageName : PackageName, newVersion
             .Save()
     | None -> tracefn "Updating %s in %s" (packageName.ToString()) dependenciesFileName
 
-    SmartInstallNew(dependenciesFileName, Some(NormalizedPackageName packageName), options)
+    SmartInstall(dependenciesFileName, Some(NormalizedPackageName packageName), options)
 
 /// Update command
 let UpdateNew(dependenciesFileName, options : CommonOptions) =
     let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
     if lockFileName.Exists then lockFileName.Delete()
-    SmartInstallNew(dependenciesFileName, None, options)
-
-/// Smart install command (compatibility version)
-let SmartInstall(dependenciesFileName, exclude, force, hard, withBindingRedirects) =
-    let options = CommonOptions.createLegacyOptions(force, hard, withBindingRedirects)
-    SmartInstallNew(dependenciesFileName, exclude, options)
+    SmartInstall(dependenciesFileName, None, options)
 
 /// Update a single package command (compatibility version)
 let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, force : bool, hard : bool, withBindingRedirects : bool) =

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -9,20 +9,20 @@ open System.Collections.Generic
 open Chessie.ErrorHandling
 open Paket.Logging
 
-let addPackagesFromReferenceFiles projects (dependenciesFile:DependenciesFile) =
+let addPackagesFromReferenceFiles projects (dependenciesFile : DependenciesFile) =
     let lockFileName = DependenciesFile.FindLockfile dependenciesFile.FileName
     let oldLockFile =
-        if lockFileName.Exists then 
+        if lockFileName.Exists then
             LockFile.LoadFrom(lockFileName.FullName)
         else
             LockFile.Create(lockFileName.FullName, dependenciesFile.Options, Resolution.Ok(Map.empty), [])
-            
+
     let allExistingPackages =
         oldLockFile.ResolvedPackages
         |> Seq.map (fun d -> NormalizedPackageName d.Value.Name)
         |> Set.ofSeq
 
-    let allReferencedPackages = 
+    let allReferencedPackages =
         projects
         |> Seq.collect (fun (_,referencesFile) -> referencesFile.NugetPackages)
 
@@ -33,24 +33,24 @@ let addPackagesFromReferenceFiles projects (dependenciesFile:DependenciesFile) =
             |> allExistingPackages.Contains
             |> not)
 
-    if Seq.isEmpty diff then 
+    if Seq.isEmpty diff then
         dependenciesFile
     else
         let newDependenciesFile =
             diff
-            |> Seq.fold (fun (dependenciesFile:DependenciesFile) dep -> 
-                if dependenciesFile.HasPackage dep.Name then 
+            |> Seq.fold (fun (dependenciesFile:DependenciesFile) dep ->
+                if dependenciesFile.HasPackage dep.Name then
                     dependenciesFile
                 else
                     dependenciesFile.AddAdditionalPackage(dep.Name,"",dep.Settings)) dependenciesFile
         newDependenciesFile.Save()
         newDependenciesFile
 
-let SelectiveUpdate(dependenciesFile:DependenciesFile, exclude, force) =
+let SelectiveUpdate(dependenciesFile : DependenciesFile, exclude, force) =
     let lockFileName = DependenciesFile.FindLockfile dependenciesFile.FileName
 
     let resolution =
-        if not lockFileName.Exists then 
+        if not lockFileName.Exists then
             dependenciesFile.Resolve(force)
         else
             let oldLockFile = LockFile.LoadFrom(lockFileName.FullName)

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -74,7 +74,7 @@ let SmartInstall(dependenciesFileName, exclude, options : CommonOptions) =
 
     let lockFile = SelectiveUpdate(dependenciesFile,exclude,options.Force)
 
-    InstallProcess.InstallIntoProjectsNew(
+    InstallProcess.InstallIntoProjects(
         dependenciesFile.GetAllPackageSources(),
         options,
         lockFile,

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -81,7 +81,7 @@ let SmartInstall(dependenciesFileName, exclude, options : CommonOptions) =
         projects)
 
 /// Update a single package command
-let UpdatePackageNew(dependenciesFileName, packageName : PackageName, newVersion, options : CommonOptions) =
+let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, options : CommonOptions) =
     match newVersion with
     | Some v ->
         DependenciesFile.ReadFromFile(dependenciesFileName)
@@ -96,10 +96,6 @@ let UpdateNew(dependenciesFileName, options : CommonOptions) =
     let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
     if lockFileName.Exists then lockFileName.Delete()
     SmartInstall(dependenciesFileName, None, options)
-
-/// Update a single package command (compatibility version)
-let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, force : bool, hard : bool, withBindingRedirects : bool) =
-    UpdatePackageNew(dependenciesFileName, packageName, newVersion, CommonOptions.createLegacyOptions(force, hard, withBindingRedirects))
 
 /// Update command (compatibility version)
 let Update(dependenciesFileName, force, hard, withBindingRedirects) =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -22,9 +22,9 @@ type Command =
     | [<First>][<CustomCommandLine("show-installed-packages")>] ShowInstalledPackages
     | [<First>][<CustomCommandLine("pack")>]                    Pack
     | [<First>][<CustomCommandLine("push")>]                    Push
-with 
+with
     interface IArgParserTemplate with
-        member this.Usage = 
+        member this.Usage =
             match this with
             | Add -> "Adds a new package to your paket.dependencies file."
             | Config -> "Allows to store global configuration values like NuGet credentials."
@@ -43,11 +43,11 @@ with
             | ShowInstalledPackages -> "EXPERIMENTAL: Shows all installed top-level packages."
             | Pack -> "Packs all paket.template files within this repository"
             | Push -> "Pushes all `.nupkg` files from the given directory."
-    
-    member this.Name = 
+
+    member this.Name =
         let uci,_ = Microsoft.FSharp.Reflection.FSharpValue.GetUnionFields(this, typeof<Command>)
-        (uci.GetCustomAttributes(typeof<CustomCommandLineAttribute>) 
-        |> Seq.head 
+        (uci.GetCustomAttributes(typeof<CustomCommandLineAttribute>)
+        |> Seq.head
         :?> CustomCommandLineAttribute).Name
 
 type GlobalArgs =
@@ -66,9 +66,9 @@ type AddArgs =
     | Hard
     | Redirects
     | No_Install
-with 
+with
     interface IArgParserTemplate with
-        member this.Usage = 
+        member this.Usage =
             match this with
             | Nuget(_) -> "Nuget package id."
             | Version(_) -> "Allows to specify version of the package."
@@ -79,11 +79,11 @@ with
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | No_Install -> "Skips paket install --hard process afterward generation of dependencies / references files."
 
-type ConfigArgs = 
+type ConfigArgs =
     | [<CustomCommandLine("add-credentials")>] AddCredentials of string
-with 
+with
     interface IArgParserTemplate with
-        member this.Usage = 
+        member this.Usage =
             match this with
             | AddCredentials(_) -> "Add credentials for the specified Nuget feed"
 
@@ -92,9 +92,9 @@ type ConvertFromNugetArgs =
     | No_Install
     | No_Auto_Restore
     | Creds_Migration of string
-with 
+with
     interface IArgParserTemplate with
-        member this.Usage = 
+        member this.Usage =
             match this with
             | Force -> "Forces the conversion, even if a paket.dependencies file or paket.references files are present."
             | No_Install -> "Skips paket install --hard process afterward generation of dependencies / references files."
@@ -103,24 +103,24 @@ with
 
 type FindRefsArgs =
     | [<Rest>][<CustomCommandLine("nuget")>][<Mandatory>] Packages of string
-with 
+with
     interface IArgParserTemplate with
-        member this.Usage = 
+        member this.Usage =
             match this with
             | Packages(_) -> "List of packages."
 
 type InitArgs =
     | [<Hidden>] NoArg
-with 
+with
     interface IArgParserTemplate with
         member __.Usage = ""
 
 type AutoRestoreArgs =
     | [<First>][<CustomCommandLine("on")>] On
     | [<First>][<CustomCommandLine("off")>] Off
-with 
+with
     interface IArgParserTemplate with
-        member this.Usage = 
+        member this.Usage =
             match this with
             | On -> "Turns auto restore on"
             | Off -> "Turns auto restore off"
@@ -130,19 +130,19 @@ type InstallArgs =
     | Hard
     | Redirects
     | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
-with 
+with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
             | Force -> "Forces the download and reinstallation of all packages."
-            | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."            
+            | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | Install_Only_Referenced -> "Only install packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
 
 type OutdatedArgs =
     | Ignore_Constraints
     | [<AltCommandLine("--pre")>] Include_Prereleases
-with 
+with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
@@ -156,7 +156,7 @@ type RemoveArgs =
     | [<AltCommandLine("-i")>] Interactive
     | Hard
     | No_Install
-with 
+with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
@@ -171,7 +171,7 @@ type RestoreArgs =
     | [<AltCommandLine("-f")>] Force
     | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
     | [<Rest>] References_Files of string
-with 
+with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
@@ -181,7 +181,7 @@ with
 
 type SimplifyArgs =
     | [<AltCommandLine("-i")>] Interactive
-with 
+with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
@@ -193,7 +193,7 @@ type UpdateArgs =
     | [<AltCommandLine("-f")>] Force
     | Hard
     | Redirects
-with 
+with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
@@ -273,7 +273,7 @@ with
             | ApiKey(_) -> "Optionally specify your API key on the command line. Otherwise uses the value of the `nugetkey` environment variable."
             | EndPoint(_) -> "Optionally specify a custom api endpoint to push to. Defaults to `/api/v2/package`"
 
-let cmdLineSyntax (parser:UnionArgParser<_>) commandName = 
+let cmdLineSyntax (parser:UnionArgParser<_>) commandName =
     "$ paket " + commandName + " " + parser.PrintCommandLineSyntax()
 
 let cmdLineUsageMessage (command : Command) parser =
@@ -285,20 +285,20 @@ let cmdLineUsageMessage (command : Command) parser =
         .AppendLine()
         .Append(cmdLineSyntax parser command.Name)
         .ToString()
-    
+
 let markdown (command : Command) (additionalText : string) =
-    let replace (pattern : string) (replacement : string) input = 
+    let replace (pattern : string) (replacement : string) input =
         System.Text.RegularExpressions.Regex.Replace(input, pattern, replacement)
-    
-    let syntaxAndOptions (parser : UnionArgParser<_>) = 
+
+    let syntaxAndOptions (parser : UnionArgParser<_>) =
         let options =
-            parser.Usage() 
+            parser.Usage()
             |> replace @"\s\t--help.*" ""
             |> replace @"\t([-\w \[\]|\/\?<>\.]+):" (System.Environment.NewLine + @"  `$1`:")
 
         let syntax = cmdLineSyntax parser command.Name
         syntax, options
-    
+
     let getSyntax = function
         | Add -> syntaxAndOptions (UnionArgParser.Create<AddArgs>())
         | Config -> syntaxAndOptions (UnionArgParser.Create<ConfigArgs>())
@@ -317,7 +317,7 @@ let markdown (command : Command) (additionalText : string) =
         | ShowInstalledPackages -> syntaxAndOptions (UnionArgParser.Create<ShowInstalledPackagesArgs>())
         | Pack -> syntaxAndOptions (UnionArgParser.Create<PackArgs>())
         | Push -> syntaxAndOptions (UnionArgParser.Create<PushArgs>())
-    
+
     let replaceLinks (text : string) =
         text
             .Replace("paket.dependencies file","[`paket.dependencies` file](dependencies-file.html)")
@@ -325,12 +325,12 @@ let markdown (command : Command) (additionalText : string) =
             .Replace("paket.template files","[`paket.template` files](template-files.html)")
             .Replace("paket.references files","[`paket.references` files](references-files.html)")
             .Replace("paket.references file","[`paket.references` file](references-files.html)")
-    
+
     let syntax, options = getSyntax command
 
     System.Text.StringBuilder()
         .Append("# paket ")
-        .AppendLine(command.Name)       
+        .AppendLine(command.Name)
         .AppendLine()
         .AppendLine((command :> IArgParserTemplate).Usage)
         .AppendLine()
@@ -346,5 +346,5 @@ let markdown (command : Command) (additionalText : string) =
 
 let getAllCommands () =
     Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<Command>)
-    |> Array.map (fun uci -> 
+    |> Array.map (fun uci ->
         Microsoft.FSharp.Reflection.FSharpValue.MakeUnion(uci, [||]) :?> Command)

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -127,6 +127,7 @@ type InstallArgs =
     | [<AltCommandLine("-f")>] Force
     | Hard
     | Redirects
+    | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
 with 
     interface IArgParserTemplate with
         member this.Usage =
@@ -134,6 +135,7 @@ with
             | Force -> "Forces the download and reinstallation of all packages."
             | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."            
             | Redirects -> "Creates binding redirects for the NuGet packages."
+            | Install_Only_Referenced -> "Only install packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
 
 type OutdatedArgs =
     | Ignore_Constraints
@@ -165,13 +167,15 @@ with
 
 type RestoreArgs =
     | [<AltCommandLine("-f")>] Force
+    | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
     | [<Rest>] References_Files of string
 with 
     interface IArgParserTemplate with
         member this.Usage =
             match this with
             | Force -> "Forces the download of all packages."
-            | References_Files(_) -> "Allows to restore all packages from the given paket.references files. If no paket.references file is given then all packages will be restored."
+            | Install_Only_Referenced -> "Allows to restore packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
+            | References_Files(_) -> "Allows to restore all packages from the given paket.references files. This implies --only-referenced."
 
 type SimplifyArgs =
     | [<AltCommandLine("-i")>] Interactive

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -64,6 +64,7 @@ type AddArgs =
     | [<AltCommandLine("-f")>] Force
     | [<AltCommandLine("-i")>] Interactive
     | Hard
+    | Redirects
     | No_Install
 with 
     interface IArgParserTemplate with
@@ -75,6 +76,7 @@ with
             | Force -> "Forces the download and reinstallation of all packages."
             | Interactive -> "Asks the user for every project if he or she wants to add the package to the projects's paket.references file."
             | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."
+            | Redirects -> "Creates binding redirects for the NuGet packages."
             | No_Install -> "Skips paket install --hard process afterward generation of dependencies / references files."
 
 type ConfigArgs = 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -79,6 +79,7 @@ let add (results : ArgParseResults<_>) =
     let version = defaultArg (results.TryGetResult <@ AddArgs.Version @>) ""
     let force = results.Contains <@ AddArgs.Force @>
     let hard = results.Contains <@ AddArgs.Hard @>
+    let redirects = results.Contains <@ AddArgs.Redirects @>
     let noInstall = results.Contains <@ AddArgs.No_Install @>
     match results.TryGetResult <@ AddArgs.Project @> with
     | Some projectName ->

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -15,42 +15,42 @@ open PackageSources
 let private stopWatch = new Stopwatch()
 stopWatch.Start()
 
-let filterGlobalArgs args = 
-    let globalResults = 
+let filterGlobalArgs args =
+    let globalResults =
         UnionArgParser.Create<GlobalArgs>()
-            .Parse(ignoreMissing = true, 
-                   ignoreUnrecognized = true, 
+            .Parse(ignoreMissing = true,
+                   ignoreUnrecognized = true,
                    raiseOnUsage = false)
     let verbose = globalResults.Contains <@ GlobalArgs.Verbose @>
     let logFile = globalResults.TryGetResult <@ GlobalArgs.Log_File @>
-    
-    let rest = 
+
+    let rest =
         match logFile with
-        | Some file -> 
+        | Some file ->
             args |> Array.filter (fun a -> a <> "--log-file" && a <> file)
         | None -> args
-    
-    let rest = 
-        if verbose then 
+
+    let rest =
+        if verbose then
             rest |> Array.filter (fun a -> a <> "-v" && a <> "--verbose")
         else rest
-    
+
     verbose, logFile, rest
 
 let v, logFile, args = filterGlobalArgs (Environment.GetCommandLineArgs().[1..])
-let silent = args |> Array.exists ((=) "-s") 
+let silent = args |> Array.exists ((=) "-s")
 
 if not silent then
     let assembly = Assembly.GetExecutingAssembly()
     let fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
     tracefn "Paket version %s" fvi.FileVersion
 
-let processWithValidation<'T when 'T :> IArgParserTemplate> validateF commandF command 
-    args = 
+let processWithValidation<'T when 'T :> IArgParserTemplate> validateF commandF command
+    args =
     let parser = UnionArgParser.Create<'T>()
-    let results = 
+    let results =
         parser.Parse
-            (inputs = args, raiseOnUsage = false, ignoreMissing = true, 
+            (inputs = args, raiseOnUsage = false, ignoreMissing = true,
              errorHandler = ProcessExiter())
 
     let resultsValid = validateF (results)
@@ -62,13 +62,13 @@ let processWithValidation<'T when 'T :> IArgParserTemplate> validateF commandF c
             Environment.ExitCode <- 1
         else
             parser.Usage(Commands.cmdLineUsageMessage command parser) |> trace
-    else 
+    else
         commandF results
         let elapsedTime = Utils.TimeSpanToReadableString stopWatch.Elapsed
         if not silent then
             tracefn "%s - ready." elapsedTime
 
-let processCommand<'T when 'T :> IArgParserTemplate> (commandF : ArgParseResults<'T> -> unit) = 
+let processCommand<'T when 'T :> IArgParserTemplate> (commandF : ArgParseResults<'T> -> unit) =
     processWithValidation (fun _ -> true) commandF
 
 Logging.verbose <- v
@@ -89,13 +89,13 @@ let add (results : ArgParseResults<_>) =
         Dependencies.Locate().Add(packageName, version, force, hard, interactive, noInstall |> not)
 
 let validateConfig (results : ArgParseResults<_>) =
-    let args = results.GetResults <@ ConfigArgs.AddCredentials @> 
+    let args = results.GetResults <@ ConfigArgs.AddCredentials @>
     args.Length > 0
 
 let config (results : ArgParseResults<_>) =
-    let args = results.GetResults <@ ConfigArgs.AddCredentials @> 
+    let args = results.GetResults <@ ConfigArgs.AddCredentials @>
     let source = args.Item 0
-    let username = 
+    let username =
         if(args.Length > 1) then
             args.Item 1
         else
@@ -117,71 +117,71 @@ let convert (results : ArgParseResults<_>) =
     let noAutoRestore = results.Contains <@ ConvertFromNugetArgs.No_Auto_Restore @>
     let credsMigrationMode = results.TryGetResult <@ ConvertFromNugetArgs.Creds_Migration @>
     Dependencies.ConvertFromNuget(force, noInstall |> not, noAutoRestore |> not, credsMigrationMode)
-    
+
 let findRefs (results : ArgParseResults<_>) =
     let packages = results.GetResults <@ FindRefsArgs.Packages @>
     Dependencies.Locate().ShowReferencesFor(packages)
-        
+
 let init (results : ArgParseResults<InitArgs>) =
     Dependencies.Init()
 
-let install (results : ArgParseResults<_>) = 
+let install (results : ArgParseResults<_>) =
     let force = results.Contains <@ InstallArgs.Force @>
     let hard = results.Contains <@ InstallArgs.Hard @>
     let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
     let installOnlyReferenced = results.Contains <@ InstallArgs.Install_Only_Referenced @>
     Dependencies.Locate().Install(force, hard, withBindingRedirects, installOnlyReferenced)
 
-let outdated (results : ArgParseResults<_>) = 
+let outdated (results : ArgParseResults<_>) =
     let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
     let includePrereleases = results.Contains <@ OutdatedArgs.Include_Prereleases @>
     Dependencies.Locate().ShowOutdated(strict, includePrereleases)
 
-let remove (results : ArgParseResults<_>) = 
+let remove (results : ArgParseResults<_>) =
     let packageName = results.GetResult <@ RemoveArgs.Nuget @>
     let force = results.Contains <@ RemoveArgs.Force @>
     let hard = results.Contains <@ RemoveArgs.Hard @>
     let noInstall = results.Contains <@ RemoveArgs.No_Install @>
     match results.TryGetResult <@ RemoveArgs.Project @> with
-    | Some projectName -> 
+    | Some projectName ->
         Dependencies.Locate()
                     .RemoveFromProject(packageName, force, hard, projectName, noInstall |> not)
-    | None -> 
+    | None ->
         let interactive = results.Contains <@ RemoveArgs.Interactive @>
         Dependencies.Locate().Remove(packageName, force, hard, interactive, noInstall |> not)
 
-let restore (results : ArgParseResults<_>) = 
+let restore (results : ArgParseResults<_>) =
     let force = results.Contains <@ RestoreArgs.Force @>
     let files = results.GetResults <@ RestoreArgs.References_Files @>
     let installOnlyReferenced = results.Contains <@ RestoreArgs.Install_Only_Referenced @>
     if List.isEmpty files then Dependencies.Locate().Restore(force, installOnlyReferenced)
     else Dependencies.Locate().Restore(force, files)
 
-let simplify (results : ArgParseResults<_>) = 
+let simplify (results : ArgParseResults<_>) =
     let interactive = results.Contains <@ SimplifyArgs.Interactive @>
     Dependencies.Locate().Simplify(interactive)
 
-let update (results : ArgParseResults<_>) = 
+let update (results : ArgParseResults<_>) =
     let hard = results.Contains <@ UpdateArgs.Hard @>
     let force = results.Contains <@ UpdateArgs.Force @>
     match results.TryGetResult <@ UpdateArgs.Nuget @> with
-    | Some packageName -> 
+    | Some packageName ->
         let version = results.TryGetResult <@ UpdateArgs.Version @>
         Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
-    | _ -> 
+    | _ ->
         let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
         Dependencies.Locate().Update(force, hard, withBindingRedirects)
 
-let pack (results : ArgParseResults<_>) = 
+let pack (results : ArgParseResults<_>) =
     let outputPath = results.GetResult <@ PackArgs.Output @>
     Dependencies.Locate()
-                .Pack(outputPath, 
-                      ?buildConfig = results.TryGetResult <@ PackArgs.BuildConfig @>, 
-                      ?version = results.TryGetResult <@ PackArgs.Version @>, 
+                .Pack(outputPath,
+                      ?buildConfig = results.TryGetResult <@ PackArgs.BuildConfig @>,
+                      ?version = results.TryGetResult <@ PackArgs.Version @>,
                       ?releaseNotes = results.TryGetResult <@ PackArgs.ReleaseNotes @>,
                       ?templateFile = results.TryGetResult <@ PackArgs.TemplateFile @>)
 
-let findPackages (results : ArgParseResults<_>) = 
+let findPackages (results : ArgParseResults<_>) =
     let maxResults = defaultArg (results.TryGetResult <@ FindPackagesArgs.MaxResults @>) 10000
     let silent = results.Contains <@ FindPackagesArgs.Silent @>
     let sources  =
@@ -204,7 +204,7 @@ let findPackages (results : ArgParseResults<_>) =
             tracefn "%s" p
 
     match results.TryGetResult <@ FindPackagesArgs.SearchText @> with
-    | None ->             
+    | None ->
         let searchText = ref ""
         while !searchText <> ":q" do
             if not silent then
@@ -214,9 +214,9 @@ let findPackages (results : ArgParseResults<_>) =
 
     | Some searchText -> searchAndPrint searchText
 
-let showInstalledPackages (results : ArgParseResults<_>) =    
+let showInstalledPackages (results : ArgParseResults<_>) =
     let dependenciesFile = Dependencies.Locate()
-    let packages = 
+    let packages =
         match results.TryGetResult <@ ShowInstalledPackagesArgs.Project @> with
         | None ->
             if results.Contains <@ ShowInstalledPackagesArgs.All @> then
@@ -243,26 +243,26 @@ let findPackageVersions (results : ArgParseResults<_>) =
     let result =
         NuGetV3.FindVersionsForPackage(None,source,name,maxResults)
         |> Async.RunSynchronously
-        
+
     for p in result do
         tracefn "%s" p
 
-let push (results : ArgParseResults<_>) = 
+let push (results : ArgParseResults<_>) =
     let fileName = results.GetResult <@ PushArgs.FileName @>
-    Dependencies.Push(fileName, ?url = results.TryGetResult <@ PushArgs.Url @>, 
+    Dependencies.Push(fileName, ?url = results.TryGetResult <@ PushArgs.Url @>,
                       ?endPoint = results.TryGetResult <@ PushArgs.EndPoint @>,
                       ?apiKey = results.TryGetResult <@ PushArgs.ApiKey @>)
 
 try
     let parser = UnionArgParser.Create<Command>()
-    let results = 
+    let results =
         parser.Parse(inputs = args,
-                   ignoreMissing = true, 
-                   ignoreUnrecognized = true, 
-                   raiseOnUsage = false)
+                     ignoreMissing = true,
+                     ignoreUnrecognized = true,
+                     raiseOnUsage = false)
 
     match results.GetAllResults() with
-    | [ command ] -> 
+    | [ command ] ->
         let handler =
             match command with
             | Add -> processCommand add
@@ -283,17 +283,17 @@ try
             | Pack -> processCommand pack
             | Push -> processCommand push
 
-        let args = args.[1..]      
+        let args = args.[1..]
 
         handler command args
-    | [] -> 
+    | [] ->
         Environment.ExitCode <- 1
         traceError "Command was:"
         traceError ("  " + String.Join(" ",Environment.GetCommandLineArgs()))
         parser.Usage("available commands:") |> traceError
     | _ -> failwith "expected only one command"
 with
-| exn when not (exn :? System.NullReferenceException) -> 
+| exn when not (exn :? System.NullReferenceException) ->
     Environment.ExitCode <- 1
     traceErrorfn "Paket failed with:%s\t%s" Environment.NewLine exn.Message
 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -128,7 +128,8 @@ let install (results : ArgParseResults<_>) =
     let force = results.Contains <@ InstallArgs.Force @>
     let hard = results.Contains <@ InstallArgs.Hard @>
     let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
-    Dependencies.Locate().Install(force, hard, withBindingRedirects)
+    let installOnlyReferenced = results.Contains <@ InstallArgs.Install_Only_Referenced @>
+    Dependencies.Locate().Install(force, hard, withBindingRedirects, installOnlyReferenced)
 
 let outdated (results : ArgParseResults<_>) = 
     let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
@@ -151,7 +152,9 @@ let remove (results : ArgParseResults<_>) =
 let restore (results : ArgParseResults<_>) = 
     let force = results.Contains <@ RestoreArgs.Force @>
     let files = results.GetResults <@ RestoreArgs.References_Files @>
-    Dependencies.Locate().Restore(force, files)
+    let installOnlyReferenced = results.Contains <@ RestoreArgs.Install_Only_Referenced @>
+    if List.isEmpty files then Dependencies.Locate().Restore(force, installOnlyReferenced)
+    else Dependencies.Locate().Restore(force, files)
 
 let simplify (results : ArgParseResults<_>) = 
     let interactive = results.Contains <@ SimplifyArgs.Interactive @>


### PR DESCRIPTION
## paket restore --only-referenced
As the title says: This pull requests makes it possible to say:
```bash
paket restore --only-referenced
```
which is the same as:
```
paket restore --references-files <all paket.references files that paket install would find>
```

## paket install--only-referenced
Consequently, it also adds:
```
paket install --only-referenced
```
which works analogous to `paket restore --only-referenced`.

## Refactorings
To make such additions easier in the future, `InstallProcess` and `UpdateProcess` were refactored to use the Parameter Object pattern for the different flags (`Force`, `Hard`,  `WithBindingRedirects`).
The naming for the new record types `InstallerOptions` and `SmartInstallOptions` is not optimal, so I'm open for feedback.

## Testing
I've not yet added tests for the new functionality. I'd be thankful if you could point me to the correct files where tests for `InstallProcess` and `UpdateProcess` sould be added.

## Compatibility
`Dependencies`/`PublicAPI.fs` has been changed in a backwards compatible way by adding two new public members. The changes to `InstallProcess` and `UpateProcess` are not backwards compatible, but this is nearly unavoidable due to the quirks of F#.