### PR TITLE
Exclusion syntax for paket.template files

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -100,6 +100,18 @@ If the source part refers to a file then it is copied into the target directory.
 refers to a directory, the contents of the directory will be copied into the target folder.
 If you omit the target folder, then the source is copied into the `lib` folder of the package.
 
+Excluding certain files looks like this:
+
+    [lang=batchfile]
+    files
+        relative/to/template/file ==> folder/in/nupkg
+        second/thing/**/file.* ==> folder/in/nupkg
+        !second/thing/**/file.zip
+        ../outside/file.* ==> folder/in/nupkg/other
+        !../outside/file.zip
+
+The pattern needs to match file-names, excluding directories like `!second` won't have an effect, please use `!second/*.*` instead.
+
 In a project template, the files included will be:
 
 * the output assembly of the matching project (in the correct lib directory if a library, or tools if an exe)
@@ -123,7 +135,7 @@ A block with framework assembly references looks like this:
     [lang=batchfile]
     frameworkAssemblies
 	    System.Xml
-		System.Xml.Linq	    
+		System.Xml.Linq
 
 If you omit the references block then all libraries in the packages will get referenced.
 

--- a/src/Paket.Core/NupkgWriter.fs
+++ b/src/Paket.Core/NupkgWriter.fs
@@ -202,10 +202,6 @@ let Write (core : CompleteCoreInfo) optional workingDir outputDir =
         let isWinDrive = Regex(@"^\w:\\.*", RegexOptions.Compiled).IsMatch
         let isNixRoot = Regex(@"^\/.*", RegexOptions.Compiled).IsMatch
 
-        printfn "fixRelativePath: %s" p
-        printfn "isWinDrive: %A" <| isWinDrive p
-        printfn "isNixRoot: %A" <| isNixRoot p
-
         let prepend,path =
             match p with
             | s when isWinDrive s -> [|s.Substring(0,3)|],s.Substring(3)
@@ -213,20 +209,14 @@ let Write (core : CompleteCoreInfo) optional workingDir outputDir =
             | s when String.IsNullOrWhiteSpace s -> failwith "Empty exclusion path!"
             | s -> [||],s
 
-        printfn "storePrefix: %A , %s" prepend path
-
-        let transformed =   path.Split('\\','/')
-                            |> Array.fold (fun (xs:string []) x ->
-                                match x with
-                                | s when "..".Equals s -> Array.sub xs 0 (xs.Length-1)
-                                | s when ".".Equals s -> xs
-                                | _ -> Array.append xs [|x|]) [||]
-                            |> Array.append prepend
-                            |> Array.fold (fun p' x -> Path.Combine(p',x)) ""
-
-        printfn "transormed: %A" transformed
-
-        transformed
+        path.Split('\\','/')
+        |> Array.fold (fun (xs:string []) x ->
+            match x with
+            | s when "..".Equals s -> Array.sub xs 0 (xs.Length-1)
+            | s when ".".Equals s -> xs
+            | _ -> Array.append xs [|x|]) [||]
+        |> Array.append prepend
+        |> Array.fold (fun p' x -> Path.Combine(p',x)) ""
 
     let exclusions =
         optional.FilesExcluded

--- a/src/Paket.Core/TemplateFile.fs
+++ b/src/Paket.Core/TemplateFile.fs
@@ -223,14 +223,12 @@ module internal TemplateFile =
     
     let private fromReg = Regex("from (?<from>.*)", RegexOptions.Compiled)
     let private toReg = Regex("to (?<to>.*)", RegexOptions.Compiled)
-    
-    let private fileExclusionChar = '!'
-    let private isFileExclusion (l:string) = l.Trim().StartsWith(fileExclusionChar.ToString())
+    let private isExclude = Regex("\s*!\S", RegexOptions.Compiled)
 
     let private getFiles (map : Map<string, string>) = 
         Map.tryFind "files" map
         |> Option.map (fun d -> d.Split '\n')
