### PR TITLE
Handle dynamic OutputPath

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -789,9 +789,11 @@ type ProjectFile =
                         then data
                         else addData data node
 
+        let startingData = Map.empty<string,string>.Add("Configuration", buildConfiguration)
+
         this.Document
         |> getDescendants "PropertyGroup"
-        |> Seq.fold handleElement Map.empty<string,string>
+        |> Seq.fold handleElement startingData
         |> Map.tryFind "OutputPath"
         |> function
             | None -> failwithf "Unable to find %s output path node in file %s" buildConfiguration this.FileName

--- a/src/Paket.Core/Xml.fs
+++ b/src/Paket.Core/Xml.fs
@@ -67,6 +67,9 @@ let inline getDescendants name (node:XmlNode) =
         |> Seq.cast<XmlNode>
         |> Seq.toList
 
+/// [omit]
+let inline getChildNodes (node:XmlNode) = System.Linq.Enumerable.Cast<XmlNode>(node)
+
 
 module Linq =
 

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -33,7 +33,7 @@ let ``should detect target framework for Project2 proj file``() =
 
 [<Test>]
 let ``should detect output path for proj file``
-        ([<Values("Project1", "Project2")>] project)
+        ([<Values("Project1", "Project2", "Project3")>] project)
         ([<Values("Debug", "Release")>] configuration) =
     ProjectFile.Load(sprintf "./ProjectFile/TestData/%s.fsprojtest" project).Value.GetOutputDirectory configuration
     |> shouldEqual (System.IO.Path.Combine(@"bin", configuration) |> normalizePath)

--- a/tests/Paket.Tests/ProjectFile/TestData/Project1.fsprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/Project1.fsprojtest
@@ -15,13 +15,13 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Debug\fsharp_project_scaffold_tests.XML</DocumentationFile>
@@ -35,7 +35,6 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\Paket.Tests.xml</DocumentationFile>

--- a/tests/Paket.Tests/ProjectFile/TestData/Project2.fsprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/Project2.fsprojtest
@@ -15,6 +15,7 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <OutputPath>bin\Fail\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Partial implementation so far, updates `ProjectFile.GetOutputDirectory` to iterate through every `PropertyGroup` node in the project file loading values. Need to find a nice way to process basic placeholder values (the full supported syntax is a [bit expansive](https://msdn.microsoft.com/en-us/library/dd633440.aspx) for my liking) and the [`Condition` attribute](https://msdn.microsoft.com/en-us/library/7szfhaft.aspx). Should also provide some default values in the `Map<string, string>` at start, such as the `buildConfiguration` value.

As a side-effect of rewriting this code, I've accidentally corrected how Paket handles project files with multiple `OutputPath` nodes. MSBuild appears to process everything top-to-bottom, and so the last `OutputPath` node wins, whereas Paket will currently output a warning and use the first `OutputPath` it found.