### PR TITLE
Update ProjectFile.GetTargetProfile to work with conditional nodes

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -916,9 +916,7 @@ type ProjectFile =
         |> Seq.head
 
     member this.GetTargetFrameworkIdentifier() =
-        seq { for outputType in this.Document |> getDescendants "TargetFrameworkIdentifier" ->
-                outputType.InnerText }
-        |> Seq.tryHead
+        this.GetProperty "TargetFrameworkIdentifier"
 
     member this.GetTargetFrameworkProfile() =
         seq {for outputType in this.Document |> getDescendants "TargetFrameworkProfile" ->

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -125,7 +125,7 @@ type ProjectFile =
 
             if !isPaketNode = paketOnes then yield node]
 
-    member this.GetProperty propertyName defaultProperties =
+    member this.GetPropertyWithDefaults propertyName defaultProperties =
         let rec handleElement (data : Map<string, string>) (node : XmlNode) =
             let processPlaceholders (data : Map<string, string>) text =
                 let getPlaceholderValue (name:string) =
@@ -338,6 +338,9 @@ type ProjectFile =
         |> getDescendants "PropertyGroup"
         |> Seq.fold handleElement defaultProperties
         |> Map.tryFind propertyName
+
+    member this.GetProperty propertyName =
+        this.GetPropertyWithDefaults propertyName Map.empty<string, string>
 
     member this.Name = FileInfo(this.FileName).Name
 
@@ -968,7 +971,7 @@ type ProjectFile =
     member this.GetOutputDirectory buildConfiguration =
         let startingData = Map.empty<string,string>.Add("Configuration", buildConfiguration)
 
-        this.GetProperty "OutputPath" startingData
+        this.GetPropertyWithDefaults "OutputPath" startingData
         |> function
             | None -> failwithf "Unable to find %s output path node in file %s" buildConfiguration this.FileName
             | Some s -> s.TrimEnd [|'\\'|] |> normalizePath

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -919,9 +919,7 @@ type ProjectFile =
         this.GetProperty "TargetFrameworkIdentifier"
 
     member this.GetTargetFrameworkProfile() =
-        seq {for outputType in this.Document |> getDescendants "TargetFrameworkProfile" ->
-                outputType.InnerText }
-        |> Seq.tryHead
+        this.GetProperty "TargetFrameworkProfile"
 
     member this.GetTargetProfile() =
         match this.GetTargetFrameworkProfile() with

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -39,6 +39,11 @@ let ``should detect output path for proj file``
     |> shouldEqual (System.IO.Path.Combine(@"bin", configuration) |> normalizePath)
 
 [<Test>]
+let ``should detect framework profile for ProjectWithConditions file`` () =
+    ProjectFile.TryLoad("./ProjectFile/TestData/ProjectWithConditions.fsprojtest").Value.GetTargetProfile()
+    |> shouldEqual (SinglePlatform(DotNetFramework(FrameworkVersion.V4_6)))
+
+[<Test>]
 let ``should detect assembly name for Project1 proj file`` () =
     ProjectFile.TryLoad("./ProjectFile/TestData/Project1.fsprojtest").Value.GetAssemblyName()
     |> shouldEqual ("Paket.Tests.dll")

--- a/tests/Paket.Tests/ProjectFile/TestData/ProjectWithConditions.fsprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/ProjectWithConditions.fsprojtest
@@ -9,10 +9,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Paket.Tests</RootNamespace>
     <AssemblyName>Paket.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.6</TargetFrameworkVersion>
+    <TargetFrameworkProfile Condition="'$(TargetFrameworkVersion)' == 'v4.0'">Client</TargetFrameworkProfile>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>Paket.Tests</Name>
-    <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>


### PR DESCRIPTION
Working on #1221 (cc/ @theggelund and @forki), the contents of the test file I changed in 73e6f8c686ca5a26fd9a7decee82435cad929daf appear to work as of b905c750d736a328931ac436359e8eddf18fa2a1.

The output looks correct to me, but I'll need one of you to confirm, as I'm not sure what the output from the paket_bug project is supposed to be. Just testing from an fsx file like so:

```FSharp
#r @"bin\Paket.Core.dll"
let proj = Paket.ProjectFile.LoadFromFile @"tests\Paket.Tests\ProjectFile\TestData\ProjectWithConditions.fsprojtest"
let profile = proj.GetTargetProfile()
```

`profile` outputs as `SinglePlatform (DotNetFramework V4_6)`. If I change the `TargetFrameworkProfile` node's condition to check for framework `v4.6` instead, then I get `SinglePlatform (DotNetFramework V4_Client)`. Doesn't make sense since there isn't a client profile for 4.6 (that I know of?), but shows that the condition on the node is being evaluated.