### PR TITLE
Change of default owner under "fsprojects"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The [MIT license][6]
 - [@isaacabraham](https://github.com/isaacabraham)
 - [@theimowski](https://github.com/theimowski)
 
-The default maintainer account for projects under "fsprojects" is [@fsgit](https://github.com/fsgit) - F# Community Project Incubation Space (repo management)
+The default maintainer account for projects under "fsprojects" is [@fsprojectsgit](https://github.com/fsprojectsgit) - F# Community Project Incubation Space (repo management)
 
  [1]: https://github.com/fsprojects/Paket/
  [2]: http://fsprojects.github.io/Paket/


### PR DESCRIPTION
We are changing to "fsprojectsgit" as the default owner for projects under "fsprojects"