### PR TITLE
Update description of push command

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -379,8 +379,6 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =
-        let currentDirectory = DirectoryInfo(Environment.CurrentDirectory)
-
         let urlWithEndpoint = RemoteUpload.GetUrlWithEndpoint url endPoint
         let apiKey = defaultArg apiKey (Environment.GetEnvironmentVariable("nugetkey"))
         if String.IsNullOrEmpty apiKey then

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -42,7 +42,7 @@ with
             | FindPackageVersions -> "EXPERIMENTAL: Allows to search for package versions."
             | ShowInstalledPackages -> "EXPERIMENTAL: Shows all installed top-level packages."
             | Pack -> "Packs all paket.template files within this repository"
-            | Push -> "Pushes all `.nupkg` files from the given directory."
+            | Push -> "Pushes the given `.nupkg` file."
 
     member this.Name =
         let uci,_ = Microsoft.FSharp.Reflection.FSharpValue.GetUnionFields(this, typeof<Command>)


### PR DESCRIPTION
The `push` command doesn't behave like this since v0.30.0 or so. Found it a bit misleading while using Paket on the command line today.