### PR TITLE
Establish beta-level compatibility with Klondike

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.18.3
+* Support Odata query fallback for package details with /odata prefix
+* Establish beta-level comatibility with Klondike nuget server
+
 #### 1.18.2 - 23.06.2015
 * BUGFIX: Use updated globbing for paket.template
 

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -4,11 +4,11 @@ using System.Reflection;
 [assembly: AssemblyTitleAttribute("Paket.Bootstrapper")]
 [assembly: AssemblyProductAttribute("Paket")]
 [assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")]
-[assembly: AssemblyVersionAttribute("1.18.2")]
-[assembly: AssemblyFileVersionAttribute("1.18.2")]
-[assembly: AssemblyInformationalVersionAttribute("1.18.2")]
+[assembly: AssemblyVersionAttribute("1.18.3")]
+[assembly: AssemblyFileVersionAttribute("1.18.3")]
+[assembly: AssemblyInformationalVersionAttribute("1.18.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "1.18.2";
+        internal const string Version = "1.18.3";
     }
 }

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("1.18.2")>]
-[<assembly: AssemblyFileVersionAttribute("1.18.2")>]
-[<assembly: AssemblyInformationalVersionAttribute("1.18.2")>]
+[<assembly: AssemblyVersionAttribute("1.18.3")>]
+[<assembly: AssemblyFileVersionAttribute("1.18.3")>]
+[<assembly: AssemblyInformationalVersionAttribute("1.18.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.18.2"
+    let [<Literal>] Version = "1.18.3"

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -239,7 +239,15 @@ let getDetailsFromNuGetViaOData auth nugetURL package (version:SemVerInfo) =
             return! getDetailsFromNuGetViaODataFast auth nugetURL package version
         with _ ->         
             let url = sprintf "%s/Packages(Id='%s',Version='%s')" nugetURL package (version.ToString())
-            let! raw = getFromUrl(auth,url)
+            let! response = safeGetFromUrl(auth,url)
+                    
+            let! raw =
+                match response with
+                | Some(r) -> async { return r }
+                | None ->
+                    let url = sprintf "%s/odata/Packages(Id='%s',Version='%s')" nugetURL package (version.ToString())
+                    getXmlFromUrl(auth,url)
+
             if verbose then
                 tracefn "Response from %s:" url
                 tracefn ""

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -188,6 +188,24 @@ let getFromUrl (auth:Auth option, url : string) =
             return ""
     }
 
+let getXmlFromUrl (auth:Auth option, url : string) =
+    async { 
+        try
+            use client = createWebClient(url,auth)
+
+            // mimic the headers sent from nuget client to odata/ endpoints
+            client.Headers.Add(HttpRequestHeader.Accept, "application/atom+xml, application/xml")
+            client.Headers.Add(HttpRequestHeader.AcceptCharset, "UTF-8")
+            client.Headers.Add("DataServiceVersion", "1.0;NetFx")
+            client.Headers.Add("MaxDataServiceVersion", "2.0;NetFx")
+
+            return! client.AsyncDownloadString(Uri(url))
+        with
+        | exn -> 
+            failwithf "Could not retrieve data from %s%s Message: %s" url Environment.NewLine exn.Message
+            return ""
+    }
+    
 /// [omit]
 let safeGetFromUrl (auth:Auth option, url : string) = 
     async { 

--- a/src/Paket.PowerShell/AssemblyInfo.fs
+++ b/src/Paket.PowerShell/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("1.18.2")>]
-[<assembly: AssemblyFileVersionAttribute("1.18.2")>]
-[<assembly: AssemblyInformationalVersionAttribute("1.18.2")>]
+[<assembly: AssemblyVersionAttribute("1.18.3")>]
+[<assembly: AssemblyFileVersionAttribute("1.18.3")>]
+[<assembly: AssemblyInformationalVersionAttribute("1.18.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.18.2"
+    let [<Literal>] Version = "1.18.3"

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("1.18.2")>]
-[<assembly: AssemblyFileVersionAttribute("1.18.2")>]
-[<assembly: AssemblyInformationalVersionAttribute("1.18.2")>]
+[<assembly: AssemblyVersionAttribute("1.18.3")>]
+[<assembly: AssemblyFileVersionAttribute("1.18.3")>]
+[<assembly: AssemblyInformationalVersionAttribute("1.18.3")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.18.2"
+    let [<Literal>] Version = "1.18.3"


### PR DESCRIPTION
I did some quick fixup in order to get Klondike to be more chatty with Paket. More specifically, I had problems to obtain package details from Klodike during `paket install` and `paket restore` operations. After some investigation, I realized that I was not alone (see #682).

After sniffing on the conversation between original nuget.exe and Klondike, I came up with what you can see now in this PR.

I tested it with several projects of mid-range (10-25 deps) with mixed sources (from nuget and Klondike). NTL, I would still not be to positive about the Klondike support. It _seems_ to work fine.
