### PR TITLE
a couple of tests to discuss the behavior for http file protocol, as issued in #1313

### DIFF
--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -374,6 +374,45 @@ let ``should read http source file from config without quotes with file specs``(
             Commit = Some "/raw/1M/1"
             AuthKey = None } ]
 
+[<Test>]
+let ``should read http source with file protocol and interpret three slashes as localhost`` () =
+    let config = """http file:///absolute/path/to/file1.dll"""
+    let dependencies = DependenciesFile.FromCode(config)
+    dependencies.Groups.[Constants.MainDependencyGroup].RemoteFiles
+    |> shouldEqual
+        [ { Owner = "localhost"
+            Project = ""
+            Name = "file1.dll"
+            Origin = ModuleResolver.SingleSourceFileOrigin.HttpLink "file://localhost"
+            Commit = Some "/absolute/path/to/"
+            AuthKey = None } ]
+
+[<Test>]
+let ``should read http source with file protocol and file specs`` () =
+    let config = """http file://localhost/absolute/path/to/file1.dll file1/file1.dll"""
+    let dependencies = DependenciesFile.FromCode(config)
+    dependencies.Groups.[Constants.MainDependencyGroup].RemoteFiles
+    |> shouldEqual
+        [ { Owner = "localhost"
+            Project = ""
+            Name = "file1/file1.dll"
+            Origin = ModuleResolver.SingleSourceFileOrigin.HttpLink "file://localhost"
+            Commit = Some "/absolute/path/to/"
+            AuthKey = None } ]  
+            
+[<Test>]     
+let ``should read http source with file protocol and absolute windows paths`` () =
+    let config = """http file://localhost/C:/absolute/path/to/file1.dll"""
+    let dependencies = DependenciesFile.FromCode(config)
+    dependencies.Groups.[Constants.MainDependencyGroup].RemoteFiles
+    |> shouldEqual
+        [ { Owner = "localhost"
+            Project = ""
+            Name = "file1.dll"
+            Origin = ModuleResolver.SingleSourceFileOrigin.HttpLink "file://localhost"
+            Commit = Some "/C:/absolute/path/to/"
+            AuthKey = None } ]  
+
 
 [<Test>]
 let ``should read http source file from config without quotes with file specs and project and query string after filename``() =

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -271,6 +271,38 @@ let ``should generate lock file for http source files``() =
     |> LockFileSerializer.serializeSourceFiles
     |> shouldEqual (normalizeLineEndings expectedWithHttp)
 
+let expectedWithHttpFileProtocol = """HTTP
+  remote: file://localhost
+  specs:
+    file1.dll (/absolute/path/to/file1.dll)"""
+
+[<Test>]
+let ``should generate lock file for http source files with file protocol``() =
+    let config = """http file://localhost/absolute/path/to/file1.dll"""
+
+    let cfg = DependenciesFile.FromCode(config)
+    
+    cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
+    |> List.map trivialResolve
+    |> LockFileSerializer.serializeSourceFiles
+    |> shouldEqual (normalizeLineEndings expectedWithHttpFileProtocol)
+
+let expectedWithHttpFileProtocolWindowsPath = """HTTP
+  remote: file://localhost
+  specs:
+    file1.dll (/C:/absolute/path/to/file1.dll)"""
+
+[<Test>]
+let ``should generate lock file for http source files with file protocol and absolute windows path``() =
+    let config = """http file://localhost/C:/absolute/path/to/file1.dll"""
+
+    let cfg = DependenciesFile.FromCode(config)
+    
+    cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
+    |> List.map trivialResolve
+    |> LockFileSerializer.serializeSourceFiles
+    |> shouldEqual (normalizeLineEndings expectedWithHttpFileProtocolWindowsPath)
+
 let expectedMultiple = """HTTP
   remote: http://www.fssnip.net
   specs:

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -401,6 +401,20 @@ let ``should parse simple http reference``() =
     references.[0].Name |> shouldEqual "ikvmbin-8.0.5449.0.zip"  
     references.[0].Origin |> shouldEqual (SingleSourceFileOrigin.HttpLink("http://www.frijters.net/ikvmbin-8.0.5449.0.zip"))
 
+let httpWithFileProtocol =  """
+HTTP
+  remote: file://localhost
+  specs:
+    file1.dll (/absolute/path/to/file1.dll)
+"""
+
+[<Test>]
+let ``should parse simple http reference with file protocol``() = 
+    let lockFile = LockFileParser.Parse(toLines httpWithFileProtocol) |> List.head
+    let references = lockFile.SourceFiles
+
+    references.[0].Name |> shouldEqual "file1.dll"  
+    references.[0].Origin |> shouldEqual (SingleSourceFileOrigin.HttpLink("file://localhost"))
 
 let lockFileForStanfordNLPdotNET = """HTTP
   remote: http://www.frijters.net


### PR DESCRIPTION
The desired functionality is:

* file protocol works for http sources, i.e.:  `file://localhost/absolute/path/to/file1.txt`
* when three slashes are used `localhost` is inferred.

I am getting the following error that I have not been able to reproduce through a test: `The given path's format is not supported`. If I get some hints to create this test I may be able to fix it.
Thanks.