### PR TITLE
[https://github.com/fsprojects/Paket/issues/966] Paket mixed responses and downloads [Fix]

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -215,7 +215,7 @@ let getDetailsFromNuGetViaODataFast auth nugetURL package (version:SemVerInfo) =
     async {         
         try 
             let url = sprintf "%s/Packages?$filter=Id eq '%s' and NormalizedVersion eq '%s'" nugetURL package (version.Normalize())
-            let! raw = getFromUrl(auth,url)
+            let raw = getFromUrl(auth,url) |> Async.RunSynchronously
             if verbose then
                 tracefn "Response from %s:" url
                 tracefn ""
@@ -223,7 +223,7 @@ let getDetailsFromNuGetViaODataFast auth nugetURL package (version:SemVerInfo) =
             return parseODataDetails(nugetURL,package,version,raw)
         with _ ->         
             let url = sprintf "%s/Packages?$filter=Id eq '%s' and Version eq '%s'" nugetURL package (version.ToString())
-            let! raw = getFromUrl(auth,url)
+            let raw = getFromUrl(auth,url) |> Async.RunSynchronously
             if verbose then
                 tracefn "Response from %s:" url
                 tracefn ""
@@ -238,14 +238,14 @@ let getDetailsFromNuGetViaOData auth nugetURL package (version:SemVerInfo) =
             return! getDetailsFromNuGetViaODataFast auth nugetURL package version
         with _ ->         
             let url = sprintf "%s/Packages(Id='%s',Version='%s')" nugetURL package (version.ToString())
-            let! response = safeGetFromUrl(auth,url)
+            let response = safeGetFromUrl(auth,url) |> Async.RunSynchronously
                     
-            let! raw =
+            let raw =
                 match response with
-                | Some(r) -> async { return r }
+                | Some(r) -> async { return r } |> Async.RunSynchronously
                 | None ->
                     let url = sprintf "%s/odata/Packages(Id='%s',Version='%s')" nugetURL package (version.ToString())
-                    getXmlFromUrl(auth,url)
+                    getXmlFromUrl(auth,url) |> Async.RunSynchronously
 
             if verbose then
                 tracefn "Response from %s:" url

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -170,7 +170,7 @@ let getFromUrl (auth:Auth option, url : string) =
     async { 
         try
             use client = createWebClient(url,auth)
-            return! client.AsyncDownloadString(Uri(url))
+            return client.DownloadString(Uri(url))
         with
         | exn -> 
             failwithf "Could not retrieve data from %s%s Message: %s" url Environment.NewLine exn.Message
@@ -200,7 +200,7 @@ let safeGetFromUrl (auth:Auth option, url : string) =
     async { 
         try 
             use client = createWebClient(url,auth)
-            let! raw = client.AsyncDownloadString(Uri(url))
+            let raw = client.DownloadString(Uri(url))
             return Some raw
         with _ -> return None
     }


### PR DESCRIPTION
I tested this modifications on several of our windows server 2012 r2 and we didn't see the fail happening again.
I know that this is not the best approuch (not using the async for downloading the string anymore) but it seems to do it's job.
Note: I used '|> Async.RunSynchronously' so it wil be easy to remove it at a later time after we correctly identified the issues.
