### PR TITLE
Cleans binding redirects

### DIFF
--- a/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
+++ b/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
@@ -4,6 +4,7 @@ open System
 open System.IO
 open NUnit.Framework
 open FsUnit
+open System.Text.RegularExpressions
 
 [<Test>]
 let ``install should redirect required assemblies only``() = 
@@ -140,4 +141,81 @@ let ``#1218 install hard should replace all assembly redirects with required onl
     config4.Contains xunit |> shouldEqual false
     config4.Contains ``xunit.extensions`` |> shouldEqual false
     config4 |> shouldContainText ``Castle.Core``
+    config4.Contains ``Castle.Windsor`` |> shouldEqual false
+    
+[<Test>]
+let ``#1218 install should replace paket's binding redirects with required only``() = 
+    paket "install --redirects --createnewbindingfiles" "i001218-binding-redirect-replaces-all-redirects-with-required-only" |> ignore
+
+    let path = Path.Combine(scenarioTempPath "i001218-binding-redirect-replaces-all-redirects-with-required-only")
+    let config1Path = Path.Combine(path, "Project1", "app.config")
+    let config2Path = Path.Combine(path, "Project2", "app.config")
+    let config3Path = Path.Combine(path, "Project3", "app.config")
+    let config4Path = Path.Combine(path, "Project4", "app.config")
+
+    let config1 = File.ReadAllText(config1Path)
+    let config2 = File.ReadAllText(config2Path)
+    let config3 = File.ReadAllText(config3Path)
+    let config4 = File.ReadAllText(config4Path)
+
+    let paketMark = "<Paket>True</Paket>\s*"
+
+    let Albedo = """<assemblyIdentity name="Ploeh.Albedo" publicKeyToken="179ef6dd03497bbd" culture="neutral" />"""
+    let AutoFixture = """<assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let ``AutoFixture.Idioms`` = """<assemblyIdentity name="Ploeh.AutoFixture.Idioms" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let ``AutoFixture.Xunit`` = """<assemblyIdentity name="Ploeh.AutoFixture.Xunit" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let log4net = """<assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />"""
+    let ``Newtonsoft.Json`` = """<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+    let ``Newtonsoft.Json.Schema`` = """<assemblyIdentity name="Newtonsoft.Json.Schema" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+    let xunit = """<assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
+    let ``xunit.extensions`` = """<assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
+    let ``Castle.Core`` = """<assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
+    let ``Castle.Windsor`` = """<assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
+
+    Regex.IsMatch(config1, paketMark + Albedo) |> shouldEqual true
+    Regex.IsMatch(config1, paketMark + AutoFixture) |> shouldEqual true
+    config1.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config1.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config1.Contains log4net |> shouldEqual false
+    Regex.IsMatch(config1, paketMark + ``Newtonsoft.Json``) |> shouldEqual true
+    config1.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config1.Contains xunit |> shouldEqual false
+    Regex.IsMatch(config1, paketMark + ``xunit.extensions``) |> shouldEqual true
+    Regex.IsMatch(config1, paketMark + ``Castle.Core``) |> shouldEqual true
+    config1.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config2.Contains Albedo |> shouldEqual false
+    config2.Contains AutoFixture |> shouldEqual false
+    config2.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config2.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config2.Contains log4net |> shouldEqual false
+    config2 |> shouldContainText ``Newtonsoft.Json``
+    config2.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config2.Contains xunit |> shouldEqual false
+    config2.Contains ``xunit.extensions`` |> shouldEqual false
+    config2.Contains ``Castle.Core`` |> shouldEqual false
+    config2.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config3.Contains Albedo |> shouldEqual false
+    config3 |> shouldContainText AutoFixture
+    config3.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config3.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config3.Contains log4net |> shouldEqual false
+    Regex.IsMatch(config3, paketMark + ``Newtonsoft.Json``) |> shouldEqual true
+    config3.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config3.Contains xunit |> shouldEqual false
+    config3.Contains ``xunit.extensions`` |> shouldEqual false
+    Regex.IsMatch(config3, paketMark + ``Castle.Core``) |> shouldEqual true
+    config3.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config4.Contains Albedo |> shouldEqual false
+    config4.Contains AutoFixture |> shouldEqual false
+    config4.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config4.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config4.Contains log4net |> shouldEqual false
+    config4 |> shouldContainText ``Newtonsoft.Json``
+    config4.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config4.Contains xunit |> shouldEqual false
+    config4.Contains ``xunit.extensions`` |> shouldEqual false
+    Regex.IsMatch(config4, paketMark + ``Castle.Core``) |> shouldEqual true
     config4.Contains ``Castle.Windsor`` |> shouldEqual false

--- a/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
+++ b/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
@@ -76,3 +76,68 @@ let ``#1195 should report broken app.config``() =
         failwith "paket should fail"
     with
     | exn when exn.Message.Contains("Project1") && exn.Message.Contains("app.config") -> ()
+
+[<Test>]
+let ``#1218 install hard should replace all assembly redirects with required only``() = 
+    paket "install --redirects --createnewbindingfiles --hard" "i001218-binding-redirect-replaces-all-redirects-with-required-only" |> ignore
+
+    let path = Path.Combine(scenarioTempPath "i001218-binding-redirect-replaces-all-redirects-with-required-only")
+    let config1Path = Path.Combine(path, "Project1", "app.config")
+    let config2Path = Path.Combine(path, "Project2", "app.config")
+    let config3Path = Path.Combine(path, "Project3", "app.config")
+    let config4Path = Path.Combine(path, "Project4", "app.config")
+
+    let config1 = File.ReadAllText(config1Path)
+    let config2 = File.ReadAllText(config2Path)
+    let config3 = File.ReadAllText(config3Path)
+    let config4 = File.ReadAllText(config4Path)
+
+    let Albedo = """<assemblyIdentity name="Ploeh.Albedo" publicKeyToken="179ef6dd03497bbd" culture="neutral" />"""
+    let AutoFixture = """<assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let ``AutoFixture.Idioms`` = """<assemblyIdentity name="Ploeh.AutoFixture.Idioms" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let ``AutoFixture.Xunit`` = """<assemblyIdentity name="Ploeh.AutoFixture.Xunit" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let log4net = """<assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />"""
+    let ``Newtonsoft.Json`` = """<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+    let ``Newtonsoft.Json.Schema`` = """<assemblyIdentity name="Newtonsoft.Json.Schema" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+    let xunit = """<assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
+    let ``xunit.extensions`` = """<assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
+    let ``Castle.Core`` = """<assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
+    let ``Castle.Windsor`` = """<assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
+
+    config1 |> shouldContainText Albedo
+    config1 |> shouldContainText AutoFixture
+    config1.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config1.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config1.Contains log4net |> shouldEqual false
+    config1 |> shouldContainText ``Newtonsoft.Json``
+    config1.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config1.Contains xunit |> shouldEqual false
+    config1 |> shouldContainText ``xunit.extensions``
+    config1 |> shouldContainText ``Castle.Core``
+    config1.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config2.Contains "<assemblyIdentity " |> shouldEqual false
+
+    config3.Contains Albedo |> shouldEqual false
+    config3.Contains AutoFixture |> shouldEqual false
+    config3.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config3.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config3.Contains log4net |> shouldEqual false
+    config3 |> shouldContainText ``Newtonsoft.Json``
+    config3.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config3.Contains xunit |> shouldEqual false
+    config3.Contains ``xunit.extensions`` |> shouldEqual false
+    config3 |> shouldContainText ``Castle.Core``
+    config3.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config4.Contains Albedo |> shouldEqual false
+    config4.Contains AutoFixture |> shouldEqual false
+    config4.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config4.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config4.Contains log4net |> shouldEqual false
+    config4.Contains ``Newtonsoft.Json`` |> shouldEqual false
+    config4.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config4.Contains xunit |> shouldEqual false
+    config4.Contains ``xunit.extensions`` |> shouldEqual false
+    config4 |> shouldContainText ``Castle.Core``
+    config4.Contains ``Castle.Windsor`` |> shouldEqual false

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project1/Project1.fsprojtemplate
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project1/Project1.fsprojtemplate
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>e789c72a-5cfd-436b-8ef1-61aa2852a89f</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Project1</RootNamespace>
+    <AssemblyName>Project1</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <Name>Project1</Name>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\fsharp_project_scaffold_tests.XML</DocumentationFile>
+    <StartAction>Project</StartAction>
+    <StartProgram>
+    </StartProgram>
+    <StartArguments>
+    </StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Project1.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Project3\Project3.fsproj">
+      <Name>Project3</Name>
+      <Project>{3241afe4-afee-4465-a482-5abbc0bf6457}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project1/paket.references
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project1/paket.references
@@ -1,0 +1,3 @@
+AutoFixture.Xunit
+AutoFixture.Idioms
+Newtonsoft.Json

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/Project2.fsprojtemplate
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/Project2.fsprojtemplate
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>bdf41042-8cb5-4723-aa90-18c05f9ffe85</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Project2</RootNamespace>
+    <AssemblyName>Project2</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <Name>Project2</Name>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\fsharp_project_scaffold_tests.XML</DocumentationFile>
+    <StartAction>Project</StartAction>
+    <StartProgram>
+    </StartProgram>
+    <StartArguments>
+    </StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Project2.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/app.config
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/app.config
@@ -6,6 +6,7 @@
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
   </dependentAssembly>
   <dependentAssembly>
