### PR TITLE
Compare SemVers instead of strings

### DIFF
--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -83,7 +83,9 @@ namespace Paket.Bootstrapper
                 }
                 else
                 {
-                    if (!localVersion.StartsWith(latestVersion, StringComparison.OrdinalIgnoreCase))
+                    var currentSemVer = SemVer.Create(localVersion);
+                    var latestSemVer = SemVer.Create(latestVersion);
+                    if (currentSemVer.CompareTo(latestSemVer) != 0)
                     {
                         downloadStrategy.DownloadVersion(latestVersion, dlArgs.Target, silent);
                         if (!silent)


### PR DESCRIPTION
This allows updates from e.g. 2.26.0-alpha002 to 2.26.0. Couldn't update today with the bootstrapper because of this.