### PR TITLE
Allow nuget packages to put version in the path

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ nuget Newtonsoft.Json
 nuget UnionArgParser
 nuget NUnit.Runners
 nuget NUnit
-nuget FAKE
+nuget FAKE prerelease
 nuget FSharp.Formatting
 nuget FSharp.Core
 nuget ILRepack

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    FAKE (3.36.0)
+    FAKE (4.0.0-alpha004)
     FSharp.Compiler.Service (1.3.1.0)
     FSharp.Core (3.1.2.5)
     FSharp.Formatting (2.9.10)
@@ -28,9 +28,9 @@ GITHUB
     FsUnit.fs (81d27fd09575a32c4ed52eadb2eeac5f365b8348)
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (3bde7566d4514ce83e88d376141ee848847ae6e9)
+    modules/Octokit/Octokit.fsx (8b027106c29c4e05f30fe0dc3dbf6332293e05fa)
       Octokit
-    src/app/FakeLib/Globbing/Globbing.fs (3bde7566d4514ce83e88d376141ee848847ae6e9)
+    src/app/FakeLib/Globbing/Globbing.fs (8b027106c29c4e05f30fe0dc3dbf6332293e05fa)
   remote: fsprojects/Chessie
   specs:
     src/Chessie/ErrorHandling.fs (2e4d76714d6d01ac64913317870f05d7f7ae8e37)

--- a/src/Paket.Core/Constants.fs
+++ b/src/Paket.Core/Constants.fs
@@ -52,6 +52,9 @@ let PaketVersionFileName = "paket.version"
 let TemplateFile = "paket.template"
 
 [<Literal>]
+let PackagesConfigFile = "packages.config"
+
+[<Literal>]
 let FullProjectSourceFileName = "FULLPROJECT"
 
 [<Literal>]

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -13,6 +13,7 @@ open System.Collections.Generic
 open FSharp.Polyfill
 open System.Reflection
 open System.Diagnostics
+open Paket.PackagesConfigFile
 open Paket.Requirements
 open System.Security.AccessControl
 
