### PR TITLE
Make redirects off skip binding redirects

### DIFF
--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -103,6 +103,28 @@ This option tells paket to create [Assembly Binding Redirects](https://msdn.micr
 
     nuget UnionArgParser ~> 0.7
 
+On the other hand, you can instruct Paket to create no [Assembly Binding Redirects](https://msdn.microsoft.com/en-us/library/433ysdt1(v=vs.110).aspx), regardless a package instructs otherwise.
+
+    redirects: off
+    source https://nuget.org/api/v2
+
+    nuget UnionArgParser ~> 0.7 redirects: on
+    nuget FSharp.Core redirects: force
+
+If you're using multiple groups, you must set `redirects: off` for each one of them.
+
+    redirects: off
+    source https://nuget.org/api/v2
+
+    nuget UnionArgParser ~> 0.7 redirects: on
+    nuget FSharp.Core redirects: force
+
+    group Build
+        redirects: off
+	    source https://nuget.org/api/v2
+		
+        nuget FAKE redirects: on
+
 ### Strategy option
 
 This option tells Paket what resolver strategy it will use by default. 

--- a/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
+++ b/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
@@ -303,3 +303,17 @@ let ``#1248 redirects off for main only``() =
     config |> shouldContainText AlphaFS
     config.Contains ``Newtonsoft.Json`` |> shouldEqual false
     config.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    
+[<Test>]
+let ``#1248 redirects off with --redirects``() = 
+    paket "install --redirects" "i001248-redirects-off" |> ignore
+    let path = Path.Combine(scenarioTempPath "i001248-redirects-off")
+    let configPath = Path.Combine(path, "MyClassLibrary", "MyClassLibrary", "app.config")
+    let originalPath = Path.Combine(originalScenarioPath "i001248-redirects-off")
+    let originalConfigPath = Path.Combine(originalPath, "MyClassLibrary", "MyClassLibrary", "app.config")
+
+    let config = File.ReadAllText(configPath)
+    let originalConfig = File.ReadAllText(originalConfigPath)
+
+    config |> shouldEqual originalConfig
+    

--- a/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
+++ b/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
@@ -272,3 +272,34 @@ let ``#1270 redirects from references``() =
     config.Contains AlphaFS |> shouldEqual false
     config |> shouldContainText ``Newtonsoft.Json.Schema``
     config.Contains ``Newtonsoft.Json`` |> shouldEqual false
+    
+[<Test>]
+let ``#1248 redirects off``() = 
+    paket "install" "i001248-redirects-off" |> ignore
+    let path = Path.Combine(scenarioTempPath "i001248-redirects-off")
+    let configPath = Path.Combine(path, "MyClassLibrary", "MyClassLibrary", "app.config")
+    let originalPath = Path.Combine(originalScenarioPath "i001248-redirects-off")
+    let originalConfigPath = Path.Combine(originalPath, "MyClassLibrary", "MyClassLibrary", "app.config")
+
+    let config = File.ReadAllText(configPath)
+    let originalConfig = File.ReadAllText(originalConfigPath)
+
+    config |> shouldEqual originalConfig
+    
+[<Test>]
+let ``#1248 redirects off for main only``() = 
+    paket "install" "i001248-redirects-off" |> ignore
+    let path = Path.Combine(scenarioTempPath "i001248-redirects-off")
+    let configPath = Path.Combine(path, "MyClassLibrary", "MyClassLibrary2", "app.config")
+
+    let ``FSharp.Core`` = """<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />"""
+    let AlphaFS = """<assemblyIdentity name="AlphaFS" publicKeyToken="4d31a58f7d7ad5c9" culture="neutral" />"""
+    let ``Newtonsoft.Json`` = """<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+    let ``Newtonsoft.Json.Schema`` = """<assemblyIdentity name="Newtonsoft.Json.Schema" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+
+    let config = File.ReadAllText(configPath)
+
+    config |> shouldContainText ``FSharp.Core``
+    config |> shouldContainText AlphaFS
+    config.Contains ``Newtonsoft.Json`` |> shouldEqual false
+    config.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary.sln
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{673951A0-5216-4FBD-BA08-7FA057D5CC0D}"
+	ProjectSection(SolutionItems) = preProject
+		..\paket.dependencies = ..\paket.dependencies
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyClassLibrary", "MyClassLibrary\MyClassLibrary.csproj", "{CD678800-8DFC-4BB1-911A-7234F492EA29}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/Class1.cs
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CD678800-8DFC-4BB1-911A-7234F492EA29}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MyClassLibrary</RootNamespace>
+    <AssemblyName>MyClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net35\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net45\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net40\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net451\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/Properties/AssemblyInfo.cs
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MyClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MyClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cd678800-8dfc-4bb1-911a-7234f492ea29")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/app.config
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/paket.references
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/paket.references
@@ -1,0 +1,2 @@
+FSharp.Core
+Newtonsoft.Json.Schema

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/Class1.cs
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/MyClassLibrary.csprojtemplate
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/MyClassLibrary.csprojtemplate
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CD678800-8DFC-4BB1-911A-7234F492EA29}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MyClassLibrary</RootNamespace>
+    <AssemblyName>MyClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net35\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net45\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net40\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="AlphaFS">
+          <HintPath>..\..\packages\AlphaFS\lib\net451\AlphaFS.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Transactions">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/Properties/AssemblyInfo.cs
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MyClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MyClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cd678800-8dfc-4bb1-911a-7234f492ea29")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/app.config
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/paket.references
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary2/paket.references
@@ -1,0 +1,5 @@
+FSharp.Core
+Newtonsoft.Json.Schema
+
+group Second
+	AlphaFS

