### PR TITLE
Warns when package is pinned

### DIFF
--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -222,7 +222,22 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
                 exploredPackages.[(normalizedPackageName,version)] <- package
                 package
             | _ -> package
-        | false,_ ->         
+        | false,_ ->
+            let getPinnedVersion d = 
+                match d.Parent with
+                | DependenciesFile _ ->
+                    match d.VersionRequirement.Range with
+                    | Specific v -> Some v
+                    | OverrideAll v -> Some v
+                    | _ -> None
+                | Package _ -> None
+            requirements
+            |> Set.filter (fun r -> NormalizedPackageName dependency.Name = NormalizedPackageName r.Name)
+            |> Set.map getPinnedVersion
+            |> Seq.choose id
+            |> Seq.tryHead
+            |> Option.iter (traceWarnfn " %O is pinned to version %O" dependency.Name)
+
             tracefn  " - %s %A" name version
             let packageDetails : PackageDetails = getPackageDetailsF dependency.Sources dependency.Name version
             let restrictedDependencies = DependencySetFilter.filterByRestrictions (dependency.Settings.FrameworkRestrictions @ globalFrameworkRestrictions) packageDetails.DirectDependencies


### PR DESCRIPTION
This PR warns when a package is pinned to a specific version.

This is what it looks like:
```
Paket version 1.31.0.0
Updating Ninject.Extensions.Logging.Log4Net in D:\Projects\paket-test\paket.dependencies
Resolving packages:
 Ninject.Extensions.Logging.Log4Net is pinned to version 2.2.0.4
 - Ninject.Extensions.Logging.Log4Net 2.2.0.4
 Ninject.Extensions.Logging is pinned to version 2.2.0.4
 - Ninject.Extensions.Logging 2.2.0.4
 - Ninject 2.2.1.4
 - log4net 2.0.3
D:\Projects\paket-test\paket.lock is already up-to-date
2 seconds - ready.
```

This is the first PR I'm working on to better report why a package had a version chosen, aiming to close #786 and #946.