### PR TITLE
Fix compiling Paket.Bootstrapper.Tests with Visual Studio

### DIFF
--- a/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
+++ b/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="EnvWebProxyShould.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.paket\paket.targets" />
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>


### PR DESCRIPTION
import paket.targets fixes visual studio compiling.
a clean visual studio build will be failed without the paket.targets