### PR TITLE
PackageSources: do not print feed password to output #1224

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -651,7 +651,7 @@ let GetVersions root (sources, packageName:PackageName) =
     let versions = 
         match v with
         | versions when Array.isEmpty versions |> not -> versions
-        | _ -> failwithf "Could not find versions for package %O in any of the sources in %A." packageName sources
+        | _ -> failwithf "Could not find versions for package %O in any of the sources in %A." packageName (sources |> Seq.map (fun (s:PackageSource) -> s.ToString()) |> List.ofSeq)
 
     versions
     |> Seq.toList


### PR DESCRIPTION
In `NuGetV2.GetVersions` use the same approach as in `GetPackageDetails` to just print the feed url instead of the full record including the password, to avoid leaking the password unnecessarily to the console output.

It is correct that the password is lying around (at least encrypted) in paket.config, but it's still awkward seeing your personal password floating by on the console when pair-programming ;)

See also #1224 