### PR TITLE
Fixes analyzers that were never removed during updates

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -485,6 +485,7 @@ type ProjectFile =
         propertyNameNodes,chooseNode,propertyChooseNode,analyzersNode
         
     member this.RemovePaketNodes() =
+        this.DeletePaketNodes("Analyzer")
         this.DeletePaketNodes("Reference")
 
         let rec PaketNodes (node:XmlNode) =

--- a/tests/Paket.Tests/InstallModel/Xml/Microsoft.CodeAnalysis.Analyzers.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Microsoft.CodeAnalysis.Analyzers.fs
@@ -1,0 +1,107 @@
+﻿module Paket.InstallModel.Xml.MicrosoftCodeAnalysisAnalyzersSpecs
+
+open FsUnit
+open NUnit.Framework
+open Paket
+open Paket.Constants
+open Paket.Domain
+open Paket.TestHelpers
+open System.Text
+open System.IO
+
+let model =
+    InstallModel.CreateFromLibs(PackageName "Microsoft.CodeAnalysis.Analyzers", SemVer.Parse "1.0.0", [],
+            [],
+            [],
+            [
+                [".."; "Microsoft.CodeAnalysis.Analyzers"; "analyzers"; "dotnet"; "cs"; "Microsoft.CodeAnalysis.Analyzers.dll"] |> toPath
+                [".."; "Microsoft.CodeAnalysis.Analyzers"; "analyzers"; "dotnet"; "cs"; "Microsoft.CodeAnalysis.CSharp.Analyzers.dll"] |> toPath
+                [".."; "Microsoft.CodeAnalysis.Analyzers"; "analyzers"; "dotnet"; "vb"; "Microsoft.CodeAnalysis.Analyzers.dll"] |> toPath
+                [".."; "Microsoft.CodeAnalysis.Analyzers"; "analyzers"; "dotnet"; "vb"; "Microsoft.CodeAnalysis.VisualBasic.Analyzers.dll"] |> toPath
+            ],
+            Nuspec.All)
+
+let expectedCs = """
+<ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Analyzer Include="..\..\..\Microsoft.CodeAnalysis.Analyzers\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+  <Analyzer Include="..\..\..\Microsoft.CodeAnalysis.Analyzers\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+</ItemGroup>"""
+
+[<Test>]
+let ``should generate Xml for Microsoft.CodeAnalysis.Analyzers in CSharp project``() = 
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true,None)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expectedCs)
+
+let expectedVb = """
+<ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Analyzer Include="..\..\..\Microsoft.CodeAnalysis.Analyzers\analyzers\dotnet\vb\Microsoft.CodeAnalysis.Analyzers.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+  <Analyzer Include="..\..\..\Microsoft.CodeAnalysis.Analyzers\analyzers\dotnet\vb\Microsoft.CodeAnalysis.VisualBasic.Analyzers.dll">
+    <Paket>True</Paket>
+  </Analyzer>
+</ItemGroup>"""
+
+[<Test>]
+let ``should generate Xml for RefactoringEssentials in VisualBasic project``() = 
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(model,true,true,None)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expectedVb)
+
+let oldModel =
+    InstallModel.CreateFromLibs(PackageName "Microsoft.CodeAnalysis.Analyzers", SemVer.Parse "1.0.0-rc2", [],
+            [],
+            [],
+            [], // Analyzers weren't in the correct folder and won't be found for this version
+            Nuspec.All)
+
+let expectedEmpty = """<ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />"""
+
+[<Test>]
+let ``should generate Xml for Microsoft.CodeAnalysis.Analyzers 1.0.0-rc2``() = 
+    let project = ProjectFile.Load("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
+    Assert.IsTrue(project.IsSome)
+    let _,_,_,analyzerNodes = project.Value.GenerateXml(oldModel,true,true,None)
+    analyzerNodes
+    |> (fun n -> n.OuterXml)
+    |> normalizeXml
+    |> shouldEqual (normalizeXml expectedEmpty)
+
+let projectAfter100Installed = """
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <ItemGroup xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Analyzer Include="..\..\..\Microsoft.CodeAnalysis.Analyzers\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll">
+      <Paket>True</Paket>
+    </Analyzer>
+    <Analyzer Include="..\..\..\Microsoft.CodeAnalysis.Analyzers\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll">
+      <Paket>True</Paket>
+    </Analyzer>
+  </ItemGroup>
+</Project>"""
+
+[<Test>]
+let ``can remove analyzer paket nodes``() = 
+    use stream = new MemoryStream(projectAfter100Installed |> Encoding.ASCII.GetBytes)
+    let project = ProjectFile.LoadFromStream("Test.csproj", stream)
+    
+    project.RemovePaketNodes()
+
+    let analyzerCount = project.FindPaketNodes "Analyzer" |> List.length
+
+    analyzerCount |> shouldEqual 0
+
+    

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -299,6 +299,7 @@
     <Compile Include="InstallModel\Xml\Microsoft.Bcl.Build.fs" />
     <Compile Include="InstallModel\Xml\CodeCracker.fs" />
     <Compile Include="InstallModel\Xml\RefactoringEssentials.fs" />
+    <Compile Include="InstallModel\Xml\Microsoft.CodeAnalysis.Analyzers.fs" />
     <Compile Include="InstallModel\Penalty\PenaltySpecs.fs" />
     <Compile Include="InstallModel\Penalty\FrameworkConditionsSpecs.fs" />
     <Compile Include="InstallModel\AnalyzerSpecs.fs" />


### PR DESCRIPTION
The issue is #1047 the nodes where created with `<Paket>True</Paket>` markers but they weren't removed as all others.