### PR TITLE
added fix for windows-style network source-paths in dependencies parser

### DIFF
--- a/src/Paket.Core/PackageSources.fs
+++ b/src/Paket.Core/PackageSources.fs
@@ -99,7 +99,7 @@ type PackageSource =
 
     static member Parse(source,auth) = 
         match tryParseWindowsStyleNetworkPath source with
-        | Some path -> LocalNuget(path)
+        | Some path -> PackageSource.Parse(path)
         | _ ->
             match System.Uri.TryCreate(source, System.UriKind.Absolute) with
             | true, uri -> if uri.Scheme = System.Uri.UriSchemeFile then LocalNuget(source) else Nuget({ Url = source; Authentication = auth })


### PR DESCRIPTION
Since (on windows) nuget sources can be specified like

    nuget \\server\share

It would be very helpful to support these paths on linux too.
My fix is simply transforming those paths to

    nuget smb://server/share

whenever the OS is linux or MacOS (which is working at least on ubuntu)