### PR TITLE
Selective update resolves the graph for selected package

### DIFF
--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -348,7 +348,7 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
                             VersionRequirement = v })
             |> Seq.toList
 
-        { ResolvedPackages = PackageResolver.Resolve(getVersionF, getPackageDetailsF, options.Settings.FrameworkRestrictions, remoteDependencies @ rootDependencies)
+        { ResolvedPackages = PackageResolver.Resolve(getVersionF, getPackageDetailsF, options.Settings.FrameworkRestrictions, remoteDependencies @ rootDependencies, Set.ofList packages)
           ResolvedSourceFiles = remoteFiles }        
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF) =

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -315,13 +315,13 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
         this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force,packages)   
 
     member this.Resolve(force) = 
-        this.Resolve(force,packages)
+        this.Resolve(force,Some packages)
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF,rootDependencies) =
         let rootDependencies =
             match rootDependencies with
-            | [] -> packages
-            | _ -> rootDependencies
+            | None -> packages
+            | Some d -> d
 
         let resolveSourceFile(file:ResolvedSourceFile) : PackageRequirement list =
             let parserF text =
@@ -352,7 +352,7 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
           ResolvedSourceFiles = remoteFiles }        
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF) =
-        __.Resolve(getSha1,getVersionF,getPackageDetailsF,packages)
+        __.Resolve(getSha1,getVersionF,getPackageDetailsF,Some packages)
 
     member __.AddAdditionalPackage(packageName:PackageName,versionRequirement,resolverStrategy,settings,?pinDown) =
         let pinDown = defaultArg pinDown false

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -206,13 +206,15 @@ module LockFileParser =
                                        Settings = InstallSettings.Parse(optionsString)
                                        Version = SemVer.Parse version } :: state.Packages }
                 | None -> failwith "no source has been specified."
-            | NugetDependency (name, _) ->
+            | NugetDependency (name, v) ->
+                let parts = v.Split([|" - "|],StringSplitOptions.None)
+                let version = parts.[0]
                 if state.LastWasPackage then                 
                     match state.Packages with
                     | currentPackage :: otherPackages -> 
                         { state with
                                 Packages = { currentPackage with
-                                                Dependencies = Set.add (PackageName name, VersionRequirement.AllReleases, []) currentPackage.Dependencies
+                                                Dependencies = Set.add (PackageName name, DependenciesFileParser.parseVersionRequirement version, []) currentPackage.Dependencies
                                             } :: otherPackages }                    
                     | [] -> failwith "cannot set a dependency - no package has been specified."
                 else

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -247,7 +247,7 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
 
                 let requirement =
                     requirements
-                    |> Seq.tryFind (fun r -> currentRequirement.Name = r.Name)
+                    |> Seq.tryFind (fun r -> NormalizedPackageName currentRequirement.Name = NormalizedPackageName r.Name)
                     
                 let isInRange ver =
                     let inRange = currentRequirement.VersionRequirement.IsInRange(ver)

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -151,7 +151,7 @@ type Resolved = {
     ResolvedSourceFiles : ModuleResolver.ResolvedSourceFile list }
 
 /// Resolves all direct and transitive dependencies
-let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootDependencies, requirements) =
+let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootDependencies, (requirements : Set<PackageRequirement>)) =
     tracefn "Resolving packages:"
     let exploredPackages = Dictionary<NormalizedPackageName*SemVerInfo,ResolvedPackage>()
     let allVersions = Dictionary<NormalizedPackageName,SemVerInfo list>()
@@ -244,13 +244,14 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
             match Map.tryFind currentRequirement.Name filteredVersions with
             | None ->
                 // we didn't select a version yet so all versions are possible
-                let closedRequirement =
-                    closedRequirements
-                    |> Seq.tryFind (fun r -> currentRequirement.Name = r.Name)
 
+                let requirement =
+                    requirements
+                    |> Seq.tryFind (fun r -> currentRequirement.Name = r.Name)
+                    
                 let isInRange ver =
                     let inRange = currentRequirement.VersionRequirement.IsInRange(ver)