@@ -233,6 +234,18 @@ let InstallIntoProjects(sources, options : InstallerOptions, lockFile : LockFile
             |> Map.ofSeq
 
         project.UpdateReferences(model, usedPackageSettings, options.Hard)
+
+        let packagesConfigFile = Path.Combine(FileInfo(project.FileName).Directory.FullName, Constants.PackagesConfigFile)        
+
+        usedPackageVersions
+        |> Seq.filter (fun kv -> defaultArg (fst kv.Value).IncludeVersionInPath false)
+        |> Seq.map (fun kv ->
+            let settings,version = kv.Value
+            { Id = kv.Key.ToString()
+              Version = version
+              TargetFramework = None })
+        |> PackagesConfigFile.Save packagesConfigFile
+        
 
         removeCopiedFiles project
 

--- a/src/Paket.Core/PackagesConfigFile.fs
+++ b/src/Paket.Core/PackagesConfigFile.fs
@@ -1,0 +1,60 @@
+﻿module Paket.PackagesConfigFile
+
+open Paket
+open System
+open System.IO
+open System.Xml
+open Paket.Xml
+open Paket.Domain
+open Chessie.ErrorHandling
+
+type NugetPackage = {
+    Id : string
+    Version : SemVerInfo
+    TargetFramework : string option
+}
+
+let Read fileName = 
+    let file = FileInfo fileName
+    if file.Exists |> not then [] else
+    let doc = XmlDocument()
+    doc.Load file.FullName
+    
+    [for node in doc.SelectNodes("//package") ->
+        { Id = node.Attributes.["id"].Value
+          Version = SemVer.Parse node.Attributes.["version"].Value 
+          TargetFramework = 
+            node 
+            |> getAttribute "targetFramework" 
+            |> Option.map (fun t -> ">= " + t) } ]
+
+let Serialize (packages: NugetPackage seq) =
+    if Seq.isEmpty packages then "" else
+    let packages = 
+        packages 
+        |> Seq.map (fun p -> 
+            let framework = 
+                match p.TargetFramework with
+                | Some tf -> sprintf "targetFramework=\"%s\" " (tf.Replace(">= ",""))
+                | _ -> ""
+
+            sprintf """  <package id="%s" version="%O" %s/>""" p.Id p.Version framework)
+
+    sprintf """<?xml version="1.0" encoding="utf-8"?>
+<packages>
+%s
+</packages>""" (String.Join(Environment.NewLine,packages))
+
+let Save fileName packages =
+    let original = 
+        if File.Exists fileName then
+            File.ReadAllText fileName |> normalizeLineEndings
+        else ""
+
+    let newFile = Serialize packages |> normalizeLineEndings
+
+    if newFile = "" then
+        if File.Exists fileName then File.Delete fileName
+    else
+        if newFile <> original then
+            File.WriteAllText(fileName,newFile)

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -113,6 +113,7 @@
     <Compile Include="TemplateFile.fs" />
     <Compile Include="NupkgWriter.fs" />
     <Compile Include="ProcessOptions.fs" />
+    <Compile Include="PackagesConfigFile.fs" />
     <Compile Include="InstallProcess.fs" />
     <Compile Include="UpdateProcess.fs" />
     <Compile Include="RemoveProcess.fs" />

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -461,7 +461,7 @@ type ProjectFile =
             (this.Document |> getDescendants "None") @ 
             (this.Document |> getDescendants "Content")
 
-        match noneAndContentNodes |> List.tryFind (withAttributeValue "Include" "packages.config") with
+        match noneAndContentNodes |> List.tryFind (withAttributeValue "Include" Constants.PackagesConfigFile) with
         | None -> ()
         | Some nugetNode ->
             match noneAndContentNodes |> List.filter (withAttributeValue "Include" Constants.ReferencesFile) with 

--- a/src/Paket.Core/ReferencesFile.fs
+++ b/src/Paket.Core/ReferencesFile.fs
@@ -70,7 +70,7 @@ type ReferencesFile =
         let lines = File.ReadAllLines(fileName)
         { ReferencesFile.FromLines lines with FileName = fileName }
 
-    member this.AddNuGetReference(packageName : PackageName, copyLocal: bool, importTargets: bool, frameworkRestrictions, omitContent : bool) =
+    member this.AddNuGetReference(packageName : PackageName, copyLocal: bool, importTargets: bool, frameworkRestrictions, includeVersionInPath, omitContent : bool) =
         let (PackageName referenceName) = packageName
         let normalized = NormalizedPackageName packageName
         if this.NugetPackages |> Seq.exists (fun p -> NormalizedPackageName p.Name = normalized) then
@@ -84,11 +84,12 @@ type ReferencesFile =
                     { CopyLocal = if not copyLocal then Some copyLocal else None
                       ImportTargets = if not importTargets then Some importTargets else None
                       FrameworkRestrictions = frameworkRestrictions
+                      IncludeVersionInPath = if includeVersionInPath then Some includeVersionInPath else None
                       OmitContent = if omitContent then Some omitContent else None } }
 
             { this with NugetPackages = this.NugetPackages @ [ package ] }
 
-    member this.AddNuGetReference(packageName : PackageName) = this.AddNuGetReference(packageName, true, true, [], false)
+    member this.AddNuGetReference(packageName : PackageName) = this.AddNuGetReference(packageName, true, true, [], false, false)
 
     member this.RemoveNuGetReference(packageName : PackageName) =
         let (PackageName referenceName) = packageName

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -169,6 +169,7 @@ type InstallSettings =
                 FrameworkRestrictions = (self.FrameworkRestrictions @ other.FrameworkRestrictions) |> Seq.ofList |> Seq.distinct |> List.ofSeq
                 OmitContent = self.OmitContent ++ other.OmitContent
                 CopyLocal = self.CopyLocal ++ other.CopyLocal
+                IncludeVersionInPath = self.IncludeVersionInPath ++ other.IncludeVersionInPath
         }
 
     static member Parse(text:string) : InstallSettings =

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -128,12 +128,14 @@ type InstallSettings =
     { ImportTargets : bool option
       FrameworkRestrictions: FrameworkRestrictions
       OmitContent : bool option
+      IncludeVersionInPath: bool option
       CopyLocal : bool option }
 
     static member Default =
         { CopyLocal = None
           ImportTargets = None
           FrameworkRestrictions = []
+          IncludeVersionInPath = None
           OmitContent = None }
 
     member this.ToString(asLines) =
@@ -147,6 +149,9 @@ type InstallSettings =
               match this.OmitContent with
               | Some true -> yield "content: none"
               | Some false -> yield "content: true"
