### PR TITLE
Implement --no-install and --redirects for "paket update".

### DIFF
--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -33,7 +33,7 @@ let private add installToProjects addToProjectsF dependenciesFileName package ve
 
         if installAfter then
             let sources = dependenciesFile.GetAllPackageSources()
-            InstallProcess.Install(sources, { SmartInstallOptions.Default with Common = options }, lockFile)
+            InstallProcess.Install(sources, options, lockFile)
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, package, version, options : InstallerOptions, projectName, installAfter) =

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -148,7 +148,7 @@ let findAllReferencesFiles root =
     |> collect
 
 /// Installs all packages from the lock file.
-let InstallIntoProjects(sources, options : SmartInstallOptions, lockFile : LockFile, projects : (ProjectFile * ReferencesFile) list) =
+let InstallIntoProjects(sources, options : InstallerOptions, lockFile : LockFile, projects : (ProjectFile * ReferencesFile) list) =
     let packagesToInstall =
         if options.OnlyReferenced then
             projects
@@ -163,7 +163,7 @@ let InstallIntoProjects(sources, options : SmartInstallOptions, lockFile : LockF
             |> Seq.map (fun kv -> kv.Key)
 
     let root = Path.GetDirectoryName lockFile.FileName
-    let extractedPackages = createModel(root, sources, options.Common.Force, lockFile, Set.ofSeq packagesToInstall)
+    let extractedPackages = createModel(root, sources, options.Force, lockFile, Set.ofSeq packagesToInstall)
 
     let model =
         extractedPackages
@@ -255,7 +255,7 @@ let InstallIntoProjects(sources, options : SmartInstallOptions, lockFile : LockF
             |> Seq.map (fun u -> NormalizedPackageName u.Key,u.Value)
             |> Map.ofSeq
 
-        project.UpdateReferences(model, usedPackageSettings, options.Common.Hard)
+        project.UpdateReferences(model, usedPackageSettings, options.Hard)
 
         removeCopiedFiles project
 
@@ -282,15 +282,15 @@ let InstallIntoProjects(sources, options : SmartInstallOptions, lockFile : LockF
                                   Include = createRelativePath project.FileName file.FullName
                                   Link = None })
 
-        project.UpdateFileItems(gitRemoteItems @ nuGetFileItems, options.Common.Hard)
+        project.UpdateFileItems(gitRemoteItems @ nuGetFileItems, options.Hard)
 
         project.Save()
 
-    if options.Common.Redirects || lockFile.Options.Redirects then
+    if options.Redirects || lockFile.Options.Redirects then
         applyBindingRedirects root extractedPackages
 
 /// Installs all packages from the lock file.
-let Install(sources, options : SmartInstallOptions, lockFile : LockFile) =
+let Install(sources, options : InstallerOptions, lockFile : LockFile) =
     let root = FileInfo(lockFile.FileName).Directory.FullName
     let projects = findAllReferencesFiles root |> returnOrFail
     InstallIntoProjects(sources, options, lockFile, projects)

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -407,4 +407,4 @@ let replaceNugetWithPaket initAutoRestore installAfter result =
     if installAfter then
         UpdateProcess.Update(
             result.PaketEnv.DependenciesFile.FileName,
-            { InstallerOptions.Default with Force = true; Hard = true; Redirects = true })
+            { UpdaterOptions.Default with Common = { InstallerOptions.Default with Force = true; Hard = true; Redirects = true }})

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -1,19 +1,22 @@
 namespace Paket
 
 // Options for UpdateProcess and InstallProcess.
