### PR TITLE
Add analyzers support

### DIFF
--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -9,13 +9,10 @@ open Paket.BindingRedirects
 open Paket.ModuleResolver
 open Paket.PackageResolver
 open System.IO
-open System.Collections.Generic
 open FSharp.Polyfill
 open System.Reflection
-open System.Diagnostics
 open Paket.PackagesConfigFile
 open Paket.Requirements
-open System.Security.AccessControl
 
 let findPackageFolder root (groupName,PackageName name) (version,settings) =
     let includeVersionInPath = defaultArg settings.IncludeVersionInPath false
@@ -88,12 +85,13 @@ let private removeCopiedFiles (project: ProjectFile) =
 
 let CreateInstallModel(root, groupName, sources, force, package) =
     async {
-        let! (package, files, targetsFiles) = RestoreProcess.ExtractPackage(root, groupName, sources, force, package)
+        let! (package, files, targetsFiles, analyzerFiles) = RestoreProcess.ExtractPackage(root, groupName, sources, force, package)
         let (PackageName name) = package.Name
         let nuspec = Nuspec.Load(root,groupName,package.Version,defaultArg package.Settings.IncludeVersionInPath false,package.Name)
         let files = files |> Array.map (fun fi -> fi.FullName)
         let targetsFiles = targetsFiles |> Array.map (fun fi -> fi.FullName)
-        return (groupName,package.Name), (package,InstallModel.CreateFromLibs(package.Name, package.Version, package.Settings.FrameworkRestrictions, files, targetsFiles, nuspec))
+        let analyzerFiles = analyzerFiles |> Array.map (fun fi -> fi.FullName)
+        return (groupName,package.Name), (package,InstallModel.CreateFromLibs(package.Name, package.Version, package.Settings.FrameworkRestrictions, files, targetsFiles, analyzerFiles, nuspec))
     }
 
 /// Restores the given packages from the lock file.

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -587,7 +587,7 @@ let GetLibFiles(targetFolder) = GetSomeFiles targetFolder "lib" "libraries"
 let GetTargetsFiles(targetFolder) = GetSomeFiles targetFolder "build" ".targets files"
 
 /// Finds all analyzer files in a nuget package.
-let GetAnalyzerFiles(targetFolder) = GetSomeFiles targetFolder "analyzer" "analyzer dlls"
+let GetAnalyzerFiles(targetFolder) = GetSomeFiles targetFolder "analyzers" "analyzer dlls"
 
 let GetPackageDetails root force sources packageName (version:SemVerInfo) : PackageResolver.PackageDetails = 
     let package = packageName.ToString()

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -97,7 +97,8 @@ type ProjectFile =
     { FileName: string
       OriginalText : string
       Document : XmlDocument
-      ProjectNode : XmlNode }
+      ProjectNode : XmlNode
+      Language : ProjectLanguage }
 
     member private this.FindNodes paketOnes name =
         [for node in this.Document |> getDescendants name do
@@ -113,8 +114,6 @@ type ProjectFile =
     member this.NameWithoutExtension = Path.GetFileNameWithoutExtension this.Name
 
     member this.GetCustomReferenceAndFrameworkNodes() = this.FindNodes false "Reference"
-
-    member this.Language = LanguageEvaluation.getProjectLanguage this.Document
 
     /// Finds all project files
     static member FindAllProjects(folder) = 
@@ -322,7 +321,7 @@ type ProjectFile =
 
             itemGroup
 
-        let shouldBeInstalled analyzer = 
+        let shouldBeInstalled (analyzer : AnalyzerLib) = 
             match analyzer.Language, this.Language with
             | AnalyzerLanguage.Any, projectLanguage -> projectLanguage <> ProjectLanguage.Unknown
             | AnalyzerLanguage.CSharp, ProjectLanguage.CSharp -> true
@@ -938,7 +937,8 @@ type ProjectFile =
                 FileName = fi.FullName
                 Document = doc
                 ProjectNode = projectNode
-                OriginalText = Utils.normalizeXml doc }
+                OriginalText = Utils.normalizeXml doc
+                Language = LanguageEvaluation.getProjectLanguage doc }
         with
         | exn -> 
             traceWarnfn "Unable to parse %s:%s      %s" fileName Environment.NewLine exn.Message

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -297,7 +297,7 @@ type Dependencies(dependenciesFileName: string) =
             let nuspec = Nuspec.Load nuspec.FullName
             let files = NuGetV2.GetLibFiles(folder.FullName)
             let files = files |> Array.map (fun fi -> fi.FullName)
