### PR TITLE
expose TemplateFile types and Dependencies member

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -470,3 +470,11 @@ type Dependencies(dependenciesFileName: string) =
             failwithf "Could not push package %s. Please specify a NuGet API key via environment variable \"nugetkey\"." packageFileName
         let maxTrials = defaultArg maxTrials 5
         RemoteUpload.Push maxTrials urlWithEndpoint apiKey packageFileName
+
+    // lists all `TemplateFile`s in the current solution
+    member this.ListTemplateFiles() : TemplateFile list =
+        let lockFile = getLockFile()
+        ProjectFile.FindAllProjects(this.RootPath)
+        |> Array.choose (fun p -> ProjectFile.FindTemplatesFile(FileInfo(p.FileName)))
+        |> Array.map (fun path -> TemplateFile.Load(path, lockFile, None))
+        |> Array.toList

--- a/src/Paket.Core/TemplateFile.fs
+++ b/src/Paket.Core/TemplateFile.fs
@@ -89,7 +89,7 @@ module private TemplateParser =
             Map = Map.empty
         }
 
-type internal CompleteCoreInfo =
+type CompleteCoreInfo =
     { Id : string
       Version : SemVerInfo option
       Authors : string list
@@ -100,7 +100,7 @@ type internal CompleteCoreInfo =
         | None -> failwithf "No version given for %s" this.Id
     member this.NuspecFileName = this.Id + ".nuspec"
 
-type internal ProjectCoreInfo =
+type ProjectCoreInfo =
     { Id : string option
       Version : SemVerInfo option
       Authors : string list option
@@ -111,7 +111,7 @@ type internal ProjectCoreInfo =
           Version = None
           Description = None }
 
-type internal OptionalPackagingInfo =
+type OptionalPackagingInfo =
     { Title : string option
       Owners : string list
       ReleaseNotes : string option
@@ -150,13 +150,13 @@ type internal OptionalPackagingInfo =
           Files = []
           FilesExcluded = [] }
 
-type internal CompleteInfo = CompleteCoreInfo * OptionalPackagingInfo
+type CompleteInfo = CompleteCoreInfo * OptionalPackagingInfo
 
-type internal TemplateFileContents =
+type TemplateFileContents =
     | CompleteInfo of CompleteInfo
     | ProjectInfo of ProjectCoreInfo * OptionalPackagingInfo
 
-type internal TemplateFile =
+type TemplateFile =
     { FileName : string
       Contents : TemplateFileContents }
 


### PR DESCRIPTION
This PR corresponds to an issue I opened #1201 

I removed `internal` from all involved types in the TemplateFile API and added a member in `Dependencies` to enumerate them. Since most of the code is already tested as far as I can see, I didn't add a test case. Ping me if I should anyways ;)