+              | None -> ()
+              match this.IncludeVersionInPath with
+              | Some x -> yield "version_in_path: " + x.ToString().ToLower()
               | None -> ()
               match this.FrameworkRestrictions with
               | [] -> ()
@@ -183,6 +188,11 @@ type InstallSettings =
             | true, "none" -> Some true 
             | true, "true" -> Some false 
             | _ ->  None
+          IncludeVersionInPath =         
+            match kvPairs.TryGetValue "version_in_path" with
+            | true, "false" -> Some false 
+            | true, "true" -> Some true
+            | _ -> None 
           CopyLocal =         
             match kvPairs.TryGetValue "copy_local" with
             | true, "false" -> Some false 

--- a/src/Paket.Core/SolutionFile.fs
+++ b/src/Paket.Core/SolutionFile.fs
@@ -59,7 +59,7 @@ type SolutionFile(fileName: string) =
     member __.FileName = fileName
 
     member __.RemoveNugetEntries() =
-        for file in ["nuget.targets";"packages.config";"nuget.exe";"nuget.config"] do
+        for file in ["nuget.targets"; Constants.PackagesConfigFile; "nuget.exe"; "nuget.config"] do
             match content |> Seq.tryFindIndex (fun line -> line.ToLower().Contains(sprintf ".nuget\\%s" file)) with
             | Some(index) -> content.RemoveAt(index)
             | None -> ()            

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -238,6 +238,8 @@ let inline normalizePath(path:string) = path.Replace("\\",Path.DirectorySeparato
 /// Gets all files with the given pattern
 let inline FindAllFiles(folder, pattern) = DirectoryInfo(folder).GetFiles(pattern, SearchOption.AllDirectories)
 
+let getTargetFolder root name (version:SemVerInfo) includeVersionInPath = Path.Combine(root, Constants.PackagesFolderName, name + if includeVersionInPath then "." + version.ToString() else "")
+
 
 let RunInLockedAccessMode(rootFolder,action) =
     let packagesFolder = Path.Combine(rootFolder,Constants.PackagesFolderName)

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -48,7 +48,7 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
-    <StartArguments>install</StartArguments>
+    <StartArguments>update</StartArguments>
     <StartWorkingDirectory>D:\code\commandline</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -48,8 +48,8 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
-    <StartArguments>update</StartArguments>
-    <StartWorkingDirectory>D:\code\paketkopie</StartWorkingDirectory>
+    <StartArguments>install</StartArguments>
+    <StartWorkingDirectory>D:\code\commandline</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -296,7 +296,7 @@ let frameworkRestricted' = """NUGET
     FsControl (1.0.9)
     FSharpPlus (0.0.4)
       FsControl (>= 1.0.9)
-    LinqBridge (1.3.0) - import_targets: false, content: none, framework: >= net20 < net35
+    LinqBridge (1.3.0) - import_targets: false, content: none, version_in_path: true, framework: >= net20 < net35
     ReadOnlyCollectionExtensions (1.2.0)
       LinqBridge (>= 1.3.0) - framework: >= net20 < net35
       ReadOnlyCollectionInterfaces (1.0.0) - framework: net20, net35, >= net40
@@ -316,6 +316,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[3].Settings.FrameworkRestrictions |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
     packages.[3].Settings.CopyLocal |> shouldEqual None
     packages.[3].Settings.ImportTargets |> shouldEqual (Some false)
+    packages.[3].Settings.IncludeVersionInPath |> shouldEqual (Some true)
     packages.[3].Settings.OmitContent |> shouldEqual (Some true)
 
     packages.[5].Source |> shouldEqual PackageSources.DefaultNugetSource
@@ -324,6 +325,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[5].Settings.ImportTargets |> shouldEqual (Some false)
     packages.[5].Settings.CopyLocal |> shouldEqual (Some false)
     packages.[5].Settings.OmitContent |> shouldEqual None
+    packages.[5].Settings.IncludeVersionInPath |> shouldEqual None
     packages.[5].Settings.FrameworkRestrictions 
     |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))

