### PR TITLE
Skip unchanged groups during install

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.11.0-alpha001 - 08.10.2015
+* Skip unchanged groups during install
+
 #### 2.10.0 - 08.10.2015
 * Make resolver to evaluate versions lazily
 * BUGFIX: Paket.Pack was broken on filesystems with forward slash seperator - https://github.com/fsprojects/Paket/issues/1119

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -4,11 +4,11 @@ using System.Reflection;
 [assembly: AssemblyTitleAttribute("Paket.Bootstrapper")]
 [assembly: AssemblyProductAttribute("Paket")]
 [assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")]
-[assembly: AssemblyVersionAttribute("2.10.0")]
-[assembly: AssemblyFileVersionAttribute("2.10.0")]
-[assembly: AssemblyInformationalVersionAttribute("2.10.0")]
+[assembly: AssemblyVersionAttribute("2.11.0")]
+[assembly: AssemblyFileVersionAttribute("2.11.0")]
+[assembly: AssemblyInformationalVersionAttribute("2.11.0-alpha001")]
 namespace System {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.10.0";
+        internal const string Version = "2.11.0";
     }
 }

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.10.0")>]
-[<assembly: AssemblyFileVersionAttribute("2.10.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.10.0")>]
+[<assembly: AssemblyVersionAttribute("2.11.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.11.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.11.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.10.0"
+    let [<Literal>] Version = "2.11.0"

--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -70,31 +70,19 @@ type RemoteFileChange =
     override this.Equals(that) = 
         match that with
         | :? RemoteFileChange as that -> 
-            this.Owner = that.Owner &&
-             this.Project = that.Project &&
-             this.Name = that.Name &&
-             this.Origin = that.Origin &&
-             ((this.Commit = that.Commit) || this.Commit = None || that.Commit = None) &&
-             this.AuthKey = that.AuthKey
+            this.FieldsWithoutCommit = that.FieldsWithoutCommit &&
+             ((this.Commit = that.Commit) || this.Commit = None || that.Commit = None)
         | _ -> false
 
     override this.ToString() = sprintf "%O/%s/%s" this.Origin this.Project this.Name
 
-    override this.GetHashCode() = hash (this.Owner,this.Name,this.AuthKey,this.Project,this.Origin)
+    member private this.FieldsWithoutCommit = this.Owner,this.Name,this.AuthKey,this.Project,this.Origin
+    member private this.FieldsWithCommit = this.FieldsWithoutCommit,this.Commit
+    override this.GetHashCode() = hash this.FieldsWithCommit
 
-    static member Compare(x,y) =
+    static member Compare(x:RemoteFileChange,y:RemoteFileChange) =
         if x = y then 0 else
-        let c1 = compare x.Owner y.Owner
-        if c1 <> 0 then c1 else
-        let c2 = compare x.Project y.Project
-        if c2 <> 0 then c2 else
-        let c3 = compare x.Name y.Name
-        if c3 <> 0 then c3 else
-        let c4 = compare x.Origin y.Origin
-        if c4 <> 0 then c4 else
-        let c5 = compare x.AuthKey y.AuthKey
-        if c5 <> 0 then c5 else
-        compare x.Commit y.Commit
+        compare x.FieldsWithCommit y.FieldsWithCommit
 
     interface System.IComparable with
        member this.CompareTo that = 

--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -158,7 +158,8 @@ let findRemoteFileChangesInDependenciesFile(dependenciesFile:DependenciesFile,lo
                 // all removed
                 lockFile.GetGroup(groupName).RemoteFiles
                 |> List.map createResolvedVersion
-                |> Set.ofList)
+                |> Set.ofList
+            |> Set.map (fun x -> groupName,x))
     |> Seq.concat
     |> Set.ofSeq
 

--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -4,11 +4,9 @@ open Paket.Domain
 open Paket.Requirements
 open Paket.PackageResolver
 
-let findChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFile:LockFile) =
-    let hasChanged (newRequirement:PackageRequirement) (originalPackage:ResolvedPackage) =
-        if newRequirement.VersionRequirement.IsInRange originalPackage.Version |> not then 
-            true
-        else 
+let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFile:LockFile) =
+    let inline hasChanged (newRequirement:PackageRequirement) (originalPackage:ResolvedPackage) =
+        newRequirement.VersionRequirement.IsInRange originalPackage.Version |> not ||
             newRequirement.Settings <> originalPackage.Settings
 
     let added groupName =
