### PR TITLE
Shows conflicts with requirements

### DIFF
--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -352,6 +352,7 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
                         tracefn "  Conflicts with:"
                     
                         closedRequirements
+                        |> Set.union requirements
                         |> Seq.filter (fun d -> d.Name = currentRequirement.Name)
                         |> fun xs -> String.Join(Environment.NewLine + "    ",xs)
                         |> tracefn "    %s"


### PR DESCRIPTION
This PR shows conflicts that conflict with requirements from ```paket.lock``` as well.