### PR TITLE
settings for dependent packages should be respected

### DIFF
--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -155,6 +155,15 @@ type InstallSettings =
 
     override this.ToString() = this.ToString(false)
 
+    static member (+)(self, other : InstallSettings) =
+        {
+            self with 
+                ImportTargets = self.ImportTargets ++ other.ImportTargets
+                FrameworkRestrictions = (self.FrameworkRestrictions @ other.FrameworkRestrictions) |> Seq.ofList |> Seq.distinct |> List.ofSeq
+                OmitContent = self.OmitContent ++ other.OmitContent
+                CopyLocal = self.CopyLocal ++ other.CopyLocal
+        }
+
     static member Parse(text:string) : InstallSettings =
         let kvPairs = parseKeyValuePairs text
 


### PR DESCRIPTION
Consider a paket.dependencies file:

    source api.nuget.org/etc/etc

    nuget A
    nuget B content: none


and a paket.references file in a project that just specifies a dependency on A

Now imagine that B is a dependency of A


Right now on install for a project we take the full set of packages [A,B] and extract from it the top-level dependencies of the project, resulting in [A].  We then configure the installSettings for this dependency, which in this case is the empty InstallSettings.

After we build the top-level map we augment it with the n-tier dependencies of each top-level dependency, and use the parent's configured InstallSettings only.  This results in an install of package B where the content: none directive is not honored.

This pull request resolves the settings for the n-tier dependencies in a similar manner to the top-level dependencies, while allowing any top-level dependency settings to override the settings configured for the lower-level package if any are present.


