### PR TITLE
ContinueOnError in paket.targets restore

### DIFF
--- a/.paket/paket.targets
+++ b/.paket/paket.targets
@@ -36,6 +36,6 @@
     <Exec Command="$(DownloadPaketCommand)" IgnoreStandardErrorWarningFormat="true" Condition=" '$(DownloadPaket)' == 'true' AND !Exists('$(PaketExePath)')" />
   </Target>
   <Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
-    <Exec Command="$(RestoreCommand)" IgnoreStandardErrorWarningFormat="true" WorkingDirectory="$(PaketRootPath)" Condition="Exists('$(PaketReferences)')" />
+    <Exec Command="$(RestoreCommand)" IgnoreStandardErrorWarningFormat="true" WorkingDirectory="$(PaketRootPath)" Condition="Exists('$(PaketReferences)')" ContinueOnError="true" />
   </Target>
 </Project>


### PR DESCRIPTION
the build in VS will fail anyways if restore forgot important stuff.
This is mainly a workaround because of VS locking