-            InstallModel.CreateFromLibs(PackageName packageName, SemVer.Parse version, [], files, [], nuspec)
+            InstallModel.CreateFromLibs(PackageName packageName, SemVer.Parse version, [], files, [], [], nuspec)
 
     /// Returns all libraries for the given package and framework.
     member this.GetLibraries(packageName,frameworkIdentifier:FrameworkIdentifier) =

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -8,7 +8,6 @@ open Paket.Logging
 open Paket.PackageResolver
 open Paket.PackageSources
 open FSharp.Polyfill
-open System
 
 /// Downloads and extracts a package.
 let ExtractPackage(root, groupName, sources, force, package : ResolvedPackage) = 
@@ -25,18 +24,18 @@ let ExtractPackage(root, groupName, sources, force, package : ResolvedPackage) =
                                | _ -> None)
             try 
                 let! folder = NuGetV2.DownloadPackage(root, auth, source.Url, groupName, name, v, includeVersionInPath, force)
-                return package, NuGetV2.GetLibFiles folder, NuGetV2.GetTargetsFiles folder
+                return package, NuGetV2.GetLibFiles folder, NuGetV2.GetTargetsFiles folder, NuGetV2.GetAnalyzerFiles folder
             with _ when not force -> 
                 tracefn "Something went wrong with the download of %s %A - automatic retry with --force." name v
                 let! folder = NuGetV2.DownloadPackage(root, auth, source.Url, groupName, name, v, includeVersionInPath, true)
-                return package, NuGetV2.GetLibFiles folder, NuGetV2.GetTargetsFiles folder
+                return package, NuGetV2.GetLibFiles folder, NuGetV2.GetTargetsFiles folder, NuGetV2.GetAnalyzerFiles folder
         | LocalNuget path ->         
             let path = Utils.normalizeLocalPath path
             let di = Utils.getDirectoryInfo path root
             let nupkg = NuGetV2.findLocalPackage di.FullName name v
 
             let! folder = NuGetV2.CopyFromCache(root, groupName, nupkg.FullName, "", name, v, includeVersionInPath, force) // TODO: Restore license
-            return package, NuGetV2.GetLibFiles folder, NuGetV2.GetTargetsFiles folder
+            return package, NuGetV2.GetLibFiles folder, NuGetV2.GetTargetsFiles folder, NuGetV2.GetAnalyzerFiles folder
     }
 
 /// Restores the given dependencies from the lock file.

--- a/tests/Paket.Tests/InstallModel/ProcessingSpecs.fs
+++ b/tests/Paket.Tests/InstallModel/ProcessingSpecs.fs
@@ -497,7 +497,7 @@ let ``should filter .NET 4.0 dlls for System.Net.Http 2.2.8``() =
                @"..\Microsoft.Net.Http\lib\win8\System.Net.Http.Extensions.dll"; 
                @"..\Microsoft.Net.Http\lib\win8\System.Net.Http.Primitives.dll"; 
                @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Extensions.dll"; 
-               @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Primitives.dll" ], [], Nuspec.All)
+               @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Primitives.dll" ], [], [], Nuspec.All)
 
     model.GetLibReferences(SinglePlatform(DotNetFramework(FrameworkVersion.V4)))
     |> shouldEqual expected
@@ -531,7 +531,7 @@ let ``should filter .NET 4.5 dlls for System.Net.Http 2.2.8``() =
                @"..\Microsoft.Net.Http\lib\win8\System.Net.Http.Extensions.dll"; 
                @"..\Microsoft.Net.Http\lib\win8\System.Net.Http.Primitives.dll"; 
                @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Extensions.dll"; 
-               @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Primitives.dll" ], [], Nuspec.All)
+               @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Primitives.dll" ], [], [], Nuspec.All)
 
     model.GetLibReferences(SinglePlatform(DotNetFramework(FrameworkVersion.V4_5)))
     |> shouldEqual expected

