### PR TITLE
Make SemVer update available in CLI

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.12.0-alpha001 - 10.10.2015
+* Better SemVer update by adding --keep-major, --keep-minor, --keep-patch to the CLI
+
 #### 2.11.1 - 09.10.2015
 * EXPERIMENTAL: Support for WiX installer projects
 

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -4,11 +4,11 @@ using System.Reflection;
 [assembly: AssemblyTitleAttribute("Paket.Bootstrapper")]
 [assembly: AssemblyProductAttribute("Paket")]
 [assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")]
-[assembly: AssemblyVersionAttribute("2.11.1")]
-[assembly: AssemblyFileVersionAttribute("2.11.1")]
-[assembly: AssemblyInformationalVersionAttribute("2.11.1")]
+[assembly: AssemblyVersionAttribute("2.12.0")]
+[assembly: AssemblyFileVersionAttribute("2.12.0")]
+[assembly: AssemblyInformationalVersionAttribute("2.12.0-alpha001")]
 namespace System {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.11.1";
+        internal const string Version = "2.12.0";
     }
 }

--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -23,7 +23,7 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
             existingDependenciesFile
                 .Add(groupName,package,version)
 
-        let lockFile = UpdateProcess.SelectiveUpdate(dependenciesFile, PackageResolver.UpdateMode.Install, options.Force)
+        let lockFile = UpdateProcess.SelectiveUpdate(dependenciesFile, PackageResolver.UpdateMode.Install, options.SemVerUpdateMode, options.Force)
         let projects = seq { for p in ProjectFile.FindAllProjects(Path.GetDirectoryName lockFile.FileName) -> p } // lazy sequence in case no project install required
 
         dependenciesFile.Save()

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.11.1")>]
-[<assembly: AssemblyFileVersionAttribute("2.11.1")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.11.1")>]
+[<assembly: AssemblyVersionAttribute("2.12.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.12.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.12.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.11.1"
+    let [<Literal>] Version = "2.12.0"

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -1,5 +1,12 @@
 namespace Paket
 
+[<RequireQualifiedAccess>]
+type SemVerUpdateMode =
+    | All
+    | Major
+    | Minor
+    | Patch
+
 // Options for UpdateProcess and InstallProcess.
 /// Force          - Force the download and reinstallation of all packages
 /// Hard           - Replace package references within project files even if they are not yet adhering
@@ -9,6 +16,7 @@ namespace Paket
 type InstallerOptions =
     { Force : bool
       Hard : bool
+      SemVerUpdateMode : SemVerUpdateMode
       Redirects : bool
       CreateNewBindingFiles : bool
       OnlyReferenced : bool }
@@ -17,6 +25,7 @@ type InstallerOptions =
         { Force = false
           Hard = false
           Redirects = false
+          SemVerUpdateMode = SemVerUpdateMode.All
           CreateNewBindingFiles = false
           OnlyReferenced = false }
 

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -2,10 +2,10 @@ namespace Paket
 
 [<RequireQualifiedAccess>]
 type SemVerUpdateMode =
-    | All
-    | Major
-    | Minor
-    | Patch
+    | NoRestriction
+    | KeepMajor
+    | KeepMinor
+    | KeepPatch
 
 // Options for UpdateProcess and InstallProcess.
 /// Force          - Force the download and reinstallation of all packages
@@ -25,16 +25,17 @@ type InstallerOptions =
         { Force = false
           Hard = false
           Redirects = false
-          SemVerUpdateMode = SemVerUpdateMode.All
+          SemVerUpdateMode = SemVerUpdateMode.NoRestriction
           CreateNewBindingFiles = false
           OnlyReferenced = false }
 
-    static member CreateLegacyOptions(force, hard, redirects, createNewBindingFiles) =
+    static member CreateLegacyOptions(force, hard, redirects, createNewBindingFiles, semVerUpdateMode) =
         { InstallerOptions.Default with
             Force = force
             Hard = hard
             CreateNewBindingFiles = createNewBindingFiles
-            Redirects = redirects }
+            Redirects = redirects 
+            SemVerUpdateMode = semVerUpdateMode }
 
 type UpdaterOptions =
     { Common : InstallerOptions

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -380,7 +380,7 @@ type Dependencies(dependenciesFileName: string) =
     member this.Remove(groupName, package: string): unit = this.Remove(groupName, package, false, false, false, true)
 
     /// Removes the given package from dependencies file.
-    member this.Remove(groupName, package: string,force: bool,hard: bool,interactive: bool,installAfter: bool): unit =
+    member this.Remove(groupName, package: string, force: bool,hard: bool,interactive: bool,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> RemoveProcess.Remove(dependenciesFileName, groupName, PackageName package, force, hard, interactive, installAfter))

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -106,22 +106,22 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Adds the given package with the given version to the dependencies file.
     member this.Add(groupName, package: string,version: string): unit =
-        this.Add(groupName, package, version, force = false, hard = false, withBindingRedirects = false,  createNewBindingFiles = false, interactive = false, installAfter = true)
+        this.Add(groupName, package, version, force = false, hard = false, withBindingRedirects = false,  createNewBindingFiles = false, interactive = false, installAfter = true, semVerUpdateMode = SemVerUpdateMode.NoRestriction)
 
     /// Adds the given package with the given version to the dependencies file.
-    member this.Add(groupName, package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool, createNewBindingFiles:bool, interactive: bool,installAfter: bool): unit =
+    member this.Add(groupName, package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool, createNewBindingFiles:bool, interactive: bool,installAfter: bool, semVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.Add(dependenciesFileName, groupName, PackageName(package.Trim()), version,
-                                     InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles),
+                                     InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode),
                                      interactive, installAfter))
 
    /// Adds the given package with the given version to the dependencies file.
-    member this.AddToProject(groupName, package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool, createNewBindingFiles:bool, projectName: string,installAfter: bool): unit =
+    member this.AddToProject(groupName, package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool, createNewBindingFiles:bool, projectName: string,installAfter: bool, semVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.AddToProject(dependenciesFileName, groupName, PackageName package, version,
-                                              InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles),
+                                              InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode),
                                               projectName, installAfter))
 
     /// Adds credentials for a Nuget feed