--- a/integrationtests/scenarios/i001248-redirects-off/before/paket.dependencies
+++ b/integrationtests/scenarios/i001248-redirects-off/before/paket.dependencies
@@ -1,0 +1,9 @@
+source https://www.nuget.org/api/v2/
+redirects: off
+nuget FSharp.Core redirects: force
+nuget Newtonsoft.Json 7.0.1
+nuget Newtonsoft.Json.Schema 1.0.11
+
+group Second
+source https://www.nuget.org/api/v2/
+nuget AlphaFS redirects: force

--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -129,7 +129,8 @@ let private applyBindingRedirects isFirstGroup cleanBindingRedirects bindingRedi
         with
         | exn -> failwithf "Parsing of %s failed.%s%s" configFilePath Environment.NewLine exn.Message
 
-    let original = config.ToString(SaveOptions.None).Replace("\r","").Replace("\n","")
+    use originalContents = new StringReader(config.ToString())
+    let original = XDocument.Load(originalContents, LoadOptions.None).ToString()
 
     let isMarked e =
         match tryGetElement (Some bindingNs) "Paket" e with
@@ -146,7 +147,8 @@ let private applyBindingRedirects isFirstGroup cleanBindingRedirects bindingRedi
 
     let config = Seq.fold setRedirect config bindingRedirects
     indentAssemblyBindings config
-    let newText = config.ToString(SaveOptions.None).Replace("\r","").Replace("\n","")
+    use newContents = new StringReader(config.ToString())
+    let newText = XDocument.Load(newContents, LoadOptions.None).ToString()
     if newText <> original then
         config.Save(configFilePath, SaveOptions.DisableFormatting)
 

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -13,13 +13,13 @@ open Paket.PackageSources
 /// [omit]
 type InstallOptions = 
     { Strict : bool 
-      Redirects : bool
+      Redirects : bool option
       ResolverStrategy : ResolverStrategy option
       Settings : InstallSettings }
 
     static member Default = { 
         Strict = false
-        Redirects = false
+        Redirects = None
         ResolverStrategy = None
         Settings = InstallSettings.Default }
 