--- a/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
@@ -1,0 +1,91 @@
+﻿
+module Paket.InstallModel.Xml.CodeCrackerSpecs
+
+open FsUnit
+open NUnit.Framework
+open Paket
+open Paket.Domain
+open Paket.TestHelpers
+
+let expectedEmpty = """
+<ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
+
+let expectedCsharp = """
+<ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Analyzer Include="..\..\..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.CSharp.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+  <Analyzer Include="..\..\..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.Common.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+</ItemGroup>"""
+
+[<Test>]
+let ``should generate Xml for codecracker.CSharp``() = 
+    let model =
+        InstallModel.CreateFromLibs(PackageName "codecracker.CSharp", SemVer.Parse "1.0.0-rc2", [],
+              [],
+              [],
+              [
+                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.CSharp.dll" 
+                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.Common.dll" 
+              ],
+              Nuspec.All)
+    
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expectedCsharp)
+
+[<Test>]
+let ``should generate Xml for codecracker.CSharp in VisualBasic project``() = 
+    let model =
+        InstallModel.CreateFromLibs(PackageName "codecracker.CSharp", SemVer.Parse "1.0.0-rc2", [],
+              [],
+              [],
+              [
+                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.CSharp.dll" 
+                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.Common.dll" 
+              ],
+              Nuspec.All)
+    
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expectedEmpty)
+
+let expectedVb = """
+<ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Analyzer Include="..\..\..\codecracker.CSharp\analyzers\dotnet\vb\CodeCracker.Common.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+  <Analyzer Include="..\..\..\codecracker.CSharp\analyzers\dotnet\vb\CodeCracker.VisualBasic.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+</ItemGroup>"""
+
+[<Test>]
+let ``should generate Xml for codecracker.VisualBasic``() = 
+    let model =
+        InstallModel.CreateFromLibs(PackageName "codecracker.VisualBasic", SemVer.Parse "1.0.0-rc2", [],
+              [],
+              [],
+              [
+                @"..\codecracker.CSharp\analyzers\dotnet\vb\CodeCracker.VisualBasic.dll" 
+                @"..\codecracker.CSharp\analyzers\dotnet\vb\CodeCracker.Common.dll" 
+              ],
+              Nuspec.All)
+    
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expectedVb)

--- a/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
@@ -1,5 +1,4 @@
-﻿
-module Paket.InstallModel.Xml.CodeCrackerSpecs
+﻿module Paket.InstallModel.Xml.CodeCrackerSpecs
 
 open FsUnit
 open NUnit.Framework

--- a/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
@@ -33,7 +33,7 @@ let ``should generate Xml for codecracker.CSharp``() =
     
     let project = ProjectFile.Load("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true,None)
     analyzerNodes
     |> (fun n -> n.OuterXml)
     |> normalizeXml
@@ -53,7 +53,7 @@ let ``should generate Xml for codecracker.CSharp in VisualBasic project``() =
     
     let project = ProjectFile.Load("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true,None)
     analyzerNodes
     |> (fun n -> n.OuterXml)
     |> normalizeXml
@@ -83,7 +83,7 @@ let ``should generate Xml for codecracker.VisualBasic``() =
     
     let project = ProjectFile.Load("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true,None)
     analyzerNodes
     |> (fun n -> n.OuterXml)
     |> normalizeXml

--- a/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
@@ -26,8 +26,8 @@ let ``should generate Xml for codecracker.CSharp``() =
               [],
               [],
               [
-                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.CSharp.dll" 
-                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.Common.dll" 
+                [".."; "codecracker.CSharp"; "analyzers"; "dotnet"; "cs"; "CodeCracker.CSharp.dll"] |> toPath
+                [".."; "codecracker.CSharp"; "analyzers"; "dotnet"; "cs"; "CodeCracker.Common.dll"] |> toPath
               ],
               Nuspec.All)
     
@@ -46,8 +46,8 @@ let ``should generate Xml for codecracker.CSharp in VisualBasic project``() =
               [],
               [],
               [
-                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.CSharp.dll" 
-                @"..\codecracker.CSharp\analyzers\dotnet\cs\CodeCracker.Common.dll" 
+                [".."; "codecracker.CSharp"; "analyzers"; "dotnet"; "cs"; "CodeCracker.CSharp.dll"] |> toPath
+                [".."; "codecracker.CSharp"; "analyzers"; "dotnet"; "cs"; "CodeCracker.Common.dll"] |> toPath
               ],
               Nuspec.All)
     
@@ -76,8 +76,8 @@ let ``should generate Xml for codecracker.VisualBasic``() =
               [],
               [],
               [
-                @"..\codecracker.CSharp\analyzers\dotnet\vb\CodeCracker.VisualBasic.dll" 
-                @"..\codecracker.CSharp\analyzers\dotnet\vb\CodeCracker.Common.dll" 
+                [".."; "codecracker.CSharp"; "analyzers"; "dotnet"; "vb"; "CodeCracker.VisualBasic.dll"] |> toPath
+                [".."; "codecracker.CSharp"; "analyzers"; "dotnet"; "vb"; "CodeCracker.Common.dll"] |> toPath
               ],
               Nuspec.All)
     

--- a/tests/Paket.Tests/InstallModel/Xml/FSharp.Data.SqlClient.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/FSharp.Data.SqlClient.fs
@@ -39,7 +39,7 @@ let ``should generate Xml for FSharp.Data.SqlClient 1.4.4``() =
               [],
               Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec"))
     
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/FSharp.Data.SqlClient.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/FSharp.Data.SqlClient.fs
@@ -36,6 +36,7 @@ let ``should generate Xml for FSharp.Data.SqlClient 1.4.4``() =
               @"..\FSharp.Data.SqlClient\lib\net40\Microsoft.SqlServer.TransactSql.ScriptDom.dll"
               @"..\FSharp.Data.SqlClient\lib\net40\Microsoft.SqlServer.Types.dll" ],
               [],
+              [],
               Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec"))
     
     let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)

--- a/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
@@ -24,6 +24,7 @@ let ``should generate Xml for Fantomas 1.5``() =
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
               [],
+              [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
     let propertyNodes,chooseNode,additionalNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
@@ -59,6 +60,7 @@ let ``should generate full Xml for Fantomas 1.5``() =
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
               [],
+              [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
     let project = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value
@@ -78,6 +80,7 @@ let ``should not generate full Xml for Fantomas 1.5 if not referenced``() =
             [ @"..\Fantomas\lib\FantomasLib.dll" 
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
+              [],
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
@@ -113,6 +116,7 @@ let ``should generate full Xml with reference condition for Fantomas 1.5``() =
             [ @"..\Fantomas\lib\FantomasLib.dll" 
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
+              [],
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
     

--- a/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
@@ -27,7 +27,7 @@ let ``should generate Xml for Fantomas 1.5``() =
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
-    let propertyNodes,chooseNode,additionalNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let propertyNodes,chooseNode,additionalNode, _ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
@@ -27,7 +27,7 @@ let ``should generate Xml for Fantomas 1.5``() =
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,false,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,false,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
@@ -24,6 +24,7 @@ let ``should generate Xml for Fantomas 1.5``() =
               @"..\Fantomas\Lib\FSharp.Core.dll" 
               @"..\Fantomas\Lib\Fantomas.exe" ],
               [],
+              [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
     let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,false,true,None)

--- a/tests/Paket.Tests/InstallModel/Xml/Fuchu.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fuchu.fs
@@ -27,7 +27,7 @@ let ``should generate Xml for Fuchu 0.4``() =
               [],
               Nuspec.All)
     
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/Fuchu.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fuchu.fs
@@ -24,6 +24,7 @@ let ``should generate Xml for Fuchu 0.4``() =
               @"..\Fuchu\lib\Fuchu.XML" 
               @"..\Fuchu\lib\Fuchu.pdb" ],
               [],
+              [],
               Nuspec.All)
     
     let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)

--- a/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
@@ -22,6 +22,7 @@ let ``should generate Xml for GitInfoPlanter2.0.0``() =
         InstallModel.CreateFromLibs(PackageName "GitInfoPlanter", SemVer.Parse "0.21", [],
             [ ],
             [ @"..\GitInfoPlanter\build\GitInfoPlanter.targets" ],
+            [],
               Nuspec.All)
 
     let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)

--- a/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
@@ -25,7 +25,7 @@ let ``should generate Xml for GitInfoPlanter2.0.0``() =
             [],
               Nuspec.All)
 
-    let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let propertyNodes,chooseNode,propertyChooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyReferences)

--- a/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
@@ -38,6 +38,7 @@ let ``should generate Xml for LibGit2Sharp 2.0.0``() =
         InstallModel.CreateFromLibs(PackageName "LibGit2Sharp", SemVer.Parse "0.21", [],
             [ @"..\LibGit2Sharp\lib\net40\LibGit2Sharp.dll" ],
             [ @"..\LibGit2Sharp\build\net40\LibGit2Sharp.props" ],
+            [],
               Nuspec.All)
     
     model.GetLibReferences(SinglePlatform (DotNetFramework FrameworkVersion.V4_Client)) |> shouldContain @"..\LibGit2Sharp\lib\net40\LibGit2Sharp.dll"

--- a/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
@@ -43,7 +43,7 @@ let ``should generate Xml for LibGit2Sharp 2.0.0``() =
     
     model.GetLibReferences(SinglePlatform (DotNetFramework FrameworkVersion.V4_Client)) |> shouldContain @"..\LibGit2Sharp\lib\net40\LibGit2Sharp.dll"
 
-    let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let propertyNodes,chooseNode,propertyChooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedReferenceNodes)

--- a/tests/Paket.Tests/InstallModel/Xml/ManualNodes.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/ManualNodes.fs
@@ -14,6 +14,7 @@ let ``should find custom nodes in doc``() =
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
               [],
+              [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
     ProjectFile.Load("./ProjectFile/TestData/CustomFantomasNode.fsprojtest").Value.GetCustomModelNodes(model).IsEmpty
@@ -26,6 +27,7 @@ let ``should find custom Paket nodes in doc``() =
             [ @"..\Fantomas\lib\FantomasLib.dll" 
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
+              [],
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
@@ -41,6 +43,7 @@ let ``should not find custom nodes if there are none``() =
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
               [],
+              [],
               Nuspec.Explicit ["FantomasLib.dll"])
 
     ProjectFile.Load("./ProjectFile/TestData/NoCustomFantomasNode.fsprojtest").Value.GetCustomModelNodes(model).IsEmpty
@@ -54,6 +57,7 @@ let ``should delete custom nodes if there are some``() =
             [ @"..\Fantomas\lib\FantomasLib.dll" 
               @"..\Fantomas\lib\FSharp.Core.dll" 
               @"..\Fantomas\lib\Fantomas.exe" ],
+              [],
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
 

--- a/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
@@ -11,6 +11,7 @@ let ``should not install targets node for Microsoft.Bcl.Build``() =
         InstallModel.CreateFromLibs(PackageName "Microsoft.Bcl.Build", SemVer.Parse "1.0.21", [],
             [ ],
             [ @"..\Microsoft.Bcl.Build\build\Microsoft.Bcl.Build.Tasks.dll"; @"..\Microsoft.Bcl.Build\build\Microsoft.Bcl.Build.targets" ],
+            [],
               Nuspec.All)
     
     model.GetTargetsFiles(SinglePlatform (DotNetFramework FrameworkVersion.V4)) |> shouldNotContain @"..\Microsoft.Bcl.Build\build\Microsoft.Bcl.Build.targets"

--- a/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
@@ -16,6 +16,6 @@ let ``should not install targets node for Microsoft.Bcl.Build``() =
     
     model.GetTargetsFiles(SinglePlatform (DotNetFramework FrameworkVersion.V4)) |> shouldNotContain @"..\Microsoft.Bcl.Build\build\Microsoft.Bcl.Build.targets"
 
-    let propertyNodes,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let propertyNodes,_,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
 
     propertyNodes |> Seq.length |> shouldEqual 0

--- a/tests/Paket.Tests/InstallModel/Xml/Plossum.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Plossum.fs
@@ -26,6 +26,7 @@ let ``should generate Xml for Plossum``() =
         InstallModel.CreateFromLibs(PackageName "Plossum.CommandLine", SemVer.Parse "1.5.0", [],
             [ @"..\Plossum.CommandLine\lib\net40\Plossum CommandLine.dll" ],
               [],
+              [],
               Nuspec.All)
     
     let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)

--- a/tests/Paket.Tests/InstallModel/Xml/Plossum.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Plossum.fs
@@ -29,7 +29,7 @@ let ``should generate Xml for Plossum``() =
               [],
               Nuspec.All)
     
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
@@ -26,7 +26,7 @@ let ``should generate Xml for RefactoringEssentials in CSharp project``() =
     
     let project = ProjectFile.Load("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true,None)
     analyzerNodes
     |> (fun n -> n.OuterXml)
     |> normalizeXml
@@ -45,7 +45,7 @@ let ``should generate Xml for RefactoringEssentials in VisualBasic project``() =
     
     let project = ProjectFile.Load("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true,None)
     analyzerNodes
     |> (fun n -> n.OuterXml)
     |> normalizeXml

--- a/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
@@ -20,7 +20,7 @@ let ``should generate Xml for RefactoringEssentials in CSharp project``() =
               [],
               [],
               [
-                @"..\RefactoringEssentials\analyzers\dotnet\RefactoringEssentials.dll" 
+                [".."; "RefactoringEssentials"; "analyzers"; "dotnet"; "RefactoringEssentials.dll"] |> toPath
               ],
               Nuspec.All)
     
@@ -39,7 +39,7 @@ let ``should generate Xml for RefactoringEssentials in VisualBasic project``() =
               [],
               [],
               [
-                @"..\RefactoringEssentials\analyzers\dotnet\RefactoringEssentials.dll" 
+                [".."; "RefactoringEssentials"; "analyzers"; "dotnet"; "RefactoringEssentials.dll"] |> toPath
               ],
               Nuspec.All)
     

--- a/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
@@ -1,0 +1,52 @@
+﻿module Paket.InstallModel.Xml.RefactoringEssentialsSpec
+
+open FsUnit
+open NUnit.Framework
+open Paket
+open Paket.Domain
+open Paket.TestHelpers
+
+let expected = """
+<ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Analyzer Include="..\..\..\RefactoringEssentials\analyzers\dotnet\RefactoringEssentials.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+</ItemGroup>"""
+
+[<Test>]
+let ``should generate Xml for RefactoringEssentials in CSharp project``() = 
+    let model =
+        InstallModel.CreateFromLibs(PackageName "RefactoringEssentials", SemVer.Parse "1.2.0", [],
+              [],
+              [],
+              [
+                @"..\RefactoringEssentials\analyzers\dotnet\RefactoringEssentials.dll" 
+              ],
+              Nuspec.All)
+    
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expected)
+
+[<Test>]
+let ``should generate Xml for RefactoringEssentials in VisualBasic project``() = 
+    let model =
+        InstallModel.CreateFromLibs(PackageName "RefactoringEssentials", SemVer.Parse "1.2.0", [],
+              [],
+              [],
+              [
+                @"..\RefactoringEssentials\analyzers\dotnet\RefactoringEssentials.dll" 
+              ],
+              Nuspec.All)
+    
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
@@ -98,6 +98,7 @@ let ``should generate Xml for Rx-XAML 2.2.4 with correct framework assembly refe
               @"..\Rx-XAML\lib\windowsphone8\System.Reactive.Windows.Threading.dll" 
               @"..\Rx-XAML\lib\windowsphone71\System.Reactive.Windows.Threading.dll" ],
                [],
