### PR TITLE
Check for conflicts in selective update

### DIFF
--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -312,12 +312,12 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
     member this.Resolve(force,packages) =
         let getSha1 origin owner repo branch = RemoteDownload.getSHA1OfBranch origin owner repo branch |> Async.RunSynchronously
         let root = Path.GetDirectoryName this.FileName
-        this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force,packages)   
+        this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force,packages,[])   
 
     member this.Resolve(force) = 
         this.Resolve(force,Some packages)
 
-    member __.Resolve(getSha1,getVersionF, getPackageDetailsF,rootDependencies) =
+    member __.Resolve(getSha1,getVersionF, getPackageDetailsF,rootDependencies,requirements) =
         let rootDependencies =
             match rootDependencies with
             | None -> packages
@@ -348,11 +348,11 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
                             VersionRequirement = v })
             |> Seq.toList
 
-        { ResolvedPackages = PackageResolver.Resolve(getVersionF, getPackageDetailsF, options.Settings.FrameworkRestrictions, remoteDependencies @ rootDependencies, Set.ofList packages)
+        { ResolvedPackages = PackageResolver.Resolve(getVersionF, getPackageDetailsF, options.Settings.FrameworkRestrictions, remoteDependencies @ rootDependencies, packages @ requirements |> Set.ofList)
           ResolvedSourceFiles = remoteFiles }        
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF) =
-        __.Resolve(getSha1,getVersionF,getPackageDetailsF,Some packages)
+        __.Resolve(getSha1,getVersionF,getPackageDetailsF,Some packages,[])
 
     member __.AddAdditionalPackage(packageName:PackageName,versionRequirement,resolverStrategy,settings,?pinDown) =
         let pinDown = defaultArg pinDown false

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -309,13 +309,10 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
     member __.Lines = textRepresentation
     member __.Sources = sources
 
-    member this.Resolve(force,packages) =
+    member this.Resolve(force,packages,requirements) =
         let getSha1 origin owner repo branch = RemoteDownload.getSHA1OfBranch origin owner repo branch |> Async.RunSynchronously
         let root = Path.GetDirectoryName this.FileName
-        this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force,packages,[])   
-
-    member this.Resolve(force) = 
-        this.Resolve(force,Some packages)
+        this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force,packages,requirements)   
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF,rootDependencies,requirements) =
         let rootDependencies =
@@ -353,6 +350,9 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF) =
         __.Resolve(getSha1,getVersionF,getPackageDetailsF,Some packages,[])
+
+    member this.Resolve(force) = 
+        this.Resolve(force,Some packages,[])
 
     member __.AddAdditionalPackage(packageName:PackageName,versionRequirement,resolverStrategy,settings,?pinDown) =
         let pinDown = defaultArg pinDown false

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -71,10 +71,11 @@ let createPackageRequirement parent (packageName, version, restrictions) =
       Sources = []
     }
 
-let createPackageRequirements resolution =
+let createPackageRequirements exclude resolution =
     resolution
     |> Map.toSeq
     |> Seq.map snd
+    |> Seq.filter (fun p -> exclude |> List.contains (NormalizedPackageName p.Name) |> not)
     |> Seq.collect (fun p -> p.Dependencies |> Seq.map (createPackageRequirement p))
 
 type PackageResolution = Map<NormalizedPackageName, ResolvedPackage>

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -72,9 +72,18 @@ let createPackageRequirement parent (packageName, version, restrictions) =
     }
 
 let createPackageRequirements exclude resolution =
-    resolution
-    |> Map.toSeq
-    |> Seq.map snd
+    let packages =
+        resolution
+        |> Map.toSeq
+        |> Seq.map snd
+
+    let transitive = 
+        packages
+        |> Seq.collect (fun d -> d.Dependencies |> Seq.map (fun (n,_,_) -> n))
+        |> List.ofSeq
+
+    packages
+    |> Seq.filter (fun p -> transitive |> List.contains p.Name |> not)
     |> Seq.filter (fun p -> exclude |> List.contains (NormalizedPackageName p.Name) |> not)
     |> Seq.collect (fun p -> p.Dependencies |> Seq.map (createPackageRequirement p))
 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -62,6 +62,21 @@ type ResolvedPackage =
         let (PackageName name) = this.Name
         sprintf "%s %s" name (this.Version.ToString())
 
