### PR TITLE
Add options to force Nuget source and use local file paths with bootstrapper

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -14,7 +14,11 @@ Options:
   `version`: Downloads the given version of paket.exe from github.com.
 
   `--prefer-nuget`: Downloads the given version of paket.exe from nuget.org instead of github.com. Uses github.com as fallback, when nuget.org fails
-  
+
+  `--force-nuget`: As with the `--prefer-nuget` option, downloads paket.exe from nuget.org instead of github.com, but does *not* use github.com as a fallback.
+
+  `--nuget-source`: When specified as `--nuget-source=http://local.site/path/here`, the specified path is used instead of nuget.org when trying to fetch paket.exe as a nuget package. Combine this with either `--prefer-nuget` or `--force-nuget` to get paket.exe from a custom source.
+
   `--self`: Self updating the paket.bootstrapper.exe. When this option is used the download of paket.exe will be skipped. (Can be combined with `--prefer-nuget`)
 
   `-s`: If this flag is set the bootstrapper will not perform any output.
@@ -22,5 +26,5 @@ Options:
 Environment Variables:
 
   `PAKET.VERSION`: The requested version can also be set using this environment variable. Above options take precedence over the environment variable 
-  
+
 

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -118,7 +118,7 @@ namespace Paket.Bootstrapper
 
                 var paketDownloadUrl = apiHelper.GetLatestPackage();
                 var paketFile = paketNupkgFile;
