### PR TITLE
Handle silverlight framework identifiers comparison

### DIFF
--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -141,6 +141,23 @@ type FrameworkIdentifier =
         | WindowsPhoneApp _ -> [ WindowsPhoneApp "v8.1" ]
         | WindowsPhoneSilverlight _ -> [ WindowsPhoneSilverlight "v8.1" ]
 
+    /// Return if the parameter is of the same framework category (dotnet, windows phone, silverlight, ...)
+    member x.IsSameCategoryAs y =
+        match (x, y) with
+        | DotNetFramework _, DotNetFramework _ -> true
+        | Silverlight _, Silverlight _ -> true
+        | DNX _, DNX _ -> true
+        | DNXCore _, DNXCore _ -> true
+        | MonoAndroid _, MonoAndroid _ -> true
+        | MonoMac _, MonoMac _ -> true
+        | MonoTouch _, MonoTouch _ -> true
+        | Windows _, Windows _ -> true
+        | WindowsPhoneApp _, WindowsPhoneApp _ -> true
+        | WindowsPhoneSilverlight _, WindowsPhoneSilverlight _ -> true
+        | XamarinMac _, XamarinMac _ -> true
+        | XamariniOS _, XamariniOS _ -> true
+        | _ -> false
+
 
 module FrameworkDetection =
     let private cache = System.Collections.Concurrent.ConcurrentDictionary<_,_>()

