### PR TITLE
Eagerly create app.config files and add to all projects.

### DIFF
--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -81,10 +81,33 @@ let private applyBindingRedirects bindingRedirects (configFilePath:string) =
     indentAssemblyBindings config
     config.Save configFilePath
 
+let private configFiles = [ "app"; "web" ] |> Set.ofList
+let private toLower (s:string) = s.ToLower()
+let private isAppOrWebConfig = configFiles.Contains << (Path.GetFileNameWithoutExtension >> toLower)
+let internal getFoldersWithPaketReferencesAndNoConfig getFiles rootPath  =
+    getFiles(rootPath, "paket.references", SearchOption.AllDirectories)
+    |> Seq.map Path.GetDirectoryName
+    |> Seq.filter(fun directory -> getFiles(directory, "*.config", SearchOption.TopDirectoryOnly) |> Seq.forall (not << isAppOrWebConfig))
+    |> Seq.toList
+let private getExistingConfigFiles getFiles rootPath = 
+    getFiles(rootPath, "*.config", SearchOption.AllDirectories)
+    |> Seq.filter isAppOrWebConfig
+let private baseConfig = """<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+</configuration>
+"""
+let private createAppConfigFile folder = File.WriteAllText(Path.Combine(folder, "app.config"), baseConfig)
+
 /// Applies a set of binding redirects to all .config files in a specific folder.
 let applyBindingRedirectsToFolder rootPath bindingRedirects =
-    Directory.GetFiles(rootPath, "*.config", SearchOption.AllDirectories) 
-    |> Seq.filter (fun x -> x.EndsWith(Path.DirectorySeparatorChar.ToString() + "web.config", StringComparison.CurrentCultureIgnoreCase) || x.EndsWith(Path.DirectorySeparatorChar.ToString() + "app.config", StringComparison.CurrentCultureIgnoreCase))
+    // First create missing configuration files.
+    rootPath
+    |> getFoldersWithPaketReferencesAndNoConfig Directory.GetFiles
+    |> Seq.iter createAppConfigFile
+
+    // Now ensure all configuration files have binding redirects.
+    rootPath
+    |> getExistingConfigFiles Directory.GetFiles
     |> Seq.iter (applyBindingRedirects bindingRedirects)
 
 /// Calculates the short form of the public key token for use with binding redirects, if it exists.

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -12,7 +12,7 @@ open Paket.Requirements
 /// File item inside of project files.
 type FileItem = 
     { BuildAction : string
-      Include : string      
+      Include : string
       Link : string option }
 
 /// Project references inside of project files.
@@ -101,7 +101,7 @@ type ProjectFile =
     member this.CreateNode(name) = 
         this.Document.CreateElement(name, Constants.ProjectDefaultNameSpace)
 
-    member this.HasPackageInstalled(package:NormalizedPackageName) =        
+    member this.HasPackageInstalled(package:NormalizedPackageName) =
         let proj = FileInfo(this.FileName)
         match ProjectFile.FindReferencesFile proj with
         | None -> false
@@ -145,10 +145,8 @@ type ProjectFile =
             node.ParentNode.RemoveChild(node) |> ignore
 
     member this.UpdateFileItems(fileItems : FileItem list, hard) = 
-
-        let firstItemGroup = this.ProjectNode |> getNodes "ItemGroup" |> List.tryHead
-
         let newItemGroups = 
