### PR TITLE
make ListTemplateFiles more robust

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -475,6 +475,10 @@ type Dependencies(dependenciesFileName: string) =
     member this.ListTemplateFiles() : TemplateFile list =
         let lockFile = getLockFile()
         ProjectFile.FindAllProjects(this.RootPath)
-        |> Array.choose (fun p -> ProjectFile.FindTemplatesFile(FileInfo(p.FileName)))
-        |> Array.map (fun path -> TemplateFile.Load(path, lockFile, None))
+        |> Array.choose (fun proj -> ProjectFile.FindTemplatesFile(FileInfo(proj.FileName)))
+        |> Array.choose (fun path ->
+                         try
+                           Some(TemplateFile.Load(path, lockFile, None))
+                         with
+                           | _ -> None)
         |> Array.toList


### PR DESCRIPTION
A TemplateFile may not be loadable if some of the referenced files are not available (e.g. the Paket.PowerShell project and its dependencies on Linux) and thus renders the method useless in these scenarios.

I refined the loading process to skip TemplateFiles that crash on Load.