-                    match closedRequirement with
+                    match requirement with
                     | None -> inRange
                     | Some requirement -> inRange && requirement.VersionRequirement.IsInRange(ver)
 
@@ -333,6 +334,6 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
             | true,Resolution.Conflict(_) -> tryToImprove true |> snd       
             | _,x-> x
 
-    match step (Map.empty, [], requirements, Set.ofList rootDependencies) with
+    match step (Map.empty, [], Set.empty, Set.ofList rootDependencies) with
     | Resolution.Conflict(_) as c -> c
     | Resolution.Ok model -> Resolution.Ok(cleanupNames model)

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -47,9 +47,9 @@ let addPackagesFromReferenceFiles projects (dependenciesFile : DependenciesFile)
         newDependenciesFile
 
 let selectiveUpdate resolve lockFile dependenciesFile updateAll package =
-    let install changedPackages =
+    let install () =
         let changedDependencies = DependencyChangeDetection.findChangesInDependenciesFile(dependenciesFile,lockFile)
-        let dependenciesFile = DependencyChangeDetection.PinUnchangedDependencies dependenciesFile lockFile changedPackages
+        let dependenciesFile = DependencyChangeDetection.PinUnchangedDependencies dependenciesFile lockFile Set.empty
         resolve dependenciesFile []
 
     let selectiveUpdate package =
@@ -59,18 +59,18 @@ let selectiveUpdate resolve lockFile dependenciesFile updateAll package =
 
         let selectiveResolution = resolve dependenciesFile packages
 
-        let changedPackages =
-            selectiveResolution.ResolvedPackages.GetModelOrFail()
-            |> Seq.map (fun x -> x.Key)
-            |> Set.ofSeq
-        install changedPackages
+        let merge destination source = 
+            Map.fold (fun acc key value -> Map.add key value acc) destination source
+
+        let resolution = Resolution.Ok(merge lockFile.ResolvedPackages (selectiveResolution.ResolvedPackages.GetModelOrFail()))
+        { ResolvedPackages = resolution; ResolvedSourceFiles = lockFile.SourceFiles }
 
     let resolution =
         if updateAll then
             resolve dependenciesFile []
         else
             match package with
-            | None -> install Set.empty
+            | None -> install ()
             | Some package -> selectiveUpdate package
 
     LockFile(lockFile.FileName, dependenciesFile.Options, resolution.ResolvedPackages.GetModelOrFail(), resolution.ResolvedSourceFiles)

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -97,7 +97,13 @@ let selectiveUpdate resolve lockFile dependenciesFile updateAll package =
     LockFile(lockFile.FileName, dependenciesFile.Options, resolution.ResolvedPackages.GetModelOrFail(), resolution.ResolvedSourceFiles)
 
 let SelectiveUpdate(dependenciesFile : DependenciesFile, updateAll, exclude, force) =
-    let oldLockFile = LockFile.LoadFrom <| dependenciesFile.FindLockfile().FullName 
+    let lockFileName = DependenciesFile.FindLockfile dependenciesFile.FileName
+    let oldLockFile =
+        if not lockFileName.Exists then
+            LockFile.Parse(lockFileName.FullName, [||])
+        else
+            LockFile.LoadFrom lockFileName.FullName
+
     let lockFile = selectiveUpdate (fun d p -> d.Resolve(force, p)) oldLockFile dependenciesFile updateAll exclude
     lockFile.Save()
     lockFile

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -50,12 +50,13 @@ let selectiveUpdate resolve lockFile dependenciesFile updateAll package =
     let install () =
         let changedDependencies = DependencyChangeDetection.findChangesInDependenciesFile(dependenciesFile,lockFile)
         let dependenciesFile = DependencyChangeDetection.PinUnchangedDependencies dependenciesFile lockFile Set.empty
-        resolve dependenciesFile []
+        resolve dependenciesFile None
 
     let selectiveUpdate package =
         let selectiveResolution = 
             dependenciesFile.Packages
             |> List.filter (fun p -> package = NormalizedPackageName p.Name)
+            |> Some
             |> resolve dependenciesFile
 
         let merge destination source = 
