### PR TITLE
Cache which source contains versions in GetVersions

### DIFF
--- a/src/Paket.Core/FindOutdated.fs
+++ b/src/Paket.Core/FindOutdated.fs
@@ -27,6 +27,7 @@ let private adjustVersionRequirements strict includingPrereleases (dependenciesF
 /// Finds all outdated packages.
 let FindOutdated strict includingPrereleases environment = trial {
     let! lockFile = environment |> PaketEnv.ensureLockFileExists
+    let force = true
 
     let dependenciesFile =
         environment.DependenciesFile
@@ -36,14 +37,14 @@ let FindOutdated strict includingPrereleases environment = trial {
     let root = Path.GetDirectoryName dependenciesFile.FileName
 
     let getVersionsF sources resolverStrategy groupName packageName =
-        let versions = NuGetV2.GetVersions root (sources, packageName)
+        let versions = NuGetV2.GetVersions force root (sources, packageName)
                 
         match resolverStrategy with
         | ResolverStrategy.Max -> List.sortDescending versions
         | ResolverStrategy.Min -> List.sort versions
         |> List.toSeq
 
-    let newResolution = dependenciesFile.Resolve(true, getSha1, getVersionsF, NuGetV2.GetPackageDetails root true, dependenciesFile.Groups, PackageResolver.UpdateMode.UpdateAll)
+    let newResolution = dependenciesFile.Resolve(force, getSha1, getVersionsF, NuGetV2.GetPackageDetails root true, dependenciesFile.Groups, PackageResolver.UpdateMode.UpdateAll)
 
     let changed = 
         [for kv in lockFile.Groups do

--- a/src/Paket.Core/Nuget.fs
+++ b/src/Paket.Core/Nuget.fs
@@ -36,9 +36,10 @@ let inline normalizeUrl(url:string) = url.Replace("https","http").Replace("www."
 
 let getCacheFileName nugetURL (packageName:PackageName) (version:SemVerInfo) =
     let h = nugetURL |> normalizeUrl |> hash |> abs
-    let packageUrl = sprintf "%O.%s.s%d.json" packageName (version.Normalize()) h
+    let packageUrl = 
+        sprintf "%O.%s.s%d.json" 
+           packageName (version.Normalize()) h
     FileInfo(Path.Combine(CacheFolder,packageUrl))
-
 
 let getDetailsFromCacheOr force nugetURL (packageName:PackageName) (version:SemVerInfo) (get : unit -> NuGetPackageCache Async) : NuGetPackageCache Async = 
     let cacheFile = getCacheFileName nugetURL packageName version

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -168,7 +168,7 @@ let SelectiveUpdate(dependenciesFile : DependenciesFile, updateMode, semVerUpdat
     let getSha1 origin owner repo branch auth = RemoteDownload.getSHA1OfBranch origin owner repo branch auth |> Async.RunSynchronously
     let root = Path.GetDirectoryName dependenciesFile.FileName
     let inline getVersionsF sources resolverStrategy groupName packageName = 
-        let versions = NuGetV2.GetVersions root (sources, packageName)
+        let versions = NuGetV2.GetVersions force root (sources, packageName)
         match resolverStrategy with
         | ResolverStrategy.Max -> List.sortDescending versions
         | ResolverStrategy.Min -> List.sort versions


### PR DESCRIPTION
This is should improve the second update run since we cache if a nuget feed doesn't have versions for a given package. It should be a good alternative to #1320
/cc @ctaggart 