### PR TITLE
Remove Seq.toArray before Async.Parallel

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -610,7 +610,6 @@ let GetPackageDetails root force sources packageName (version:SemVerInfo) : Pack
             with e ->
                 verbosefn "Source '%O' exception: %O" source e
                 return None })
-        |> Seq.toArray
         |> Async.Parallel
         |> Async.RunSynchronously
         |> Array.tryPick id


### PR DESCRIPTION
No need to convert a sequence to an array before Async.Parallel. Order is preserved anyway.