+               [],
                { References = NuspecReferences.All
                  OfficialName = "Reactive Extensions - XAML Support Library"
                  Dependencies = []

--- a/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
@@ -110,7 +110,7 @@ let ``should generate Xml for Rx-XAML 2.2.4 with correct framework assembly refe
                   { AssemblyName = "System.Windows"; FrameworkRestrictions = [FrameworkRestriction.Exactly(Silverlight "v5.0")] }
                   { AssemblyName = "System.Windows"; FrameworkRestrictions = [FrameworkRestriction.Exactly(WindowsPhoneSilverlight "v7.1")] }]})
 
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
@@ -90,7 +90,7 @@ let ``should generate Xml for SQLite``() =
             [],
               Nuspec.All)
     
-    let propertyNodes,chooseNode,propertyDefinitionNodes = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let propertyNodes,chooseNode,propertyDefinitionNodes,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedReferenceNodes)

--- a/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
@@ -87,6 +87,7 @@ let ``should generate Xml for SQLite``() =
               @"..\System.Data.SQLite.Core\build\net40\System.Data.SQLite.Core.targets"
               @"..\System.Data.SQLite.Core\build\net45\System.Data.SQLite.Core.targets"
               @"..\System.Data.SQLite.Core\build\net451\System.Data.SQLite.Core.targets" ],