@@ -135,15 +135,15 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(this.RootPath, fun () -> ConfigFile.AddToken(source, token) |> returnOrFail)
 
     /// Installs all dependencies.
-    member this.Install(force: bool, hard: bool) = this.Install(force, hard, false, false)
+    member this.Install(force: bool, hard: bool) = this.Install(force, hard, false, false, SemVerUpdateMode.NoRestriction)
 
     /// Installs all dependencies.
-    member this.Install(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool): unit =
-        this.Install(force, hard, withBindingRedirects, createNewBindingFiles, false)
+    member this.Install(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, semVerUpdateMode): unit =
+        this.Install(force, hard, withBindingRedirects, createNewBindingFiles, false, semVerUpdateMode)
 
     /// Installs all dependencies.
-    member this.Install(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, onlyReferenced: bool): unit =
-        this.Install({ InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles) with OnlyReferenced = onlyReferenced })
+    member this.Install(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, onlyReferenced: bool, semVerUpdateMode): unit =
+        this.Install({ InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode) with OnlyReferenced = onlyReferenced })
 
     /// Installs all dependencies.
     member private this.Install(options: InstallerOptions): unit =
@@ -155,7 +155,7 @@ type Dependencies(dependenciesFileName: string) =
                             { UpdaterOptions.Default with Common = options }))
 
     /// Creates a paket.dependencies file with the given text in the current directory and installs it.
-    static member Install(dependencies, ?path: string, ?force, ?hard, ?withBindingRedirects, ?createNewBindingFiles) =
+    static member Install(dependencies, ?path: string, ?force, ?hard, ?withBindingRedirects, ?createNewBindingFiles, ?semVerUpdateMode) =
         let path = defaultArg path Environment.CurrentDirectory
         let fileName = Path.Combine(path, Constants.DependenciesFileName)
         File.WriteAllText(fileName, dependencies)
