### PR TITLE
search for paket.references in startup directory (auto-restore feature)

### DIFF
--- a/.paket/paket.targets
+++ b/.paket/paket.targets
@@ -20,6 +20,7 @@
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 $(PaketBootStrapperExePath)</PaketBootStrapperCommand>
     <!-- Commands -->
     <PaketReferences Condition="!Exists('$(MSBuildProjectFullPath).paket.references')">$(MSBuildProjectDirectory)\paket.references</PaketReferences>
+    <PaketReferences Condition="!Exists('$(PaketReferences)')">$(MSBuildStartupDirectory)\paket.references</PaketReferences>
     <PaketReferences Condition="Exists('$(MSBuildProjectFullPath).paket.references')">$(MSBuildProjectFullPath).paket.references</PaketReferences>
     <RestoreCommand>$(PaketCommand) restore --references-files "$(PaketReferences)"</RestoreCommand>
     <DownloadPaketCommand>$(PaketBootStrapperCommand)</DownloadPaketCommand>


### PR DESCRIPTION
search for paket.references in startup diretory if there is no such file in the project folder.
this makes it possible to use the auto-restore feature too (e.g. building with visual studio)
without that, the packages are not restored.