+	<Paket>TRUE</Paket>
     <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.9.2.1705" />
   </dependentAssembly>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/app.config
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/app.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.9.2.1705" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/paket.references
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project2/paket.references
@@ -1,0 +1,1 @@
+Newtonsoft.Json

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/Project3.fsprojtemplate
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/Project3.fsprojtemplate
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>3241afe4-afee-4465-a482-5abbc0bf6457</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Project3</RootNamespace>
+    <AssemblyName>Project3</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <Name>Project3</Name>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\fsharp_project_scaffold_tests.XML</DocumentationFile>
+    <StartAction>Project</StartAction>
+    <StartProgram>
+    </StartProgram>
+    <StartArguments>
+    </StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Project3.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Project4\Project4.fsproj">
+      <Name>Project4</Name>
+      <Project>{3e02dbb4-ab9c-4495-9b52-4a69ce15eefd}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/app.config
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/app.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.36.9.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.9.2.1705" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/app.config
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/app.config
@@ -14,6 +14,7 @@
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
   </dependentAssembly>
   <dependentAssembly>
+	<Paket>True</Paket>
     <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.9.2.1705" />
   </dependentAssembly>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/paket.references
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project3/paket.references
@@ -1,0 +1,2 @@
+log4net
+Newtonsoft.Json.Schema

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/Project4.fsprojtemplate
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/Project4.fsprojtemplate
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>3e02dbb4-ab9c-4495-9b52-4a69ce15eefd</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Project4</RootNamespace>
+    <AssemblyName>Project4</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <Name>Project4</Name>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\fsharp_project_scaffold_tests.XML</DocumentationFile>
+    <StartAction>Project</StartAction>
+    <StartProgram>
+    </StartProgram>
+    <StartArguments>
+    </StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Project4.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/app.config
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/app.config
@@ -10,6 +10,7 @@
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
   </dependentAssembly>
   <dependentAssembly>