@@ -60,21 +58,112 @@ let findChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFile:Loc
     |> Seq.concat
     |> Set.ofSeq
 
-let GetUnchangedDependenciesPins (oldLockFile:LockFile) (changedDependencies:Set<GroupName*PackageName>) =
+[<CustomEquality;CustomComparison>]
+type RemoteFileChange =
+    { Owner : string
+      Project : string
+      Name : string
+      Origin : ModuleResolver.SingleSourceFileOrigin
+      Commit : string option
+      AuthKey : string option }
+
+    override this.Equals(that) = 
+        match that with
+        | :? RemoteFileChange as that -> 
+            this.Owner = that.Owner &&
+             this.Project = that.Project &&
+             this.Name = that.Name &&
+             this.Origin = that.Origin &&
+             ((this.Commit = that.Commit) || this.Commit = None || that.Commit = None) &&
+             this.AuthKey = that.AuthKey
+        | _ -> false
+
+    override this.ToString() = sprintf "%O/%s/%s" this.Origin this.Project this.Name
+
+    override this.GetHashCode() = hash (this.Owner,this.Name,this.AuthKey,this.Project,this.Origin)
+
+    static member Compare(x,y) =
+        if x = y then 0 else
+        let c1 = compare x.Owner y.Owner
+        if c1 <> 0 then c1 else
+        let c2 = compare x.Project y.Project
+        if c2 <> 0 then c2 else
+        let c3 = compare x.Name y.Name
+        if c3 <> 0 then c3 else
+        let c4 = compare x.Origin y.Origin
+        if c4 <> 0 then c4 else
+        let c5 = compare x.AuthKey y.AuthKey
+        if c5 <> 0 then c5 else
+        compare x.Commit y.Commit
+
+    interface System.IComparable with
+       member this.CompareTo that = 
+          match that with 
+          | :? RemoteFileChange as that -> RemoteFileChange.Compare(this,that)
+          | _ -> invalidArg "that" "cannot compare value of different types"
+
+
+let findRemoteFileChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFile:LockFile) =
+    let groupNames =
+        dependenciesFile.Groups
+        |> Seq.map (fun kv -> kv.Key)
+        |> Seq.append (lockFile.Groups |> Seq.map (fun kv -> kv.Key))
+
+    let createUnresolvedVersion (resolvedFile:ModuleResolver.UnresolvedSourceFile) : RemoteFileChange =
+          { Owner = resolvedFile.Owner
+            Project = resolvedFile.Project
+            Name = resolvedFile.Name
+            Origin = resolvedFile.Origin
+            Commit = resolvedFile.Commit
+            AuthKey = resolvedFile.AuthKey }
+
+    let createResolvedVersion (resolvedFile:ModuleResolver.ResolvedSourceFile) : RemoteFileChange =
+          { Owner = resolvedFile.Owner
+            Project = resolvedFile.Project
+            Name = resolvedFile.Name
+            Origin = resolvedFile.Origin
+            Commit = Some resolvedFile.Commit
+            AuthKey = resolvedFile.AuthKey }
+
+    groupNames
+    |> Seq.map (fun groupName ->
+            match dependenciesFile.Groups |> Map.tryFind groupName with
+            | Some dependenciesFileGroup ->
+                match lockFile.Groups |> Map.tryFind groupName with
+                | Some lockFilegroup ->
+                    let lockFileRemoteFiles =
+                        lockFilegroup.RemoteFiles
+                        |> List.map createResolvedVersion
+                        |> Set.ofList
+
+                    let dependenciesFileRemoteFiles =
+                        dependenciesFileGroup.RemoteFiles
+                        |> List.map createUnresolvedVersion
+                        |> Set.ofList
+
+                    let u =
+                        dependenciesFileRemoteFiles
+                        |> Set.union lockFileRemoteFiles
+                    let i =
+                        dependenciesFileRemoteFiles
+                        |> Set.intersect lockFileRemoteFiles
+
+                    Set.difference u i
+                | None -> 
+                    // all added
+                    dependenciesFileGroup.RemoteFiles 
+                    |> List.map createUnresolvedVersion 
+                    |> Set.ofList 
+            | None -> 
+                // all removed
+                lockFile.GetGroup(groupName).RemoteFiles
+                |> List.map createResolvedVersion
+                |> Set.ofList)
+    |> Seq.concat
+    |> Set.ofSeq
+
+let GetPreferredNuGetVersions (oldLockFile:LockFile) (changedDependencies:Set<GroupName*PackageName>) =
     oldLockFile.GetGroupedResolution()
     |> Seq.filter (fun kv -> not <| changedDependencies.Contains(kv.Key))
     |> Seq.map (fun kv -> kv.Key, kv.Value.Version)
     |> Map.ofSeq
