### PR TITLE
Support local read-only .nupkg-files

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -305,7 +305,7 @@ let getDetailsFromLocalFile root localNugetPath (packageName:PackageName) (versi
         let nupkg = findLocalPackage di.FullName packageName version
         
         fixArchive nupkg.FullName
-        use zipToCreate = new FileStream(nupkg.FullName, FileMode.Open)
+        use zipToCreate = new FileStream(nupkg.FullName, FileMode.Open, FileAccess.Read)
         use zip = new ZipArchive(zipToCreate,ZipArchiveMode.Read)
         
         let zippedNuspec = zip.Entries |> Seq.find (fun f -> f.FullName.EndsWith ".nuspec")


### PR DESCRIPTION
We needed support for read-only unc-directories. Fixed by not opening the nupkg FileStream with write access.