### PR TITLE
don't add -prerelease to nuspec dependency nodes for project references

### DIFF
--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -188,8 +188,8 @@ let findDependencies (dependencies : DependenciesFile) config (template : Templa
                         if not lockDependencies
                         then Minimum v
                         else Specific v
-                    PackageName core.Id, VersionRequirement(versionConstraint, PreReleaseStatus.All)
-                | none ->failwithf "There was no version given for %s." templateFile.FileName
+                    PackageName core.Id, VersionRequirement(versionConstraint, PreReleaseStatus.No)
+                | None ->failwithf "There was no version given for %s." templateFile.FileName
             | IncompleteTemplate -> failwithf "You cannot create a dependency on a template file (%s) with incomplete metadata." templateFile.FileName)
         |> List.fold addDependency templateWithOutput
     


### PR DESCRIPTION
Pack is adding -prerelease to the end of project reference dependency nodes, e.g:

    <dependency id="BlahBlah.BlahBlah" version="1.0.0-prerelease" />

when that project has been packed correctly as 1.0.0.

Fairly easy to repro - have two projects, both with paket.template files (type project), and one referencing the other.   Paket pack version 1.0.0 will generate the above.