+let createPackageRequirement parent (packageName, version, restrictions) =
+    { Name = packageName
+      VersionRequirement = version
+      ResolverStrategy = ResolverStrategy.Max
+      Settings = parent.Settings
+      Parent = Package(parent.Name, parent.Version)
+      Sources = []
+    }
+
+let createPackageRequirements resolution =
+    resolution
+    |> Map.toSeq
+    |> Seq.map snd
+    |> Seq.collect (fun p -> p.Dependencies |> Seq.map (createPackageRequirement p))
+
 type PackageResolution = Map<NormalizedPackageName, ResolvedPackage>
 
 let allPrereleases versions = versions |> List.filter (fun v -> v.PreRelease <> None) = versions

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -77,14 +77,18 @@ let createPackageRequirements exclude resolution =
         |> Map.toSeq
         |> Seq.map snd
 
+    let contains list package = list |> List.contains (NormalizedPackageName package.Name)
+
     let transitive = 
         packages
+        |> Seq.filter (contains exclude)
         |> Seq.collect (fun d -> d.Dependencies |> Seq.map (fun (n,_,_) -> n))
+        |> Seq.map NormalizedPackageName
         |> List.ofSeq
 
     packages
-    |> Seq.filter (fun p -> transitive |> List.contains p.Name |> not)
-    |> Seq.filter (fun p -> exclude |> List.contains (NormalizedPackageName p.Name) |> not)
+    |> Seq.filter ((contains transitive) >> not)
+    |> Seq.filter ((contains exclude) >> not)
     |> Seq.collect (fun p -> p.Dependencies |> Seq.map (createPackageRequirement p))
 
 type PackageResolution = Map<NormalizedPackageName, ResolvedPackage>

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -100,9 +100,9 @@ let createPackageRequirements exclude resolution =
         |> List.ofSeq
 
     packages
-    |> Seq.filter ((contains transitive) >> not)
-    |> Seq.filter ((contains exclude) >> not)
-    |> Seq.collect (getDependencyGraph packages)
+    |> List.filter ((contains transitive) >> not)
+    |> List.filter ((contains exclude) >> not)
+    |> List.collect (getDependencyGraph packages)
 
 type PackageResolution = Map<NormalizedPackageName, ResolvedPackage>
 

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -49,7 +49,7 @@ let addPackagesFromReferenceFiles projects (dependenciesFile : DependenciesFile)
 let selectiveUpdate resolve lockFile dependenciesFile updateAll package =
     let install () =
         let changedDependencies = DependencyChangeDetection.findChangesInDependenciesFile(dependenciesFile,lockFile)
