### PR TITLE
Only check PackageDetails for Sources that have versions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,20 +1,11 @@
-#### 2.36.7 - 19.12.2015
+#### 2.37.0-alpha001 - 19.12.2015
+* Paket checks PackageDetails only for sources that responded with versions for a package - https://github.com/fsprojects/Paket/issues/1317
 * Implemented support for specifying per-template versions in paket pack - https://github.com/fsprojects/Paket/pull/1314
- 
-#### 2.36.6 - 15.12.2015
 * Added support for relative src link to package content - https://github.com/fsprojects/Paket/pull/1311
-
-#### 2.36.5 - 14.12.2015
 * BUGFIX: Fix NullReferenceException - https://github.com/fsprojects/Paket/issues/1307
-
-#### 2.36.3 - 14.12.2015
-* COSMETICS: No need to show cache warnings
-
-#### 2.36.2 - 13.12.2015
 * BUGFIX: NuGet packages with FrameworkAssembly nodes did not work - https://github.com/fsprojects/Paket/issues/1306
-
-#### 2.36.1 - 12.12.2015
 * Paket install did an unnecessary update when framework restriction were present - https://github.com/fsprojects/Paket/issues/1305
+* COSMETICS: No need to show cache warnings
 
 #### 2.36.0 - 10.12.2015
 * Getting assembly metadata without loading the assembly - https://github.com/fsprojects/Paket/pull/1293

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 2.37.0-alpha001 - 19.12.2015
+#### 2.37.0-alpha002 - 20.12.2015
 * Paket checks PackageDetails only for sources that responded with versions for a package - https://github.com/fsprojects/Paket/issues/1317
 * Implemented support for specifying per-template versions in paket pack - https://github.com/fsprojects/Paket/pull/1314
 * Added support for relative src link to package content - https://github.com/fsprojects/Paket/pull/1311

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 2.37.0-alpha002 - 20.12.2015
+#### 2.37.0-alpha003 - 20.12.2015
 * Paket checks PackageDetails only for sources that responded with versions for a package - https://github.com/fsprojects/Paket/issues/1317
 * Implemented support for specifying per-template versions in paket pack - https://github.com/fsprojects/Paket/pull/1314
 * Added support for relative src link to package content - https://github.com/fsprojects/Paket/pull/1311

--- a/paket.lock
+++ b/paket.lock
@@ -9,7 +9,7 @@ NUGET
 GITHUB
   remote: fsharp/FAKE
   specs:
-    src/app/FakeLib/Globbing/Globbing.fs (25ca24118d3b0f7b51d5c72e6895b27329683b59)
+    src/app/FakeLib/Globbing/Globbing.fs (821e264e79dbe73a5e67f00defd60265646b37b9)
   remote: fsharp/FSharp.Data
   specs:
     src/CommonProviderImplementation/AssemblyReader.fs (2d3d68b59864a4e0db2b264314871522e1bf7fa3)
@@ -17,14 +17,14 @@ GROUP Build
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    FAKE (4.10.5)
+    FAKE (4.11.0)
     FSharp.Compiler.Service (1.4.0.6)
     FSharp.Formatting (2.12.0)
       FSharp.Compiler.Service (1.4.0.6)
       FSharpVSPowerTools.Core (2.1.0)
     FSharpVSPowerTools.Core (2.1.0)
       FSharp.Compiler.Service (>= 1.4.0.6)
-    ILRepack (2.0.8)
+    ILRepack (2.0.9)
     Microsoft.Bcl (1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21) - import_targets: false
