### PR TITLE
Get version requirements from paket.lock

### DIFF
--- a/docs/content/commands/pack.md
+++ b/docs/content/commands/pack.md
@@ -48,7 +48,7 @@ Depending on which command you issue, Paket creates different version requiremen
   </tbody> 
 </table>
 
-As you see here, the first command (without the `lock-dependencies` parameter) creates version requirements as specified in your [`paket.dependencies` file][depfile]. The second command takes the currently resolved version from your [`paket.lock` file][lockfile] and "locks" it to this specific version.
+As you see here, the first command (without the `lock-dependencies` parameter) creates version requirements as specified in your [`paket.dependencies` file][depfile]. The second command takes the currently resolved versions from your [`paket.lock` file][lockfile] and "locks" them to these specific versions.
 
   [lockfile]: lock-file.html
   [depfile]: dependencies-file.html

--- a/docs/content/commands/pack.md
+++ b/docs/content/commands/pack.md
@@ -1,0 +1,51 @@
+## Creating NuGet-Packages
+
+Consider the following `paket.dependencies` file in your project's root:
+
+    source https://nuget.org/api/v2
+
+    nuget Castle.Windsor ~> 3.2
+    nuget NUnit
+
+And one of your projects having a `paket.references` file like this:
+
+    Castle.Windsor
+
+Now, when you run `paket install`, your `paket.lock` file would look like this:
+
+    NUGET
+      remote: https://nuget.org/api/v2
+      specs:
+        Castle.Core (3.3.3)
+        Castle.Windsor (3.3.0)
+          Castle.Core (>= 3.3.0)
+        NUnit (2.6.4)
+
+Now, when you are done programming and wish to create a NuGet-Package of your project, create a `paket.template` file with `type project` and run:
+
+    [lang=batch]
+    paket pack output nugets version 1.0.0
+
+Or, you could run:
+
+    [lang=batch]
+    paket pack output nugets version 1.0.0 lock-dependencies
+
+Depending on which command you issue, Paket creates different version requirements of the packages you depend on in the resulting `.nuspec` file of your package:
+
+<table>
+  <thead>
+    <th>Dependency</th>
+    <th>Default</th>
+    <th>With locked dependencies</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Castle.Windsor</td>
+      <td><code>[3.2,4.0)</code></td>
+      <td><code>[3.3.0]</code></td>
+    </tr>
+  </tbody> 
+</table>
+
+As you see here, the first command (without the `lock-dependencies` parameter) creates version requirements as specified in your `paket.dependencies` file. The second command takes the currently resolved version from your `paket.lock` file and "locks" it to this specific version.

--- a/docs/content/commands/pack.md
+++ b/docs/content/commands/pack.md
@@ -1,17 +1,17 @@
 ## Creating NuGet-Packages
 
-Consider the following `paket.dependencies` file in your project's root:
+Consider the following [`paket.dependencies` file][depfile] in your project's root:
 
     source https://nuget.org/api/v2
 
     nuget Castle.Windsor ~> 3.2
     nuget NUnit
 
-And one of your projects having a `paket.references` file like this:
+And one of your projects having a [`paket.references` file][reffile] like this:
 
     Castle.Windsor
 
-Now, when you run `paket install`, your `paket.lock` file would look like this:
+Now, when you run `paket install`, your [`paket.lock` file][lockfile] would look like this:
 
     NUGET
       remote: https://nuget.org/api/v2
@@ -21,7 +21,7 @@ Now, when you run `paket install`, your `paket.lock` file would look like this:
           Castle.Core (>= 3.3.0)
         NUnit (2.6.4)
 
-Now, when you are done programming and wish to create a NuGet-Package of your project, create a `paket.template` file with `type project` and run:
+Now, when you are done programming and wish to create a NuGet-Package of your project, create a [`paket.template`][templatefile] file with `type project` and run:
 
     [lang=batch]
     paket pack output nugets version 1.0.0
@@ -48,4 +48,9 @@ Depending on which command you issue, Paket creates different version requiremen
   </tbody> 
 </table>
 
-As you see here, the first command (without the `lock-dependencies` parameter) creates version requirements as specified in your `paket.dependencies` file. The second command takes the currently resolved version from your `paket.lock` file and "locks" it to this specific version.
+As you see here, the first command (without the `lock-dependencies` parameter) creates version requirements as specified in your [`paket.dependencies` file][depfile]. The second command takes the currently resolved version from your [`paket.lock` file][lockfile] and "locks" it to this specific version.
+
+  [lockfile]: lock-file.html
+  [depfile]: dependencies-file.html
+  [reffile]: references-files.html
+  [templatefile]: template-files.html