+            [],
               Nuspec.All)
     
     let propertyNodes,chooseNode,propertyDefinitionNodes = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)

--- a/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
@@ -18,6 +18,7 @@ let ``should generate Xml for StyleCop.MSBuild``() =
     let model =
         InstallModel.CreateFromLibs(PackageName "StyleCop.MSBuild", SemVer.Parse "4.7.49.1", [],[],
             [ @"..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets" ],
+            [],
               Nuspec.All)
 
     model.GetTargetsFiles(SinglePlatform (DotNetFramework FrameworkVersion.V2)) |> shouldContain @"..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets" 

--- a/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
@@ -23,7 +23,7 @@ let ``should generate Xml for StyleCop.MSBuild``() =
 
     model.GetTargetsFiles(SinglePlatform (DotNetFramework FrameworkVersion.V2)) |> shouldContain @"..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets" 
     
-    let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let propertyNodes,chooseNode,propertyChooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     
     propertyChooseNode.OuterXml
     |> normalizeXml

--- a/tests/Paket.Tests/InstallModel/Xml/System.Spatial.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/System.Spatial.fs
@@ -44,7 +44,7 @@ let ``should generate Xml for System.Spatial``() =
               @"..\System.Spatial\lib\sl4\zh-Hans\System.Spatial.resources.dll" 
             ],[],[],Nuspec.All)
     
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/System.Spatial.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/System.Spatial.fs
@@ -42,7 +42,7 @@ let ``should generate Xml for System.Spatial``() =
               @"..\System.Spatial\lib\sl4\de\System.Spatial.resources.dll"
               @"..\System.Spatial\lib\sl4\es\System.Spatial.resources.dll"
               @"..\System.Spatial\lib\sl4\zh-Hans\System.Spatial.resources.dll" 