@@ -164,42 +164,43 @@ type Dependencies(dependenciesFileName: string) =
             force = defaultArg force false,
             hard = defaultArg hard false,
             withBindingRedirects = defaultArg withBindingRedirects false,
-            createNewBindingFiles = defaultArg createNewBindingFiles false)
+            createNewBindingFiles = defaultArg createNewBindingFiles false, 
+            semVerUpdateMode = defaultArg semVerUpdateMode SemVerUpdateMode.NoRestriction)
 
     /// Updates all dependencies.
     member this.Update(force: bool, hard: bool): unit = this.Update(force, hard, false, false)
 
     /// Updates all dependencies.
     member this.Update(force: bool, hard: bool, withBindingRedirects:bool, createNewBindingFiles:bool): unit =
-        this.Update(force, hard, withBindingRedirects, createNewBindingFiles, true)
+        this.Update(force, hard, withBindingRedirects, createNewBindingFiles, true, SemVerUpdateMode.NoRestriction)
 
     /// Updates all dependencies.
-    member this.Update(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool): unit =
+    member this.Update(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> UpdateProcess.Update(
                         dependenciesFileName,
                         { UpdaterOptions.Default with
-                            Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles)
+                            Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
                             NoInstall = installAfter |> not }))
 
     /// Updates dependencies in single group.
-    member this.UpdateGroup(groupName, force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool): unit =
+    member this.UpdateGroup(groupName, force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode:SemVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> UpdateProcess.UpdateGroup(
                             dependenciesFileName,
                             GroupName groupName,
                             { UpdaterOptions.Default with
-                                Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles)
+                                Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
                                 NoInstall = installAfter |> not }))
 
     /// Updates the given package.
-    member this.UpdatePackage(groupName, package: string, version: string option, force: bool, hard: bool): unit =
-        this.UpdatePackage(groupName, package, version, force, hard, false, false, true)
+    member this.UpdatePackage(groupName, package: string, version: string option, force: bool, hard: bool, semVerUpdateMode): unit =
+        this.UpdatePackage(groupName, package, version, force, hard, false, false, true, semVerUpdateMode)
 
     /// Updates the given package.
-    member this.UpdatePackage(groupName: string option, package: string, version: string option, force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool): unit =
+    member this.UpdatePackage(groupName: string option, package: string, version: string option, force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
         let groupName = 
             match groupName with
             | None -> Constants.MainDependencyGroup
@@ -209,7 +210,7 @@ type Dependencies(dependenciesFileName: string) =
             this.RootPath,
             fun () -> UpdateProcess.UpdatePackage(dependenciesFileName, groupName, PackageName package, version,
                                                   { UpdaterOptions.Default with
-                                                      Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles)
+                                                      Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
                                                       NoInstall = installAfter |> not }))
 
     /// Restores all dependencies.

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -40,7 +40,7 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
         let dependenciesFile = exisitingDependenciesFile.Remove(groupName,package)
         dependenciesFile.Save()
         
-        dependenciesFile,UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,force)
+        dependenciesFile,UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,SemVerUpdateMode.All,force)
     
     if installAfter then
         InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false), dependenciesFile, lockFile)

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -30,7 +30,7 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
                 | None -> false
                 | Some group -> group.NugetPackages |> Seq.exists (fun p -> p.Name = package))
 
-    let oldLockFile =    
+    let oldLockFile =
         let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
         LockFile.LoadFrom(lockFileName.FullName)
 
@@ -40,10 +40,10 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
         let dependenciesFile = exisitingDependenciesFile.Remove(groupName,package)
         dependenciesFile.Save()
         
-        dependenciesFile,UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,SemVerUpdateMode.All,force)
+        dependenciesFile,UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,SemVerUpdateMode.NoRestriction,force)
     
     if installAfter then
-        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false), dependenciesFile, lockFile)
+        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), dependenciesFile, lockFile)
 
 /// Removes a package with the option to remove it from a specified project.
 let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =    

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -46,10 +46,10 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
             | None -> ""
 
         match semVerUpdateMode with
