### PR TITLE
fix for parsing output path when condition has no spaces

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -633,15 +633,16 @@ type ProjectFile =
                         |     _, false, c    -> parseWord (data.Append(c)) input (index + 1) false
 
                 let rec parseComparison (data:System.Text.StringBuilder) (input:string) index =
+                    let isCompChar c = c = '<' || c = '>' || c = '!' || c = '='
                     if input.Length <= index
                     then None
                     else
                         let c = input.[index]
                         if data.Length = 0 && c = ' '
                         then parseComparison data input (index + 1)
-                        elif data.Length = 2 && c <> ' ' && c <> '\''
+                        elif data.Length = 2 && isCompChar c
                         then None
-                        elif c = '<' || c = '>' || c = '!' || c = '='
+                        elif isCompChar c
                         then parseComparison (data.Append(c)) input (index + 1)
                         else
                             let s = data.ToString()

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -639,7 +639,7 @@ type ProjectFile =
                         let c = input.[index]
                         if data.Length = 0 && c = ' '
                         then parseComparison data input (index + 1)
-                        elif data.Length = 2 && c <> ' '
+                        elif data.Length = 2 && c <> ' ' && c <> '\''
                         then None
                         elif c = '<' || c = '>' || c = '!' || c = '='
                         then parseComparison (data.Append(c)) input (index + 1)

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -33,7 +33,7 @@ let ``should detect target framework for Project2 proj file``() =
 
 [<Test>]
 let ``should detect output path for proj file``
-        ([<Values("Project1", "Project2", "Project3")>] project)
+        ([<Values("Project1", "Project2", "Project3", "ProjectWithConditions")>] project)
         ([<Values("Debug", "Release")>] configuration) =
     ProjectFile.Load(sprintf "./ProjectFile/TestData/%s.fsprojtest" project).Value.GetOutputDirectory configuration
     |> shouldEqual (System.IO.Path.Combine(@"bin", configuration) |> normalizePath)

--- a/tests/Paket.Tests/ProjectFile/TestData/ProjectWithConditions.fsprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/ProjectWithConditions.fsprojtest
@@ -16,7 +16,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)'=='Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -31,7 +31,7 @@
     <StartArguments>
     </StartArguments>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)'=='Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>


### PR DESCRIPTION
Fix for issue: https://github.com/fsprojects/Paket/issues/1057

The tests pass, but @amazingant (who wrote the parsing code) may need to double check that to see that it doesn't break any other scenarios.