### PR TITLE
Escape file names in a NuGet compatible way

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -405,14 +405,14 @@ let ExtractPackage(fileName:string, targetFolder, name, version:SemVerInfo) =
             // cleanup folder structure
             let rec cleanup (dir : DirectoryInfo) = 
                 for sub in dir.GetDirectories() do
-                    let newName = sub.FullName.Replace("%2B", "+").Replace("%20", " ")
+                    let newName = Uri.UnescapeDataString(sub.FullName)
                     if sub.FullName <> newName && not (Directory.Exists newName) then 
                         Directory.Move(sub.FullName, newName)
                         cleanup (DirectoryInfo newName)
                     else
                         cleanup sub
                 for file in dir.GetFiles() do
-                    let newName = file.Name.Replace("%2B", "+").Replace("%20", " ")
+                    let newName = Uri.UnescapeDataString(file.Name)
                     if file.Name <> newName && not (File.Exists <| Path.Combine(file.DirectoryName, newName)) then
                         File.Move(file.FullName, Path.Combine(file.DirectoryName, newName))
 

--- a/src/Paket.Core/NupkgWriter.fs
+++ b/src/Paket.Core/NupkgWriter.fs
@@ -228,8 +228,13 @@ let Write (core : CompleteCoreInfo) optional workingDir outputDir =
         exclusions |> List.exists (fun f -> f path)
 
     let ensureValidName (target: string) =
-        Uri.EscapeDataString(target.Replace("\\", "/")).Replace("%5C", "/").Replace("%2F", "/")
-          |> fun s -> if s.StartsWith("./") then s.Remove(0,2) else s
+        let escapedTargetParts = target.Replace("\\", "/").Split('/') |> Array.map Uri.EscapeDataString
+        let escapedTarget = String.Join("/",escapedTargetParts)
+
+        let uri1 = Uri(escapedTarget, UriKind.Relative)
+        let uri2 = Uri(uri1.GetComponents(UriComponents.SerializationInfoString, UriFormat.SafeUnescaped), UriKind.Relative)
+        
+        uri2.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped)
 
     let addEntry path writerF =
         if entries.Contains(path) then () else


### PR DESCRIPTION
Fixes #975 

I did some digging into what NuGet was actually doing. The claim that it URL encodes the paths is technically correct, it just chooses a strange selection of categories to encode. Eventually it calls [this](
http://referencesource.microsoft.com/#WindowsBase/Base/System/IO/Packaging/PackUriHelper.cs,915 ) where it does the actual encoding.

I've also changed the extracting to URL decode the file paths.

Edit: Repro script here: https://gist.github.com/will14smith/3c87a3ac7cc82cd0034b

/cc @jamescrowley