### PR TITLE
Only creates requirements from lock file when updating a single package

### DIFF
--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -104,14 +104,12 @@ let SelectiveUpdate(dependenciesFile : DependenciesFile, updateAll, exclude, for
         else
             LockFile.LoadFrom lockFileName.FullName
 
-    let excludePackages =
-        match exclude with
-        | Some e -> [e]
-        | None -> []
-
     let requirements =
-        oldLockFile.ResolvedPackages
-        |> createPackageRequirements excludePackages
+        match exclude with
+        | Some e -> 
+            oldLockFile.ResolvedPackages
+            |> createPackageRequirements [e]
+        | None -> []
 
     let lockFile = selectiveUpdate (fun d p -> d.Resolve(force, p, requirements)) oldLockFile dependenciesFile updateAll exclude
     lockFile.Save()


### PR DESCRIPTION
When I'm updating all packages, there should be no requirements created from lock file.

Requirements should only be created when you don't resolve the whole graph (i.e. update a single package).