### PR TITLE
Add monoandroid403 to be matched as Some MonoAndroid

### DIFF
--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -186,7 +186,7 @@ module FrameworkDetection =
                 | "net453" -> Some (DotNetFramework FrameworkVersion.V4_5_3)
                 | "net46" -> Some (DotNetFramework FrameworkVersion.V4_6)
                 | "monotouch" | "monotouch10" | "monotouch1" -> Some MonoTouch
-                | "monoandroid" | "monoandroid10" | "monoandroid1" -> Some MonoAndroid
+                | "monoandroid" | "monoandroid10" | "monoandroid1" | "monoandroid403" -> Some MonoAndroid
                 | "monomac" | "monomac10" | "monomac1" -> Some MonoMac
                 | "xamarinios" | "xamarinios10" | "xamarinios1" | "xamarin.ios10" -> Some XamariniOS
                 | "xamarinmac" | "xamarinmac20" | "xamarin.mac20" -> Some XamarinMac


### PR DESCRIPTION
Some Xamarin Nugets (e.g.  Xamarin.Android.Support.v4) use platform 'monoandroid403' which isn't recognized by Paket yet. The suggested fix is pretty basic by just adding it to the list of recognized platforms.  