### PR TITLE
Version range semantics changed for >= x.y.z prerelease

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,6 @@
-#### 1.26.2 - 12.08.2015
+#### 1.27.0 - 13.08.2015
+* Version range semantics changed for `>= x.y.z prerelease` - https://github.com/fsprojects/Paket/issues/976
 * BUGFIX: Version trace got lost - https://twitter.com/indy9000/status/631201649219010561
-
-#### 1.26.1 - 11.08.2015
 * BUGFIX: copy_local behaviour was broken - https://github.com/fsprojects/Paket/issues/972
 
 #### 1.26.0 - 10.08.2015

--- a/src/Paket.Core/VersionRange.fs
+++ b/src/Paket.Core/VersionRange.fs
@@ -108,10 +108,18 @@ type VersionRequirement =
                  | None -> true
                  | Some pre -> List.exists ((=) pre.Name) list
 
+        let sameVersionWithoutPreRelease v =
+            let sameVersion = 
+                match v.PreRelease with
+                | None -> v.Major = version.Major && v.Minor = version.Minor && v.Patch = version.Patch && v.Build = version.Build
+                | _ -> false
+
+            prerelease <> PreReleaseStatus.No && sameVersion && checkPrerelease prerelease version
+
         match range with
-        | Specific v -> v = version
+        | Specific v -> v = version || sameVersionWithoutPreRelease v
         | OverrideAll v -> v = version
-        | Minimum v -> v = version || (v <= version && checkPrerelease prerelease version)
+        | Minimum v -> v = version || (v <= version && checkPrerelease prerelease version) || sameVersionWithoutPreRelease v
         | GreaterThan v -> v < version && checkPrerelease prerelease version
         | Maximum v -> v = version || (v >= version && checkPrerelease prerelease version)
         | LessThan v -> v > version && checkPrerelease prerelease version

--- a/tests/Paket.Tests/FilterVersionSpecs.fs
+++ b/tests/Paket.Tests/FilterVersionSpecs.fs
@@ -101,4 +101,11 @@ let ``can support rc version``() =
 [<Test>]
 let ``can support "build" version``() = 
     "0.9.0-build06428" |> isInRange (DependenciesFileParser.parseVersionRequirement ">= 0.9.0-build06428") |> shouldEqual true
+
+
+[<Test>]
+let ``prerelase version of same version is in range``() = 
+    "1.2.3-alpha001" |> isInRange (DependenciesFileParser.parseVersionRequirement ">= 1.2.3 prerelease") |> shouldEqual true
+    "1.2.3-alpha001" |> isInRange (DependenciesFileParser.parseVersionRequirement "1.2.3 prerelease") |> shouldEqual true
+    "1.2.3-alpha001" |> isInRange (DependenciesFileParser.parseVersionRequirement "> 1.2.3 prerelease") |> shouldEqual false
     

--- a/tests/Paket.Tests/Resolver/SimpleDependenciesSpecs.fs
+++ b/tests/Paket.Tests/Resolver/SimpleDependenciesSpecs.fs
@@ -100,3 +100,21 @@ let ``should resolve fixed config4``() =
     getVersion resolved.[NormalizedPackageName (PackageName "Castle.Core")] |> shouldEqual "3.2.0"
     getVersion resolved.[NormalizedPackageName (PackageName "Castle.Windsor-log4net")] |> shouldEqual "3.2.0.1"
     getVersion resolved.[NormalizedPackageName (PackageName "Castle.Core-log4net")] |> shouldEqual "3.2.0"
+
+let config5 = """
+source "http://nuget.org/api/v2"
+
+nuget Microsoft.AspNet.Mvc >= 6.0.0 prerelease
+"""
+
+let graph5 = [
+    "Microsoft.AspNet.Mvc","6.0.0-beta6",[]
+    "Microsoft.AspNet.Mvc","6.0.0-beta1",[]
+    "Microsoft.AspNet.Mvc","5.2.3",[]
+]
+
+[<Test>]
+let ``should resolve prerelease config``() = 
+    let cfg = DependenciesFile.FromCode(config5)
+    let resolved = cfg.Resolve(noSha1,VersionsFromGraph graph5, PackageDetailsFromGraph graph5).ResolvedPackages.GetModelOrFail()
+    getVersion resolved.[NormalizedPackageName (PackageName "Microsoft.AspNet.Mvc")] |> shouldEqual "6.0.0-beta6"


### PR DESCRIPTION
Since this is a common misunderstanding and we see lots of requests I changed the semantics for `>= x.y.z prerelease` to include `x.y.z-alphaabc` versions. Before we would exclude all prereleases of `x.y.z` since they are considered smaller than `x.y.z`.

Please see the tests.