### PR TITLE
Selective update needs to consider remote files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,8 @@
-#### 2.7.3 - 03.10.2015
+#### 2.8.0 - 03.10.2015
+* BUGFIX: Selective update needs to consider remote files
 * BUGFIX: Ignore disabled upstream feeds - https://github.com/fsprojects/Paket/pull/1105
-
-#### 2.7.2 - 02.10.2015
 * BUGFIX: Don't forget to add settings from root dependencies
-
-#### 2.7.1 - 02.10.2015
-* Do not write unnecessary framework restrictions into paket.lock 
+* COSMETICS: Do not write unnecessary framework restrictions into paket.lock 
 
 #### 2.7.0 - 02.10.2015
 * Support for private GitHub repos - http://fsprojects.github.io/Paket/github-dependencies.html#Referencing-a-private-github-repository

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -371,7 +371,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
         let _,_,firstLine,lastLine =
             textRepresentation
             |> Array.fold (fun (i,currentGroup,firstLine,lastLine) line -> 
-                    if line.StartsWith "group " then
+                    if line.TrimStart().StartsWith "group " then
                         let group = line.Replace("group","").Trim()
                         if currentGroup = groupName then
                             i+1,GroupName group,firstLine,(i - 1)

--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -45,7 +45,6 @@ let findChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFile:Loc
         ]
         |> List.map lockFile.GetAllNormalizedDependenciesOf
         |> Seq.concat
-        |> Seq.map (fun p -> groupName,p)
         |> Set.ofSeq
 
     let groupNames =

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -354,7 +354,7 @@ type LockFile(fileName:string,groups: Map<GroupName,LockFileGroup>) =
         let rec addPackage (identity:PackageName) =
             match group.Resolution.TryFind identity with
             | Some package ->
-                if usedPackages.Add identity then
+                if usedPackages.Add(groupName,identity) then
                     if not group.Options.Strict then
                         for d,_,_ in package.Dependencies do
                             addPackage d

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -34,12 +34,12 @@
     <StartWorkingDirectory>c:\code\Paket09x</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\Pakettest</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\Paketkopie</StartWorkingDirectory>
-    <StartArguments>install</StartArguments>
+    <StartArguments>update nuget fake group build</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>c:\code\Paketkopie</StartWorkingDirectory>
     <StartWorkingDirectory>C:\Temp\paket_test\</StartWorkingDirectory>
-    <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
+    <StartWorkingDirectory>d:\code\paketkopie</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
@@ -5,6 +5,7 @@ open NUnit.Framework
 open FsUnit
 open TestHelpers
 open Paket.Domain
+open Paket.Requirements
 
 [<Test>]
 let ``should add new packages to the end``() = 
@@ -813,6 +814,44 @@ let ``should add Microsoft.AspNet.WebApi package to very first group``() =
 source https://nuget.org/api/v2
 
 nuget Microsoft.AspNet.WebApi"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should pin in correct group``() = 
+    let config = """source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net ~> 3.0
+    nuget FAKE
+    
+    group Group
+        source http://nuget.org/api/v2
+
+        nuget Castle.Core-log4net
+        nuget FAKE
+        nuget log4net"""
+
+    let cfg = DependenciesFile.FromCode(config)
+                 .AddFixedPackage(
+                        GroupName "main",
+                        PackageName "Castle.Core",
+                        "= 3.2.0",
+                        InstallSettings.Default)
+
+    
+    let expected = """source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net ~> 3.0
+    nuget FAKE
+nuget Castle.Core 3.2.0
+    
+    group Group
+        source http://nuget.org/api/v2
+
+        nuget Castle.Core-log4net
+        nuget FAKE
+        nuget log4net"""
 
     cfg.ToString()
     |> shouldEqual (normalizeLineEndings expected)

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -376,24 +376,13 @@ let ``SelectiveUpdate does not update any package when package does not exist``(
     nuget FAKE""")
 
     let updateAll = false
-    let lockFile = 
+    try
         Some(Constants.MainDependencyGroup, PackageName "package")
         |> selectiveUpdate resolve lockFile dependenciesFile updateAll
-    
-    let result = 
-        lockFile.GetGroupedResolution()
-        |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
-
-    let expected = 
-        [("Castle.Core-log4net","3.2.0");
-        ("Castle.Core","3.2.0");
-        ("FAKE","4.0.0");
-        ("log4net","1.2.10")]
-        |> Seq.sortBy fst
-
-    result
-    |> Seq.sortBy fst
-    |> shouldEqual expected
+        |> ignore
+        failwith "This pont should not be reached"
+    with
+    | exn when exn.Message <> "This pont should not be reached" -> ()
      
 [<Test>]
 let ``SelectiveUpdate generates paket.lock correctly``() = 
@@ -585,7 +574,7 @@ let lockFileData3 = """NUGET
   specs:
     log4f (0.4.0)
       log4net (>= 1.2.10 < 2.0.0)
-    log4net (1.0.4)
+    log4net (1.2.10)
     Ninject (2.2.1.4)
     Ninject.Extensions.Logging (2.2.0.4)
       Ninject (>= 2.2.0.0 < 2.3.0.0)
@@ -681,7 +670,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
         ("Ninject.Extensions.Interception","2.2.1.3");
         ("Ninject", "2.2.1.5");
         ("log4f", "0.4.0");
-        ("log4net", "1.0.4")]
+        ("log4net", "1.2.10")]
         |> Seq.sortBy fst
 
     result


### PR DESCRIPTION
/cc @mrinaldi 

It now works like "paket install". But instead of discovering changes from last lock file, we just add all transitive dependencies of the package in question.