-            ],[],Nuspec.All)
+            ],[],[],Nuspec.All)
     
     let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttp.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttp.fs
@@ -188,6 +188,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Primitives.dll" 
               ],
               [],
+              [],
               Nuspec.All)
 
     let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttp.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttp.fs
@@ -191,7 +191,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               [],
               Nuspec.All)
 
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
@@ -66,6 +66,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Extensions.dll" 
               @"..\Microsoft.Net.Http\lib\wpa81\System.Net.Http.Primitives.dll" ],
               [],
+              [],
               Nuspec.All)
 
     let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None) 

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
@@ -69,7 +69,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               [],
               Nuspec.All)
 
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None) 
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None) 
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
@@ -69,7 +69,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                  [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }
                   { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
 
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/FrameworkAssemblies.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/FrameworkAssemblies.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
@@ -59,6 +59,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               @"..\Microsoft.Net.Http\lib\net45\System.Net.Http.Extensions.dll" 
               @"..\Microsoft.Net.Http\lib\net45\System.Net.Http.Primitives.dll"],
                [],
+               [],
                { References = NuspecReferences.All
                  OfficialName = "Microsoft.Net.Http"
                  Dependencies = []

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
@@ -67,6 +67,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               @"..\Microsoft.Net.Http\lib\net45\System.Net.Http.Extensions.dll" 
               @"..\Microsoft.Net.Http\lib\net45\System.Net.Http.Primitives.dll"],
                [],