+	<Paket>true</Paket>
     <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.9.2.1705" />
   </dependentAssembly>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/app.config
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/app.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.3.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.9.2.1705" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/paket.references
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/Project4/paket.references
@@ -1,0 +1,1 @@
+Castle.Windsor.Extensions

--- a/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/paket.dependencies
+++ b/integrationtests/scenarios/i001218-binding-redirect-replaces-all-redirects-with-required-only/before/paket.dependencies
@@ -1,0 +1,13 @@
+source "http://nuget.org/api/v2"
+
+nuget Albedo 1.0.2
+nuget AutoFixture 3.36.9
+nuget AutoFixture.Idioms 3.35.1
+nuget AutoFixture.Xunit 3.36.9
+nuget Castle.Core 3.3.3
+nuget Castle.Windsor 3.0.0.3001
+nuget Castle.Windsor.Extensions 2.1.1
+nuget log4net 2.0.3
+nuget Newtonsoft.Json 7.0.1
+nuget Newtonsoft.Json.Schema 1.0.11
+nuget xunit 1.9.2

--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -50,6 +50,11 @@ let internal setRedirect (doc:XDocument) bindingRedirect =
                 
     let newRedirect = createElementWithNs "bindingRedirect" [ "oldVersion", "0.0.0.0-999.999.999.999"
                                                               "newVersion", bindingRedirect.Version ]
