### PR TITLE
Filter by restrictions

### DIFF
--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -31,7 +31,7 @@ module DependencySetFilter =
             |> Seq.exists (fun r2 ->
                 match r2 with
                 | FrameworkRestriction.Exactly v2 when v1 <= v2 -> true
-                | FrameworkRestriction.AtLeast v2 when v1 <= v2 -> true
+                | FrameworkRestriction.AtLeast v2 -> true
                 | FrameworkRestriction.Between(v2,v3) when v1 <= v2 && v1 < v3 -> true
                 | _ -> false)
         | _ -> true

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -32,7 +32,7 @@ module DependencySetFilter =
                 match r2 with
                 | FrameworkRestriction.Exactly v2 when v1 <= v2 -> true
                 | FrameworkRestriction.AtLeast v2 -> true
-                | FrameworkRestriction.Between(v2,v3) when v1 <= v2 && v1 < v3 -> true
+                | FrameworkRestriction.Between(v2,v3) when v1 < v3 -> true
                 | _ -> false)
         | _ -> true
 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -34,6 +34,14 @@ module DependencySetFilter =
                 | FrameworkRestriction.AtLeast v2 -> true
                 | FrameworkRestriction.Between(v2,v3) when v1 < v3 -> true
                 | _ -> false)
+        | FrameworkRestriction.Between (min, max) ->
+            restrictions 
+            |> Seq.filter (fun r2 -> restriction.IsSameCategoryAs(r2) = Some(true))
+            |> Seq.exists (fun r2 ->
+                match r2 with
+                | FrameworkRestriction.Between(min',max') when max' >= min -> true
+                | FrameworkRestriction.Between(_) -> false
+                | _ -> true)
         | _ -> true
 
     let filterByRestrictions (restrictions:FrameworkRestriction seq) (dependencies:DependencySet) : DependencySet = 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -41,6 +41,8 @@ module DependencySetFilter =
                 match r2 with
                 | FrameworkRestriction.Between(min',max') when max' >= min && min' < max -> true
                 | FrameworkRestriction.Between(_) -> false
+                | FrameworkRestriction.Exactly v when v < max -> true
+                | FrameworkRestriction.Exactly _ -> false
                 | _ -> true)
         | _ -> true
 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -39,7 +39,7 @@ module DependencySetFilter =
             |> Seq.filter (fun r2 -> restriction.IsSameCategoryAs(r2) = Some(true))
             |> Seq.exists (fun r2 ->
                 match r2 with
-                | FrameworkRestriction.Between(min',max') when max' >= min -> true
+                | FrameworkRestriction.Between(min',max') when max' >= min && min' < max -> true
                 | FrameworkRestriction.Between(_) -> false
                 | _ -> true)
         | _ -> true

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -41,7 +41,7 @@ module DependencySetFilter =
                 match r2 with
                 | FrameworkRestriction.Between(min',max') when max' >= min && min' < max -> true
                 | FrameworkRestriction.Between(_) -> false
-                | FrameworkRestriction.Exactly v when v < max -> true
+                | FrameworkRestriction.Exactly v when v >= min && v < max -> true
                 | FrameworkRestriction.Exactly _ -> false
                 | _ -> true)
         | _ -> true

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -39,11 +39,10 @@ module DependencySetFilter =
             |> Seq.filter (fun r2 -> restriction.IsSameCategoryAs(r2) = Some(true))
             |> Seq.exists (fun r2 ->
                 match r2 with
-                | FrameworkRestriction.Between(min',max') when max' >= min && min' < max -> true
-                | FrameworkRestriction.Between(_) -> false
                 | FrameworkRestriction.Exactly v when v >= min && v < max -> true
-                | FrameworkRestriction.Exactly _ -> false
-                | _ -> true)
+                | FrameworkRestriction.AtLeast v when v < max -> true
+                | FrameworkRestriction.Between(min',max') when max' >= min && min' < max -> true
+                | _ -> false)
         | _ -> true
 
     let filterByRestrictions (restrictions:FrameworkRestriction seq) (dependencies:DependencySet) : DependencySet = 

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -108,7 +108,8 @@ let ``filtered with AtLeast restriction should filter non-matching``() =
        PackageName("P4"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
        PackageName("P5"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P7"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]]
+       PackageName("P7"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]]
       |> Set.ofList
 
     let expected = 
@@ -117,7 +118,8 @@ let ``filtered with AtLeast restriction should filter non-matching``() =
        PackageName("P3"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
        PackageName("P4"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
        PackageName("P5"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]]
+       PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]]
       |> Set.ofList
 
 

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -130,6 +130,36 @@ let ``filtered with AtLeast restriction should filter non-matching``() =
     |> shouldEqual expected
 
 [<Test>]