-                if (latestVersion != String.Empty)
+                if (!String.IsNullOrWhiteSpace(latestVersion))
                 {
                     paketDownloadUrl = apiHelper.GetSpecificPackageVersion(latestVersion);
                     paketFile = String.Format(paketNupkgFileTemplate, latestVersion);
@@ -130,7 +130,7 @@ namespace Paket.Bootstrapper
 
                 if (Directory.Exists(NugetSource))
                 {
-                    if (latestVersion == String.Empty) latestVersion = this.GetLatestVersion(false);
+                    if (String.IsNullOrWhiteSpace(latestVersion)) latestVersion = this.GetLatestVersion(false);
                     var sourcePath = Path.Combine(NugetSource, String.Format(paketNupkgFileTemplate, latestVersion));
 
                     if (!silent)
@@ -173,7 +173,7 @@ namespace Paket.Bootstrapper
 
             var paketDownloadUrl = getLatestFromNugetUrl;
             var paketFile = paketNupkgFile;
-            if (latestVersion != String.Empty)
+            if (!String.IsNullOrWhiteSpace(latestVersion))
             {
                 paketDownloadUrl = apiHelper.GetSpecificPackageVersion(latestVersion);
                 paketFile = String.Format(paketNupkgFileTemplate, latestVersion);
@@ -185,7 +185,7 @@ namespace Paket.Bootstrapper
 
             if (Directory.Exists(NugetSource))
             {
-                if (latestVersion == String.Empty) latestVersion = this.GetLatestVersion(false);
+                if (String.IsNullOrWhiteSpace(latestVersion)) latestVersion = this.GetLatestVersion(false);
                 var sourcePath = Path.Combine(NugetSource, String.Format(paketNupkgFileTemplate, latestVersion));
 
                 if (!silent)

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -127,10 +127,25 @@ namespace Paket.Bootstrapper
                 var randomFullPath = Path.Combine(Folder, Path.GetRandomFileName());
                 Directory.CreateDirectory(randomFullPath);
                 var paketPackageFile = Path.Combine(randomFullPath, paketFile);
-                if (!silent)
-                    Console.WriteLine("Starting download from {0}", paketDownloadUrl);
-                PrepareWebClient(client, paketDownloadUrl);
-                client.DownloadFile(paketDownloadUrl, paketPackageFile);
+
+                if (Directory.Exists(NugetSource))
+                {
+                    if (latestVersion == String.Empty) latestVersion = this.GetLatestVersion(false);
+                    var sourcePath = Path.Combine(NugetSource, String.Format(paketNupkgFileTemplate, latestVersion));
+
+                    if (!silent)
+                        Console.WriteLine("Starting download from {0}", sourcePath);
+
+                    File.Copy(sourcePath, paketPackageFile);
+                }
+                else
+                {
+                    if (!silent)
+                        Console.WriteLine("Starting download from {0}", paketDownloadUrl);
+
+                    PrepareWebClient(client, paketDownloadUrl);
+                    client.DownloadFile(paketDownloadUrl, paketPackageFile);
+                }
 
                 ZipFile.ExtractToDirectory(paketPackageFile, randomFullPath);
                 var paketSourceFile = Path.Combine(randomFullPath, "tools", "paket.exe");

--- a/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/NugetDownloadStrategy.cs
@@ -182,13 +182,28 @@ namespace Paket.Bootstrapper
             var randomFullPath = Path.Combine(Folder, Path.GetRandomFileName());
             Directory.CreateDirectory(randomFullPath);
             var paketPackageFile = Path.Combine(randomFullPath, paketFile);
-            if (!silent)
-                Console.WriteLine("Starting download from {0}", paketDownloadUrl);
-            using (var client = new WebClient())
+
+            if (Directory.Exists(NugetSource))
             {
-                PrepareWebClient(client, paketDownloadUrl);
-                client.DownloadFile(paketDownloadUrl, paketPackageFile);
+                if (latestVersion == String.Empty) latestVersion = this.GetLatestVersion(false);
+                var sourcePath = Path.Combine(NugetSource, String.Format(paketNupkgFileTemplate, latestVersion));
+
+                if (!silent)
+                    Console.WriteLine("Starting download from {0}", sourcePath);
+
+                File.Copy(sourcePath, paketPackageFile);
             }
+            else
+            {
+                if (!silent)
+                    Console.WriteLine("Starting download from {0}", paketDownloadUrl);
+                using (var client = new WebClient())
+                {
+                    PrepareWebClient(client, paketDownloadUrl);
+                    client.DownloadFile(paketDownloadUrl, paketPackageFile);
+                }
+            }
+
             ZipFile.ExtractToDirectory(paketPackageFile, randomFullPath);
 
             var paketSourceFile = Path.Combine(randomFullPath, "tools", "paket.bootstrapper.exe");

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -14,6 +14,8 @@ namespace Paket.Bootstrapper
     {
         const string PreferNugetCommandArg = "--prefer-nuget";
         const string PreferNugetAppSettingsKey = "PreferNuget";
+        const string ForceNugetCommandArg = "--force-nuget";
+        const string ForceNugetAppSettingsKey = "ForceNuget";
         const string PrereleaseCommandArg = "prerelease";
         const string PaketVersionEnv = "PAKET.VERSION";
         const string PaketVersionAppSettingsKey = "PaketVersion";
@@ -27,6 +29,7 @@ namespace Paket.Bootstrapper
 
             var commandArgs = args;
             var preferNuget = false;
+            var forceNuget = false;
             if (commandArgs.Contains(PreferNugetCommandArg))
             {
                 preferNuget = true;
@@ -36,6 +39,15 @@ namespace Paket.Bootstrapper
             {
                 preferNuget = true;
             }
+            if (commandArgs.Contains(ForceNugetCommandArg))
+            {
+                forceNuget = true;
+                commandArgs = args.Where(x => x != ForceNugetCommandArg).ToArray();
+            }
+            else if (ConfigurationManager.AppSettings[ForceNugetAppSettingsKey] == "true")
+            {
+                forceNuget = true;
+            }
             var silent = false;
             if (commandArgs.Contains(SilentCommandArg))
             {
@@ -44,7 +56,7 @@ namespace Paket.Bootstrapper
             }
             var dlArgs = EvaluateCommandArgs(commandArgs, silent);
 
-            var effectiveStrategy = GetEffectiveDownloadStrategy(dlArgs, preferNuget, false);
+            var effectiveStrategy = GetEffectiveDownloadStrategy(dlArgs, preferNuget, forceNuget);
 
             StartPaketBootstrapping(effectiveStrategy, dlArgs, silent);
         }

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -44,7 +44,7 @@ namespace Paket.Bootstrapper
             }
             var dlArgs = EvaluateCommandArgs(commandArgs, silent);
 
-            var effectiveStrategy = GetEffectiveDownloadStrategy(dlArgs, preferNuget);
+            var effectiveStrategy = GetEffectiveDownloadStrategy(dlArgs, preferNuget, false);
 
             StartPaketBootstrapping(effectiveStrategy, dlArgs, silent);
         }
@@ -130,13 +130,18 @@ namespace Paket.Bootstrapper
             }
         }
 
-        private static IDownloadStrategy GetEffectiveDownloadStrategy(DownloadArguments dlArgs, bool preferNuget)
+        private static IDownloadStrategy GetEffectiveDownloadStrategy(DownloadArguments dlArgs, bool preferNuget, bool forceNuget)
         {
             var gitHubDownloadStrategy = new GitHubDownloadStrategy(BootstrapperHelper.PrepareWebClient, BootstrapperHelper.PrepareWebRequest, BootstrapperHelper.GetDefaultWebProxyFor);
             var nugetDownloadStrategy = new NugetDownloadStrategy(BootstrapperHelper.PrepareWebClient, BootstrapperHelper.GetDefaultWebProxyFor, dlArgs.Folder, dlArgs.NugetSource);
 
             IDownloadStrategy effectiveStrategy;
-            if (preferNuget)
+            if (forceNuget)
+            {
+                effectiveStrategy = nugetDownloadStrategy;
+                nugetDownloadStrategy.FallbackStrategy = null;
+            }
+            else if (preferNuget)
             {
                 effectiveStrategy = nugetDownloadStrategy;
                 nugetDownloadStrategy.FallbackStrategy = gitHubDownloadStrategy;


### PR DESCRIPTION
Added a `--force-nuget` command-line argument to the bootstrapper to get `paket.exe` from nuget rather than github, and to *not* automatically fallback to github as the `--prefer-nuget` option does. Did this by just setting the `FallbackStrategy` to `null`, as the bootstrapper appears to already handle that [here][1].

Additional changes coming to allow using a local file path for the nuget source specified with `--nuget-source`, rather than a web API.

[1]: https://github.com/fsprojects/Paket/blob/5da9a479b14527df509eec18315ab9a22365258c/src/Paket.Bootstrapper/Program.cs#L114