### PR TITLE
Use locked version as prefered version when resolver strategy is min

### DIFF
--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -151,8 +151,7 @@ let findRemoteFileChangesInDependenciesFile(dependenciesFile:DependenciesFile,lo
     |> Seq.concat
     |> Set.ofSeq
 
-let GetPreferredNuGetVersions (oldLockFile:LockFile) (changedDependencies:Set<GroupName*PackageName>) =
+let GetPreferredNuGetVersions (oldLockFile:LockFile) =
     oldLockFile.GetGroupedResolution()
-    |> Seq.filter (fun kv -> not <| changedDependencies.Contains(kv.Key))
     |> Seq.map (fun kv -> kv.Key, kv.Value.Version)
     |> Map.ofSeq

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -54,7 +54,15 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
 
     let getVersionsF,groupsToUpdate =
         match updateMode with
-        | UpdateAll -> getSortedAndCachedVersionsF,dependenciesFile.Groups
+        | UpdateAll ->
+            let preferredVersions = DependencyChangeDetection.GetPreferredNuGetVersions lockFile
+
+            let changes =
+                lockFile.GetGroupedResolution()
+                |> Seq.map (fun k -> k.Key)
+                |> Set.ofSeq
+
+            (getPreferredVersionsF preferredVersions changes),dependenciesFile.Groups
         | UpdateGroup groupName ->
             let groups =
                 dependenciesFile.Groups

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -64,11 +64,19 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
 
             (getPreferredVersionsF preferredVersions changes),dependenciesFile.Groups
         | UpdateGroup groupName ->
+            let preferredVersions = DependencyChangeDetection.GetPreferredNuGetVersions lockFile
+
+            let changes =
+                lockFile.GetGroupedResolution()
+                |> Seq.map (fun k -> k.Key)
+                |> Seq.filter (fun (g,_) -> g = groupName)
+                |> Set.ofSeq
+
             let groups =
                 dependenciesFile.Groups
                 |> Map.filter (fun k _ -> k = groupName)
 
-            getSortedAndCachedVersionsF,groups
+            (getPreferredVersionsF preferredVersions changes),groups
         | Install ->
             let nuGetChanges = DependencyChangeDetection.findNuGetChangesInDependenciesFile(dependenciesFile,lockFile)
             let nuGetChangesPerGroup =

--- a/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
@@ -36,8 +36,9 @@ nuget Castle.Windsor-log4net"""
     let lockFile = LockFile.Parse("",toLines lockFileData)
    
     let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile)
-    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile changedDependencies
+    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile
     newDependencies
+    |> Map.filter (fun k v -> not <| changedDependencies.Contains(k))
     |> shouldEqual Map.empty
 
 [<Test>]
@@ -73,7 +74,7 @@ nuget NUnit"""
     let lockFile = LockFile.Parse("",toLines lockFileData)
     let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile)
    
-    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile changedDependencies
+    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile
     let expected =
         Map.ofList
              [(Constants.MainDependencyGroup,PackageName "Castle.Core"), (SemVer.Parse "3.3.3");
@@ -85,6 +86,7 @@ nuget NUnit"""
 
     
     newDependencies
+    |> Map.filter (fun k v -> not <| changedDependencies.Contains(k))
     |> shouldEqual expected
 
 [<Test>]
@@ -119,7 +121,7 @@ nuget Castle.Windsor-log4net >= 3.3.0"""
     let lockFile = LockFile.Parse("",toLines lockFileData)
     let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile)
    
-    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile changedDependencies
+    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile
     let expected =
         Map.ofList
             ([(Constants.MainDependencyGroup,PackageName "Castle.Core"), (SemVer.Parse "3.3.3");
@@ -130,6 +132,7 @@ nuget Castle.Windsor-log4net >= 3.3.0"""
               (Constants.MainDependencyGroup,PackageName "log4net"),  (SemVer.Parse "1.2.10")])
     
     newDependencies
+    |> Map.filter (fun k v -> not <| changedDependencies.Contains(k))
     |> shouldEqual expected
 
 [<Test>]
@@ -164,8 +167,9 @@ nuget Castle.Windsor-log4net >= 3.4.0"""
     let lockFile = LockFile.Parse("",toLines lockFileData)
     let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile)
    
-    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile changedDependencies
+    let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions lockFile
     newDependencies
+    |> Map.filter (fun k v -> not <| changedDependencies.Contains(k))
     |> shouldEqual Map.empty
 
 [<Test>]


### PR DESCRIPTION
This PR makes resolver faster by preferring the already locked version when the resolver strategy is min.