### PR TITLE
NuGetV2.DownloadPackage: Add support for relative src link to package content

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -469,7 +469,16 @@ let DownloadPackage(root, auth, (source : PackageSource), groupName, packageName
                 verbosefn "  to %s" targetFileName
                 let! license = Async.StartChild(DownloadLicense(root,force,packageName,version,nugetPackage.LicenseUrl,licenseFileName), 5000)
 
-                let request = HttpWebRequest.Create(Uri nugetPackage.DownloadUrl) :?> HttpWebRequest
+                let downloadUri = 
+                    if Uri.IsWellFormedUriString(nugetPackage.DownloadUrl, UriKind.Absolute) then
+                        Uri nugetPackage.DownloadUrl
+                    else
+                        let sourceUrl =
+                            if nugetPackage.SourceUrl.EndsWith("/") then nugetPackage.SourceUrl
+                            else nugetPackage.SourceUrl + "/"
+                        Uri(Uri sourceUrl,  nugetPackage.DownloadUrl)
+
+                let request = HttpWebRequest.Create(downloadUri) :?> HttpWebRequest
                 request.AutomaticDecompression <- DecompressionMethods.GZip ||| DecompressionMethods.Deflate
                 request.UserAgent <- "Paket"
 


### PR DESCRIPTION
Given that the nuget package feed result of a specific package defines the content of the package with a relative link (for example <content type="application/zip" src="Packages(Id='PackageName',Version='1.0.0.0')/$value" /> )
When NuGetV2.DownloadPackage creates the WebRequest to download the package contetns
Then it should add the SourceUrl as the base address for the download Uri.