### PR TITLE
Use AssemblyInformationalVersionAttribute to do version comparisons in the bootstrapper for remote vs local

### DIFF
--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Linq;
+using System.Reflection;
 
 namespace Paket.Bootstrapper
 {
@@ -11,21 +12,15 @@ namespace Paket.Bootstrapper
 
         internal static string GetLocalFileVersion(string target)
         {
-            var localVersion = "";
+            if (!File.Exists(target)) return "";
 
-            if (File.Exists(target))
+            try
             {
-                try
-                {
-                    FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(target);
-                    if (fvi.FileVersion != null)
-                        localVersion = fvi.FileVersion;
-                }
-                catch (Exception)
-                {
-                }
+                var attr = Assembly.LoadFile(target).GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false).Cast<AssemblyInformationalVersionAttribute>().FirstOrDefault();
+                if (attr == null) return "";
+                return attr.InformationalVersion;
             }
-            return localVersion;
+            catch (Exception) { return ""; }
         }
 
         internal static void PrepareWebClient(WebClient client, string url)

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -80,7 +80,7 @@ namespace Paket.Bootstrapper
                 }
                 else
                 {
-                    if (!localVersion.StartsWith(latestVersion))
+                    if (!localVersion.StartsWith(latestVersion, StringComparison.OrdinalIgnoreCase))
                     {
                         downloadStrategy.DownloadVersion(latestVersion, dlArgs.Target, silent);
                         if (!silent)


### PR DESCRIPTION
We set the informational version on release to the same version as the nuget package/github release.
So for purposes or determining if the local version is the same as the discovered version from the download strategy we should compare against the informational version.

This implements the quick-escaping behavior requested by #1041