### PR TITLE
Handles invalid project reference when applying binding redirects

### DIFF
--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -167,7 +167,8 @@ let private applyBindingRedirects (loadedLibs:Dictionary<_,_>) createNewBindingF
             let referenceFile = ReferencesFile.FromFile fileName
 
             projectFile.GetInterProjectDependencies()
-            |> Seq.map (fun r -> ProjectFile.LoadFromFile r.Path)
+            |> Seq.map (fun r -> ProjectFile.TryLoad r.Path)
+            |> Seq.choose id
             |> Seq.collect dependencies
             |> Seq.append (
                 referenceFile.Groups


### PR DESCRIPTION
When applying the binding redirects, if a project references another project that doesn't exist, Paket would fail
```
Paket failed with:
        Could not find a part of the path '***'.
```

This PR continues applying the binding redirects for the remaining projects, ignoring the error and generating a warning:
```
Unable to parse ***:
      Could not find a part of the path '***'.
```