-        | SemVerUpdateMode.All -> dependenciesFile
-        | SemVerUpdateMode.Major -> processFile (fun v -> sprintf "~> %d" v.Major + formatPrerelease v)
-        | SemVerUpdateMode.Minor -> processFile (fun v -> sprintf "~> %d.%d" v.Major v.Minor + formatPrerelease v)
-        | SemVerUpdateMode.Patch -> processFile (fun v -> sprintf "~> %d.%d.%d" v.Major v.Minor v.Patch + formatPrerelease v)
+        | SemVerUpdateMode.NoRestriction -> dependenciesFile
+        | SemVerUpdateMode.KeepMajor -> processFile (fun v -> sprintf "~> %d" v.Major + formatPrerelease v)
+        | SemVerUpdateMode.KeepMinor -> processFile (fun v -> sprintf "~> %d.%d" v.Major v.Minor + formatPrerelease v)
+        | SemVerUpdateMode.KeepPatch -> processFile (fun v -> sprintf "~> %d.%d.%d" v.Major v.Minor v.Patch + formatPrerelease v)
 
     let getVersionsF,groupsToUpdate =
         match updateMode with

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -34,7 +34,16 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
             yield! getSortedAndCachedVersionsF sources resolverStrategy groupName packageName
         }
 
-    let noPreferredVersions = Map.empty
+    let dependenciesFile =
+      let createRequirement (v:SemVerInfo) =
+        sprintf "~> %d.%d" v.Major v.Minor
+
+      lockFile.GetGroupedResolution()
+      |> Map.fold (fun (dependenciesFile:DependenciesFile) (groupName,packageName) resolvedPackage -> 
+            dependenciesFile.AddFixedPackage(groupName,packageName,createRequirement resolvedPackage.Version)) dependenciesFile
+    let y = dependenciesFile.ToString()
+    printfn "%s" y
+      
 
     let getVersionsF,groupsToUpdate =
         match updateMode with