-/// Force     - Force the download and reinstallation of all packages
-/// Hard      - Replace package references within project files even if they are not yet adhering
-///             to the Paket's conventions (and hence considered manually managed)
-/// Redirects - Create binding redirects for the NuGet packages
+/// Force          - Force the download and reinstallation of all packages
+/// Hard           - Replace package references within project files even if they are not yet adhering
+///                  to the Paket's conventions (and hence considered manually managed)
+/// Redirects      - Create binding redirects for the NuGet packages
+/// OnlyReferenced - Only install packages that are referenced in paket.references files.
 type InstallerOptions =
     { Force : bool
       Hard : bool
-      Redirects : bool }
+      Redirects : bool
+      OnlyReferenced : bool }
 
     static member Default =
         { Force = false
           Hard = false
-          Redirects = false }
+          Redirects = false
+          OnlyReferenced = false }
 
     static member createLegacyOptions(force, hard, redirects) =
         { InstallerOptions.Default with
@@ -21,10 +24,10 @@ type InstallerOptions =
             Hard = hard
             Redirects = redirects }
 
-type SmartInstallOptions =
+type UpdaterOptions =
     { Common : InstallerOptions
-      OnlyReferenced : bool }
+      NoInstall : bool }
 
     static member Default =
         { Common = InstallerOptions.Default
-          OnlyReferenced = false }
+          NoInstall = false }

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -36,17 +36,14 @@ let private remove removeFromProjects dependenciesFileName (package: PackageName
     let lockFile =
         if stillInstalled then oldLockFile else
         let exisitingDependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
-        let dependenciesFile =
-            exisitingDependenciesFile
-                .Remove(package)
-
+        let dependenciesFile = exisitingDependenciesFile.Remove(package)
         dependenciesFile.Save()
         
         UpdateProcess.SelectiveUpdate(dependenciesFile,None,force)
     
     if installAfter then
         let sources = DependenciesFile.ReadFromFile(dependenciesFileName).GetAllPackageSources()
-        InstallProcess.Install(sources, { SmartInstallOptions.Default with Common = { InstallerOptions.Default with Force = force; Hard = hard; Redirects = false }}, lockFile )
+        InstallProcess.Install(sources, InstallerOptions.createLegacyOptions(force, hard, false), lockFile )
 
 // remove a package with the option to remove it from a specified project
 let RemoveFromProject(dependenciesFileName, package:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -193,6 +193,7 @@ type UpdateArgs =
     | [<AltCommandLine("-f")>] Force
     | Hard
     | Redirects
+    | No_Install
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -202,6 +203,7 @@ with
             | Force -> "Forces the download and reinstallation of all packages."
             | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."
             | Redirects -> "Creates binding redirects for the NuGet packages."
+            | No_Install -> "Skips paket install --hard process afterward generation of paket.lock file."
 
 type FindPackagesArgs =
     | [<CustomCommandLine("searchtext")>] SearchText of string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -164,13 +164,14 @@ let simplify (results : ArgParseResults<_>) =
 let update (results : ArgParseResults<_>) =
     let hard = results.Contains <@ UpdateArgs.Hard @>
     let force = results.Contains <@ UpdateArgs.Force @>
+    let noInstall = results.Contains <@ UpdateArgs.No_Install @>
+    let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
     match results.TryGetResult <@ UpdateArgs.Nuget @> with
     | Some packageName ->
         let version = results.TryGetResult <@ UpdateArgs.Version @>
-        Dependencies.Locate().UpdatePackage(packageName, version, force, hard)
+        Dependencies.Locate().UpdatePackage(packageName, version, force, hard, withBindingRedirects, noInstall |> not)
     | _ ->
-        let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
-        Dependencies.Locate().Update(force, hard, withBindingRedirects)
+        Dependencies.Locate().Update(force, hard, withBindingRedirects, noInstall |> not)
 
 let pack (results : ArgParseResults<_>) =
     let outputPath = results.GetResult <@ PackArgs.Output @>


### PR DESCRIPTION
This pull request adds the switch `--no-install` to `paket update`, and handles `paket update --redirects` also for the "single package update" case.
Additionally, the newly introduced `InstallerOptions` and `SmartInstallOptions` have been refactored, such that they match their usage better.
