### PR TITLE
#1100 Allow specifying Nuget Source and provide option to specify parameters with config file in bootstrapper

### DIFF
--- a/.paket/paket.targets
+++ b/.paket/paket.targets
@@ -16,8 +16,8 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
-    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-    <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 $(PaketBootStrapperExePath)</PaketBootStrapperCommand>
+    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)" $(PaketBootStrapperCommandArgs)</PaketBootStrapperCommand>
+    <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 $(PaketBootStrapperExePath) $(PaketBootStrapperCommandArgs)</PaketBootStrapperCommand>
     <!-- Commands -->
     <PaketReferences Condition="!Exists('$(MSBuildProjectFullPath).paket.references')">$(MSBuildProjectDirectory)\paket.references</PaketReferences>
     <PaketReferences Condition="!Exists('$(PaketReferences)')">$(MSBuildStartupDirectory)\paket.references</PaketReferences>

--- a/src/Paket.Bootstrapper/DownloadArguments.cs
+++ b/src/Paket.Bootstrapper/DownloadArguments.cs
@@ -4,17 +4,19 @@
     {
         public string Folder { get; private set; }
         public string Target { get; private set; }
+        public string NugetSource { get; private set; }
         public bool DoSelfUpdate { get; set; }
         public string LatestVersion { get; private set; }
         public bool IgnorePrerelease { get; private set; }
 
-        public DownloadArguments(string latestVersion, bool ignorePrerelease, string folder, string target, bool doSelfUpdate)
+        public DownloadArguments(string latestVersion, bool ignorePrerelease, string folder, string target, bool doSelfUpdate, string nugetSource)
         {
             LatestVersion = latestVersion;
             IgnorePrerelease = ignorePrerelease;
             Folder = folder;
             Target = target;
             DoSelfUpdate = doSelfUpdate;
+            NugetSource = nugetSource;
         }
     }
 }

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
I've added the ability to specify the NuGet source in the bootstrapper using the --nuget-source command line argument.
I also added the ability to specify the NuGet source, preferring NuGet, and a specific Paket version in appSettings in a config file for the bootstrapper. It seemed to me that this would be an easy way to commit the settings to a repo (certainly works for my needs!).