--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -183,7 +183,12 @@ let findDependencies (dependencies : DependenciesFile) config (template : Templa
             match templateFile with
             | CompleteTemplate(core, opt) -> 
                 match core.Version with
-                | Some v -> core.Id, VersionRequirement(Minimum(v), PreReleaseStatus.All)
+                | Some v ->
+                    let versionConstraint =
+                        if not lockDependencies
+                        then Minimum v
+                        else Specific v
+                    core.Id, VersionRequirement(versionConstraint, PreReleaseStatus.All)
                 | none ->failwithf "There was no version given for %s." templateFile.FileName
             | IncompleteTemplate -> failwithf "You cannot create a dependency on a template file (%s) with incomplete metadata." templateFile.FileName)
         |> List.fold addDependency templateWithOutput

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -10,9 +10,9 @@ open System.Collections.Generic
 open Paket.PackageMetaData
 open Chessie.ErrorHandling
 
-let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildConfig, version, releaseNotes, templateFile) =
-    let buildConfig = defaultArg buildConfig "Release"    
-    let packageOutputPath = if Path.IsPathRooted(packageOutputPath) then packageOutputPath else Path.Combine(workingDir,packageOutputPath)    
+let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildConfig, version, releaseNotes, templateFile, lockDependencies) =
+    let buildConfig = defaultArg buildConfig "Release"
+    let packageOutputPath = if Path.IsPathRooted(packageOutputPath) then packageOutputPath else Path.Combine(workingDir,packageOutputPath)
     Utils.createDir packageOutputPath |> returnOrFail
 
     let version = version |> Option.map SemVer.Parse
@@ -98,7 +98,7 @@ let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildCon
     // add dependencies
     let allTemplates =
         projectTemplates
-        |> Map.map (fun _ (t, p) -> p,findDependencies dependencies buildConfig t p projectTemplates)
+        |> Map.map (fun _ (t, p) -> p,findDependencies dependencies buildConfig t p lockDependencies projectTemplates)
         |> Map.toList
         |> List.map (fun (_,(_,x)) -> x)
         |> List.append [for fileName in allTemplateFiles -> TemplateFile.Load(fileName,version)]

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -371,10 +371,11 @@ type Dependencies(dependenciesFileName: string) =
         FindReferences.FindReferencesForPackage (PackageName package) |> this.Process
 
     // Packs all paket.template files.
-    member this.Pack(outputPath, ?buildConfig, ?version, ?releaseNotes, ?templateFile, ?workingDir) =
+    member this.Pack(outputPath, ?buildConfig, ?version, ?releaseNotes, ?templateFile, ?workingDir, ?lockDependencies) =
         let dependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
         let workingDir = defaultArg workingDir (dependenciesFile.FileName |> Path.GetDirectoryName)
-        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, version, releaseNotes, templateFile)
+        let lockDependencies = defaultArg lockDependencies false
+        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, version, releaseNotes, templateFile, lockDependencies)
 
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -251,6 +251,7 @@ type PackArgs =
     | [<CustomCommandLine("version")>] Version of string
     | [<CustomCommandLine("templatefile")>] TemplateFile of string
     | [<CustomCommandLine("releaseNotes")>] ReleaseNotes of string
+    | [<CustomCommandLine("lock-dependencies")>] LockDependencies
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -260,6 +261,7 @@ with
             | Version(_) -> "Specify version of the package."
             | TemplateFile(_) -> "Allows to specify a single template file."
             | ReleaseNotes(_) -> "Specify relase notes for the package."
+            | LockDependencies -> "Get the version requirements from paket.lock instead of paket.dependencies."
 
 type PushArgs =
     | [<CustomCommandLine("url")>][<Mandatory>] Url of string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -180,7 +180,8 @@ let pack (results : ArgParseResults<_>) =
                       ?version = results.TryGetResult <@ PackArgs.Version @>,
                       ?releaseNotes = results.TryGetResult <@ PackArgs.ReleaseNotes @>,
                       ?templateFile = results.TryGetResult <@ PackArgs.TemplateFile @>,
-                      workingDir = Environment.CurrentDirectory)
+                      workingDir = Environment.CurrentDirectory,
+                      lockDependencies = results.Contains <@ PackArgs.LockDependencies @>)
 
 let findPackages (results : ArgParseResults<_>) =
     let maxResults = defaultArg (results.TryGetResult <@ FindPackagesArgs.MaxResults @>) 10000


### PR DESCRIPTION
Addresses #901.

This allows us to get the version requirements from `paket.lock` instead of `paket.dependencies`. That means we then require the specific version (`version="[x.y.z]"`), which is resolved right now. To use this, just issue `paket pack [...] lock-dependencies` on the command line.

What do you say? Should I add some tests or maybe documentation?