@@ -45,7 +45,7 @@ type DependenciesGroup = {
         member this.CombineWith (other:DependenciesGroup) =
             { Name = this.Name
               Options = 
-                { Redirects = this.Options.Redirects || other.Options.Redirects
+                { Redirects = this.Options.Redirects ++ other.Options.Redirects
                   Settings = this.Options.Settings + other.Options.Settings
                   Strict = this.Options.Strict || other.Options.Strict
                   ResolverStrategy = this.Options.ResolverStrategy ++ other.Options.ResolverStrategy }
@@ -292,7 +292,7 @@ module DependenciesFileParser =
     let private parseOptions current options =
         match options with 
         | ReferencesMode mode -> { current.Options with Strict = mode } 
-        | Redirects mode -> { current.Options with Redirects = mode }
+        | Redirects mode -> { current.Options with Redirects = if mode then Some true else None }
         | ResolverStrategy strategy -> { current.Options with ResolverStrategy = strategy }
         | CopyLocal mode -> { current.Options with Settings = { current.Options.Settings with CopyLocal = Some mode } }
         | ImportTargets mode -> { current.Options with Settings = { current.Options.Settings with ImportTargets = Some mode } }

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -394,7 +394,7 @@ let InstallIntoProjects(options : InstallerOptions, dependenciesFile, lockFile :
                     |> Option.bind (fun p -> p.Settings.CreateBindingRedirects)
 
                 (snd kv.Value,packageRedirects))
-            |> applyBindingRedirects loadedLibs !first options.CreateNewBindingFiles options.Hard (options.Redirects || g.Value.Options.Redirects) (FileInfo project.FileName).Directory.FullName g.Key lockFile.GetAllDependenciesOf
+            |> applyBindingRedirects loadedLibs !first options.CreateNewBindingFiles options.Hard (defaultArg g.Value.Options.Redirects options.Redirects) (FileInfo project.FileName).Directory.FullName g.Key lockFile.GetAllDependenciesOf
             first := false
 
 /// Installs all packages from the lock file.

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -22,7 +22,10 @@ module LockFileSerializer =
     /// [omit]
     let serializeOptionsAsLines options = [
         if options.Strict then yield "REFERENCES: STRICT"
-        if options.Redirects = Some true then yield "REDIRECTS: ON"
+        match options.Redirects with
+        | Some true -> yield "REDIRECTS: ON"
+        | Some false -> yield "REDIRECTS: OFF"
+        | None -> ()
         match options.ResolverStrategy with
         | Some ResolverStrategy.Min -> yield "STRATEGY: MIN"
         | Some ResolverStrategy.Max -> yield "STRATEGY: MAX"

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -22,7 +22,7 @@ module LockFileSerializer =
     /// [omit]
     let serializeOptionsAsLines options = [
         if options.Strict then yield "REFERENCES: STRICT"
-        if options.Redirects then yield "REDIRECTS: ON"
+        if options.Redirects = Some true then yield "REDIRECTS: ON"
         match options.ResolverStrategy with
         | Some ResolverStrategy.Min -> yield "STRATEGY: MIN"
         | Some ResolverStrategy.Max -> yield "STRATEGY: MAX"
@@ -228,7 +228,7 @@ module LockFileParser =
     let private extractOption currentGroup option =
         match option with
         | ReferencesMode mode -> { currentGroup.Options with Strict = mode }
-        | Redirects mode -> { currentGroup.Options with Redirects = mode }
+        | Redirects mode -> { currentGroup.Options with Redirects = if mode then Some true else None }
         | ImportTargets mode -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with ImportTargets = Some mode } } 
         | CopyLocal mode -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with CopyLocal = Some mode }}
         | FrameworkRestrictions r -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with FrameworkRestrictions = r }}

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -164,7 +164,7 @@ nuget "FAKE" "~> 3.0"
 let ``should read config with no redirects``() = 
     let cfg = DependenciesFile.FromCode(noRedirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual None
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some false)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NugetSource "http://nuget.org/api/v2"]
 
@@ -1011,7 +1011,7 @@ redirects off
     cfg.Groups.[Constants.MainDependencyGroup].Packages.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Force)
     cfg.Groups.[Constants.MainDependencyGroup].Packages.Tail.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual None
 
-    cfg.Groups.[GroupName "Build"].Options.Redirects |> shouldEqual None
+    cfg.Groups.[GroupName "Build"].Options.Redirects |> shouldEqual (Some false)
     cfg.Groups.[GroupName "Build"].Packages.Head.Settings.CreateBindingRedirects |> shouldEqual (Some On)
     cfg.Groups.[GroupName "Build"].Packages.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Force)
     cfg.Groups.[GroupName "Build"].Packages.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Off)

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -134,7 +134,7 @@ nuget "FAKE" "~> 3.0"
 let ``should read strict config``() = 
     let cfg = DependenciesFile.FromCode(strictConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual true
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual false
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual None
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NugetSource "http://nuget.org/api/v2"]
 
@@ -149,7 +149,7 @@ nuget "FAKE" "~> 3.0"
 let ``should read config with redirects``() = 
     let cfg = DependenciesFile.FromCode(redirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual true
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some true)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NugetSource "http://nuget.org/api/v2"]
 