+            let firstItemGroup = this.ProjectNode |> getNodes "ItemGroup" |> List.tryHead
             match firstItemGroup with
             | None ->
                 ["Content", this.CreateNode("ItemGroup")

--- a/tests/Paket.Tests/BindingRedirect.fs
+++ b/tests/Paket.Tests/BindingRedirect.fs
@@ -118,38 +118,44 @@ let ``redirects got properly indented for readability``() =
     let dependency = doc.Descendants(xNameForNs "dependentAssembly") |> Seq.head
     dependency.ToString() |> shouldEqual "<dependentAssembly xmlns=\"urn:schemas-microsoft-com:asm.v1\">\r\n    <assemblyIdentity name=\"Assembly\" publicKeyToken=\"PUBLIC_KEY\" culture=\"neutral\" />\r\n    <bindingRedirect oldVersion=\"0.0.0.0-999.999.999.999\" newVersion=\"1.0.0\" />\r\n  </dependentAssembly>"
 
+let toSafePath = System.IO.Path.GetFullPath
 let buildMockGetFiles outcomes =
+    let outcomes =
+        outcomes
+        |> List.map(fun ((path, extension), results) ->
+            (path |> toSafePath, extension), results |> List.map toSafePath)
     fun (path, wildcard, _) ->
         outcomes
-        |> List.tryFind (fst >> (=) (path, wildcard)) 
+        |> List.tryFind (fst >> (=) (path |> toSafePath, wildcard))
         |> Option.map snd
         |> defaultArg <| []
         |> List.toArray
+let rootPath = @"C:/rootpath/" |> toSafePath
 
 [<Test>]
 let ``app.config file is marked for creation in folders containing paket.references``() =
     let mockGetFiles =
         buildMockGetFiles
-            [ (@"C:\rootpath", "paket.references"), [ @"C:\rootpath\source\paket.references" ]
-              (@"C:\rootpath\source", "*.config"), [ @"C:\rootpath\source\paket.references" ]
+            [ (@"C:/rootpath/", "paket.references"), [ @"C:/rootpath/source/paket.references" ]
+              (@"C:/rootpath/source", "*.config"), []
             ]
-    let foldersToCreateConfigFor = getFoldersWithPaketReferencesAndNoConfig mockGetFiles @"C:\rootpath"
-    foldersToCreateConfigFor |> shouldEqual [ @"C:\rootpath\source"]
+    let foldersToCreateConfigFor = getFoldersWithPaketReferencesAndNoConfig mockGetFiles rootPath
+    foldersToCreateConfigFor |> shouldEqual [ @"C:/rootpath/source" |> toSafePath ]
 
 [<Test>]
 let ``app.config file is not marked for creation in folders not containing paket.references``() =
-    let mockGetFiles = buildMockGetFiles [ (@"C:\rootpath", "paket.references"), [] ]
-    let foldersToCreateConfigFor = getFoldersWithPaketReferencesAndNoConfig mockGetFiles @"C:\rootpath"
+    let mockGetFiles = buildMockGetFiles [ (@"C:/rootpath/", "paket.references"), [] ]
+    let foldersToCreateConfigFor = getFoldersWithPaketReferencesAndNoConfig mockGetFiles rootPath
     foldersToCreateConfigFor |> shouldEqual []
 
 [<Test>]
 let ``app.config file is not marked for creation in folders if one already exists``() =
     let mockGetFiles =
         buildMockGetFiles
-            [ (@"C:\rootpath", "paket.references"), [ @"C:\rootpath\source\paket.references" ]
-              (@"C:\rootpath\source", "*.config"), [ @"C:\rootpath\source\paket.references"; @"C:\rootpath\source\app.config" ]
+            [ (@"C:/rootpath/", "paket.references"), [ @"C:/rootpath/source/paket.references" ]
+              (@"C:/rootpath/source", "*.config"), [ @"C:/rootpath/source/app.config" ]
             ]
-    let foldersToCreateConfigFor = getFoldersWithPaketReferencesAndNoConfig mockGetFiles @"C:\rootpath"
+    let foldersToCreateConfigFor = getFoldersWithPaketReferencesAndNoConfig mockGetFiles rootPath
     foldersToCreateConfigFor |> shouldEqual []
 
 


### PR DESCRIPTION
Can someone review this, as it's quite an invasive change in terms of files that can be amended / created as a result of this. Whenever the binding redirects code now gets called, Paket will: -

1. Locate all paket.references files.
2. Create an very bare app.config file if one doesn't already exist.
3. Go through the standard app.config binding redirects code, applying BRs to both existing configuration files and those that were just created.
4. Add any new app.config files to any cs / fs / vbproj that it finds alongside it.