### PR TITLE
Use .NET4 version of NUnit test runners

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,7 +2,7 @@ source https://nuget.org/api/v2
 
 nuget Newtonsoft.Json
 nuget Argu
-nuget NUnit.Runners
+nuget NUnit.Runners.Net4
 nuget NUnit
 nuget FAKE
 nuget FSharp.Formatting

--- a/paket.lock
+++ b/paket.lock
@@ -19,7 +19,7 @@ NUGET
       Microsoft.Bcl.Build (>= 1.0.14)
     Newtonsoft.Json (7.0.1)
     NUnit (2.6.4)
-    NUnit.Runners (2.6.4)
+    NUnit.Runners.Net4 (2.6.4)
     Octokit (0.14.0)
       Microsoft.Net.Http
 GITHUB

--- a/tests/Paket.Tests/paket.references
+++ b/tests/Paket.Tests/paket.references
@@ -1,4 +1,4 @@
 NUnit
-NUnit.Runners
+NUnit.Runners.Net4
 File:FsUnit.fs .
 FSharp.Core


### PR DESCRIPTION
Get rid of requirement for having .NET 3.5 installed in order to run tests (now tests only run under .NET 4.x or compatible).