### PR TITLE
Changes required when Chessie would be internal - Do not merge

### DIFF
--- a/src/Paket.Core/ConfigFile.fs
+++ b/src/Paket.Core/ConfigFile.fs
@@ -159,7 +159,7 @@ let GetAuthenticationForUrl (source : string) url =
 let GetAuthentication (source : string) =
     GetAuthenticationForUrl source source
 
-let AddCredentials(source, username, password) = 
+let internal AddCredentials(source, username, password) = 
     trial { 
         let! credentialsNode = getConfigNode "credentials"
         let newCredentials = 
@@ -177,7 +177,7 @@ let AddCredentials(source, username, password) =
         | None -> ()
     }
 
-let AddToken(source, token) =
+let internal AddToken(source, token) =
     trial {
         let! credentialsNode = getConfigNode "credentials"
         let newToken = 
@@ -195,7 +195,7 @@ let AddToken(source, token) =
         | None -> () 
     }
 
-let askAndAddAuth (source : string) (username : string) = 
+let internal askAndAddAuth (source : string) (username : string) = 
     let username =
         if(username = "") then
             Console.Write("Username: ")

--- a/src/Paket.Core/Environment.fs
+++ b/src/Paket.Core/Environment.fs
@@ -21,7 +21,7 @@ module PaketEnv =
           LockFile = lockFile
           Projects = projects }
 
