### PR TITLE
UtilsSpecs: Unit test corrected + compatibility issues with Klondike NuGet server

### DIFF
--- a/src/Paket.Core/NuGetV3.fs
+++ b/src/Paket.Core/NuGetV3.fs
@@ -44,7 +44,7 @@ let getSearchAPI(auth,nugetUrl) =
             | None -> None
             | Some v3Path ->
                 let serviceData =
-                    safeGetFromUrl(auth,v3Path) 
+                    safeGetFromUrl(auth,v3Path,acceptJson)
                     |> Async.RunSynchronously
 
                 match serviceData with
@@ -62,7 +62,7 @@ let internal findVersionsForPackage(auth, nugetURL, package, includingPrerelease
     async {
         match getSearchAPI(auth,nugetURL) with        
         | Some url ->
-            let! response = safeGetFromUrl(auth,sprintf "%s?id=%s&take=%d%s" url package (max maxResults 100000) (if includingPrereleases then "&prerelease=true" else "")) // Nuget is showing old versions first
+            let! response = safeGetFromUrl(auth,sprintf "%s?id=%s&take=%d%s" url package (max maxResults 100000) (if includingPrereleases then "&prerelease=true" else ""), acceptXml) // Nuget is showing old versions first
             match response with
             | Some text ->
                 let versions =
@@ -94,7 +94,7 @@ let private getPackages(auth, nugetURL, packageNamePrefix, maxResults) = async {
     match getSearchAPI(auth,nugetURL) with
     | Some url -> 
         let query = sprintf "%s?q=%s&take=%d" url packageNamePrefix maxResults
-        let! response = safeGetFromUrl(auth,query)
+        let! response = safeGetFromUrl(auth,query,acceptJson)
         match response with
         | Some text -> return extractPackages text
         | None -> return [||]

--- a/src/Paket.Core/RemoteDownload.fs
+++ b/src/Paket.Core/RemoteDownload.fs
@@ -13,12 +13,12 @@ let getSHA1OfBranch origin owner project branch =
         match origin with
         | ModuleResolver.SingleSourceFileOrigin.GitHubLink -> 
             let url = sprintf "https://api.github.com/repos/%s/%s/commits/%s" owner project branch
-            let! document = getFromUrl(None, url)
+            let! document = getFromUrl(None, url, null)
             let json = JObject.Parse(document)
             return json.["sha"].ToString()
         | ModuleResolver.SingleSourceFileOrigin.GistLink ->  
             let url = sprintf "https://api.github.com/gists/%s/%s" project branch
-            let! document = getFromUrl(None, url)
+            let! document = getFromUrl(None, url, null)
             let json = JObject.Parse(document)
             let latest = json.["history"].First.["version"]
             return latest.ToString()
@@ -44,7 +44,7 @@ let downloadDependenciesFile(rootPath,parserF,remoteFile:ModuleResolver.Resolved
         | ModuleResolver.GistLink -> 
             rawGistFileUrl remoteFile.Owner remoteFile.Project dependenciesFileName
         | ModuleResolver.HttpLink url -> url.Replace(remoteFile.Name,Constants.DependenciesFileName)
-    let! result = safeGetFromUrl(None,url)
+    let! result = safeGetFromUrl(None,url,null)
 
     match result with
     | Some text when parserF text ->        
@@ -83,7 +83,7 @@ let downloadRemoteFiles(remoteFile:ResolvedSourceFile,destination) = async {
         let projectPath = fi.Directory.FullName
 
         let url = sprintf "https://api.github.com/gists/%s" remoteFile.Project
-        let! document = getFromUrl(None, url)
+        let! document = getFromUrl(None, url, null)
         let json = JObject.Parse(document)
         let files = json.["files"] |> Seq.map (fun i -> i.First.["filename"].ToString(), i.First.["raw_url"].ToString())
 

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -12,6 +12,11 @@ open Paket.Logging
 open Chessie.ErrorHandling
 open Paket.Domain
 
+let acceptXml = "application/atom+xml,application/xml"
+let acceptJson = "application/atom+json,application/json"
+
+let notNullOrEmpty = not << System.String.IsNullOrEmpty
+
 type Auth = 
     { Username : string
       Password : string }
@@ -168,10 +173,12 @@ let downloadFromUrl (auth:Auth option, url : string) (filePath: string) =
     }
 
 /// [omit]
-let getFromUrl (auth:Auth option, url : string) = 
+let getFromUrl (auth:Auth option, url : string, contentType : string) =
     async { 
         try
             use client = createWebClient(url,auth)
+            if notNullOrEmpty contentType then
+                client.Headers.Add(HttpRequestHeader.Accept, contentType)
             let s = client.DownloadStringTaskAsync(Uri(url)) |> Async.AwaitTask
             return! s
         with
@@ -200,10 +207,14 @@ let getXmlFromUrl (auth:Auth option, url : string) =
     }
     
 /// [omit]
-let safeGetFromUrl (auth:Auth option, url : string) = 
+let safeGetFromUrl (auth:Auth option, url : string, contentType : string) =
     async { 
         try 
             use client = createWebClient(url,auth)
+            
+            if notNullOrEmpty contentType then
+                client.Headers.Add(HttpRequestHeader.Accept, contentType)
+
             let s = client.DownloadStringTaskAsync(Uri(url)) |> Async.AwaitTask
             let! raw = s
             return Some raw

--- a/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
+++ b/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
@@ -116,7 +116,7 @@ let ``can calculate v3 path``() =
 
 [<Test>]
 let ``can read all versions from single page with multiple entries``() =
-    let getUrlContentsStub _ = async { return File.ReadAllText "NuGetOData/NUnit.xml" }
+    let getUrlContentsStub _ _ = async { return File.ReadAllText "NuGetOData/NUnit.xml" }
     
     let versions = getAllVersionsFromNugetOData(getUrlContentsStub, fakeUrl, "NUnit")
                    |> Async.RunSynchronously

--- a/tests/Paket.Tests/UtilsSpecs.fs
+++ b/tests/Paket.Tests/UtilsSpecs.fs
@@ -15,7 +15,7 @@ let ``createRelativePath should handle spaces``() =
 let ``normalize path with home directory``() =
     "~/data" 
     |> Utils.normalizeLocalPath
-    |> shouldEqual (AbsolutePath (GetHomeDirectory() + Path.DirectorySeparatorChar.ToString()  +  "data"))
+    |> shouldEqual (AbsolutePath (Path.Combine(GetHomeDirectory(), "data")))
         
 [<Test>]
 let ``relative local path is returned as is``() =


### PR DESCRIPTION
First commit 71b69f3
- Use Path.Combine instead of +Path.DirectorySeparatorChar.ToString()+
- Fixes error if HOMEPATH=\ (Root directory, result was 'H:\\' or '//data' on Unix)

Second commit fd394fc
- WARNING: I am not a F# developer and this code could possibly break alternative NuGet server versions :-)
- "It works on my machine" using the current master of Klondike (https://github.com/themotleyfool/Klondike)