@@ -87,7 +88,7 @@ let selectiveUpdate resolve lockFile dependenciesFile updateAll package =
 
     let resolution =
         if updateAll then
-            resolve dependenciesFile []
+            resolve dependenciesFile None
         else
             match package with
             | None -> install ()

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -47,12 +47,12 @@ let ``should parse lock file``() =
     packages.[1].Source |> shouldEqual PackageSources.DefaultNugetSource
     packages.[1].Name |> shouldEqual (PackageName "Castle.Windsor-log4net")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.3")
-    packages.[1].Dependencies |> shouldEqual (Set.ofList [PackageName "Castle.Windsor", VersionRequirement.AllReleases, []; PackageName "log4net", VersionRequirement.AllReleases, []])
+    packages.[1].Dependencies |> shouldEqual (Set.ofList [PackageName "Castle.Windsor", VersionRequirement(Minimum(SemVer.Parse "2.0"), PreReleaseStatus.No), []; PackageName "log4net", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), []])
     
     packages.[5].Source |> shouldEqual PackageSources.DefaultNugetSource
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
-    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement.AllReleases, []])
+    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), []])
 
     let sourceFiles = List.rev lockFile.SourceFiles
     sourceFiles|> shouldEqual
@@ -103,7 +103,7 @@ let ``should parse strict lock file``() =
     packages.[5].Source |> shouldEqual PackageSources.DefaultNugetSource
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
-    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement.AllReleases, []])
+    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), []])
 
 let redirectsLockFile = """REDIRECTS: ON
 IMPORT-TARGETS: TRUE

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -94,6 +94,7 @@
     </Content>
     <Compile Include="PackagesConfig\ReadConfig.fs" />
     <Compile Include="PackagesConfig\WriteConfig.fs" />
+    <Compile Include="UpdateProcessSpecs.fs" />
     <Compile Include="RemotePushUrlSpecs.fs" />
     <Content Include="Nuspec\FSharp.Data.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/Paket.Tests/TestHelpers.fs
+++ b/tests/Paket.Tests/TestHelpers.fs
@@ -38,7 +38,7 @@ let safeResolve graph (dependencies : (string * VersionRange) list)  =
                               Parent = PackageRequirementSource.DependenciesFile ""
                               Settings = InstallSettings.Default
                               ResolverStrategy = ResolverStrategy.Max })
-    PackageResolver.Resolve(VersionsFromGraph graph, PackageDetailsFromGraph graph, [], packages)
+    PackageResolver.Resolve(VersionsFromGraph graph, PackageDetailsFromGraph graph, [], packages, Set.empty)
 
 let resolve graph dependencies = (safeResolve graph dependencies).GetModelOrFail()
 

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -1,0 +1,175 @@
+﻿module Paket.UpdateProcess.Test
+
+open Paket
+open Paket.Domain
+open Paket.PackageSources
+open Paket.PackageResolver
+open Paket.TestHelpers
+open NUnit.Framework
+open FsUnit
+
+let lockFileData = """NUGET
+  remote: http://nuget.org/api/v2
+  specs:
+    Castle.Core (3.2.0)
+    Castle.Core-log4net (3.2.0)
+      Castle.Core (>= 3.2.0)
+      log4net (1.2.10)
+    FAKE (4.0.0)
+    log4net (1.2.10)
+"""
+
+let graph = 
+    [ "Castle.Core-log4net", "3.2.0", 
+      [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "3.2.0",PreReleaseStatus.No)
+        "log4net", VersionRequirement(VersionRange.AtLeast "1.2.10",PreReleaseStatus.No) ]
+      "Castle.Core-log4net", "3.3.3", 
+      [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "3.3.3",PreReleaseStatus.No)
+        "log4net", VersionRequirement(VersionRange.AtLeast "1.2.10",PreReleaseStatus.No) ]
+      "Castle.Core-log4net", "4.0.0", 
+      [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "4.0.0",PreReleaseStatus.No) ]
+      "Castle.Core", "3.2.0", []
+      "Castle.Core", "3.3.3", []
+      "Castle.Core", "4.0.0", []
+      "FAKE", "4.0.0", []
+      "FAKE", "4.0.1", []
+      "log4net", "1.2.10", [] ]
+
+let getVersions = VersionsFromGraph graph
+let getPackageDetails = PackageDetailsFromGraph graph
+
+let lockFile = LockFile.Parse("",toLines lockFileData)
+let resolve (dependenciesFile : DependenciesFile) = dependenciesFile.Resolve(noSha1, getVersions, getPackageDetails)
+
+[<Test>]
+let ``SelectiveUpdate does not update any package when it is neither updating all nor selective updating``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net ~> 3.2
+    nuget FAKE""")
+    
+    let updateAll = false    
+    let lockFile = selectiveUpdate resolve lockFile dependenciesFile updateAll None
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.2.0");
+        ("Castle.Core","3.2.0");
+        ("FAKE","4.0.0");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    
+[<Test>]
+let ``SelectiveUpdate updates all packages not constraining version``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net ~> 3.2
+    nuget FAKE""")
+
+    let updateAll = true
+    let lockFile = selectiveUpdate resolve lockFile dependenciesFile updateAll None
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.3.3");
+        ("Castle.Core","4.0.0");
+        ("FAKE","4.0.1");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    
+[<Test>]
+let ``SelectiveUpdate updates all packages constraining version``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net < 4.0
+    nuget Castle.Core ~> 3.2
+    nuget FAKE = 4.0.0""")
+
+    let updateAll = true
+    let lockFile = selectiveUpdate resolve lockFile dependenciesFile updateAll None
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.3.3");
+        ("Castle.Core","3.3.3");
+        ("FAKE","4.0.0");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    
+[<Test>]
+let ``SelectiveUpdate removes a dependency when it is updated to a version that does not depend on a library``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget FAKE""")
+
+    let updateAll = true
+    let lockFile = selectiveUpdate resolve lockFile dependenciesFile updateAll None
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","4.0.0");
+        ("Castle.Core","4.0.0");
+        ("FAKE","4.0.1")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    
+[<Test>]
+let ``SelectiveUpdate updates a single package``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget FAKE""")
+
+    let updateAll = false
+    let lockFile = 
+        Some(NormalizedPackageName(PackageName "FAKE"))
+        |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.2.0");
+        ("Castle.Core","3.2.0");
+        ("FAKE","4.0.1");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -33,7 +33,9 @@ let graph =
       "Castle.Core", "4.0.0", []
       "FAKE", "4.0.0", []
       "FAKE", "4.0.1", []