+               [],
                { References = NuspecReferences.All
                  OfficialName = "Microsoft.Net.Http"
                  Dependencies = []

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
@@ -77,7 +77,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                  [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))] }
                   { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
 
-    let _,chooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let _,chooseNode,_,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
@@ -33,6 +33,7 @@ let ``should generate Xml for xunit.runner.visualstudio 2.0.0``() =
         InstallModel.CreateFromLibs(PackageName "xunit.runner.visualstudio", SemVer.Parse "2.50.0", [],[],
             [ @"..\xunit.runner.visualstudio\build\net20\xunit.runner.visualstudio.props" 
               @"..\xunit.runner.visualstudio\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.runner.visualstudio.props"  ],
+            [],
               Nuspec.All)
     
     let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
@@ -59,6 +60,7 @@ let ``should not generate Xml for xunit.runner.visualstudio 2.0.0 if import is d
         InstallModel.CreateFromLibs(PackageName "xunit.runner.visualstudio", SemVer.Parse "2.50.0", [],[],
             [ @"..\xunit.runner.visualstudio\build\net20\xunit.runner.visualstudio.props" 
               @"..\xunit.runner.visualstudio\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.runner.visualstudio.props"  ],
+              [],
               Nuspec.All)
     
     let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,false,None)

--- a/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
@@ -36,7 +36,7 @@ let ``should generate Xml for xunit.runner.visualstudio 2.0.0``() =
             [],
               Nuspec.All)
     
-    let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
+    let propertyNodes,chooseNode,propertyChooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyReferenceNodes)
@@ -63,7 +63,7 @@ let ``should not generate Xml for xunit.runner.visualstudio 2.0.0 if import is d
               [],
               Nuspec.All)
     
-    let propertyNodes,chooseNode,propertyChooseNode = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,false,None)
+    let propertyNodes,chooseNode,propertyChooseNode,_ = ProjectFile.Load("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,false,None)
     chooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyReferenceNodes)

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -220,44 +220,54 @@
     <Compile Include="Lockfile\ParserWithMultipleSourcesSpecs.fs" />
     <Compile Include="ReferencesFile\ReferencesFileSpecs.fs" />
     <Compile Include="Simplifier\BasicScenarioSpecs.fs" />
+    <None Include="ProjectFile\TestData\EmptyCsharpGuid.csprojtest">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\EmptyFsharpGuid.fsprojtest">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\EmptyVbGuid.vbprojtest">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="ProjectFile\TestData\Project1.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\Project2.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\Project3.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\ProjectWithConditions.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\Empty.fsprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\EmptyWithOldStuff.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\FrameworkAssemblies.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\CustomFantomasNode.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\CustomPaketFantomasNode.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\NoCustomFantomasNode.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\MaintainsOrdering.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\NewSilverlightClassLibrary.csprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\FSharp.Core.Fluent-3.1.fsprojtest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Include="ProjectFile\ConditionSpecs.fs" />
     <Compile Include="ProjectFile\TargetFrameworkSpecs.fs" />
@@ -286,6 +296,7 @@
     <Compile Include="InstallModel\Xml\FSharp.Data.SqlClient.fs" />
     <Compile Include="InstallModel\Xml\RxXaml.fs" />
     <Compile Include="InstallModel\Xml\Microsoft.Bcl.Build.fs" />