@@ -164,7 +164,7 @@ nuget "FAKE" "~> 3.0"
 let ``should read config with no redirects``() = 
     let cfg = DependenciesFile.FromCode(noRedirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual false
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual None
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NugetSource "http://nuget.org/api/v2"]
 
@@ -1004,14 +1004,14 @@ redirects off
 
     let cfg = DependenciesFile.FromCode(config)
 
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual true
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some true)
 
     cfg.Groups.[Constants.MainDependencyGroup].Packages.Head.Settings.CreateBindingRedirects |> shouldEqual (Some On)
     cfg.Groups.[Constants.MainDependencyGroup].Packages.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Off)
     cfg.Groups.[Constants.MainDependencyGroup].Packages.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Force)
     cfg.Groups.[Constants.MainDependencyGroup].Packages.Tail.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual None
 
-    cfg.Groups.[GroupName "Build"].Options.Redirects |> shouldEqual false
+    cfg.Groups.[GroupName "Build"].Options.Redirects |> shouldEqual None
     cfg.Groups.[GroupName "Build"].Packages.Head.Settings.CreateBindingRedirects |> shouldEqual (Some On)
     cfg.Groups.[GroupName "Build"].Packages.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Force)
     cfg.Groups.[GroupName "Build"].Packages.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Off)

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -114,20 +114,45 @@ NUGET
   remote: "D:\code\temp with space"
   specs:
     Castle.Windsor (2.1)
+
+GROUP Test
+NUGET
+  remote: "D:\code\temp with space"
+  specs:
+    xUnit (2.0.0)
+
+GROUP Build
+REDIRECTS: OFF
+NUGET
+  remote: "D:\code\temp with space"
+  specs:
+    FAKE (4.0.0)
 """   
 
 [<Test>]
 let ``should parse redirects lock file``() = 
-    let lockFile = LockFileParser.Parse(toLines redirectsLockFile) |> List.head
-    let packages = List.rev lockFile.Packages
-    
-    packages.Length |> shouldEqual 1
-    lockFile.Options.Strict |> shouldEqual false
-    lockFile.Options.Redirects |> shouldEqual (Some true)
-    lockFile.Options.Settings.ImportTargets |> shouldEqual (Some true)
-    lockFile.Options.Settings.CopyLocal |> shouldEqual (Some true)
+    let lockFile = LockFileParser.Parse(toLines redirectsLockFile)
 
-    packages.Head.Source |> shouldEqual (PackageSource.LocalNuget("D:\code\\temp with space"))
+    let main = lockFile.Tail.Tail.Head
+    main.Packages.Length |> shouldEqual 1
+    main.Options.Strict |> shouldEqual false
+    main.Options.Redirects |> shouldEqual (Some true)
+    main.Options.Settings.ImportTargets |> shouldEqual (Some true)
+    main.Options.Settings.CopyLocal |> shouldEqual (Some true)
+
+    let test = lockFile.Tail.Head
+    test.Packages.Length |> shouldEqual 1
+    test.Options.Strict |> shouldEqual false
+    test.Options.Redirects |> shouldEqual None
+    test.Options.Settings.ImportTargets |> shouldEqual None
+    test.Options.Settings.CopyLocal |> shouldEqual None
+
+    let build = lockFile.Head
+    build.Packages.Length |> shouldEqual 1
+    build.Options.Strict |> shouldEqual false
+    build.Options.Redirects |> shouldEqual (Some false)
+    build.Options.Settings.ImportTargets |> shouldEqual None
+    build.Options.Settings.CopyLocal |> shouldEqual None
 
 let lockFileWithFrameworkRestrictions = """FRAMEWORK: >= NET45
 IMPORT-TARGETS: TRUE

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -656,12 +656,19 @@ NUGET
   remote: "D:\code\temp with space"
   specs:
     FAKE (4.0) - redirects: on