--- a/src/Paket.Core/InstallModel.fs
+++ b/src/Paket.Core/InstallModel.fs
@@ -230,21 +230,21 @@ type InstallModel =
                 restrictions
                 |> List.exists (fun restriction ->
                       match restriction with
-                      | FrameworkRestriction.Portable p ->
+                      | FrameworkRestriction.Portable _ ->
                             folder.Targets 
                             |> List.exists (fun target ->
                                 match target with
-                                | SinglePlatform t -> false
+                                | SinglePlatform _ -> false
                                 | _ -> true)
                       | FrameworkRestriction.Exactly target ->
                             folder.GetSinglePlatforms() 
                             |> List.exists (fun t -> t = target)
                         | FrameworkRestriction.AtLeast target ->
                             folder.GetSinglePlatforms() 
-                            |> List.exists (fun t -> t >= target)
+                            |> List.exists (fun t -> t >= target && t.IsSameCategoryAs(target))
                         | FrameworkRestriction.Between(min,max) ->
                             folder.GetSinglePlatforms() 
-                            |> List.exists (fun t -> t >= min && t < max)                            )
+                            |> List.exists (fun t -> t >= min && t < max && t.IsSameCategoryAs(min)))
             
         this.MapFolders(fun folder ->
             if referenceApplies folder then

--- a/src/Paket.Core/InstallModel.fs
+++ b/src/Paket.Core/InstallModel.fs
@@ -288,25 +288,7 @@ type InstallModel =
         | [] -> this
         | restrictions ->
             let applRestriction folder =
-                { folder with 
-                    Targets = 
-                        folder.Targets
-                        |> List.filter 
-                            (function 
-                             | SinglePlatform pf -> 
-                                restrictions
-                                |> List.exists (fun restriction ->
-                                        match restriction with
-                                        | FrameworkRestriction.Exactly fw -> pf = fw
-                                        | FrameworkRestriction.Portable r -> false
-                                        | FrameworkRestriction.AtLeast fw -> pf >= fw                
-                                        | FrameworkRestriction.Between(min,max) -> pf >= min && pf < max)
-                             | _ -> 
-                                restrictions
-                                |> List.exists (fun restriction ->
-                                        match restriction with
-                                        | FrameworkRestriction.Portable r -> true
-                                        | _ -> false))}
+                { folder with Targets = applyRestrictionsToTargets restrictions folder.Targets}
 
             {this with 
                 ReferenceFileFolders = 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -18,6 +18,7 @@ module DependencySetFilter =
         match restriction with
         | FrameworkRestriction.Exactly v1 -> 
             restrictions 
+            |> Seq.filter (fun r2 -> restriction.IsSameCategoryAs(r2) = Some(true))
             |> Seq.exists (fun r2 ->
                 match r2 with
                 | FrameworkRestriction.Exactly v2 when v1 = v2 -> true
@@ -26,6 +27,7 @@ module DependencySetFilter =
                 | _ -> false)
         | FrameworkRestriction.AtLeast v1 -> 
             restrictions 
+            |> Seq.filter (fun r2 -> restriction.IsSameCategoryAs(r2) = Some(true))
             |> Seq.exists (fun r2 ->
                 match r2 with
                 | FrameworkRestriction.Exactly v2 when v1 <= v2 -> true

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -213,6 +213,29 @@ let filterRestrictions (list1:FrameworkRestrictions) (list2:FrameworkRestriction
                 if c <> [] then yield! c]
     |> optimizeRestrictions
 
+/// Get if a target should be considered with the specified restrictions
+let isTargetMatchingRestrictions (restrictions:FrameworkRestrictions) = function
+    | SinglePlatform pf ->
+        restrictions
+        |> List.exists (fun restriction ->
+                match restriction with
+                | FrameworkRestriction.Exactly fw -> pf = fw
+                | FrameworkRestriction.Portable _ -> false
+                | FrameworkRestriction.AtLeast fw -> pf >= fw
+                | FrameworkRestriction.Between(min,max) -> pf >= min && pf < max)
+    | _ ->
+        restrictions
+        |> List.exists (fun restriction ->
+                match restriction with
+                | FrameworkRestriction.Portable r -> true
+                | _ -> false)
+
+/// Get all targets that should be considered with the specified restrictions
+let applyRestrictionsToTargets (restrictions:FrameworkRestrictions) (targets: TargetProfile list) =
+    let result = targets |> List.filter (isTargetMatchingRestrictions restrictions)
+    result
+
+
 type ContentCopySettings =
 | Omit
 | Overwrite

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -91,6 +91,7 @@
     <Compile Include="TemplateFileParsing.fs" />
     <Compile Include="NuspecWriterSpecs.fs" />
     <Compile Include="RestrictionFilterSpecs.fs" />
+    <Compile Include="RestrictionApplicationSpecs.fs" />
     <Compile Include="PackageProcessSpecs.fs" />
     <Content Include="PackagesConfig\xunit.visualstudio.packages.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/tests/Paket.Tests/RestrictionApplicationSpecs.fs
+++ b/tests/Paket.Tests/RestrictionApplicationSpecs.fs
@@ -1,0 +1,19 @@
+﻿module Packet.RestrictionApplicationSpecs
+
+open System.IO
+open Paket
+open Paket.Domain
+open Chessie.ErrorHandling
+open FsUnit
+open NUnit.Framework
+open TestHelpers
+open Paket.Requirements
+
+[<Test>]
+let ``>= net40 does not include silverlight (#1124)`` () =
+    /// https://github.com/fsprojects/Paket/issues/1124
+    let restrictions = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let targets = KnownTargetProfiles.DotNetFrameworkProfiles @ KnownTargetProfiles.SilverlightProfiles
+    let restricted = applyRestrictionsToTargets restrictions targets
+    
+    restricted |> shouldEqual KnownTargetProfiles.DotNetFrameworkProfiles

--- a/tests/Paket.Tests/RestrictionApplicationSpecs.fs
+++ b/tests/Paket.Tests/RestrictionApplicationSpecs.fs
@@ -1,19 +1,83 @@
-﻿module Packet.RestrictionApplicationSpecs
+﻿module Paket.Requirements.RestrictionApplicationSpecs
 
-open System.IO
 open Paket
-open Paket.Domain
-open Chessie.ErrorHandling
 open FsUnit
 open NUnit.Framework
-open TestHelpers
 open Paket.Requirements
 
+let dotnet x = SinglePlatform(DotNetFramework(x))
+
+module TestTargetProfiles =
+    let DotNetFrameworkVersions =
+       [FrameworkVersion.V1
+        FrameworkVersion.V1_1
+        FrameworkVersion.V2
+        FrameworkVersion.V3
+        FrameworkVersion.V3_5
+        FrameworkVersion.V4_Client
+        FrameworkVersion.V4
+        FrameworkVersion.V4_5
+        FrameworkVersion.V4_5_1
+        FrameworkVersion.V4_5_2
+        FrameworkVersion.V4_5_3
+        FrameworkVersion.V4_6]
+
+    let DotNetFrameworkProfiles = DotNetFrameworkVersions |> List.map dotnet
+
+    let WindowsProfiles =
+       [SinglePlatform(Windows "v4.5")
+        SinglePlatform(Windows "v4.5.1")]
+
+    let SilverlightProfiles =
+       [SinglePlatform(Silverlight "v3.0")
+        SinglePlatform(Silverlight "v4.0")
+        SinglePlatform(Silverlight "v5.0")]
+
+    let WindowsPhoneSilverlightProfiles =
+       [SinglePlatform(WindowsPhoneSilverlight "v7.0")
+        SinglePlatform(WindowsPhoneSilverlight "v7.1")
+        SinglePlatform(WindowsPhoneSilverlight "v8.0")
+        SinglePlatform(WindowsPhoneSilverlight "v8.1")]
+
+    let AllProfiles =
+       DotNetFrameworkProfiles @ 
+       WindowsProfiles @ 
+       SilverlightProfiles @
+       WindowsPhoneSilverlightProfiles @
+       [SinglePlatform(MonoAndroid)
+        SinglePlatform(MonoTouch)
+        SinglePlatform(XamariniOS)
+        SinglePlatform(XamarinMac)
+        SinglePlatform(WindowsPhoneApp "v8.1")
+       ]
+
 [<Test>]
-let ``>= net40 does not include silverlight (#1124)`` () =
+let ``>= net10 contains all but only dotnet versions (#1124)`` () =
     /// https://github.com/fsprojects/Paket/issues/1124
-    let restrictions = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
-    let targets = KnownTargetProfiles.DotNetFrameworkProfiles @ KnownTargetProfiles.SilverlightProfiles
-    let restricted = applyRestrictionsToTargets restrictions targets
+    let restrictions = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V1))]
+    let restricted = applyRestrictionsToTargets restrictions TestTargetProfiles.AllProfiles
     
-    restricted |> shouldEqual KnownTargetProfiles.DotNetFrameworkProfiles
+    restricted |> shouldEqual TestTargetProfiles.DotNetFrameworkProfiles
+
+[<Test>]
+let ``>= net452 contains 4.5.2 and following versions`` () =
+    let restrictions = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5_2))]
+    let restricted = applyRestrictionsToTargets restrictions TestTargetProfiles.AllProfiles
+    let expected = [FrameworkVersion.V4_5_2; FrameworkVersion.V4_5_3; FrameworkVersion.V4_6] |> List.map dotnet
+
+    restricted |> shouldEqual expected
+
+[<Test>]
+let ``>= net40 < net451 contains 4.0 and 4.5`` () =
+    let restrictions = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4), DotNetFramework(FrameworkVersion.V4_5_1))]
+    let restricted = applyRestrictionsToTargets restrictions TestTargetProfiles.AllProfiles
+    let expected = [FrameworkVersion.V4; FrameworkVersion.V4_5] |> List.map dotnet
+
+    restricted |> shouldEqual expected
+
+[<Test>]
+let ``>= sl30 contains all but only silverlight versions`` () =
+    let restrictions = [FrameworkRestriction.AtLeast(Silverlight "v3.0")]
+    let restricted = applyRestrictionsToTargets restrictions TestTargetProfiles.AllProfiles
+    
+    restricted |> shouldEqual TestTargetProfiles.SilverlightProfiles


### PR DESCRIPTION
Continue on & rebase #1130 (That was itself based on #1127)

I didn't keep the history because the back & forth was just making the pull request unreadable.

`FrameworkRestriction.IsSameCategoryAs` was introduced in addition to the version on `FrameworkIdentifier` to avoid repeating the checks over and over.