+    <Compile Include="InstallModel\Xml\CodeCracker.fs" />
     <Compile Include="InstallModel\Penalty\PenaltySpecs.fs" />
     <Compile Include="InstallModel\Penalty\FrameworkConditionsSpecs.fs" />
     <Compile Include="DependencyModel\ProjectDependencySpecs.fs" />

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -297,6 +297,7 @@
     <Compile Include="InstallModel\Xml\RxXaml.fs" />
     <Compile Include="InstallModel\Xml\Microsoft.Bcl.Build.fs" />
     <Compile Include="InstallModel\Xml\CodeCracker.fs" />
+    <Compile Include="InstallModel\Xml\RefactoringEssentials.fs" />
     <Compile Include="InstallModel\Penalty\PenaltySpecs.fs" />
     <Compile Include="InstallModel\Penalty\FrameworkConditionsSpecs.fs" />
     <Compile Include="DependencyModel\ProjectDependencySpecs.fs" />

--- a/tests/Paket.Tests/ProjectFile/FileBuildActionSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/FileBuildActionSpecs.fs
@@ -9,7 +9,8 @@ let createProject name =
     { FileName = name
       OriginalText = ""
       Document = XmlDocument()
-      ProjectNode = null }
+      ProjectNode = null
+      Language = ProjectLanguage.Unknown }
 
 [<Test>]
 let ``should recognize compilable files``() =

--- a/tests/Paket.Tests/ProjectFile/TestData/EmptyCsharpGuid.csprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/EmptyCsharpGuid.csprojtest
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+</Project>

--- a/tests/Paket.Tests/ProjectFile/TestData/EmptyFsharpGuid.fsprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/EmptyFsharpGuid.fsprojtest
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{F2A71F9B-5D33-465A-A702-920D77279786}</ProjectTypeGuids>
+  </PropertyGroup>
+</Project>

--- a/tests/Paket.Tests/ProjectFile/TestData/EmptyVbGuid.vbprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/EmptyVbGuid.vbprojtest
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</ProjectTypeGuids>
+  </PropertyGroup>
+</Project>

--- a/tests/Paket.Tests/Simplifier/BasicScenarioSpecs.fs
+++ b/tests/Paket.Tests/Simplifier/BasicScenarioSpecs.fs
@@ -13,7 +13,8 @@ let dummyProjectFile =
     { FileName = ""
       OriginalText = ""
       Document = null
-      ProjectNode = null }
+      ProjectNode = null
+      Language = ProjectLanguage.Unknown }
 
 let lockFile1 = """
 NUGET

--- a/tests/Paket.Tests/TestHelpers.fs
+++ b/tests/Paket.Tests/TestHelpers.fs
@@ -78,3 +78,5 @@ let normalizeXml(text:string) =
     doc.WriteTo(xmlTextWriter)
     xmlTextWriter.Flush()
     stringWriter.GetStringBuilder().ToString()
+
+let toPath elems = System.IO.Path.Combine(elems |> Seq.toArray)


### PR DESCRIPTION
(Follows #1029 but the GitHub doesn't let me change the base branch so it got confused when I rebased from `master` to `groups`)

This PR add the support for the "analyzers" folder in NuGet packages.

They contain roslyn based analyzers. Packages can either contain only analyzers or normal libraries could include their analyzers along with the main lib.

The documentation details for the NuGet feature is still in flux https://github.com/NuGet/NuGetDocs/pull/362/files / https://github.com/jmarolf/NuGetDocs/blob/AnalyzerConventions/NuGet.Docs/Create/Analyzers-Conventions.md but as VS2015 support them, the current status is "Whatever works in VS2015".

Languages
---------------

Analyzers are contained either in per-language folders or shared between languages so I had to add code to get the language of a project file (Implemented using both the "ProjectTypeGuids" node and the file extension)

As the documentation specify that F# is a supported analyzer language I added it but the F# project type doesn't support analyzers for now :(

Framework
----------------

In theory their folders can also specify the framework of the host but nobody does that for now (All analyzers are in 'dotnet' subfolder as it is the platform supported by visual studio) but I ignored that completely.
if it is needed at some point the `paket.dependencies` files would need to specify it.

It seem to me that the feature of specifying the framework in there is broken anyway and microsoft didn't think long enough before introducing it.

Tests
-------

I don't know if there is enough tests, especially the code in `LanguageEvaluation` and my additions to `ExtractPackage` aren't tested. But I wanted to make this review to know if I was on the good track or if I did something really stupid somewhere.

To manually test the feature the easiest is to add 'RefactoringEssentials' as reference to any C# project and run `paket install`.

Then code like `int[] values = new int[] { 1, 2, 3 };` will trigger the "Array Creation can be replaced with Array Initializer" analyzer.