-      "log4net", "1.2.10", [] ]
+      "log4net", "1.2.10", []
+      "Newtonsoft.Json", "7.0.1", []
+      "Newtonsoft.Json", "6.0.8", [] ]
 
 let getVersions = VersionsFromGraph graph
 let getPackageDetails = PackageDetailsFromGraph graph
@@ -224,6 +226,34 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
         ("Castle.Core","3.3.3");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    
+[<Test>]
+let ``SelectiveUpdate installs new packages``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget FAKE
+    nuget Newtonsoft.Json""")
+
+    let updateAll = false
+    let lockFile = selectiveUpdate resolve lockFile dependenciesFile updateAll None
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.2.0");
+        ("Castle.Core","3.2.0");
+        ("FAKE","4.0.0");
+        ("log4net", "1.2.10");
+        ("Newtonsoft.Json", "7.0.1")]
         |> Seq.sortBy (fun (key,_) -> key)
 
     result

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -316,3 +316,32 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
     |> Seq.sortBy (fun (key,_) -> key)
     |> shouldEqual expected
    
+[<Test>]
+let ``SelectiveUpdate considers package name case difference``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget castle.core = 3.2.0
+    nuget FAKE""")
+
+    let updateAll = false
+    let lockFile = 
+        Some(NormalizedPackageName(PackageName "Castle.Core-log4net"))
+        |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.2.0");
+        ("Castle.Core","3.2.0");
+        ("FAKE","4.0.0");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+        
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+   

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -287,3 +287,32 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
     |> Seq.sortBy (fun (key,_) -> key)
     |> shouldEqual expected
     