-        let dependenciesFile = DependencyChangeDetection.PinUnchangedDependencies dependenciesFile lockFile Set.empty
+        let dependenciesFile = DependencyChangeDetection.PinUnchangedDependencies dependenciesFile lockFile changedDependencies
         resolve dependenciesFile None
 
     let selectiveUpdate package =

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -112,7 +112,6 @@ let SelectiveUpdate(dependenciesFile : DependenciesFile, updateAll, exclude, for
     let requirements =
         oldLockFile.ResolvedPackages
         |> createPackageRequirements excludePackages
-        |> List.ofSeq
 
     let lockFile = selectiveUpdate (fun d p -> d.Resolve(force, p, requirements)) oldLockFile dependenciesFile updateAll exclude
     lockFile.Save()

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -104,7 +104,17 @@ let SelectiveUpdate(dependenciesFile : DependenciesFile, updateAll, exclude, for
         else
             LockFile.LoadFrom lockFileName.FullName
 
-    let lockFile = selectiveUpdate (fun d p -> d.Resolve(force, p)) oldLockFile dependenciesFile updateAll exclude
+    let excludePackages =
+        match exclude with
+        | Some e -> [e]
+        | None -> []
+
+    let requirements =
+        oldLockFile.ResolvedPackages
+        |> createPackageRequirements excludePackages
+        |> List.ofSeq
+
+    let lockFile = selectiveUpdate (fun d p -> d.Resolve(force, p, requirements)) oldLockFile dependenciesFile updateAll exclude
     lockFile.Save()
     lockFile
 

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -442,7 +442,6 @@ let ``SelectiveUpdate does not update when package conflicts with a transitive d
     let requirements =
         lockFile.ResolvedPackages
         |> createPackageRequirements [packageName]
-        |> List.ofSeq
     let resolve = resolve' graph requirements
 
     let lockFile = 
@@ -520,7 +519,6 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     let requirements =
         lockFile2.ResolvedPackages
         |> createPackageRequirements [packageName]
-        |> List.ofSeq
     let resolve = resolve' graph2 requirements
 
     let lockFile = 
@@ -558,7 +556,6 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     let requirements =
         lockFile2.ResolvedPackages
         |> createPackageRequirements [packageName]
-        |> List.ofSeq
     let resolve = resolve' graph2 requirements
 
     let lockFile = 
@@ -621,7 +618,6 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     let requirements =
         lockFile3.ResolvedPackages
         |> createPackageRequirements [packageName]
-        |> List.ofSeq
     let resolve = resolve' graph3 requirements
 
     let lockFile = 
@@ -661,7 +657,6 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     let requirements =
         lockFile3.ResolvedPackages
         |> createPackageRequirements [packageName]
-        |> List.ofSeq
     let resolve = resolve' graph3 requirements
 
     let lockFile = 
@@ -720,7 +715,6 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     let requirements =
         lockFile4.ResolvedPackages
         |> createPackageRequirements [packageName]
-        |> List.ofSeq
     let resolve = resolve' graph4 requirements
 
     let lockFile = 

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -65,10 +65,10 @@ let ``SelectiveUpdate does not update any package when it is neither updating al
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -91,10 +91,10 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.1");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -118,10 +118,10 @@ let ``SelectiveUpdate updates all packages constraining version``() =
         ("Castle.Core","3.3.3");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -143,10 +143,10 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
         [("Castle.Core-log4net","4.0.0");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.1")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -171,10 +171,10 @@ let ``SelectiveUpdate updates a single package``() =
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.1");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -199,10 +199,10 @@ let ``SelectiveUpdate updates a single constrained package``() =
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
      
 [<Test>]
@@ -228,10 +228,10 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
         ("Castle.Core","3.3.3");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -256,10 +256,10 @@ let ``SelectiveUpdate installs new packages``() =
         ("FAKE","4.0.0");
         ("log4net", "1.2.10");
         ("Newtonsoft.Json", "7.0.1")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -283,10 +283,10 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
         [("Castle.Core-log4net","4.0.0");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.0")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -312,10 +312,10 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
         
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
    
 [<Test>]
@@ -341,10 +341,10 @@ let ``SelectiveUpdate considers package name case difference``() =
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
         
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
     
 [<Test>]
@@ -387,10 +387,10 @@ let ``SelectiveUpdate does not update any package when package does not exist``(
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
-        |> Seq.sortBy (fun (key,_) -> key)
+        |> Seq.sortBy fst
 
     result
-    |> Seq.sortBy (fun (key,_) -> key)
+    |> Seq.sortBy fst
     |> shouldEqual expected
      
 [<Test>]

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -644,6 +644,28 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     |> shouldEqual expected
     
 [<Test>]
+let ``SelectiveUpdate conflicts with a transitive dependency of another package when paket.dependencies requirement has changed``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Ninject ~> 3.0
+    nuget Ninject.Extensions.Logging.Log4net
+    nuget Ninject.Extensions.Interception""")
+    
+    let updateAll = false
+    let packageName = NormalizedPackageName(PackageName "Ninject")
+    let requirements =
+        lockFile3.ResolvedPackages
+        |> createPackageRequirements [packageName]
+    let resolve = resolve' graph3 requirements
+
+    (fun () ->
+    Some(packageName)
+    |> selectiveUpdate resolve lockFile3 dependenciesFile updateAll
+    |> ignore)
+    |> shouldFail
+    
+[<Test>]
 let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency of another package to correct version``() = 
 
     let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -40,12 +40,10 @@ let graph =
       "Newtonsoft.Json", "7.0.1", []
       "Newtonsoft.Json", "6.0.8", [] ]
 
-let getVersions = VersionsFromGraph graph
-let getPackageDetails = PackageDetailsFromGraph graph
-
-let lockFile = LockFile.Parse("",toLines lockFileData)
-let resolve' requirements (dependenciesFile : DependenciesFile) packages = dependenciesFile.Resolve(noSha1, getVersions, getPackageDetails, packages, requirements)
-let resolve = resolve' []
+let getLockFile lockFileData = LockFile.Parse("",toLines lockFileData)
+let lockFile = lockFileData |> getLockFile
+let resolve' graph requirements (dependenciesFile : DependenciesFile) packages = dependenciesFile.Resolve(noSha1, VersionsFromGraph graph, PackageDetailsFromGraph graph, packages, requirements)
+let resolve = resolve' graph []
 
 [<Test>]
 let ``SelectiveUpdate does not update any package when it is neither updating all nor selective updating``() = 
@@ -438,16 +436,17 @@ let ``SelectiveUpdate does not update when package conflicts with a transitive d
     nuget Castle.Core-log4net
     nuget FAKE
     nuget log4net""")
-    
+
     let updateAll = false
+    let packageName = NormalizedPackageName(PackageName "log4net")
     let requirements =
         lockFile.ResolvedPackages
-        |> createPackageRequirements
+        |> createPackageRequirements [packageName]
         |> List.ofSeq
-    let resolve = resolve' requirements
+    let resolve = resolve' graph requirements
 
     let lockFile = 
-        Some(NormalizedPackageName(PackageName "log4net"))
+        Some(packageName)
         |> selectiveUpdate resolve lockFile dependenciesFile updateAll
     
     let result = 
@@ -461,6 +460,84 @@ let ``SelectiveUpdate does not update when package conflicts with a transitive d
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net", "1.2.10")]
+        |> Seq.sortBy fst
+
+    result
+    |> Seq.sortBy fst
+    |> shouldEqual expected
+
+
+let graph2 = 
+    [ "Ninject", "2.2.1.4", []
+      "Ninject", "2.2.1.5", []
+      "Ninject", "2.3.1.4", []
+      "Ninject", "3.2.0", []
+      "Ninject.Extensions.Logging.Log4net", "2.2.0.4",
+      [ "Ninject.Extensions.Logging", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No)
+        "log4net", VersionRequirement(VersionRange.AtLeast "1.0.4",PreReleaseStatus.No) ]
+      "Ninject.Extensions.Logging.Log4net", "2.2.0.5",
+      [ "Ninject.Extensions.Logging", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No)
+        "log4net", VersionRequirement(VersionRange.AtLeast "1.0.4",PreReleaseStatus.No) ]
+      "Ninject.Extensions.Logging.Log4net", "3.2.3",
+      [ "Ninject.Extensions.Logging", VersionRequirement(VersionRange.Between("3.2.0.0","3.3.0.0"),PreReleaseStatus.No)
+        "log4net", VersionRequirement(VersionRange.AtLeast "1.2.11",PreReleaseStatus.No) ]
+      "Ninject.Extensions.Logging", "2.2.0.4", [ "Ninject", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
+      "Ninject.Extensions.Logging", "2.2.0.5", [ "Ninject", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
+      "Ninject.Extensions.Logging", "3.2.3", [ "Ninject", VersionRequirement(VersionRange.Between("3.2.0.0","3.3.0.0"),PreReleaseStatus.No) ]
+      "log4f", "0.4.0", [ "log4net", VersionRequirement(VersionRange.Between("1.2.10","2.0.0"),PreReleaseStatus.No) ]
+      "log4f", "0.5.0", [ "log4net", VersionRequirement(VersionRange.AtLeast "1.2.10",PreReleaseStatus.No) ]
+      "log4net", "1.0.4", []
+      "log4net", "1.2.10", []
+      "log4net", "1.2.11", []
+      "log4net", "2.0.3", [] ]
+
+[<Test>]
+let ``SelectiveUpdate updates package that conflicts with a transitive dependency with correct version``() = 
+
+    let lockFileData = """NUGET
+  remote: http://nuget.org/api/v2
+  specs:
+    log4f (0.4.0)
+      log4net (>= 1.2.10 < 2.0.0)
+    log4net (1.0.4)
+    Ninject (2.2.1.4)
+    Ninject.Extensions.Logging (2.2.0.4)
+      Ninject (>= 2.2.0.0 < 2.3.0.0)
+    Ninject.Extensions.Logging.Log4net (2.2.0.4)
+      Ninject.Extensions.Logging (>= 2.2.0.0 < 2.3.0.0)
+      log4net (>= 1.0.4)
+"""
+    let lockFile = lockFileData |> getLockFile
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget log4f
+    nuget Ninject.Extensions.Logging.Log4net""")
+    
+    let updateAll = false
+    let packageName = NormalizedPackageName(PackageName "log4f")
+    let requirements =
+        lockFile.ResolvedPackages
+        |> createPackageRequirements [packageName]
+        |> List.ofSeq
+    let resolve = resolve' graph2 requirements
+
+    let lockFile = 
+        Some(packageName)
+        |> selectiveUpdate resolve lockFile dependenciesFile updateAll
+    
+    let result = 
+        lockFile.ResolvedPackages
+        |> Map.toSeq
+        |> Seq.map snd
+        |> Seq.map (fun r -> (string r.Name, string r.Version))
+
+    let expected = 
+        [("Ninject.Extensions.Logging.Log4net","2.2.0.4");
+        ("Ninject.Extensions.Logging","2.2.0.4");
+        ("Ninject", "2.2.1.4");
+        ("log4f", "0.5.0");
+        ("log4net", "2.0.3")]
         |> Seq.sortBy fst
 
     result


### PR DESCRIPTION
This PR complements the #957.

Since it doesn't resolve the whole graph, it must create constraints from the information in lock file to later check for conflicts while resolving the graph for the package selected.