--- a/src/Paket.PowerShell/AssemblyInfo.fs
+++ b/src/Paket.PowerShell/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.11.1")>]
-[<assembly: AssemblyFileVersionAttribute("2.11.1")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.11.1")>]
+[<assembly: AssemblyVersionAttribute("2.12.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.12.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.12.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.11.1"
+    let [<Literal>] Version = "2.12.0"

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.11.1")>]
-[<assembly: AssemblyFileVersionAttribute("2.11.1")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.11.1")>]
+[<assembly: AssemblyVersionAttribute("2.12.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.12.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.12.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.11.1"
+    let [<Literal>] Version = "2.12.0"

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -61,6 +61,9 @@ type AddArgs =
     | Redirects
     | CreateNewBindingFiles
     | No_Install
+    | Keep_Major
+    | Keep_Minor
+    | Keep_Patch
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -75,6 +78,10 @@ with
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
             | No_Install -> "Skips paket install --hard process afterward generation of dependencies / references files."
+            | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
+            | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
+            | Keep_Patch -> "Allows only updates that are not changing the patch version of the NuGet packages."
+     
 
 type ConfigArgs =
     | [<CustomCommandLine("add-credentials")>] AddCredentials of string
@@ -130,7 +137,10 @@ type InstallArgs =
     | [<AltCommandLine("-f")>] Force
     | Hard
     | Redirects
-    | CreateNewBindingFiles
+    | CreateNewBindingFiles    
+    | Keep_Major
+    | Keep_Minor
+    | Keep_Patch
     | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
 with
     interface IArgParserTemplate with
@@ -141,6 +151,9 @@ with
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
             | Install_Only_Referenced -> "Only install packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
+            | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
+            | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
+            | Keep_Patch -> "Allows only updates that are not changing the patch version of the NuGet packages."
 
 type OutdatedArgs =
     | Ignore_Constraints
@@ -203,6 +216,9 @@ type UpdateArgs =
     | Redirects
     | CreateNewBindingFiles
     | No_Install
+    | Keep_Major
+    | Keep_Minor
+    | Keep_Patch
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -215,7 +231,10 @@ with
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
             | No_Install -> "Skips paket install --hard process afterward generation of paket.lock file."
-
+            | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
+            | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
+            | Keep_Patch -> "Allows only updates that are not changing the patch version of the NuGet packages."
+            
 type FindPackagesArgs =
     | [<CustomCommandLine("searchtext")>] SearchText of string
     | [<CustomCommandLine("source")>] Source of string

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -37,7 +37,7 @@
     <StartArguments>update group Build</StartArguments>
     <StartArguments>pack output D:\code\paketbug\output</StartArguments>
     <StartArguments>install</StartArguments>
-    <StartArguments>install</StartArguments>
+    <StartArguments>update</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>c:\code\Paketkopie</StartWorkingDirectory>
@@ -45,7 +45,7 @@
     <StartWorkingDirectory>d:\code\paketkopie</StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketbug</StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
-    <StartWorkingDirectory>d:\code\paketrepro1</StartWorkingDirectory>
+    <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -37,7 +37,7 @@
     <StartArguments>update group Build</StartArguments>
     <StartArguments>pack output D:\code\paketbug\output</StartArguments>
     <StartArguments>install</StartArguments>
-    <StartArguments>update</StartArguments>
+    <StartArguments>update --keep-minor</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>c:\code\Paketkopie</StartWorkingDirectory>
@@ -45,7 +45,7 @@
     <StartWorkingDirectory>d:\code\paketkopie</StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketbug</StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
-    <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
+    <StartWorkingDirectory>C:\Users\Steffen\Dropbox\PaketRepro</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -52,7 +52,7 @@ let ``SelectiveUpdate does not update any package when it is neither updating al
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
     
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -77,7 +77,7 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -103,7 +103,7 @@ let ``SelectiveUpdate updates all packages constraining version``() =
     nuget Castle.Core ~> 3.2
     nuget FAKE = 4.0.0""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -128,7 +128,7 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -155,7 +155,7 @@ let ``SelectiveUpdate updates a single package``() =
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "FAKE")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "FAKE")) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -182,7 +182,7 @@ let ``SelectiveUpdate updates a single constrained package``() =
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -210,7 +210,7 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -236,7 +236,7 @@ let ``SelectiveUpdate installs new packages``() =
     nuget FAKE
     nuget Newtonsoft.Json""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -264,7 +264,7 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -292,7 +292,7 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
     let result = 
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
@@ -319,7 +319,7 @@ let ``SelectiveUpdate considers package name case difference``() =
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -348,7 +348,7 @@ let ``SelectiveUpdate conflicts when a dependency is contrained``() =
 
     (fun () ->
     selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-        (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+        (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
     |> ignore)
     |> shouldFail
 
@@ -362,7 +362,7 @@ let ``SelectiveUpdate does not update any package when package does not exist``(
 
     try
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "package")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "package")) SemVerUpdateMode.NoRestriction
         |> ignore
         failwith "This pont should not be reached"
     with
@@ -379,7 +379,7 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core")) SemVerUpdateMode.NoRestriction
     
     let result = 
             String.Join
@@ -415,7 +415,7 @@ let ``SelectiveUpdate does not update when package conflicts with a transitive d
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -486,7 +486,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -517,7 +517,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -573,7 +573,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -606,7 +606,7 @@ let ``SelectiveUpdate does not conflict with a transitive dependency of another 
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -638,7 +638,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -690,7 +690,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph4) (PackageDetailsFromGraph graph4) lockFile4 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -740,7 +740,7 @@ let ``SelectiveUpdate updates package that conflicts with transitive dependency 
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph5) (PackageDetailsFromGraph graph5) lockFile5 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -777,7 +777,7 @@ let ``SelectiveUpdate updates all packages from all groups if no group is specif
 
         nuget Castle.Core-log4net ~> 4.0""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile
 
@@ -828,7 +828,7 @@ let ``SelectiveUpdate updates only packages from specific group if group is spec
 
         nuget Castle.Core-log4net""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup) SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup) SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile |> Seq.toList
 