+
+    match tryGetElementWithNs "Paket" dependentAssembly with
+    | Some e -> e.Value <- "True"
+    | None -> dependentAssembly.AddFirst(XElement(XName.Get("Paket", bindingNs), "True"))
+
     match dependentAssembly |> tryGetElementWithNs "bindingRedirect" with
     | Some redirect -> redirect.ReplaceWith(newRedirect)
     | None -> dependentAssembly.Add(newRedirect)

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -223,6 +223,7 @@ let private applyBindingRedirects (loadedLibs:Dictionary<_,_>) createNewBindingF
               Version = assembly.GetName().Version.ToString()
               PublicKeyToken = token
               Culture = None })
+        |> Seq.sort
 
     applyBindingRedirectsToFolder createNewBindingFiles cleanBindingRedirects root bindingRedirects
 

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -161,7 +161,7 @@ let createModel(root, force, dependenciesFile:DependenciesFile, lockFile : LockF
     extractedPackages
 
 /// Applies binding redirects for all strong-named references to all app. and web.config files.
-let private applyBindingRedirects (loadedLibs:Dictionary<_,_>) createNewBindingFiles root groupName findDependencies (extractedPackages:seq<_*InstallModel>) =
+let private applyBindingRedirects (loadedLibs:Dictionary<_,_>) createNewBindingFiles cleanBindingRedirects root groupName findDependencies (extractedPackages:seq<_*InstallModel>) =
     let dependencyGraph = ConcurrentDictionary<_,Set<_>>()
     let projects = ConcurrentDictionary<_,ProjectFile option>();
 
@@ -224,7 +224,7 @@ let private applyBindingRedirects (loadedLibs:Dictionary<_,_>) createNewBindingF
               PublicKeyToken = token
               Culture = None })
 
-    applyBindingRedirectsToFolder createNewBindingFiles root bindingRedirects
+    applyBindingRedirectsToFolder createNewBindingFiles cleanBindingRedirects root bindingRedirects
 
 let findAllReferencesFiles root =
     root
@@ -376,7 +376,7 @@ let InstallIntoProjects(options : InstallerOptions, dependenciesFile, lockFile :
                 let isEnabled = defaultArg packageRedirects (options.Redirects || g.Value.Options.Redirects)
                 isEnabled && (fst kv.Key) = g.Key)
             |> Seq.map (fun kv -> kv.Value)
-            |> applyBindingRedirects loadedLibs options.CreateNewBindingFiles (FileInfo project.FileName).Directory.FullName g.Key lockFile.GetAllDependenciesOf
+            |> applyBindingRedirects loadedLibs options.CreateNewBindingFiles options.Hard (FileInfo project.FileName).Directory.FullName g.Key lockFile.GetAllDependenciesOf
 
 /// Installs all packages from the lock file.
 let Install(options : InstallerOptions, dependenciesFile, lockFile : LockFile) =


### PR DESCRIPTION
This PR closes #1218.

It removes all binding redirects when the `--hard` flag is used.

It also marks all binding redirects with a `<!--Paket-->` comment.
This was the best way I've found to mark the paket's redirects.
Since it does that, it also removes all binding redirects marked with the comment, regardless the `--hard` is used.

Take this `app.config` for example:
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
  <dependentAssembly>
    <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.36.9.0" />
  </dependentAssembly>
  <dependentAssembly>
    <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.0.0.0" />
  </dependentAssembly>
  <dependentAssembly>
    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
  </dependentAssembly>
  <dependentAssembly>
	<!-- Paket -->
    <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.9.2.1705" />
  </dependentAssembly>
</assemblyBinding></runtime></configuration>
```

*This project only needs `Castle.Core` and `Newtonsoft.Json` binding redirect*

Running `paket install`, this is the result:
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
  <dependentAssembly>
    <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.36.9.0" />
  </dependentAssembly>
  <dependentAssembly>
    <!--Paket-->
    <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.3.0.0" />
  </dependentAssembly>
  <dependentAssembly>
    <!--Paket-->
    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
  </dependentAssembly>
</assemblyBinding></runtime></configuration>
```

Note that `Ploeh.AutoFixture` redirect was not removed because it was not marked.
`xunit.extensions` redirect was marked though, hence it was removed.

On the other hand, running `paket install --hard` this is the resulting file:
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
  <dependentAssembly>
    <!--Paket-->
    <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.3.0.0" />
  </dependentAssembly>
  <dependentAssembly>
    <!--Paket-->
    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="7.0.0.0" />
  </dependentAssembly>
</assemblyBinding></runtime></configuration>
```

Note that regardless the redirect was marked, it was removed, leaving only the required redirects.