+let ``filtered with Between restriction should filter non-matching`` () =
+    let original =
+      [PackageName("P01"), VersionRequirement.AllReleases, []
+       PackageName("P02"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P03"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P04"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P05"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P06"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P07"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
+      |> Set.ofList
+
+    let expected =
+      [PackageName("P01"), VersionRequirement.AllReleases, []
+       PackageName("P02"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P03"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P04"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P05"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P06"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
+      |> Set.ofList
+
+
+    original
+    |> DependencySetFilter.filterByRestrictions [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_1))]
+    |> shouldEqual expected
+
+[<Test>]
 let ``should optimize ZendeskApi_v2 ``() = 
     let original =
         [PackageName("Newtonsoft.Json"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -142,7 +142,9 @@ let ``filtered with Between restriction should filter non-matching`` () =
        PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
        PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P10"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5_1),DotNetFramework(FrameworkVersion.V4_6))]
-       PackageName("P11"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5_1))]]
+       PackageName("P11"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5_1))]
+       PackageName("P12"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P13"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]]
       |> Set.ofList
 
     let expected =
@@ -153,7 +155,8 @@ let ``filtered with Between restriction should filter non-matching`` () =
        PackageName("P05"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P06"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
+       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P13"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]]
       |> Set.ofList
 
 

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -144,7 +144,8 @@ let ``filtered with Between restriction should filter non-matching`` () =
        PackageName("P10"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5_1),DotNetFramework(FrameworkVersion.V4_6))]
        PackageName("P11"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5_1))]
        PackageName("P12"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P13"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]]
+       PackageName("P13"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P14"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5_1))]]
       |> Set.ofList
 
     let expected =

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -140,7 +140,8 @@ let ``filtered with Between restriction should filter non-matching`` () =
        PackageName("P06"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P07"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
        PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
+       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P10"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5_1),DotNetFramework(FrameworkVersion.V4_6))]]
       |> Set.ofList
 
     let expected =

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -109,7 +109,8 @@ let ``filtered with AtLeast restriction should filter non-matching``() =
        PackageName("P5"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P7"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]]
+       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P9"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
       |> Set.ofList
 
     let expected = 
@@ -119,7 +120,8 @@ let ``filtered with AtLeast restriction should filter non-matching``() =
        PackageName("P4"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
        PackageName("P5"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
        PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]]
+       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P9"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
       |> Set.ofList
 
 

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -141,7 +141,8 @@ let ``filtered with Between restriction should filter non-matching`` () =
        PackageName("P07"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
        PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
        PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P10"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5_1),DotNetFramework(FrameworkVersion.V4_6))]]
+       PackageName("P10"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5_1),DotNetFramework(FrameworkVersion.V4_6))]
+       PackageName("P11"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5_1))]]
       |> Set.ofList
 
     let expected =


### PR DESCRIPTION
Using a restriction in `paket.dependencies`, it wouldn't reference the dependencies depending on the restrictions it has.

Examples that were fixed:
`>= net35` would not be referenced when `paket.dependencies` has a `>= net40` restriction.
`>= net35 < net452` would not be referenced when `paket.dependencies` has a `>= net40` restriction.

Moreover, it would not filter at all dependencies when ranged restrictions were used in `paket.dependencies`.

Here is a small repro:
```
framework >= net45
source https://nuget.org/api/v2

nuget Microsoft.Owin.Host.SystemWeb ~> 2.1
```

Running `paket install` would generate the following incorrect `paket.lock`
```
FRAMEWORK: >= NET45
NUGET
  remote: https://nuget.org/api/v2
  specs:
    Microsoft.Owin.Host.SystemWeb (2.1.0)
```


On the other hand, the below file would also generate an incorrect `paket.lock`
```
framework >= net45 < net46
source https://nuget.org/api/v2

nuget Microsoft.Owin.Host.SystemWeb ~> 2.1
```

```
FRAMEWORK: >= NET45 < NET46
NUGET
  remote: https://nuget.org/api/v2
  specs:
    Microsoft.Owin (3.0.1)
      Owin (>= 1.0)
    Microsoft.Owin.Host.SystemWeb (2.1.0)
      Microsoft.Owin (>= 2.1.0) - framework: >= net40
      Microsoft.Web.Infrastructure (>= 1.0.0.0) - framework: net40
      Owin (>= 1.0) - framework: >= net40
    Microsoft.Web.Infrastructure (1.0.0)
    Owin (1.0.0)
```

This is the correct `paket.lock` for both cases:
```
FRAMEWORK: >= NET45
NUGET
  remote: https://nuget.org/api/v2
  specs:
    Microsoft.Owin (3.0.1)
      Owin (>= 1.0)
    Microsoft.Owin.Host.SystemWeb (2.1.0)
      Microsoft.Owin (>= 2.1.0) - framework: >= net40
      Owin (>= 1.0) - framework: >= net40
    Owin (1.0.0)
```