### PR TITLE
New optional parameter _input_ for pack command

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -371,11 +371,11 @@ type Dependencies(dependenciesFileName: string) =
         FindReferences.FindReferencesForPackage (PackageName package) |> this.Process
 
     // Packs all paket.template files.
-    member this.Pack(outputPath, ?buildConfig, ?version, ?releaseNotes, ?templateFile, ?workingDir, ?lockDependencies) =
+    member this.Pack(outputPath, ?inputPath, ?buildConfig, ?version, ?releaseNotes, ?templateFile, ?workingDir, ?lockDependencies) =
         let dependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
         let workingDir = defaultArg workingDir (dependenciesFile.FileName |> Path.GetDirectoryName)
         let lockDependencies = defaultArg lockDependencies false
-        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, version, releaseNotes, templateFile, lockDependencies)
+        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, inputPath, buildConfig, version, releaseNotes, templateFile, lockDependencies)
 
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -249,6 +249,7 @@ with
 
 type PackArgs =
     | [<CustomCommandLine("output")>][<Mandatory>] Output of string
+    | [<CustomCommandLine("input")>] Input of string
     | [<CustomCommandLine("buildconfig")>] BuildConfig of string
     | [<CustomCommandLine("version")>] Version of string
     | [<CustomCommandLine("templatefile")>] TemplateFile of string
@@ -259,6 +260,7 @@ with
         member this.Usage =
             match this with
             | Output(_) -> "Output directory to put nupkgs."
+            | Input(_) -> "Directory that contains all build artifacts (defaults to output directory defined in project settings)"
             | BuildConfig(_) -> "Optionally specify build configuration that should be packaged (defaults to Release)."
             | Version(_) -> "Specify version of the package."
             | TemplateFile(_) -> "Allows to specify a single template file."

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -171,6 +171,7 @@ let pack (results : ParseResults<_>) =
     let outputPath = results.GetResult <@ PackArgs.Output @>
     Dependencies.Locate()
                 .Pack(outputPath,
+                      ?inputPath = results.TryGetResult <@ PackArgs.Input @>,
                       ?buildConfig = results.TryGetResult <@ PackArgs.BuildConfig @>,
                       ?version = results.TryGetResult <@ PackArgs.Version @>,
                       ?releaseNotes = results.TryGetResult <@ PackArgs.ReleaseNotes @>,

--- a/tests/Paket.Tests/PackageProcessSpecs.fs
+++ b/tests/Paket.Tests/PackageProcessSpecs.fs
@@ -41,7 +41,31 @@ let ``Loading assembly metadata works``() =
         if workingDir.Contains "Debug" then "Debug"
         else "Release"
 
-    let assembly,id,fileName = PackageMetaData.loadAssemblyId config projFile.Value
+    let artifactPath = Option<string>.None
+    let assembly,id,fileName = PackageMetaData.loadAssemblyId config (projFile.Value,artifactPath)
+    id |> shouldEqual "Paket.Tests"
+
+    let attribs = PackageMetaData.loadAssemblyAttributes fileName assembly
+    PackageMetaData.getVersion assembly attribs |> shouldEqual <| Some(SemVer.Parse "1.0.0.0")
+    PackageMetaData.getAuthors attribs |> shouldEqual <| Some([ "Two"; "Authors" ])
+    PackageMetaData.getDescription attribs |> shouldEqual <| Some("A description")
+
+[<Test>]
+let ``Loading assembly metadata using optional input directory works``() =
+    let workingDir = Path.GetFullPath(".")
+
+    let projFile =
+        Path.Combine(workingDir, "..", "..", "Paket.Tests.fsproj")
+        |> normalizePath
+        |> ProjectFile.Load
+
+    let config =
+        if workingDir.Contains "Debug" then "Debug"
+        else "Release"
+
+    let artifactPath = Option<string>.Some(workingDir)
+
+    let assembly,id,fileName = PackageMetaData.loadAssemblyId config (projFile.Value,artifactPath)
     id |> shouldEqual "Paket.Tests"
     
     let attribs = PackageMetaData.loadAssemblyAttributes fileName assembly


### PR DESCRIPTION
Hello,

We are using a single output directory for all project builds (like [FAKE](http://fsharp.github.io/FAKE/) suggests in the sample build script). 

Unfortunately I cannot use ```paket pack ..``` + ```type project ``` (_paket.template_) with this approach:
```
$ paket pack output _build.output/nuget/
Paket version 1.32.0.0
Paket failed with:
        Ein Teil des Pfades "some\path\project\bin\Release\project.dll" konnte nicht gefunden werden.
```
Currently _paket.exe_ analyzes the project settings to figure out which bin directory to use (normally bin\Release or bin\Debug).

I have added an optional parameter called ```input```. If defined, _paket.exe_ will lookup all assemblies from this directory.

@forki can you review this code please? :-) As I said in my previous pull request: I am not a F# developer and really afraid to break something crucial.