-    let fromRootDirectory (directory : DirectoryInfo) = trial {
+    let internal fromRootDirectory (directory : DirectoryInfo) = trial {
         if not directory.Exists then 
             return! fail (DirectoryDoesntExist directory)
         else
@@ -61,7 +61,7 @@ module PaketEnv =
             |> Seq.tryFind File.Exists
             |> Option.map (fun f -> DirectoryInfo(Path.GetDirectoryName(f)))
 
-    let ensureNotExists (directory : DirectoryInfo) =
+    let internal ensureNotExists (directory : DirectoryInfo) =
         match fromRootDirectory directory with
         | Result.Ok(_) -> fail (PaketEnvAlreadyExistsInDirectory directory)
         | Result.Bad(msgs) -> 
@@ -73,15 +73,15 @@ module PaketEnv =
             if filtered |> List.isEmpty then ok directory
             else Result.Bad filtered
 
-    let ensureNotInStrictMode environment =
+    let internal ensureNotInStrictMode environment =
         if not environment.DependenciesFile.Groups.[Constants.MainDependencyGroup].Options.Strict then ok environment
         else fail StrictModeDetected
 
-    let ensureLockFileExists environment =
+    let internal ensureLockFileExists environment =
         environment.LockFile
         |> failIfNone (LockFileNotFound environment.RootDirectory)
 
-    let init (directory : DirectoryInfo) =
+    let internal init (directory : DirectoryInfo) =
         match locatePaketRootDirectory directory with
         | Some rootDirectory when rootDirectory.FullName = directory.FullName -> 
             Logging.tracefn "Paket is already initialized in %s" rootDirectory.FullName

--- a/src/Paket.Core/FindOutdated.fs
+++ b/src/Paket.Core/FindOutdated.fs
@@ -25,7 +25,7 @@ let private adjustVersionRequirements strict includingPrereleases (dependenciesF
     DependenciesFile(dependenciesFile.FileName, groups, dependenciesFile.Lines)
 
 /// Finds all outdated packages.
-let FindOutdated strict includingPrereleases environment = trial {
+let internal FindOutdated strict includingPrereleases environment = trial {
     let! lockFile = environment |> PaketEnv.ensureLockFileExists
 
     let dependenciesFile =
@@ -74,7 +74,7 @@ let private printOutdated changed =
                 tracefn "    * %O %O -> %O" packageName oldVersion newVersion
 
 /// Prints all outdated packages.
-let ShowOutdated strict includingPrereleases environment = trial {
+let internal ShowOutdated strict includingPrereleases environment = trial {
     let! allOutdated = FindOutdated strict includingPrereleases environment
     printOutdated allOutdated
 }

--- a/src/Paket.Core/FindReferences.fs
+++ b/src/Paket.Core/FindReferences.fs
@@ -22,13 +22,13 @@ let private findReferencesFor groupName package (lockFile: LockFile) projects = 
     return referencedIn |> List.choose id
 }
 
-let FindReferencesForPackage groupName package environment = trial {
+let internal FindReferencesForPackage groupName package environment = trial {
     let! lockFile = environment |> PaketEnv.ensureLockFileExists
 
     return! findReferencesFor groupName package lockFile environment.Projects
 }
 
-let ShowReferencesFor packages environment = trial {
+let internal ShowReferencesFor packages environment = trial {
     let! lockFile = environment |> PaketEnv.ensureLockFileExists
     let! projectsPerPackage =
         packages

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -227,7 +227,7 @@ let private applyBindingRedirects (loadedLibs:Dictionary<_,_>) createNewBindingF
 
     applyBindingRedirectsToFolder createNewBindingFiles cleanBindingRedirects root bindingRedirects
 
-let findAllReferencesFiles root =
+let internal findAllReferencesFiles root =
     root
     |> ProjectFile.FindAllProjects
     |> Array.map (fun p ->         

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -567,7 +567,7 @@ type LockFile(fileName:string,groups: Map<GroupName,LockFileGroup>) =
         |> Seq.concat
         |> Map.ofSeq
 
-    member this.GetPackageHullSafe(referencesFile,groupName) =
+    member internal this.GetPackageHullSafe(referencesFile,groupName) =
         match referencesFile.Groups |> Map.tryFind groupName with
         | None -> Result.Succeed(Set.empty)
         | Some group ->

--- a/src/Paket.Core/Releases.fs
+++ b/src/Paket.Core/Releases.fs
@@ -53,13 +53,13 @@ let private downloadLatestVersionOf files destDir =
     }
 
 /// Downloads the latest version of the paket.bootstrapper to the .paket dir
-let downloadLatestBootstrapper environment =
+let internal downloadLatestBootstrapper environment =
     let exeDir = Path.Combine(environment.RootDirectory.FullName, Constants.PaketFolderName)
 
     downloadLatestVersionOf [Constants.BootstrapperFileName] exeDir
 
 /// Downloads the latest version of the paket.bootstrapper and paket.targets to the .paket dir
-let downloadLatestBootstrapperAndTargets environment =
+let internal downloadLatestBootstrapperAndTargets environment =
     let exeDir = Path.Combine(environment.RootDirectory.FullName, Constants.PaketFolderName)
 
     downloadLatestVersionOf [Constants.TargetsFileName; Constants.BootstrapperFileName] exeDir

--- a/src/Paket.Core/Simplifier.fs
+++ b/src/Paket.Core/Simplifier.fs
@@ -27,7 +27,7 @@ let private removePackage(packageName, transitivePackages, fileName, interactive
     else
         false
 
-let simplifyDependenciesFile (dependenciesFile : DependenciesFile, groupName, flatLookup, interactive) = trial {
+let internal simplifyDependenciesFile (dependenciesFile : DependenciesFile, groupName, flatLookup, interactive) = trial {
     let packages = dependenciesFile.Groups.[groupName].Packages |> List.map (fun p -> p.Name)
     let! transitive = findTransitive(groupName, packages, flatLookup, DependencyNotFoundInLockFile)
 
@@ -39,7 +39,7 @@ let simplifyDependenciesFile (dependenciesFile : DependenciesFile, groupName, fl
                 else d) dependenciesFile
 }
 
-let simplifyReferencesFile (refFile:ReferencesFile, groupName, flatLookup, interactive) = trial {
+let internal simplifyReferencesFile (refFile:ReferencesFile, groupName, flatLookup, interactive) = trial {
     match refFile.Groups |> Map.tryFind groupName with
     | None -> return refFile
     | Some g -> 
@@ -62,7 +62,7 @@ let beforeAndAfter environment dependenciesFile projects =
         DependenciesFile = dependenciesFile
         Projects = projects }
 
-let simplify interactive environment = trial {
+let internal simplify interactive environment = trial {
     let! lockFile = environment |> PaketEnv.ensureLockFileExists
 
     let flatLookup = lockFile.GetDependencyLookupTable()

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -59,7 +59,7 @@ let getDirectoryInfo pathInfo root =
             | RelativePath s -> DirectoryInfo(Path.Combine(root, s))
         
 /// Creates a directory if it does not exist.
-let createDir path = 
+let internal createDir path = 
     try
         let dir = DirectoryInfo path
         if not dir.Exists then dir.Create()
@@ -68,7 +68,7 @@ let createDir path =
         DirectoryCreateError path |> fail
 
 /// Cleans a directory by deleting it and recreating it.
-let CleanDir path = 
+let internal CleanDir path = 
     let di = DirectoryInfo path
     if di.Exists then 
         try
@@ -398,27 +398,27 @@ let parseKeyValuePairs(s:string) =
             dict.[!lastKey] <- dict.[!lastKey] + ", " + p
     dict
 
-let downloadStringSync (url : string) (client : System.Net.WebClient) = 
+let internal downloadStringSync (url : string) (client : System.Net.WebClient) = 
     try 
         client.DownloadString url |> ok
     with _ ->
         DownloadError url |> fail 
 
-let downloadFileSync (url : string) (fileName : string) (client : System.Net.WebClient) = 
+let internal downloadFileSync (url : string) (fileName : string) (client : System.Net.WebClient) = 
     tracefn "Downloading file from %s to %s" url fileName
     try 
         client.DownloadFile(url, fileName) |> ok
     with _ ->
         DownloadError url |> fail 
 
-let saveFile (fileName : string) (contents : string) =
+let internal saveFile (fileName : string) (contents : string) =
     tracefn "Saving file %s" fileName
     try 
         File.WriteAllText(fileName, contents) |> ok
     with _ ->
         FileSaveError fileName |> fail
 
-let removeFile (fileName : string) =
+let internal removeFile (fileName : string) =
     if File.Exists fileName then
         tracefn "Removing file %s" fileName
         try

--- a/src/Paket.Core/VSIntegration.fs
+++ b/src/Paket.Core/VSIntegration.fs
@@ -8,7 +8,7 @@ open Domain
 open Releases
 
 /// Activates the Visual Studio Nuget autorestore feature in all projects
-let TurnOnAutoRestore environment =
+let internal TurnOnAutoRestore environment =
     let exeDir = Path.Combine(environment.RootDirectory.FullName, ".paket")
 
     trial {         
@@ -25,7 +25,7 @@ let TurnOnAutoRestore environment =
     } 
 
 /// Deactivates the Visual Studio Nuget autorestore feature in all projects
-let TurnOffAutoRestore environment = 
+let internal TurnOffAutoRestore environment = 
     let exeDir = Path.Combine(environment.RootDirectory.FullName, ".paket")
     
     trial {


### PR DESCRIPTION
If `Chessie` would provide a way to have an internal version of the types, we would have to apply those changes to make the compiler happy.
@forki can you review it, as I don't know whether some of the functions were being used by other tools, like `ionide`.

My thoughts about the way to provide internalized version:
The author of the library, like `Chessie`, would have to mark the types with a comment, something like `(*Paket:internal*)`. `Paket` could than parse the file and replace the comment with the content after the colon.