### PR TITLE
Makes conflicts fail faster

### DIFF
--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -276,6 +276,7 @@ module DependenciesFileParser =
         { Name = packageName
           ResolverStrategy = parseResolverStrategy version
           Parent = parent
+          Graph = []
           Settings = InstallSettings.Parse(optionsText).AdjustWithSpecialCases packageName
           VersionRequirement = parseVersionRequirement((version + " " + prereleases).Trim(strategyOperators |> Array.ofList)) } 
 
@@ -486,6 +487,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
                           VersionRequirement = v
                           ResolverStrategy = Some ResolverStrategy.Max
                           Parent = PackageRequirementSource.DependenciesFile fileName
+                          Graph = []
                           Settings = group.Options.Settings })
                 |> Seq.toList
 

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -216,7 +216,8 @@ let createPackageRequirement (packageName, version, restrictions) dependenciesFi
                 VersionRequirement(VersionRange.Exactly version, PreReleaseStatus.No)
        ResolverStrategy = Some ResolverStrategy.Max
        Settings = { InstallSettings.Default with FrameworkRestrictions = restrictions }
-       Parent = PackageRequirementSource.DependenciesFile dependenciesFileName }
+       Parent = PackageRequirementSource.DependenciesFile dependenciesFileName
+       Graph = [] }
 
 let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
     

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -133,7 +133,7 @@ type Resolution =
                         match x.Parent with
                         | DependenciesFile _ ->
                             sprintf "   - Dependencies file requested: %O" x.VersionRequirement |> addToError
-                        | Package(parentName,version,_) ->
+                        | Package(parentName,version) ->
                             sprintf "   - %O %O requested: %O" parentName version x.VersionRequirement
                             |> addToError)
             
