### PR TITLE
Allowed for non semver InformationalVersion.

### DIFF
--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -37,7 +37,10 @@ let (|Title|Description|Version|InformationalVersion|Company|Ignore|) (attribute
         | x when String.IsNullOrWhiteSpace x ->
             Ignore
         | x ->
-            InformationalVersion(SemVer.Parse x)
+            try
+                InformationalVersion(SemVer.Parse x)
+            with 
+            | _ -> Ignore
     | :? AssemblyCompanyAttribute as company ->
         match company.Company with
         | x when String.IsNullOrWhiteSpace x ->


### PR DESCRIPTION
Silently ignores when not a semver compliant version.
Fixes #1133