@@ -860,7 +860,7 @@ let ``SelectiveUpdate updates only packages from specified group``() =
 
         nuget Castle.Core-log4net""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group")) SemVerUpdateMode.All
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group")) SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile
 
@@ -917,7 +917,7 @@ let ``SelectiveUpdate updates package from a specific group``() =
 
     let lockFile =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile
 
@@ -953,7 +953,7 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
 
     let lockFile =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile
 
@@ -988,7 +988,7 @@ let ``SelectiveUpdate updates package from main group``() =
 
     let lockFile =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile
 
@@ -1033,7 +1033,7 @@ let ``SelectiveUpdate updates package that has a new dependent package that also
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile7 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Package")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Package")) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -1067,7 +1067,7 @@ let ``SelectiveUpdate updates early package that has a new dependent package tha
 
     let lockFile = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile8 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "APackage")) SemVerUpdateMode.All
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "APackage")) SemVerUpdateMode.NoRestriction
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -1099,7 +1099,7 @@ let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specifi
 
     let lockFile =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
-            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.Minor
+            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.KeepMinor
     
     let result = groupMap lockFile
 

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -52,7 +52,7 @@ let ``SelectiveUpdate does not update any package when it is neither updating al
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
     
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -77,7 +77,7 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -103,7 +103,7 @@ let ``SelectiveUpdate updates all packages constraining version``() =
     nuget Castle.Core ~> 3.2
     nuget FAKE = 4.0.0""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -128,7 +128,7 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -154,9 +154,9 @@ let ``SelectiveUpdate updates a single package``() =
     nuget FAKE""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "FAKE")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-    
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "FAKE")) SemVerUpdateMode.All
+
     let result = 
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
@@ -181,9 +181,9 @@ let ``SelectiveUpdate updates a single constrained package``() =
     nuget FAKE""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-    
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+
     let result = 
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
@@ -209,9 +209,9 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
     nuget FAKE""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-    
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
+
     let result = 
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
@@ -236,7 +236,7 @@ let ``SelectiveUpdate installs new packages``() =
     nuget FAKE
     nuget Newtonsoft.Json""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -263,8 +263,8 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
     nuget FAKE""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -291,9 +291,8 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
     nuget FAKE""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
-
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
     let result = 
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
@@ -319,8 +318,8 @@ let ``SelectiveUpdate considers package name case difference``() =
     nuget FAKE""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -348,8 +347,8 @@ let ``SelectiveUpdate conflicts when a dependency is contrained``() =
     nuget FAKE""")
 
     (fun () ->
-    PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")
-    |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+    selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+        (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
     |> ignore)
     |> shouldFail
 
@@ -362,8 +361,8 @@ let ``SelectiveUpdate does not update any package when package does not exist``(
     nuget FAKE""")
 
     try
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "package")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "package")) SemVerUpdateMode.All
         |> ignore
         failwith "This pont should not be reached"
     with
@@ -379,8 +378,8 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
     nuget FAKE""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core")) SemVerUpdateMode.All
     
     let result = 
             String.Join
@@ -415,8 +414,8 @@ let ``SelectiveUpdate does not update when package conflicts with a transitive d
     let packageName = PackageName "log4net"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -486,8 +485,8 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     let packageName = PackageName "log4f"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -517,8 +516,8 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     let packageName = PackageName "Ninject.Extensions.Logging.Log4net"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -573,8 +572,8 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     let packageName = PackageName "Ninject.Extensions.Logging.Log4net"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -606,8 +605,8 @@ let ``SelectiveUpdate does not conflict with a transitive dependency of another 
     let packageName = PackageName "Ninject"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -638,8 +637,8 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     let packageName = PackageName "Ninject.Extensions.Interception"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -690,8 +689,8 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     let packageName = PackageName "Ninject.Extensions.Logging.Log4net.Deep"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph4) (PackageDetailsFromGraph graph4) lockFile4 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph4) (PackageDetailsFromGraph graph4) lockFile4 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -740,8 +739,8 @@ let ``SelectiveUpdate updates package that conflicts with transitive dependency 
     let packageName = PackageName "Ninject.Extensions.Logging"
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph5) (PackageDetailsFromGraph graph5) lockFile5 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph5) (PackageDetailsFromGraph graph5) lockFile5 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, packageName)) SemVerUpdateMode.All
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -778,7 +777,7 @@ let ``SelectiveUpdate updates all packages from all groups if no group is specif
 
         nuget Castle.Core-log4net ~> 4.0""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.All
     
     let result = groupMap lockFile
 
