### PR TITLE
Make user prompts work with redirected stdin

### DIFF
--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -280,7 +280,7 @@ let safeGetFromUrl (auth:Auth option, url : string, contentType : string) =
         with _ -> return None
     }
 
-let readKey() = System.Console.ReadLine().Trim()
+let readAnswer() = System.Console.ReadLine().Trim()
 
 /// If the guard is true then a [Y]es / [N]o question will be ask.
 /// Until the user pressed y or n.
@@ -288,7 +288,7 @@ let askYesNo question =
     let rec getAnswer() = 
         Logging.tracefn "%s" question
         Logging.tracef "    [Y]es/[N]o => "
-        let answer = readKey()
+        let answer = readAnswer()
         Logging.tracefn ""
         match answer.ToLower() with
         | "y" -> true

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -280,7 +280,7 @@ let safeGetFromUrl (auth:Auth option, url : string, contentType : string) =
         with _ -> return None
     }
 
-let readKey() = System.Console.ReadKey().KeyChar.ToString()
+let readKey() = System.Console.ReadLine().Trim()
 
 /// If the guard is true then a [Y]es / [N]o question will be ask.
 /// Until the user pressed y or n.


### PR DESCRIPTION
As per issue #1291, the prompt is now implemented with Console.ReadLine() which works with redirected standard input