### PR TITLE
Fixes lock file restrictions parsing

### DIFF
--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -273,11 +273,25 @@ let ``should parse framework restricted lock file``() =
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 7
 
+    packages.[0].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
+    |> List.item 2
+    |> shouldEqual ([FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
+
     packages.[3].Source |> shouldEqual PackageSources.DefaultNugetSource
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
     packages.[3].Settings.FrameworkRestrictions |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
     packages.[3].Settings.ImportTargets |> shouldEqual None
+
+    let dependencies4 =
+        packages.[4].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
+
+    dependencies4.Head
+    |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2), FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
+    dependencies4.Tail.Head
+    |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
+                     FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
+                     FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
 
     packages.[5].Source |> shouldEqual PackageSources.DefaultNugetSource
     packages.[5].Name |> shouldEqual (PackageName "ReadOnlyCollectionInterfaces")
@@ -312,6 +326,10 @@ let ``should parse framework restricted lock file in new syntax``() =
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 7
 
+    packages.[0].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
+    |> List.item 2
+    |> shouldEqual ([FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
+
     packages.[3].Source |> shouldEqual PackageSources.DefaultNugetSource
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
@@ -320,6 +338,16 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[3].Settings.ImportTargets |> shouldEqual (Some false)
     packages.[3].Settings.IncludeVersionInPath |> shouldEqual (Some true)
     packages.[3].Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
+
+    let dependencies4 =
+        packages.[4].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
+
+    dependencies4.Head
+    |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2), FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
+    dependencies4.Tail.Head
+    |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
+                     FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
+                     FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
 
     packages.[5].Source |> shouldEqual PackageSources.DefaultNugetSource
     packages.[5].Name |> shouldEqual (PackageName "ReadOnlyCollectionInterfaces")


### PR DESCRIPTION
This PR fixes the parsing of restrictions of transitive dependencies in lock file.

Using the `paket.dependencies` below
```
source https://nuget.org/api/v2

nuget Microsoft.Owin.Host.SystemWeb ~> 2.1
```

It generates a different `paket.lock` when I run `paket install` twice.
The same happens if I run a `paket update` followed by a `paket install`.