-
-let PinUnchangedDependencies (dependenciesFile:DependenciesFile) (oldLockFile:LockFile) (changedDependencies:Set<GroupName*PackageName>) =
-    oldLockFile.GetGroupedResolution()
-    |> Seq.filter (fun kv -> not <| changedDependencies.Contains(kv.Key))
-    |> Seq.fold 
-            (fun (dependenciesFile : DependenciesFile) kv ->
-                    let resolvedPackage = kv.Value
-                    dependenciesFile.AddFixedPackage(
-                        fst kv.Key,
-                        resolvedPackage.Name,
-                        "= " + resolvedPackage.Version.ToString(),
-                        resolvedPackage.Settings))
-            dependenciesFile

--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -109,21 +109,21 @@ let findRemoteFileChangesInDependenciesFile(dependenciesFile:DependenciesFile,lo
         |> Seq.map (fun kv -> kv.Key)
         |> Seq.append (lockFile.Groups |> Seq.map (fun kv -> kv.Key))
 
-    let createUnresolvedVersion (resolvedFile:ModuleResolver.UnresolvedSourceFile) : RemoteFileChange =
-          { Owner = resolvedFile.Owner
-            Project = resolvedFile.Project
-            Name = resolvedFile.Name
-            Origin = resolvedFile.Origin
-            Commit = resolvedFile.Commit
-            AuthKey = resolvedFile.AuthKey }
+    let createUnresolvedVersion (unresolved:ModuleResolver.UnresolvedSourceFile) : RemoteFileChange =
+          { Owner = unresolved.Owner
+            Project = unresolved.Project
+            Name = unresolved.Name
+            Origin = unresolved.Origin
+            Commit = unresolved.Commit
+            AuthKey = unresolved.AuthKey }
 
-    let createResolvedVersion (resolvedFile:ModuleResolver.ResolvedSourceFile) : RemoteFileChange =
-          { Owner = resolvedFile.Owner
-            Project = resolvedFile.Project
-            Name = resolvedFile.Name
-            Origin = resolvedFile.Origin
-            Commit = Some resolvedFile.Commit
-            AuthKey = resolvedFile.AuthKey }
+    let createResolvedVersion (resolved:ModuleResolver.ResolvedSourceFile) : RemoteFileChange =
+          { Owner = resolved.Owner
+            Project = resolved.Project
+            Name = resolved.Name
+            Origin = resolved.Origin
+            Commit = Some resolved.Commit
+            AuthKey = resolved.AuthKey }
 
     groupNames
     |> Seq.map (fun groupName ->

--- a/src/Paket.Core/ModuleResolver.fs
+++ b/src/Paket.Core/ModuleResolver.fs
@@ -15,7 +15,7 @@ type SingleSourceFileOrigin =
 type UnresolvedSourceFile =
     { Owner : string
       Project : string
-      Name : string      
+      Name : string
       Origin : SingleSourceFileOrigin
       Commit : string option
       AuthKey : string option }

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -46,9 +46,9 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
 
             getSortedAndCachedVersionsF,groups
         | Install ->
-            let changes = DependencyChangeDetection.findChangesInDependenciesFile(dependenciesFile,lockFile)
+            let changes = DependencyChangeDetection.findNuGetChangesInDependenciesFile(dependenciesFile,lockFile)
 
-            let preferredVersions = DependencyChangeDetection.GetUnchangedDependenciesPins lockFile changes
+            let preferredVersions = DependencyChangeDetection.GetPreferredNuGetVersions lockFile changes
 
             (getPreferredVersionsF preferredVersions),dependenciesFile.Groups
         | UpdatePackage(groupName,packageName) ->
@@ -56,7 +56,7 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
                 lockFile.GetAllNormalizedDependenciesOf(groupName,packageName)
                 |> Set.ofSeq
 
-            let preferredVersions = DependencyChangeDetection.GetUnchangedDependenciesPins lockFile changes
+            let preferredVersions = DependencyChangeDetection.GetPreferredNuGetVersions lockFile changes
 
             let groups =
                 dependenciesFile.Groups

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -78,9 +78,15 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
                     | None -> true
                     | Some lockFileGroup -> dependenciesFileGroup.Options <> lockFileGroup.Options
 
+            let hasChanges groupName _ = 
+                let hasChanges = hasChangedSettings groupName || hasNuGetChanges groupName || hasRemoteFileChanges groupName
+                if not hasChanges then
+                    tracefn "Skipping resolver for group %O since it is already up-to-date" groupName
+                hasChanges
+
             let groups =
                 dependenciesFile.Groups
-                |> Map.filter (fun groupName _ -> hasChangedSettings groupName || hasNuGetChanges groupName || hasRemoteFileChanges groupName)
+                |> Map.filter hasChanges
 
             (getPreferredVersionsF preferredVersions),groups
         | UpdatePackage(groupName,packageName) ->

--- a/src/Paket.PowerShell/AssemblyInfo.fs
+++ b/src/Paket.PowerShell/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.10.0")>]
-[<assembly: AssemblyFileVersionAttribute("2.10.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.10.0")>]
+[<assembly: AssemblyVersionAttribute("2.11.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.11.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.11.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.10.0"
+    let [<Literal>] Version = "2.11.0"

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.10.0")>]
-[<assembly: AssemblyFileVersionAttribute("2.10.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.10.0")>]
+[<assembly: AssemblyVersionAttribute("2.11.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.11.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.11.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.10.0"
+    let [<Literal>] Version = "2.11.0"

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -37,7 +37,7 @@
     <StartArguments>update group Build</StartArguments>
     <StartArguments>pack output D:\code\paketbug\output</StartArguments>
     <StartArguments>install</StartArguments>
-    <StartArguments>pack output bin  version  1.2.7-prerelease releaseNotes  "Prerelease with same content as 1.2.6. Needed for dependency management"</StartArguments>
+    <StartArguments>install</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>c:\code\Paketkopie</StartWorkingDirectory>
@@ -45,7 +45,7 @@
     <StartWorkingDirectory>d:\code\paketkopie</StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketbug</StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
-    <StartWorkingDirectory>d:\code\wdk-unity-ThreadSafe</StartWorkingDirectory>
+    <StartWorkingDirectory>d:\code\paketrepro1</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
When a group has no changes at all (compared to the lock file) we can skip the resolver completely.

/cc @mrinaldi