### PR TITLE
Fixes binding redirect integration test

### DIFF
--- a/integrationtests/scenarios/i001187-binding-redirect-adds-referenced-assemblies-only/before/paket.dependencies
+++ b/integrationtests/scenarios/i001187-binding-redirect-adds-referenced-assemblies-only/before/paket.dependencies
@@ -1,6 +1,7 @@
 source "http://nuget.org/api/v2"
 
 nuget Albedo 1.0.2
+nuget AutoFixture 3.36.9
 nuget AutoFixture.Idioms 3.35.1
 nuget AutoFixture.Xunit 3.36.9
 nuget Castle.Core 3.3.3


### PR DESCRIPTION
AutoFixture 3.36.10 was released with no signature, hence no binding redirect is generated for it.
This PR fixes AutoFixture in a version that is known to be signed.