@@ -165,7 +165,7 @@ let calcOpenRequirements (exploredPackage:ResolvedPackage,globalFrameworkRestric
             |> filterRestrictions globalFrameworkRestrictions
         { dependency with Name = n
                           VersionRequirement = v
-                          Parent = Package(dependency.Name, versionToExplore, dependency.Parent.Depth() + 1)
+                          Parent = Package(dependency.Name, versionToExplore)
                           Graph = [dependency] @ dependency.Graph
                           Settings = { dependency.Settings with FrameworkRestrictions = newRestrictions } })
     |> Set.filter (fun d ->
@@ -305,8 +305,8 @@ let Resolve(groupName:GroupName, sources, getVersionsF, getPackageDetailsF, stra
                 let combined =
                     (currentRequirements
                     |> List.ofSeq
-                    |> List.filter (fun x -> x.Parent.Depth() > 0)
-                    |> List.sortBy (fun x -> x.Parent.Depth(), x.ResolverStrategy <> strategy, x.ResolverStrategy <> Some ResolverStrategy.Max)
+                    |> List.filter (fun x -> x.Depth > 0)
+                    |> List.sortBy (fun x -> x.Depth, x.ResolverStrategy <> strategy, x.ResolverStrategy <> Some ResolverStrategy.Max)
                     |> List.map (fun x -> x.ResolverStrategy)
                     |> List.fold (++) None)
                     ++ strategy

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -297,9 +297,10 @@ let Resolve(groupName:GroupName, sources, getVersionsF, getPackageDetailsF, stra
                 let combined =
                     (currentRequirements
                     |> List.ofSeq
-                    |> List.sortByDescending (fun x -> x.Parent.Depth(), x.ResolverStrategy = strategy, x.ResolverStrategy = Some ResolverStrategy.Max)
+                    |> List.filter (fun x -> x.Parent.Depth() > 0)
+                    |> List.sortBy (fun x -> x.Parent.Depth(), x.ResolverStrategy <> strategy, x.ResolverStrategy <> Some ResolverStrategy.Max)
                     |> List.map (fun x -> x.ResolverStrategy)
-                    |> List.reduce (++))
+                    |> List.fold (++) None)
                     ++ strategy
                     |> function | Some s -> s | None -> ResolverStrategy.Max
 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -166,6 +166,7 @@ let calcOpenRequirements (exploredPackage:ResolvedPackage,globalFrameworkRestric
         { dependency with Name = n
                           VersionRequirement = v
                           Parent = Package(dependency.Name, versionToExplore, dependency.Parent.Depth() + 1)
+                          Graph = [dependency] @ dependency.Graph
                           Settings = { dependency.Settings with FrameworkRestrictions = newRestrictions } })
     |> Set.filter (fun d ->
         closed

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -396,21 +396,16 @@ type RemoteFileInstallSettings =
 
 type PackageRequirementSource =
 | DependenciesFile of string
-| Package of PackageName * SemVerInfo * int
+| Package of PackageName * SemVerInfo
     member this.IsRootRequirement() =
         match this with
         | DependenciesFile _ -> true
         | _ -> false
 
-    member this.Depth() =
-        match this with
-        | DependenciesFile _ -> 0
-        | Package(_,_,x) -> x
-
     override this.ToString() =
         match this with
         | DependenciesFile x -> x
-        | Package(name,version,_) ->
+        | Package(name,version) ->
           sprintf "%O %O" name version
 
 /// Represents an unresolved package.
@@ -436,12 +431,14 @@ type PackageRequirement =
     member this.IncludingPrereleases() = 
         { this with VersionRequirement = VersionRequirement(this.VersionRequirement.Range,PreReleaseStatus.All) }
     
+    member this.Depth = this.Graph.Length
+
     static member Compare(x,y,startWithPackage:PackageName option,boostX,boostY) =
         if x = y then 0 else
         seq {
             yield compare
-                (not x.VersionRequirement.Range.IsGlobalOverride,x.Parent.Depth())
-                (not y.VersionRequirement.Range.IsGlobalOverride,y.Parent.Depth())
+                (not x.VersionRequirement.Range.IsGlobalOverride,x.Depth)
+                (not y.VersionRequirement.Range.IsGlobalOverride,y.Depth)
             yield match startWithPackage with
                     | Some name when name = x.Name -> -1
                     | Some name when name = y.Name -> 1

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -439,8 +439,8 @@ type PackageRequirement =
         if x = y then 0 else
         seq {
             yield compare
-                (not x.VersionRequirement.Range.IsGlobalOverride,x.Parent)
-                (not y.VersionRequirement.Range.IsGlobalOverride,y.Parent)
+                (not x.VersionRequirement.Range.IsGlobalOverride,x.Parent.Depth())
+                (not y.VersionRequirement.Range.IsGlobalOverride,y.Parent.Depth())
             yield match startWithPackage with
                     | Some name when name = x.Name -> -1
                     | Some name when name = y.Name -> 1

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -420,6 +420,7 @@ type PackageRequirement =
       VersionRequirement : VersionRequirement
       ResolverStrategy : ResolverStrategy option
       Parent: PackageRequirementSource
+      Graph: PackageRequirement list
       Settings: InstallSettings }
 
     override this.Equals(that) = 

--- a/tests/Paket.Tests/DependenciesFile/VersionRequirementSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/VersionRequirementSpecs.fs
@@ -13,6 +13,7 @@ let require packageName strategy text : PackageRequirement =
       VersionRequirement = parse text
       ResolverStrategy = Some strategy
       Parent = PackageRequirementSource.DependenciesFile ""
+      Graph = []
       Settings = InstallSettings.Default }
 
 [<Test>]

--- a/tests/Paket.Tests/Resolver/ConflictGraphSpecs.fs
+++ b/tests/Paket.Tests/Resolver/ConflictGraphSpecs.fs
@@ -27,6 +27,7 @@ let graph =
 let defaultPackage = 
     { Name = PackageName ""
       Parent = PackageRequirementSource.DependenciesFile ""
+      Graph = []
       VersionRequirement = VersionRequirement(VersionRange.Exactly "1.0", PreReleaseStatus.No)
       Settings = InstallSettings.Default
       ResolverStrategy = Some ResolverStrategy.Max }

--- a/tests/Paket.Tests/Resolver/ConflictGraphSpecs.fs
+++ b/tests/Paket.Tests/Resolver/ConflictGraphSpecs.fs
@@ -38,7 +38,7 @@ let ``should analyze graph and report conflict``() =
     | Resolution.Conflict(_,_,stillOpen,_) ->
         let conflicting = stillOpen |> Seq.head 
         conflicting.Name |> shouldEqual (PackageName "D")
-        conflicting.VersionRequirement.Range |> shouldEqual (VersionRange.Exactly "1.4")
+        conflicting.VersionRequirement.Range |> shouldEqual (VersionRange.Exactly "1.6")
 
 let graph2 = 
     [ "A", "1.0", 
@@ -56,7 +56,7 @@ let ``should analyze graph2 and report conflict``() =
     | Resolution.Conflict(_,_,stillOpen,_) ->
         let conflicting = stillOpen |> Seq.head 
         conflicting.Name |> shouldEqual (PackageName "D")
-        conflicting.VersionRequirement.Range |> shouldEqual (VersionRange.Between("1.4", "1.5"))
+        conflicting.VersionRequirement.Range |> shouldEqual (VersionRange.Between("1.6", "1.7"))
 
 [<Test>]
 let ``should override graph2 conflict to first version``() = 

--- a/tests/Paket.Tests/Resolver/ConflictSourcesSpecs.fs
+++ b/tests/Paket.Tests/Resolver/ConflictSourcesSpecs.fs
@@ -22,6 +22,7 @@ let ``should resolve source files with correct sha``() =
     let dep =
       { Name = name
         ResolverStrategy = Some ResolverStrategy.Max
+        Graph = []
         Parent = Requirements.PackageRequirementSource.DependenciesFile ""
         Settings = InstallSettings.Default
         VersionRequirement = VersionRequirement.NoRestriction }

--- a/tests/Paket.Tests/Resolver/GlobalOptimisticStrategySpecs.fs
+++ b/tests/Paket.Tests/Resolver/GlobalOptimisticStrategySpecs.fs
@@ -124,24 +124,43 @@ let ``should respect overrides when updating single package``() =
     getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.1"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.1"
 
-let config7 = """
-strategy max
-source http://nuget.org/api/v2
-
-nuget Nancy.Bootstrappers.Windsor !~> 0.23
-nuget Castle.Windsor
-nuget Castle.Windsor-NLog !> 0
-"""
-
 [<Test>]
-let ``should favor strategy from parent``() = 
+let ``should favor strategy from parent when it overrides``() = 
+    let config = """
+    strategy max
+    source http://nuget.org/api/v2
+
+    nuget Nancy.Bootstrappers.Windsor !~> 0.23
+    nuget Castle.Windsor @> 0
+    nuget Castle.Windsor-NLog !> 0
+    """
+
     let resolved =
-        DependenciesFile.FromCode(config7)
+        DependenciesFile.FromCode(config)
         |> resolve graph2 UpdateMode.UpdateAll
     getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.1"
+    getVersion resolved.[PackageName "Nancy.Bootstrappers.Windsor"] |> shouldEqual "0.23"
+
+[<Test>]
+let ``should favor strategy from parent that overrides strategy``() = 
+    let config = """
+    strategy max
+    source http://nuget.org/api/v2
+
+    nuget Nancy.Bootstrappers.Windsor !~> 0.23
+    nuget Castle.Windsor
+    nuget Castle.Windsor-NLog !> 0
+    """
+    let resolved =
+        DependenciesFile.FromCode(config)
+        |> resolve graph2 UpdateMode.UpdateAll
+    getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Nancy.Bootstrappers.Windsor"] |> shouldEqual "0.23"
 
 let config8 = """

--- a/tests/Paket.Tests/Resolver/GlobalPessimisticStrategySpecs.fs
+++ b/tests/Paket.Tests/Resolver/GlobalPessimisticStrategySpecs.fs
@@ -140,24 +140,44 @@ let ``should respect overrides when updating single package``() =
     getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.1"
 
-let config7 = """
-strategy min
-source http://nuget.org/api/v2
-
-nuget Nancy.Bootstrappers.Windsor @~> 0.23
-nuget Castle.Windsor
-nuget Castle.Windsor-NLog @> 0
-"""
-
 [<Test>]
-let ``should favor strategy from parent``() = 
+let ``should favor strategy from parent when it overrides``() = 
+    let config = """
+    strategy min
+    source http://nuget.org/api/v2
+
+    nuget Nancy.Bootstrappers.Windsor @~> 0.23
+    nuget Castle.Windsor !> 0
+    nuget Castle.Windsor-NLog @> 0
+    """
+
     let resolved =
-        DependenciesFile.FromCode(config7)
+        DependenciesFile.FromCode(config)
         |> resolve graph2 UpdateMode.UpdateAll
     getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Nancy.Bootstrappers.Windsor"] |> shouldEqual "0.23"
+
+[<Test>]
+let ``should favor strategy from parent that overrides strategy``() = 
+    let config = """
+    strategy min
+    source http://nuget.org/api/v2
+
+    nuget Nancy.Bootstrappers.Windsor @~> 0.23
+    nuget Castle.Windsor
+    nuget Castle.Windsor-NLog @> 0
+    """
+
+    let resolved =
+        DependenciesFile.FromCode(config)
+        |> resolve graph2 UpdateMode.UpdateAll
+    getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.1"
+    getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.1"
     getVersion resolved.[PackageName "Nancy.Bootstrappers.Windsor"] |> shouldEqual "0.23"
 
 let config8 = """

--- a/tests/Paket.Tests/TestHelpers.fs
+++ b/tests/Paket.Tests/TestHelpers.fs
@@ -45,6 +45,7 @@ let safeResolve graph (dependencies : (string * VersionRange) list)  =
                { Name = PackageName n
                  VersionRequirement = VersionRequirement(v, PreReleaseStatus.No)
                  Parent = PackageRequirementSource.DependenciesFile ""
+                 Graph = []
                  Settings = InstallSettings.Default
                  ResolverStrategy = Some ResolverStrategy.Max })
         |> Set.ofList


### PR DESCRIPTION
This PR makes conflicts fail faster.

Take this `paket.dependencies` for example:
```
source https://nuget.org/api/v2

nuget Microsoft.AspNet.SignalR.JS
nuget Nancy.Serialization.JsonNet
nuget SourceLink.Fake
nuget Ninject.Extensions.Logging.Log4net == 3.2.0
nuget Ninject.Extensions.Interception.Linfu == 2.2.1.2
```

This is how `paket` is trying to resolve in 2.18.0:
```
Paket version 2.18.0.0
Resolving packages for group Main:
 - Ninject.Extensions.Logging.Log4net 3.2.0
 - Ninject.Extensions.Interception.Linfu 2.2.1.2
 - Microsoft.AspNet.SignalR.JS 2.2.0
 - Nancy.Serialization.JsonNet 1.3.0
 - SourceLink.Fake 1.1.0
 - jQuery 2.1.4
 - Nancy 1.3.0
 - Newtonsoft.Json 7.0.1
 - Ninject.Extensions.Interception 2.2.1.2
 - Ninject 2.2.1.4
 - Ninject.Extensions.Logging 3.2.3
 - Ninject.Extensions.Logging 3.2.2
 - Ninject.Extensions.Logging 3.2.1
 - Ninject.Extensions.Logging 3.2.0
 - Newtonsoft.Json 6.0.8
 - Newtonsoft.Json 6.0.7
 - Newtonsoft.Json 6.0.6
 - Newtonsoft.Json 6.0.5
 - Newtonsoft.Json 6.0.4
 - Newtonsoft.Json 6.0.3
 - Newtonsoft.Json 6.0.2
 - Newtonsoft.Json 6.0.1
 - Newtonsoft.Json 5.0.8
 - Newtonsoft.Json 5.0.7
 - Newtonsoft.Json 5.0.6
 - Newtonsoft.Json 5.0.5
 - Newtonsoft.Json 5.0.4
 - Newtonsoft.Json 5.0.3
 - Newtonsoft.Json 5.0.2
 - Newtonsoft.Json 5.0.1
 - Newtonsoft.Json 4.5.11
 - Newtonsoft.Json 4.5.10
 - Newtonsoft.Json 4.5.9
 - Newtonsoft.Json 4.5.8
 - Newtonsoft.Json 4.5.7
 - Newtonsoft.Json 4.5.6
 - Newtonsoft.Json 4.5.5
 - Newtonsoft.Json 4.5.4
 - Newtonsoft.Json 4.5.3
 - Newtonsoft.Json 4.5.2
 - Newtonsoft.Json 4.5.1
 - Newtonsoft.Json 4.0.8
 - Newtonsoft.Json 4.0.7
 - Newtonsoft.Json 4.0.6
 - Newtonsoft.Json 4.0.5
 - Newtonsoft.Json 4.0.4
 - Newtonsoft.Json 4.0.3
 - Newtonsoft.Json 4.0.2
 - Newtonsoft.Json 4.0.1
 - Newtonsoft.Json 3.5.8
 - jQuery 2.1.3
 - jQuery 2.1.2
 - jQuery 2.1.1
 - jQuery 2.1.0
 - jQuery 2.0.3
 - jQuery 2.0.2
 - jQuery 2.0.1.1
 - jQuery 2.0.1
 - jQuery 2.0.0
 - jQuery 1.11.3
 - jQuery 1.11.2
 - jQuery 1.11.1
 - jQuery 1.11.0
 - jQuery 1.10.2
 - jQuery 1.10.1
 - jQuery 1.10.0.1
 - jQuery 1.10.0
 - jQuery 1.9.1
 - jQuery 1.9.0
 - jQuery 1.8.3
 - jQuery 1.8.2
 - jQuery 1.8.1
 - jQuery 1.8.0
 - jQuery 1.7.2
 - jQuery 1.7.1.1
 - jQuery 1.7.1
 - jQuery 1.7.0
 - jQuery 1.6.4
 - SourceLink.Fake 1.0.0
 - SourceLink.Fake 0.6.1
 - SourceLink.Fake 0.6.0
 - SourceLink.Fake 0.5.0
 - SourceLink.Fake 0.4.2
 - SourceLink.Fake 0.4.0
 - SourceLink.Fake 0.3.4
 - SourceLink.Fake 0.3.3
 - SourceLink.Fake 0.3.2
 - SourceLink.Fake 0.3.1
 - SourceLink.Fake 0.3.0
 - Nancy.Serialization.JsonNet 1.2.0
 - Nancy 1.2.0
...
```
Note that it explores several versions from package that are not related to the conflict.
This is not the full output since I gave up after so many unrelated packages being explored.


This is how this PR is trying to resolve:
```
Paket version 2.18.0.0
Resolving packages for group Main:
 - Ninject.Extensions.Logging.Log4net 3.2.0
 - Ninject.Extensions.Interception.Linfu 2.2.1.2
 - Microsoft.AspNet.SignalR.JS 2.2.0
 - Nancy.Serialization.JsonNet 1.3.0
 - SourceLink.Fake 1.1.0
 - Ninject.Extensions.Logging 3.2.3
 - Ninject.Extensions.Interception 2.2.1.2
 - jQuery 2.1.4
 - Nancy 1.3.0
 - log4net 2.0.3
 - Newtonsoft.Json 7.0.1
 - Ninject.Extensions.Logging 3.2.2
 - Ninject.Extensions.Logging 3.2.1
 - Ninject.Extensions.Logging 3.2.0
Paket failed with:
        There was a version conflict during package resolution.
  Resolved packages:
   - Microsoft.AspNet.SignalR.JS 2.2.0
   - Nancy.Serialization.JsonNet 1.3.0
   - Ninject.Extensions.Interception 2.2.1.2
   - Ninject.Extensions.Interception.Linfu 2.2.1.2
   - Ninject.Extensions.Logging 3.2.0
   - Ninject.Extensions.Logging.Log4net 3.2.0
   - SourceLink.Fake 1.1.0
  Could not resolve package Ninject:
   - Ninject.Extensions.Interception 2.2.1.2 requested: >= 2.2.0.0 < 2.3.0.0
   - Ninject.Extensions.Logging 3.2.3 requested: >= 3.2.0.0 < 3.3.0.0

  Please try to relax some conditions.
```