+
+GROUP Test
+REDIRECTS: OFF
+NUGET
+  remote: "D:\code\temp with space"
+  specs:
+    xUnit (2.0.0)
 """
 
 [<Test>]
-let ``should parse and serialize redirects lock file``() = 
+let ``should parse redirects lock file and packages``() = 
     let lockFile = LockFileParser.Parse(toLines packageRedirectsLockFile)
-    let main = lockFile.Tail.Head
+    let main = lockFile.Tail.Tail.Head
     let packages = List.rev main.Packages
     
     packages.Length |> shouldEqual 4
@@ -672,13 +679,21 @@ let ``should parse and serialize redirects lock file``() =
     packages.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Off)
     packages.Tail.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some Force)
     
-    let build = lockFile.Head
+    let build = lockFile.Tail.Head
     let packages = List.rev build.Packages
     
     packages.Length |> shouldEqual 1
     build.Options.Redirects |> shouldEqual None
 
     packages.Head.Settings.CreateBindingRedirects |> shouldEqual (Some On)
+
+    let test = lockFile.Head
+    let packages = List.rev test.Packages
+    
+    packages.Length |> shouldEqual 1
+    test.Options.Redirects |> shouldEqual (Some false)
+
+    packages.Head.Settings.CreateBindingRedirects |> shouldEqual None
 
 [<Test>]
 let ``should parse and serialise redirects lockfile``() =

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -98,7 +98,7 @@ let ``should parse strict lock file``() =
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 6
     lockFile.Options.Strict |> shouldEqual true
-    lockFile.Options.Redirects |> shouldEqual false
+    lockFile.Options.Redirects |> shouldEqual None
     lockFile.Options.Settings.ImportTargets |> shouldEqual (Some false)
     lockFile.Options.Settings.CopyLocal |> shouldEqual None
 
@@ -123,7 +123,7 @@ let ``should parse redirects lock file``() =
     
     packages.Length |> shouldEqual 1
     lockFile.Options.Strict |> shouldEqual false
-    lockFile.Options.Redirects |> shouldEqual true
+    lockFile.Options.Redirects |> shouldEqual (Some true)
     lockFile.Options.Settings.ImportTargets |> shouldEqual (Some true)
     lockFile.Options.Settings.CopyLocal |> shouldEqual (Some true)
 
@@ -143,7 +143,7 @@ let ``should parse lock file with framework restrictions``() =
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 1
     lockFile.Options.Strict |> shouldEqual false
-    lockFile.Options.Redirects |> shouldEqual false
+    lockFile.Options.Redirects |> shouldEqual None
     lockFile.Options.Settings.ImportTargets |> shouldEqual (Some true)
     lockFile.Options.Settings.CopyLocal |> shouldEqual None
 
@@ -544,7 +544,7 @@ let ``should parse lock file with groups``() =
     
     packages1.Length |> shouldEqual 1
     lockFile1.Options.Strict |> shouldEqual false
-    lockFile1.Options.Redirects |> shouldEqual true
+    lockFile1.Options.Redirects |> shouldEqual (Some true)
     lockFile1.Options.Settings.ImportTargets |> shouldEqual (Some true)
     lockFile1.Options.Settings.CopyLocal |> shouldEqual (Some true)
     lockFile1.Options.Settings.ReferenceCondition |> shouldEqual None
@@ -558,7 +558,7 @@ let ``should parse lock file with groups``() =
     
     packages2.Length |> shouldEqual 1
     lockFile2.Options.Strict |> shouldEqual false
-    lockFile2.Options.Redirects |> shouldEqual true
+    lockFile2.Options.Redirects |> shouldEqual (Some true)
     lockFile2.Options.Settings.ImportTargets |> shouldEqual None
     lockFile2.Options.Settings.CopyLocal |> shouldEqual (Some true)
     lockFile2.Options.Settings.ReferenceCondition |> shouldEqual (Some "LEGACY")
@@ -640,7 +640,7 @@ let ``should parse and serialize redirects lock file``() =
     let packages = List.rev main.Packages
     
     packages.Length |> shouldEqual 4
-    main.Options.Redirects |> shouldEqual true
+    main.Options.Redirects |> shouldEqual (Some true)
 
     packages.Head.Settings.CreateBindingRedirects |> shouldEqual None
     packages.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some On)
@@ -651,7 +651,7 @@ let ``should parse and serialize redirects lock file``() =
     let packages = List.rev build.Packages
     
     packages.Length |> shouldEqual 1
-    build.Options.Redirects |> shouldEqual false
+    build.Options.Redirects |> shouldEqual None
 
     packages.Head.Settings.CreateBindingRedirects |> shouldEqual (Some On)
 


### PR DESCRIPTION
This PR makes `redirects: off` skip binding redirects completely, regardless the packages instruct otherwise as discussed in #1248.

It'll skip even when a package has a `redirects: forced`.
