### PR TITLE
Reference the correct page from sidebar

### DIFF
--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -88,7 +88,7 @@
             <li><a href="@Root/resolver.html">Package resolution algorithm</a></li>
             <li><a href="@Root/groups.html">Dependency Groups</a></li>            
             <li><a href="@Root/nuget-dependencies.html">NuGet dependencies</a></li>
-            <li><a href="@Root/github-dependencies.html">Git dependencies</a></li>
+            <li><a href="@Root/git-dependencies.html">Git dependencies</a></li>
             <li><a href="@Root/github-dependencies.html">GitHub dependencies</a></li>
             <li><a href="@Root/http-dependencies.html">HTTP dependencies</a></li>
             <li><a href="@Root/analyzers.html">Analyzers</a></li>            


### PR DESCRIPTION
Currently the link leads you to GitHub dependencies docs.