@@ -829,7 +828,7 @@ let ``SelectiveUpdate updates only packages from specific group if group is spec
 
         nuget Castle.Core-log4net""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup)
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup) SemVerUpdateMode.All
     
     let result = groupMap lockFile |> Seq.toList
 
@@ -861,7 +860,7 @@ let ``SelectiveUpdate updates only packages from specified group``() =
 
         nuget Castle.Core-log4net""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group"))
+    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group")) SemVerUpdateMode.All
     
     let result = groupMap lockFile
 
@@ -917,8 +916,8 @@ let ``SelectiveUpdate updates package from a specific group``() =
         nuget FAKE""")
 
     let lockFile =
-        PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
     
     let result = groupMap lockFile
 
@@ -953,8 +952,8 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
         nuget log4net""")
 
     let lockFile =
-        PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
     
     let result = groupMap lockFile
 
@@ -988,8 +987,8 @@ let ``SelectiveUpdate updates package from main group``() =
         nuget FAKE""")
 
     let lockFile =
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net")) SemVerUpdateMode.All
     
     let result = groupMap lockFile
 
@@ -1033,8 +1032,8 @@ let ``SelectiveUpdate updates package that has a new dependent package that also
     nuget Package""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Package")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile7 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile7 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "Package")) SemVerUpdateMode.All
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -1067,8 +1066,8 @@ let ``SelectiveUpdate updates early package that has a new dependent package tha
     nuget APackage""")
 
     let lockFile = 
-        PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "APackage")
-        |> selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile8 dependenciesFile
+        selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile8 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(Constants.MainDependencyGroup, PackageName "APackage")) SemVerUpdateMode.All
 
     let result = 
         lockFile.GetGroupedResolution()
@@ -1083,3 +1082,39 @@ let ``SelectiveUpdate updates early package that has a new dependent package tha
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
+
+[<Test>]
+let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specific group in minor version``() = 
+
+    let dependenciesFile = DependenciesFile.FromCode("""source http://nuget.org/api/v2
+
+    nuget Castle.Core-log4net ~> 3.2
+    nuget FAKE
+    
+    group Group
+        source http://nuget.org/api/v2
+
+        nuget Castle.Core-log4net
+        nuget FAKE""")
+
+    let lockFile =
+        selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
+            (PackageResolver.UpdateMode.UpdatePackage(GroupName "Group", PackageName "Castle.Core-log4net")) SemVerUpdateMode.Minor
+    
+    let result = groupMap lockFile
+
+    let expected = 
+        [("Group","Castle.Core-log4net","3.3.3");
+        ("Group","Castle.Core","3.3.3");
+        ("Group","FAKE","4.0.0");
+        ("Group","log4net","1.2.10");
+        (mainGroup,"Castle.Core-log4net","3.2.0");
+        (mainGroup,"Castle.Core","3.2.0");
+        (mainGroup,"FAKE","4.0.1");
+        (mainGroup,"log4net","1.2.10")]
+        |> Seq.sortBy gfst
+
+    result
+    |> Seq.sortBy gfst
+    |> shouldEqual expected
+    


### PR DESCRIPTION
It was always possible to use paket in strict SemVer mode by using ~> operator in the dependencies file. 
Now we add three optional parameters to the command line to make SemVer compliant updates even easier. 

`--keep-major` restricts the resolver to updates that don't change major versions. 
`--keep-minor` restricts the resolver to updates that don't change major or minor versions.
`--keep-patch` restricts the resolver to updates that don't change major, minor or patch versions. 

These flags are available for install, add and update. Of course all restrictions in the dependencies file will still be met. 