+[<Test>]
+let ``SelectiveUpdate does not update when a dependency constrain is not met``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget Castle.Core = 3.2.0
+    nuget FAKE""")
+
+    let updateAll = false
+    let lockFile = 
+        Some(NormalizedPackageName(PackageName "Castle.Core-log4net"))
+        |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.2.0");
+        ("Castle.Core","3.2.0");
+        ("FAKE","4.0.0");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+        
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+   

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -344,4 +344,21 @@ let ``SelectiveUpdate considers package name case difference``() =
     result
     |> Seq.sortBy (fun (key,_) -> key)
     |> shouldEqual expected
-   
+    
+[<Test>]
+let ``SelectiveUpdate conflicts when a dependency is contrained``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget Castle.Core = 3.2.0
+    nuget log4net > 1.2.10
+    nuget FAKE""")
+
+    let updateAll = false
+
+    (fun () ->
+    Some(NormalizedPackageName(PackageName "Castle.Core-log4net"))
+    |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+    |> ignore)
+    |> shouldFail

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -362,3 +362,32 @@ let ``SelectiveUpdate conflicts when a dependency is contrained``() =
     |> selectiveUpdate resolve lockFile dependenciesFile updateAll
     |> ignore)
     |> shouldFail
+
+[<Test>]
+let ``SelectiveUpdate does not update any package when package does not exist``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget FAKE""")
+
+    let updateAll = false
+    let lockFile = 
+        Some(NormalizedPackageName(PackageName "package"))
+        |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.2.0");
+        ("Castle.Core","3.2.0");
+        ("FAKE","4.0.0");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+     

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -200,3 +200,33 @@ let ``SelectiveUpdate updates a single constrained package``() =
     result
     |> Seq.sortBy (fun (key,_) -> key)
     |> shouldEqual expected
+     
+[<Test>]
+let ``SelectiveUpdate updates a single package with constrained dependency in dependencies file``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net ~> 3.2
+    nuget Castle.Core ~> 3.2
+    nuget FAKE""")
+
+    let updateAll = false
+    let lockFile = 
+        Some(NormalizedPackageName(PackageName "Castle.Core-log4net"))
+        |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","3.3.3");
+        ("Castle.Core","3.3.3");
+        ("FAKE","4.0.0");
+        ("log4net","1.2.10")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -260,3 +260,30 @@ let ``SelectiveUpdate installs new packages``() =
     |> Seq.sortBy (fun (key,_) -> key)
     |> shouldEqual expected
     
+[<Test>]
+let ``SelectiveUpdate removes a dependency when it updates a single package and it is updated to a version that does not depend on a library``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net
+    nuget FAKE""")
+
+    let updateAll = false
+    let lockFile = 
+        Some(NormalizedPackageName(PackageName "Castle.Core-log4net"))
+        |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+
+    let result = 
+        lockFile.ResolvedPackages
+        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
+
+    let expected = 
+        [("Castle.Core-log4net","4.0.0");
+        ("Castle.Core","4.0.0");
+        ("FAKE","4.0.0")]
+        |> Seq.sortBy (fun (key,_) -> key)
+
+    result
+    |> Seq.sortBy (fun (key,_) -> key)
+    |> shouldEqual expected
+    


### PR DESCRIPTION
This PR fixes the behavior of selective update (update specifying a package).

The current behavior is to pin the version for all packages, except the one specified, and resolve the whole graph.

This would cause the dependencies of the specified package to be pinned and the package would not be updated if it requires that one or more dependencies need to be updated as well.

For example:
``Castle.Core-log4net 3.2.0`` depends on ``Castle.Core >= 3.2.0``
``Castle.Core-log4net 3.3.3`` depends on ``Castle.Core >= 3.3.3``

If I try to update ``Castle.Core-log4net`` from ``3.2.0`` to ``3.3.3``, it would not succeed because ``Castle.Core`` is pinned to ``3.2.0``.

This PR only resolve the specified package graph.