### PR TITLE
Handle different platforms in ProjectFile.GetOutputPath

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -1012,7 +1012,7 @@ type ProjectFile =
                             traceWarnfn "No platform specified; found output path node for the %s platform after failing to find one for the following: %s" x tested
                         s.TrimEnd [|'\\'|] |> normalizePath
 
-        tryNextPlat platforms
+        tryNextPlat platforms []
 
     member this.GetAssemblyName () =
         let assemblyName =

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -980,12 +980,39 @@ type ProjectFile =
         else "Content"
 
     member this.GetOutputDirectory buildConfiguration buildPlatform =
-        let startingData = Map.empty<string,string>.Add("Configuration", buildConfiguration)
+        let platforms =
+            if not <| String.IsNullOrWhiteSpace(buildPlatform)
+            then [buildPlatform]
+            else
+                [
+                    "AnyCPU";
+                    "AnyCPU32BitPreferred";
+                    "x86";
+                    "x64";
+                    "ARM";
+                    "Itanium";
+                ]
 
-        this.GetPropertyWithDefaults "OutputPath" startingData
-        |> function
-            | None -> failwithf "Unable to find %s output path node in file %s" buildConfiguration this.FileName
-            | Some s -> s.TrimEnd [|'\\'|] |> normalizePath
+        let rec tryNextPlat platforms attempted =
+            match platforms with
+            | [] ->
+                if String.IsNullOrWhiteSpace(buildPlatform)
+                then
+                    failwithf "Unable to find %s output path node in file %s for any known platforms" buildConfiguration this.FileName
+                else
+                    failwithf "Unable to find %s output path node in file %s targeting the %s platform" buildConfiguration this.FileName buildPlatform
+            | x::xs ->
+                let startingData = Map.ofList [("Configuration", buildConfiguration); ("Platform", x)]
+                this.GetPropertyWithDefaults "OutputPath" startingData
+                |> function
+                    | None -> tryNextPlat xs (x::attempted)
+                    | Some s ->
+                        if String.IsNullOrWhiteSpace(buildPlatform) then
+                            let tested = String.Join(", ", Array.ofList attempted)
+                            traceWarnfn "No platform specified; found output path node for the %s platform after failing to find one for the following: %s" x tested
+                        s.TrimEnd [|'\\'|] |> normalizePath
+
+        tryNextPlat platforms
 
     member this.GetAssemblyName () =
         let assemblyName =

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -979,7 +979,7 @@ type ProjectFile =
         then "Compile"
         else "Content"
 
-    member this.GetOutputDirectory buildConfiguration =
+    member this.GetOutputDirectory buildConfiguration buildPlatform =
         let startingData = Map.empty<string,string>.Add("Configuration", buildConfiguration)
 
         this.GetPropertyWithDefaults "OutputPath" startingData

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -456,11 +456,11 @@ type Dependencies(dependenciesFileName: string) =
         FindReferences.FindReferencesForPackage (GroupName group) (PackageName package) |> this.Process
 
     // Packs all paket.template files.
-    member this.Pack(outputPath, ?buildConfig, ?version, ?releaseNotes, ?templateFile, ?workingDir, ?lockDependencies) =
+    member this.Pack(outputPath, ?buildConfig, ?buildPlatform, ?version, ?releaseNotes, ?templateFile, ?workingDir, ?lockDependencies) =
         let dependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
         let workingDir = defaultArg workingDir (dependenciesFile.FileName |> Path.GetDirectoryName)
         let lockDependencies = defaultArg lockDependencies false
-        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, version, releaseNotes, templateFile, lockDependencies)
+        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, releaseNotes, templateFile, lockDependencies)
 
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -303,6 +303,7 @@ with
             match this with
             | Output(_) -> "Output directory to put .nupkg files."
             | BuildConfig(_) -> "Optionally specify build configuration that should be packaged (defaults to Release)."
+            | BuildPlatform(_) -> "Optionally specify build platform that should be packaged (if not provided or empty, checks all known platform targets)."
             | Version(_) -> "Specify version of the package."
             | TemplateFile(_) -> "Allows to specify a single template file."
             | ReleaseNotes(_) -> "Specify relase notes for the package."

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -292,6 +292,7 @@ with
 type PackArgs =
     | [<CustomCommandLine("output")>][<Mandatory>] Output of string
     | [<CustomCommandLine("buildconfig")>] BuildConfig of string
+    | [<CustomCommandLine("buildplatform")>] BuildPlatform of string
     | [<CustomCommandLine("version")>] Version of string
     | [<CustomCommandLine("templatefile")>] TemplateFile of string
     | [<CustomCommandLine("releaseNotes")>] ReleaseNotes of string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -215,6 +215,7 @@ let pack (results : ParseResults<_>) =
     Dependencies.Locate()
                 .Pack(outputPath,
                       ?buildConfig = results.TryGetResult <@ PackArgs.BuildConfig @>,
+                      ?buildPlatform = results.TryGetResult <@ PackArgs.BuildPlatform @>,
                       ?version = results.TryGetResult <@ PackArgs.Version @>,
                       ?releaseNotes = results.TryGetResult <@ PackArgs.ReleaseNotes @>,
                       ?templateFile = results.TryGetResult <@ PackArgs.TemplateFile @>,

--- a/tests/Paket.Tests/PackageProcessSpecs.fs
+++ b/tests/Paket.Tests/PackageProcessSpecs.fs
@@ -48,7 +48,7 @@ let ``Loading assembly metadata works``() =
         if workingDir.Contains "Debug" then "Debug"
         else "Release"
     
-    let assembly,id,fileName = PackageMetaData.loadAssemblyId config projFile
+    let assembly,id,fileName = PackageMetaData.loadAssemblyId config "" projFile
     id |> shouldEqual "Paket.Tests"
     
     let attribs = PackageMetaData.loadAssemblyAttributes fileName assembly

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -35,7 +35,7 @@ let ``should detect target framework for Project2 proj file``() =
 let ``should detect output path for proj file``
         ([<Values("Project1", "Project2", "Project3", "ProjectWithConditions")>] project)
         ([<Values("Debug", "Release")>] configuration) =
-    ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s.fsprojtest" project).Value.GetOutputDirectory configuration
+    ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s.fsprojtest" project).Value.GetOutputDirectory configuration ""
     |> shouldEqual (System.IO.Path.Combine(@"bin", configuration) |> normalizePath)
 
 [<Test>]


### PR DESCRIPTION
Added a `buildplatform` option to the `paket pack` command and sprinkled it lovingly throughout the codebase anywhere the compiler complained loudly enough. `ProjectFile.GetOutputPath` now attempts to evaluate the project file for the `OutputPath` value given the specified platform. If no platform is specified, runs through a list of platforms until one of them works or the list becomes empty.

Given how `ProjectFile.GetPropertyWithDefaults` is currently written, these platform values look like they'll be case-sensitive, but this could easily be changed if needed.

cc/ @agross: If you have a few minutes, can you see if this resolves #1262?