### PR TITLE
Fix inconsistent parameter names of Dependencies.Add and dependencies.AddToProject

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -106,18 +106,18 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Adds the given package with the given version to the dependencies file.
     member this.Add(package: string,version: string): unit =
-        this.Add(package, version, force = false, hard = false, redirects = false, interactive = false, installAfter = true)
+        this.Add(package, version, force = false, hard = false, withBindingRedirects = false, interactive = false, installAfter = true)
 
     /// Adds the given package with the given version to the dependencies file.
     member this.Add(package: string,version: string,force: bool,hard: bool,interactive: bool,installAfter: bool): unit =
         this.Add(package, version, force, hard, false, interactive, installAfter)
 
     /// Adds the given package with the given version to the dependencies file.
-    member this.Add(package: string,version: string,force: bool,hard: bool,redirects: bool,interactive: bool,installAfter: bool): unit =
+    member this.Add(package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool,interactive: bool,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.Add(dependenciesFileName, PackageName(package.Trim()), version,
-                                     InstallerOptions.createLegacyOptions(force, hard, redirects),
+                                     InstallerOptions.createLegacyOptions(force, hard, withBindingRedirects),
                                      interactive, installAfter))
 
     /// Adds the given package with the given version to the dependencies file.
@@ -125,11 +125,11 @@ type Dependencies(dependenciesFileName: string) =
         this.AddToProject(package, version, force, hard, false, projectName, installAfter)
 
    /// Adds the given package with the given version to the dependencies file.
-    member this.AddToProject(package: string,version: string,force: bool,hard: bool,redirects: bool,projectName: string,installAfter: bool): unit =
+    member this.AddToProject(package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool,projectName: string,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.AddToProject(dependenciesFileName, PackageName package, version,
-                                              InstallerOptions.createLegacyOptions(force, hard, redirects),
+                                              InstallerOptions.createLegacyOptions(force, hard, withBindingRedirects),
                                               projectName, installAfter))
 
     /// Adds credentials for a Nuget feed


### PR DESCRIPTION
The inconsistencies were introduced by my last pull request #843 (in commit f465226b6f0568010832757886a9ff19117f841f).