### PR TITLE
Generates and parses strategy option in lock file

### DIFF
--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -23,6 +23,10 @@ module LockFileSerializer =
     let serializeOptionsAsLines options = [
         if options.Strict then yield "REFERENCES: STRICT"
         if options.Redirects then yield "REDIRECTS: ON"
+        match options.ResolverStrategy with
+        | Some ResolverStrategy.Min -> yield "STRATEGY: MIN"
+        | Some ResolverStrategy.Max -> yield "STRATEGY: MAX"
+        | None -> ()
         match options.Settings.CopyLocal with
         | Some x -> yield "COPY-LOCAL: " + x.ToString().ToUpper()
         | None -> ()

--- a/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
@@ -84,3 +84,43 @@ let ``should generate redirects lock file``() =
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
     |> shouldEqual (normalizeLineEndings expected3)
+
+[<Test>]
+let ``should generate strategy min lock file``() = 
+    let config = """
+    strategy min
+    source "http://nuget.org/api/v2"
+
+    nuget "Microsoft.SqlServer.Types"
+    """
+
+    let expected = """STRATEGY: MIN
+NUGET
+  remote: http://nuget.org/api/v2
+  specs:
+    Microsoft.SqlServer.Types (1.0)"""
+
+    let cfg = DependenciesFile.FromCode(config)
+    ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
+    |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should generate strategy max lock file``() = 
+    let config = """
+    strategy max
+    source "http://nuget.org/api/v2"
+
+    nuget "Microsoft.SqlServer.Types"
+    """
+
+    let expected = """STRATEGY: MAX
+NUGET
+  remote: http://nuget.org/api/v2
+  specs:
+    Microsoft.SqlServer.Types (1.0)"""
+
+    let cfg = DependenciesFile.FromCode(config)
+    ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
+    |> shouldEqual (normalizeLineEndings expected)

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -575,3 +575,44 @@ let ``should parse and serialise groups lockfile``() =
 
     normalizeLineEndings lockFile' 
     |> shouldEqual (normalizeLineEndings groupsLockFile)
+
+[<Test>]
+let ``should parse strategy min lock file``() = 
+    let lockFile = """STRATEGY: MIN
+NUGET
+  remote: "D:\code\temp with space"
+  specs:
+    Castle.Windsor (2.1)
+"""
+    let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
+    let packages = List.rev lockFile.Packages
+    
+    packages.Length |> shouldEqual 1
+    lockFile.Options.ResolverStrategy |> shouldEqual (Some ResolverStrategy.Min)
+    
+[<Test>]
+let ``should parse strategy max lock file``() = 
+    let lockFile = """STRATEGY: MAX
+NUGET
+  remote: "D:\code\temp with space"
+  specs:
+    Castle.Windsor (2.1)
+"""
+    let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
+    let packages = List.rev lockFile.Packages
+    
+    packages.Length |> shouldEqual 1
+    lockFile.Options.ResolverStrategy |> shouldEqual (Some ResolverStrategy.Max)
+
+[<Test>]
+let ``should parse no strategy lock file``() = 
+    let lockFile = """NUGET
+  remote: "D:\code\temp with space"
+  specs:
+    Castle.Windsor (2.1)
+"""
+    let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
+    let packages = List.rev lockFile.Packages
+    
+    packages.Length |> shouldEqual 1
+    lockFile.Options.ResolverStrategy |> shouldEqual None


### PR DESCRIPTION
This PR generates and parses strategy option in lock file. The lack of it is causing the install process to detect changes when there is none.

Running `paket install` several times against this `paket.dependencies`:
```
source https://www.nuget.org/api/v2/
strategy: min

nuget Paket.Core
```

would not skip the resolver. Here is the output:
```
Paket version 2.22.0.0
Resolving packages for group Main:
 - Paket.Core 2.22.0
 - FSharp.Core 3.0.2
 - Newtonsoft.Json 3.5.8
D:\Projects\paket-test\paket.lock is already up-to-date
1 second - ready.
```

This is the output of this PR:
```
Paket version 2.22.0.0
Skipping resolver for group Main since it is already up-to-date
D:\Projects\paket-test\paket.lock is already up-to-date
0 seconds - ready.
```

