### PR TITLE
Fails the update of a nonexistent package

### DIFF
--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -131,6 +131,11 @@ let SmartInstall(dependenciesFile, updateAll, exclude, options : UpdaterOptions)
 let UpdatePackage(dependenciesFileName, packageName : PackageName, newVersion, options : UpdaterOptions) =
     let dependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
 
+    if not <| dependenciesFile.HasPackage(packageName) then
+        packageName
+        |> string
+        |> failwithf "Package %s was not found in paket.dependencies."
+
     let dependenciesFile =
         match newVersion with
         | Some v -> dependenciesFile.UpdatePackageVersion(packageName, v)


### PR DESCRIPTION
This PR makes update of a package that doesn't exist in paket.dependencies fail.

```paket update nuget Ninject```

Before:
```
Paket version 1.31.0.0
Updating Ninject in D:\Projects\paket-test\paket.dependencies
Resolving packages:
D:\Projects\paket-test\paket.lock is already up-to-date
0 seconds - ready.
```

After:
```
Paket version 1.31.0.0
Paket failed with:
        Package Ninject was not found in paket.dependencies.
```