### PR TITLE
Add back 'AsString' in SemVerInfo

### DIFF
--- a/src/Paket.Core/SemVer.fs
+++ b/src/Paket.Core/SemVer.fs
@@ -116,6 +116,9 @@ type SemVerInfo =
         | Some version -> version.Trim()
         | None -> x.Normalize()
     
+    member x.AsString
+        with get() = x.ToString()
+
     override x.Equals(yobj) = 
         match yobj with
         | :? SemVerInfo as y -> 


### PR DESCRIPTION
It's needed for sprintf usage.

Fixes #1048