### PR TITLE
Selective update shows better error message on conflict

### DIFF
--- a/tests/Paket.Tests/Resolver/ConflictGraphSpecs.fs
+++ b/tests/Paket.Tests/Resolver/ConflictGraphSpecs.fs
@@ -36,7 +36,7 @@ let defaultPackage =
 let ``should analyze graph and report conflict``() = 
     match safeResolve graph [ "A", VersionRange.AtLeast "1.0" ] with
     | Resolution.Ok _ -> failwith "we expected an error"
-    | Resolution.Conflict(_,stillOpen) ->
+    | Resolution.Conflict(_,stillOpen,_) ->
         let conflicting = stillOpen |> Seq.head 
         conflicting.Name |> shouldEqual (PackageName "D")
         conflicting.VersionRequirement.Range |> shouldEqual (VersionRange.Exactly "1.4")
@@ -54,7 +54,7 @@ let graph2 =
 let ``should analyze graph2 and report conflict``() = 
     match safeResolve graph2 [ "A", VersionRange.AtLeast "1.0" ] with
     | Resolution.Ok _ -> failwith "we expected an error"
-    | Resolution.Conflict(_,stillOpen) ->
+    | Resolution.Conflict(_,stillOpen,_) ->
         let conflicting = stillOpen |> Seq.head 
         conflicting.Name |> shouldEqual (PackageName "D")
         conflicting.VersionRequirement.Range |> shouldEqual (VersionRange.Between("1.4", "1.5"))


### PR DESCRIPTION
When I'm updating a single package, the conflict message would not show the other packages requirements that has conflicted.

paket.dependencies:
```
source https://nuget.org/api/v2

nuget Ninject.Extensions.Interception
nuget Ninject.Extensions.Logging.Log4Net
```

paket.lock:
```
NUGET
  remote: https://nuget.org/api/v2
  specs:
    log4net (2.0.3)
    Ninject (2.2.1.4)
    Ninject.Extensions.Interception (2.2.1.2)
      Ninject (>= 2.2.0.0 < 2.3.0.0)
    Ninject.Extensions.Logging (2.2.0.4)
      Ninject (>= 2.2.0.0 < 2.3.0.0)
    Ninject.Extensions.Logging.Log4net (2.2.0.4)
      Ninject.Extensions.Logging (>= 2.2.0.0 < 2.3.0.0)
      log4net (>= 1.0.4)
```

```paket update nuget Ninject.Extensions.Logging.Log4Net version 3.0.1```
Outputs:
```
  Could not resolve package Ninject:
   - Ninject.Extensions.Logging 3.0.1 requested >= 3.0.0.0 < 3.1.0.0
```

This PR changes to output message to include what other packages have conflicted:
```
  Could not resolve package Ninject:
   - Ninject.Extensions.Interception 2.2.1.2 requested >= 2.2.0.0 < 2.3.0.0
   - Ninject.Extensions.Logging 3.0.1 requested >= 3.0.0.0 < 3.1.0.0
```