-        |> Option.map (Array.filter (fun l -> l |> isFileExclusion |> not))
+        |> Option.map (Array.filter (fun l -> l |> isExclude.IsMatch |> not))
         |> Option.map 
                (Seq.map 
                     (fun (line:string) -> 
@@ -245,10 +243,10 @@ module internal TemplateFile =
     let private getFileExcludes (map : Map<string, string>) = 
         Map.tryFind "files" map
         |> Option.map (fun d -> d.Split '\n')
-        |> Option.map (Array.filter isFileExclusion)
+        |> Option.map (Array.filter isExclude.IsMatch)
         |> Option.map 
                (Seq.map 
-                    (fun (line:string) -> line.Trim().TrimStart(fileExclusionChar)))
+                    (fun (line:string) -> line.Trim().TrimStart('!')))
         |> Option.map List.ofSeq
         |> fun x -> defaultArg x []
 

--- a/src/Paket.Core/TemplateFile.fs
+++ b/src/Paket.Core/TemplateFile.fs
@@ -224,10 +224,13 @@ module internal TemplateFile =
     let private fromReg = Regex("from (?<from>.*)", RegexOptions.Compiled)
     let private toReg = Regex("to (?<to>.*)", RegexOptions.Compiled)
     
+    let private fileExclusionChar = '!'
+    let private isFileExclusion (l:string) = l.Trim().StartsWith(fileExclusionChar.ToString())
+
     let private getFiles (map : Map<string, string>) = 
         Map.tryFind "files" map
         |> Option.map (fun d -> d.Split '\n')
-        |> Option.map (Array.filter (fun l -> l.TrimStart(' ', '\t').StartsWith("--") |> not))
+        |> Option.map (Array.filter (fun l -> l |> isFileExclusion |> not))
         |> Option.map 
                (Seq.map 
                     (fun (line:string) -> 
@@ -242,13 +245,10 @@ module internal TemplateFile =
     let private getFileExcludes (map : Map<string, string>) = 
         Map.tryFind "files" map
         |> Option.map (fun d -> d.Split '\n')
-        |> Option.map (Array.filter (fun l -> l.TrimStart(' ', '\t').StartsWith("--")))
+        |> Option.map (Array.filter isFileExclusion)
         |> Option.map 
                (Seq.map 
-                    (fun (line:string) -> 
-                        let exclude = line.Split([|"--"|],StringSplitOptions.RemoveEmptyEntries) 
-                                      |> Array.map (fun s -> s.Trim())
-                        exclude.[0]))
+                    (fun (line:string) -> line.Trim().TrimStart(fileExclusionChar)))
         |> Option.map List.ofSeq
         |> fun x -> defaultArg x []
 

--- a/tests/Paket.Tests/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/TemplateFileParsing.fs
@@ -374,7 +374,7 @@ version
 files
     someDir
     anotherDir ==> someLib
-    -- excludeDir
+    !excludeDir
 """
     let sut =
         TemplateFile.Parse("file1.template", None, strToStream text)

--- a/tests/Paket.Tests/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/TemplateFileParsing.fs
@@ -399,7 +399,7 @@ version
 files
     someDir
     anotherDir ==> someLib
-        
+    !dontWantThis.txt
     !dontWantThat.txt
 """
     let sut =

--- a/tests/Paket.Tests/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/TemplateFileParsing.fs
@@ -386,6 +386,31 @@ files
     | [x] -> x |> shouldEqual "excludeDir"
     | _ ->  Assert.Fail()
 
+[<Test>]
+let ``disallow the space to avoid ambiguity in exclusion file pattern``() =
+    let text = """type file
+id My.Thing
+authors Bob McBob
+description
+    A longer description
+    on two lines.
+version
+    1.0
+files
+    someDir
+    anotherDir ==> someLib
+    ! excludeDir
+"""
+    let sut =
+        TemplateFile.Parse("file1.template", None, strToStream text)
+        |> returnOrFail
+        |> function
+           | CompleteInfo (_, opt)
+           | ProjectInfo (_, opt) -> opt
+    match sut.FilesExcluded with
+    | [] -> Assert.Pass()
+    | _ ->  Assert.Fail()
+
 [<Literal>]
 let ProjectType1 = """type project
 """

--- a/tests/Paket.Tests/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/TemplateFileParsing.fs
@@ -374,7 +374,7 @@ version
 files
     someDir
     anotherDir ==> someLib
-    !excludeDir
+    !dontWantThis.txt
 """
     let sut =
         TemplateFile.Parse("file1.template", None, strToStream text)
@@ -383,7 +383,34 @@ files
            | CompleteInfo (_, opt)
            | ProjectInfo (_, opt) -> opt
     match sut.FilesExcluded with
-    | [x] -> x |> shouldEqual "excludeDir"
+    | [x] -> x |> shouldEqual "dontWantThis.txt"
+    | _ ->  Assert.Fail()
+
+[<Test>]
+let ``Detect mutliple exclude files correctly``() =
+    let text = """type file
+id My.Thing
+authors Bob McBob
+description
+    A longer description
+    on two lines.
+version
+    1.0
+files
+    someDir
+    anotherDir ==> someLib
+        
+    !dontWantThat.txt
+"""
+    let sut =
+        TemplateFile.Parse("file1.template", None, strToStream text)
+        |> returnOrFail
+        |> function
+           | CompleteInfo (_, opt)
+           | ProjectInfo (_, opt) -> opt
+    match sut.FilesExcluded with
+    | [x;y] -> x |> shouldEqual "dontWantThis.txt"
+               y |> shouldEqual "dontWantThat.txt"
     | _ ->  Assert.Fail()
 
 [<Test>]

--- a/tests/Paket.Tests/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/TemplateFileParsing.fs
@@ -361,6 +361,31 @@ files
         to2 |> shouldEqual "someLib"
     | _ ->  Assert.Fail()
 
+[<Test>]
+let ``Detect exclude files correctly``() =
+    let text = """type file
+id My.Thing
+authors Bob McBob
+description
+    A longer description
+    on two lines.
+version
+    1.0
+files
+    someDir
+    anotherDir ==> someLib
+    -- excludeDir
+"""
+    let sut =
+        TemplateFile.Parse("file1.template", None, strToStream text)
+        |> returnOrFail
+        |> function
+           | CompleteInfo (_, opt)
+           | ProjectInfo (_, opt) -> opt
+    match sut.FilesExcluded with
+    | [x] -> x |> shouldEqual "excludeDir"
+    | _ ->  Assert.Fail()
+
 [<Literal>]
 let ProjectType1 = """type project
 """


### PR DESCRIPTION
PR for #880 

- [X] parses `--` to exclude files
- [x] change to `!*` pattern
- [x] disallow the space to avoid ambiguity
- [X] apply pattern/globs during packaging
- [x] when fixing a relative path (`..`) append `\` to windows drive (`C:`)
- [ ] how to exclude entire directory