--- a/tests/Paket.Tests/PackagesConfig/ReadConfig.fs
+++ b/tests/Paket.Tests/PackagesConfig/ReadConfig.fs
@@ -1,0 +1,15 @@
+module Paket.ReadPackagesConfigSpecs
+
+open Paket
+open Paket.PackagesConfigFile
+open NUnit.Framework
+open FsUnit
+open Domain
+
+[<Test>]
+let ``can read xunit.visualstudio.packages.config``() = 
+    let config = Read("PackagesConfig/xunit.visualstudio.packages.config") |> List.head
+
+    config.Id |> shouldEqual "xunit.runner.visualstudio"
+    config.TargetFramework |> shouldEqual None
+    config.Version |> shouldEqual (SemVer.Parse "2.0.1")

--- a/tests/Paket.Tests/PackagesConfig/WriteConfig.fs
+++ b/tests/Paket.Tests/PackagesConfig/WriteConfig.fs
@@ -1,0 +1,22 @@
+﻿module Paket.WritePackagesConfigSpecs
+
+open Paket
+open Paket.PackagesConfigFile
+open NUnit.Framework
+open FsUnit
+open Domain
+open System.IO
+
+[<Test>]
+let ``can write xunit.visualstudio.packages.config``() = 
+    let fileName = "PackagesConfig/xunit.visualstudio.packages.config"
+    let config = Read fileName
+    let expected = File.ReadAllText fileName |> normalizeLineEndings
+    Serialize config |> normalizeLineEndings |> shouldEqual expected
+
+[<Test>]
+let ``can write asp.net.packages.config``() = 
+    let fileName = "PackagesConfig/asp.net.packages.config"
+    let config = Read fileName
+    let expected = File.ReadAllText fileName |> normalizeLineEndings
+    Serialize config |> normalizeLineEndings |> shouldEqual expected

--- a/tests/Paket.Tests/PackagesConfig/asp.net.packages.config
+++ b/tests/Paket.Tests/PackagesConfig/asp.net.packages.config
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Antlr" version="3.4.1.9004" targetFramework="net40" />
+  <package id="IronRuby" version="1.1.3" />
+  <package id="jQuery" version="2.0.3" targetFramework="net40" />
+  <package id="jQuery.UI.Combined" version="1.10.3" targetFramework="net40" />
+  <package id="jQuery.Validation" version="1.11.1" targetFramework="net40" />
+  <package id="jQuery.vsdoc" version="1.6" />
+  <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
+  <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net40" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
+  <package id="Microsoft.AspNet.Web.Optimization" version="1.1.2" targetFramework="net40" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
+  <package id="Modernizr" version="2.7.1" targetFramework="net40" />
+  <package id="MvcFlash" version="1.0.0" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
+  <package id="Ninject" version="3.0.1.10" targetFramework="net40" />
+  <package id="Ninject.MVC3" version="3.0.0.6" targetFramework="net40" />
+  <package id="Ninject.Web.Common" version="3.0.0.7" targetFramework="net40" />
+  <package id="NotFoundMvc" version="1.2.0" targetFramework="net40" />
+  <package id="SassAndCoffee" version="2.1.1" targetFramework="net40" />
+  <package id="SassAndCoffee.AspNet" version="2.1.1.0" targetFramework="net40" />
+  <package id="SassAndCoffee.Core" version="2.1.1.0" targetFramework="net40" />
+  <package id="SassAndCoffee.JavaScript" version="2.1.1.0" targetFramework="net40" />
+  <package id="SassAndCoffee.Ruby" version="2.1.1.0" targetFramework="net40" />
+  <package id="WebActivator" version="1.5.3" targetFramework="net40" />
+  <package id="WebGrease" version="1.5.2" targetFramework="net40" />
+</packages>

--- a/tests/Paket.Tests/PackagesConfig/xunit.visualstudio.packages.config
+++ b/tests/Paket.Tests/PackagesConfig/xunit.visualstudio.packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit.runner.visualstudio" version="2.0.1" />
+</packages>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -86,6 +86,14 @@
     <Compile Include="TemplateFileParsing.fs" />
     <Compile Include="NuspecWriterSpecs.fs" />
     <Compile Include="PackageProcessSpecs.fs" />
+    <Content Include="PackagesConfig\xunit.visualstudio.packages.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>               
+    <Content Include="PackagesConfig\asp.net.packages.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="PackagesConfig\ReadConfig.fs" />
+    <Compile Include="PackagesConfig\WriteConfig.fs" />
     <Compile Include="RemotePushUrlSpecs.fs" />
     <Content Include="Nuspec\FSharp.Data.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
- [x] allow to use `version_in_path: true` in dependencies file
- [x] install package with version in the path
- [x] update `packages.config` file to the current version