### PR TITLE
Warn about pinned packages only when a new version is available

### DIFF
--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -309,10 +309,10 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
     member __.Lines = textRepresentation
     member __.Sources = sources
 
-    member this.Resolve(force,packages,requirements) =
+    member this.Resolve(getVersionF,force,packages,requirements) =
         let getSha1 origin owner repo branch = RemoteDownload.getSHA1OfBranch origin owner repo branch |> Async.RunSynchronously
         let root = Path.GetDirectoryName this.FileName
-        this.Resolve(getSha1,NuGetV2.GetVersions root,NuGetV2.GetPackageDetails root force,packages,requirements)   
+        this.Resolve(getSha1,NuGetV2.GetVersions root |> getVersionF this.Packages,NuGetV2.GetPackageDetails root force,packages,requirements)   
 
     member __.Resolve(getSha1,getVersionF, getPackageDetailsF,rootDependencies,requirements) =
         let rootDependencies =
@@ -352,7 +352,7 @@ type DependenciesFile(fileName,options,sources,packages : PackageRequirement lis
         __.Resolve(getSha1,getVersionF,getPackageDetailsF,Some packages,[])
 
     member this.Resolve(force) = 
-        this.Resolve(force,Some packages,[])
+        this.Resolve((fun _ f -> f),force,Some packages,[])
 
     member __.AddAdditionalPackage(packageName:PackageName,versionRequirement,resolverStrategy,settings,?pinDown) =
         let pinDown = defaultArg pinDown false

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -307,9 +307,16 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
 
                 availableVersions := getAllVersions(currentRequirement.Sources,currentRequirement.Name,currentRequirement.VersionRequirement.Range)
 
+                let preRelease v =
+                    v.PreRelease = None
+                    || match currentRequirement.VersionRequirement.Range with
+                        | Specific v -> v.PreRelease <> None
+                        | OverrideAll v -> v.PreRelease <> None
+                        | _ -> false
+
                 let lastest =
                     !availableVersions
-                    |> List.filter (fun v -> v.PreRelease = None)
+                    |> List.filter preRelease
                     |> List.sortDescending
                     |> List.tryHead
 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -242,12 +242,8 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
         match allVersions.TryGetValue(normalizedPackageName) with
         | false,_ ->            
             let versions = 
-                match vr with
-                | OverrideAll v -> [v]
-                | Specific v -> [v]
-                | _ -> 
-                    verbosefn "  - fetching versions for %s" name
-                    getVersionsF(sources,packageName)
+                verbosefn "  - fetching versions for %s" name
+                getVersionsF(sources,packageName)
 
             if Seq.isEmpty versions then
                 failwithf "Couldn't retrieve versions for %s." name

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -309,6 +309,7 @@ let Resolve(getVersionsF, getPackageDetailsF, globalFrameworkRestrictions, rootD
 
                 let preRelease v =
                     v.PreRelease = None
+                    || currentRequirement.VersionRequirement.PreReleases <> PreReleaseStatus.No
                     || match currentRequirement.VersionRequirement.Range with
                         | Specific v -> v.PreRelease <> None
                         | OverrideAll v -> v.PreRelease <> None


### PR DESCRIPTION
This PR will warn about pinned packages only when there's a new version available as requested [here](https://github.com/fsprojects/Paket/pull/999#issuecomment-134120569).

It'll also disable the warning for install command because install pins the unchanged packages to the current version.

I could have changed the install to only resolve the changed packages, thus eliminating the need to disable the warning. However it wouldn't re-download the packages if ```--force``` were used.