@@ -36,7 +36,7 @@ NUGET
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (25ca24118d3b0f7b51d5c72e6895b27329683b59)
+    modules/Octokit/Octokit.fsx (821e264e79dbe73a5e67f00defd60265646b37b9)
       Octokit
 GROUP Test
 NUGET

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 [assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")]
 [assembly: AssemblyVersionAttribute("2.37.0")]
 [assembly: AssemblyFileVersionAttribute("2.37.0")]
-[assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")]
+[assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha003")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const string Version = "2.37.0";

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 [assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")]
 [assembly: AssemblyVersionAttribute("2.37.0")]
 [assembly: AssemblyFileVersionAttribute("2.37.0")]
-[assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")]
+[assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const string Version = "2.37.0";

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -4,11 +4,11 @@ using System.Reflection;
 [assembly: AssemblyTitleAttribute("Paket.Bootstrapper")]
 [assembly: AssemblyProductAttribute("Paket")]
 [assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")]
-[assembly: AssemblyVersionAttribute("2.36.7")]
-[assembly: AssemblyFileVersionAttribute("2.36.7")]
-[assembly: AssemblyInformationalVersionAttribute("2.36.7")]
+[assembly: AssemblyVersionAttribute("2.37.0")]
+[assembly: AssemblyFileVersionAttribute("2.37.0")]
+[assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")]
 namespace System {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.36.7";
+        internal const string Version = "2.37.0";
     }
 }

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
 [<assembly: AssemblyVersionAttribute("2.37.0")>]
 [<assembly: AssemblyFileVersionAttribute("2.37.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha003")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.36.7")>]
-[<assembly: AssemblyFileVersionAttribute("2.36.7")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.36.7")>]
+[<assembly: AssemblyVersionAttribute("2.37.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.37.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.36.7"
+    let [<Literal>] Version = "2.37.0"

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
 [<assembly: AssemblyVersionAttribute("2.37.0")>]
 [<assembly: AssemblyFileVersionAttribute("2.37.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -162,5 +162,5 @@ let findRemoteFileChangesInDependenciesFile(dependenciesFile:DependenciesFile,lo
 
 let GetPreferredNuGetVersions (oldLockFile:LockFile) =
     oldLockFile.GetGroupedResolution()
-    |> Seq.map (fun kv -> kv.Key, kv.Value.Version)
+    |> Seq.map (fun kv -> kv.Key, (kv.Value.Version, kv.Value.Source))
     |> Map.ofSeq

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -85,19 +85,19 @@ let tryGetPackageVersionsViaJson (auth, nugetURL, package:PackageName) =
             with _ -> return None
     }
 
-let tryNuGetV3 (auth, nugetV3Url, package:PackageName) = 
+let tryNuGetV3 (source, auth, nugetV3Url, package:PackageName) = 
     async { 
         try 
             let! data = NuGetV3.findVersionsForPackage(nugetV3Url, auth, package)
             match data with
-            | Some data -> return Some data
+            | Some data -> return Some (source,data)
             | _ -> return None
         with exn -> return None
     }
 
 
 /// Gets versions of the given package from local Nuget feed.
-let getAllVersionsFromLocalPath (localNugetPath, package:PackageName, root) =
+let getAllVersionsFromLocalPath (source, localNugetPath, package:PackageName, root) =
     async {
         let localNugetPath = Utils.normalizeLocalPath localNugetPath
         let di = getDirectoryInfo localNugetPath root
@@ -111,7 +111,7 @@ let getAllVersionsFromLocalPath (localNugetPath, package:PackageName, root) =
                             let _match = Regex(sprintf @"^%O\.(\d.*)\.nupkg" package, RegexOptions.IgnoreCase).Match(fi.Name)
                             if _match.Groups.Count > 1 then Some _match.Groups.[1].Value else None)
             |> Seq.toArray
-        return Some versions
+        return Some(source,versions)
     }
 
 
@@ -607,7 +607,7 @@ let GetPackageDetails root force sources packageName (version:SemVerInfo) : Pack
 
 let protocolCache = System.Collections.Concurrent.ConcurrentDictionary<_,_>()
 
-let getVersionsCached key f (auth, nugetURL, package) =
+let getVersionsCached key f (source, auth, nugetURL, package) =
     async {
         match protocolCache.TryGetValue((auth, nugetURL)) with
         | true, v when v <> key -> return None
@@ -616,7 +616,7 @@ let getVersionsCached key f (auth, nugetURL, package) =
             match result with
             | Some x ->
                 protocolCache.TryAdd((auth, nugetURL), key) |> ignore
-                return Some x
+                return Some (source, x)
             | _ -> return None
     }
 
@@ -624,19 +624,20 @@ let getVersionsCached key f (auth, nugetURL, package) =
 let GetVersions root (sources, packageName:PackageName) = 
     let getVersions() =
         sources
-        |> Seq.map (function
+        |> Seq.map (fun nugetSource -> 
+                   match nugetSource with
                    | Nuget source -> 
                         let auth = source.Authentication |> Option.map toBasicAuth
                         let v3Feeds = 
                             match NuGetV3.getAllVersionsAPI(source.Authentication,source.Url) with
                             | None -> []
-                            | Some v3Url -> [ tryNuGetV3 (auth, v3Url, packageName) ]
+                            | Some v3Url -> [ tryNuGetV3 (nugetSource, auth, v3Url, packageName) ]
 
                         let v2Feeds =
-                            [ yield getVersionsCached "OData" tryGetPackageVersionsViaOData (auth, source.Url, packageName)
-                              yield getVersionsCached "ODataWithFilter" tryGetAllVersionsFromNugetODataWithFilter (auth, source.Url, packageName)
+                            [ yield getVersionsCached "OData" tryGetPackageVersionsViaOData (nugetSource, auth, source.Url, packageName)
+                              yield getVersionsCached "ODataWithFilter" tryGetAllVersionsFromNugetODataWithFilter (nugetSource, auth, source.Url, packageName)
                               if not (source.Url.ToLower().Contains "teamcity" || source.Url.ToLower().Contains "feedservice.svc") then
-                                yield getVersionsCached "Json" tryGetPackageVersionsViaJson (auth, source.Url, packageName)
+                                yield getVersionsCached "Json" tryGetPackageVersionsViaJson (nugetSource, auth, source.Url, packageName)
                               ]
 
                         v2Feeds @ v3Feeds
@@ -645,18 +646,20 @@ let GetVersions root (sources, packageName:PackageName) =
                             async {
                                 let! autoCompleteUrl = PackageSources.getNugetV3Resource source AllVersionsAPI
                                 return!
-                                    tryNuGetV3 (source.Authentication |> Option.map toBasicAuth, 
+                                    tryNuGetV3 (nugetSource, 
+                                                source.Authentication |> Option.map toBasicAuth, 
                                                 autoCompleteUrl,
                                                 packageName)
                             }
                         
                         [ resp ]
-                   | LocalNuget path -> [ getAllVersionsFromLocalPath (path, packageName, root) ])
+                   | LocalNuget path -> [ getAllVersionsFromLocalPath (nugetSource, path, packageName, root) ])
         |> Seq.toArray
         |> Array.map Async.Choice
         |> Async.Parallel
         |> Async.RunSynchronously
         |> Array.choose id
+        |> Array.map (fun (s,versions) -> versions |> Array.map (fun v -> v,s))
         |> Array.concat
 
     let versions = 
@@ -666,4 +669,5 @@ let GetVersions root (sources, packageName:PackageName) =
 
     versions
     |> Seq.toList
-    |> List.map SemVer.Parse
+    |> List.groupBy fst
+    |> List.map (fun (v,s) -> SemVer.Parse v,s |> List.map snd)

--- a/src/Paket.PowerShell/AssemblyInfo.fs
+++ b/src/Paket.PowerShell/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
 [<assembly: AssemblyVersionAttribute("2.37.0")>]
 [<assembly: AssemblyFileVersionAttribute("2.37.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha003")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Paket.PowerShell/AssemblyInfo.fs
+++ b/src/Paket.PowerShell/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.36.7")>]
-[<assembly: AssemblyFileVersionAttribute("2.36.7")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.36.7")>]
+[<assembly: AssemblyVersionAttribute("2.37.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.37.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.36.7"
+    let [<Literal>] Version = "2.37.0"

--- a/src/Paket.PowerShell/AssemblyInfo.fs
+++ b/src/Paket.PowerShell/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
 [<assembly: AssemblyVersionAttribute("2.37.0")>]
 [<assembly: AssemblyFileVersionAttribute("2.37.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
 [<assembly: AssemblyVersionAttribute("2.37.0")>]
 [<assembly: AssemblyFileVersionAttribute("2.37.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha003")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.36.7")>]
-[<assembly: AssemblyFileVersionAttribute("2.36.7")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.36.7")>]
+[<assembly: AssemblyVersionAttribute("2.37.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.37.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.36.7"
+    let [<Literal>] Version = "2.37.0"

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
 [<assembly: AssemblyVersionAttribute("2.37.0")>]
 [<assembly: AssemblyFileVersionAttribute("2.37.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha001")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.37.0-alpha002")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -37,7 +37,7 @@
     <StartArguments>update group Build</StartArguments>
     <StartArguments>pack output D:\code\paketbug\output</StartArguments>
     <StartArguments>install</StartArguments>
-    <StartArguments>restore</StartArguments>
+    <StartArguments>install</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>c:\code\Paketkopie</StartWorkingDirectory>
@@ -46,7 +46,7 @@
     <StartWorkingDirectory>d:\code\paketbug</StartWorkingDirectory>
     <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001270-net461\temp</StartWorkingDirectory>
-    <StartWorkingDirectory>C:\code\restore</StartWorkingDirectory>
+    <StartWorkingDirectory>C:\code\paketkopie</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
@@ -113,6 +113,7 @@ nuget NUnit"""
     
     newDependencies
     |> Map.filter (fun k v -> not <| changedDependencies.Contains(k))
+    |> Map.map (fun k (v,_) -> v)
     |> shouldEqual expected
 
 [<Test>]
@@ -159,6 +160,7 @@ nuget Castle.Windsor-log4net >= 3.3.0"""
     
     newDependencies
     |> Map.filter (fun k v -> not <| changedDependencies.Contains(k))
+    |> Map.map (fun k (v,_) -> v)
     |> shouldEqual expected
 
 [<Test>]

--- a/tests/Paket.Tests/TestHelpers.fs
+++ b/tests/Paket.Tests/TestHelpers.fs
@@ -29,6 +29,7 @@ let VersionsFromGraph (graph : seq<string * string * (string * VersionRequiremen
         |> Seq.filter (fun (p, _, _) -> (PackageName p) = packageName)
         |> Seq.map (fun (_, v, _) -> SemVer.Parse v)
         |> Seq.toList
+        |> List.map (fun v -> v,sources)
 
     match resolverStrategy with
     | ResolverStrategy.Max -> List.sortDescending versions


### PR DESCRIPTION
Currently we check all configured feeds for NuGet package details even if the feed didn't respond with the version when we asked for "GetAllVersions". This makes way to many calls - see #1317