### PR TITLE
WIP: Allow to build git sources and use their nupks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 3.0.0-alpha012 - 08.01.2016
+#### 3.0.0-alpha013 - 08.01.2016
 * Allow to reference git repositories - http://fsprojects.github.io/Paket/git-dependencies.html
+* Allow to run build commands on git repositories - http://fsprojects.github.io/Paket/git-dependencies.html#Running-a-build-in-git-repositories
 * Allow to use git repositories as NuGet source - http://fsprojects.github.io/Paket/git-dependencies.html#Using-Git-repositories-as-NuGet-source
 
 #### 2.41.1 - 08.01.2016

--- a/docs/content/git-dependencies.md
+++ b/docs/content/git-dependencies.md
@@ -24,6 +24,14 @@ If you want to restrict Paket to a special branch, tag or a concrete commit then
     git http://github.com/forki/AskMe.git 97ee5ae7074b // short hash
     git https://github.com/forki/FsUnit.git 1.0        // tag
 
+## Running a build in git repositories
+
+If your referenced git repository contains a build script then Paket can excute this scipt after restore:
+
+    git https://github.com/forki/nupkgtest.git build build:"build.cmd"
+
+This allows you to excute arbitray commands after restore.
+
 ## Using Git repositories as NuGet source
 
 If you have NuGet packages inside a git repository you can easily use the repository as a NuGet source from the [`paket.dependencies` file](dependencies-file.html):
@@ -42,3 +50,9 @@ The generated [`paket.lock` file](lock-file.html) will look like this:
       remote: https://github.com/forki/nupkgtest.git
       specs:
          (05366e390e7552a569f3f328a0f3094249f3b93b)
+
+It's also possible to [run build scripts](git-dependencies.html#Running-a-build-in-git-repositories) to create the NuGet packages:
+
+    git https://github.com/forki/nupkgtest.git build build:"build.cmd", Packages: /source/
+    
+    nuget Argu

--- a/integrationtests/Paket.IntegrationTests/FullGitSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/FullGitSpecs.fs
@@ -48,20 +48,26 @@ let ``#1353 should use NuGet source from git repo``() =
 
 [<Test>]
 let ``#1353 should restore NuGet source from built git repo``() = 
-    let lockFile = restore "i001353-git-build-as-source-restore"
-    let paketFilesRoot = Path.Combine(scenarioTempPath "i001353-git-build-as-source-restore","paket-files")
-    let repoDir = Path.Combine(paketFilesRoot,"github.com","nupkgtest")
-    Git.Handling.getCurrentHash repoDir |> shouldEqual (Some "2942d23fcb13a2574b635194203aed7610b21903")
+    if isMono then
+        ()
+    else
+        let lockFile = restore "i001353-git-build-as-source-restore"
+        let paketFilesRoot = Path.Combine(scenarioTempPath "i001353-git-build-as-source-restore","paket-files")
+        let repoDir = Path.Combine(paketFilesRoot,"github.com","nupkgtest")
+        Git.Handling.getCurrentHash repoDir |> shouldEqual (Some "2942d23fcb13a2574b635194203aed7610b21903")
 
-    let arguPackagesDir = Path.Combine(scenarioTempPath "i001353-git-build-as-source-restore","packages","Argu")
-    Directory.Exists arguPackagesDir |> shouldEqual true
+        let arguPackagesDir = Path.Combine(scenarioTempPath "i001353-git-build-as-source-restore","packages","Argu")
+        Directory.Exists arguPackagesDir |> shouldEqual true
 
 [<Test>]
 let ``#1353 should build NuGet source from git repo``() = 
-    let lockFile = update "i001353-git-build-as-source"
-    let paketFilesRoot = Path.Combine(FileInfo(lockFile.FileName).Directory.FullName,"paket-files")
-    let repoDir = Path.Combine(paketFilesRoot,"github.com","nupkgtest")
-    Git.Handling.getCurrentHash repoDir |> shouldEqual (Some "2942d23fcb13a2574b635194203aed7610b21903")
+    if isMono then
+        ()
+    else
+        let lockFile = update "i001353-git-build-as-source"
+        let paketFilesRoot = Path.Combine(FileInfo(lockFile.FileName).Directory.FullName,"paket-files")
+        let repoDir = Path.Combine(paketFilesRoot,"github.com","nupkgtest")
+        Git.Handling.getCurrentHash repoDir |> shouldEqual (Some "2942d23fcb13a2574b635194203aed7610b21903")
 
-    lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Argu"].Version
-    |> shouldEqual (SemVer.Parse "1.1.3")
+        lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Argu"].Version
+        |> shouldEqual (SemVer.Parse "1.1.3")

--- a/integrationtests/Paket.IntegrationTests/FullGitSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/FullGitSpecs.fs
@@ -45,3 +45,23 @@ let ``#1353 should use NuGet source from git repo``() =
 
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Argu"].Version
     |> shouldEqual (SemVer.Parse "1.1.3")
+
+[<Test>]
+let ``#1353 should restore NuGet source from built git repo``() = 
+    let lockFile = restore "i001353-git-build-as-source-restore"
+    let paketFilesRoot = Path.Combine(scenarioTempPath "i001353-git-build-as-source-restore","paket-files")
+    let repoDir = Path.Combine(paketFilesRoot,"github.com","nupkgtest")
+    Git.Handling.getCurrentHash repoDir |> shouldEqual (Some "2942d23fcb13a2574b635194203aed7610b21903")
+
+    let arguPackagesDir = Path.Combine(scenarioTempPath "i001353-git-build-as-source-restore","packages","Argu")
+    Directory.Exists arguPackagesDir |> shouldEqual true
+
+[<Test>]
+let ``#1353 should build NuGet source from git repo``() = 
+    let lockFile = update "i001353-git-build-as-source"
+    let paketFilesRoot = Path.Combine(FileInfo(lockFile.FileName).Directory.FullName,"paket-files")
+    let repoDir = Path.Combine(paketFilesRoot,"github.com","nupkgtest")
+    Git.Handling.getCurrentHash repoDir |> shouldEqual (Some "2942d23fcb13a2574b635194203aed7610b21903")
+
+    lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Argu"].Version
+    |> shouldEqual (SemVer.Parse "1.1.3")

--- a/integrationtests/Paket.IntegrationTests/PaketCoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PaketCoreSpecs.fs
@@ -25,8 +25,8 @@ let ``#1251 full installer demo``() =
         [GroupName "Main",PackageName "FAKE"
          GroupName "Main",PackageName "FSharp.Formatting"] 
 
-    let lockFile = UpdateProcess.SelectiveUpdate(dependenciesFile, PackageResolver.UpdateMode.Install, SemVerUpdateMode.NoRestriction, force)
-    let model = Paket.InstallProcess.CreateModel(Path.GetDirectoryName dependenciesFile.FileName, force, dependenciesFile, lockFile, Set.ofSeq packagesToInstall) |> Map.ofArray
+    let lockFile,_ = UpdateProcess.SelectiveUpdate(dependenciesFile, PackageResolver.UpdateMode.Install, SemVerUpdateMode.NoRestriction, force)
+    let model = Paket.InstallProcess.CreateModel(Path.GetDirectoryName dependenciesFile.FileName, force, dependenciesFile, lockFile, Set.ofSeq packagesToInstall, Map.empty) |> Map.ofArray
 
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FAKE"].Version
     |> shouldBeGreaterThan (SemVer.Parse "4")

--- a/integrationtests/scenarios/i001353-git-build-as-source-restore/before/paket.dependencies
+++ b/integrationtests/scenarios/i001353-git-build-as-source-restore/before/paket.dependencies
@@ -1,0 +1,3 @@
+git https://github.com/forki/nupkgtest.git build build:"build.cmd", Packages: /source/
+
+nuget Argu

--- a/integrationtests/scenarios/i001353-git-build-as-source-restore/before/paket.lock
+++ b/integrationtests/scenarios/i001353-git-build-as-source-restore/before/paket.lock
@@ -1,0 +1,9 @@
+NUGET
+  remote: paket-files/github.com/nupkgtest/source
+  specs:
+    Argu (1.1.3)
+GIT
+  remote: https://github.com/forki/nupkgtest.git
+  specs:
+     (2942d23fcb13a2574b635194203aed7610b21903)
+      build: build.cmd

--- a/integrationtests/scenarios/i001353-git-build-as-source/before/paket.dependencies
+++ b/integrationtests/scenarios/i001353-git-build-as-source/before/paket.dependencies
@@ -1,0 +1,3 @@
+git https://github.com/forki/nupkgtest.git build build:"build.cmd", Packages: /source/
+
+nuget Argu

--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -23,7 +23,7 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
             existingDependenciesFile
                 .Add(groupName,package,version)
 
-        let lockFile = UpdateProcess.SelectiveUpdate(dependenciesFile, PackageResolver.UpdateMode.Install, options.SemVerUpdateMode, options.Force)
+        let lockFile,updatedGroups = UpdateProcess.SelectiveUpdate(dependenciesFile, PackageResolver.UpdateMode.Install, options.SemVerUpdateMode, options.Force)
         let projects = seq { for p in ProjectFile.FindAllProjects(Path.GetDirectoryName lockFile.FileName) -> p } // lazy sequence in case no project install required
 
         dependenciesFile.Save()
@@ -31,7 +31,7 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
         addToProjectsF projects groupName package
 
         if installAfter then
-            InstallProcess.Install(options, dependenciesFile, lockFile)
+            InstallProcess.Install(options, dependenciesFile, lockFile, updatedGroups)
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, groupName, package, version, options : InstallerOptions, projectName, installAfter) =

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -565,7 +565,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
 
 
     member private this.AddFrameworkRestriction(groupName, frameworkRestrictions:FrameworkRestrictions) =
-        if frameworkRestrictions = [] then this else
+        if List.isEmpty frameworkRestrictions then this else
         let restrictionString = sprintf "framework %s" (String.Join(", ",frameworkRestrictions))
 
         let list = new System.Collections.Generic.List<_>()

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -168,6 +168,10 @@ module LockFileSerializer =
                         | Some authKey -> yield sprintf "    %s %s" path authKey
                         | None -> yield sprintf "    %s" path
 
+                    match file.Command with
+                    | None -> ()
+                    | Some command -> yield "      build: " + command
+
                     for (name,v) in file.Dependencies do
                         let versionStr = 
                             let s = v.ToString()

--- a/src/Paket.Core/ModuleResolver.fs
+++ b/src/Paket.Core/ModuleResolver.fs
@@ -95,9 +95,9 @@ let resolve getDependencies getSha1 (file : UnresolvedSource) : ResolvedSourceFi
           Project = file.Project
           Dependencies = Set.empty
           Name = file.Name
-          Command = None
-          OperatingSystemRestriction = None
-          PackagePath = None
+          Command = file.Command
+          OperatingSystemRestriction = file.OperatingSystemRestriction
+          PackagePath = file.PackagePath
           AuthKey = file.AuthKey  }
     
     let dependencies = 

--- a/src/Paket.Core/RemoteDownload.fs
+++ b/src/Paket.Core/RemoteDownload.fs
@@ -178,7 +178,7 @@ let downloadRemoteFiles(remoteFile:ResolvedSourceFile,destination) = async {
         // checkout to local folder
         if Directory.Exists repoFolder then
             Git.CommandHelper.runSimpleGitCommand repoFolder ("remote set-url origin " + cacheCloneUrl) |> ignore
-            tracefn "Fetching %s to %s" cacheCloneUrl repoFolder 
+            verbosefn "Fetching %s to %s" cacheCloneUrl repoFolder 
             Git.CommandHelper.runSimpleGitCommand repoFolder "fetch -f" |> ignore
         else
             if not <| Directory.Exists destination then

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -36,23 +36,25 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
 
     let dependenciesFile,lockFile =
         let exisitingDependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
-        if stillInstalled then exisitingDependenciesFile,oldLockFile else        
+        if stillInstalled then exisitingDependenciesFile,oldLockFile else
         let dependenciesFile = exisitingDependenciesFile.Remove(groupName,package)
         dependenciesFile.Save()
         
-        dependenciesFile,UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,SemVerUpdateMode.NoRestriction,force)
+        let lockFile,_ = UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,SemVerUpdateMode.NoRestriction,force)
+        dependenciesFile,lockFile
     
     if installAfter then
-        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), dependenciesFile, lockFile)
+        let updatedGroups = Map.add groupName 0 Map.empty
+        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), dependenciesFile, lockFile,updatedGroups)
 
 /// Removes a package with the option to remove it from a specified project.
-let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =    
+let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =
     let groupName = 
         match groupName with
         | None -> Constants.MainDependencyGroup
         | Some name -> GroupName name
 
-    let removeFromSpecifiedProject (projects : ProjectFile seq) =        
+    let removeFromSpecifiedProject (projects : ProjectFile seq) =
         match ProjectFile.TryFindProject(projects,projectName) with
         | Some p ->
             if p.HasPackageInstalled(groupName,packageName) then
@@ -71,7 +73,7 @@ let Remove(dependenciesFileName, groupName, packageName:PackageName, force, hard
         | Some name -> GroupName name
 
     let removeFromProjects (projects: ProjectFile seq) =
-        for project in projects do        
+        for project in projects do
             if project.HasPackageInstalled(groupName,packageName) then
                 if (not interactive) || Utils.askYesNo(sprintf "  Remove from %s (group %O)?" project.Name groupName) then
                     removePackageFromProject project groupName packageName

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -41,7 +41,7 @@
     <StartArguments>update -f</StartArguments>
     <StartArguments>install</StartArguments>
     <StartArguments>update</StartArguments>
-    <StartArguments>install</StartArguments>
+    <StartArguments>install -f</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>c:\code\Paketkopie</StartWorkingDirectory>
@@ -56,7 +56,7 @@
     <StartWorkingDirectory>d:\code\Paket\integrationtests\scenarios\i000284-full-git\temp\</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\ConsoleApplication8</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i000284-full-git\temp\</StartWorkingDirectory>
-    <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001353-git-as-source\temp</StartWorkingDirectory>
+    <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001353-git-build-as-source\temp\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -1161,7 +1161,9 @@ group Dev
     git https://github.com/fsprojects/Paket.VisualStudio.git os : Windows, Build:"build.cmd NuGet", Packages: "/tempFolder/Any where"
     git https://github.com/fsprojects/Paket.git Packages: "/temp Folder/Any where", os: OSX
     git https://github.com/forki/nupkgtest.git nugetsource Packages: /source/
+    git https://github.com/forki/nupkgtest.git build build:"build.cmd", Packages: /source/
 
+    nuget Argu
     nuget Paket.Core
 """
 
@@ -1205,4 +1207,17 @@ let ``should read paket git config with build command``() =
     packagesSource.OperatingSystemRestriction |> shouldEqual None
 
     let nupkgtestSource = cfg.Groups.[GroupName "Dev"].Sources.Head
+    nupkgtestSource.Url |> shouldEqual "paket-files/dev/github.com/nupkgtest/source"
+
+    
+    let buildSource = cfg.Groups.[GroupName "Dev"].RemoteFiles.Tail.Tail.Tail.Tail.Head
+    buildSource.GetCloneUrl() |> shouldEqual "https://github.com/forki/nupkgtest.git"
+    buildSource.Owner |> shouldEqual "github.com"
+    buildSource.Commit |> shouldEqual (Some "build")
+    buildSource.Project |> shouldEqual "nupkgtest"
+    buildSource.PackagePath |> shouldEqual (Some "/source/")
+    buildSource.Command |> shouldEqual (Some "build.cmd")
+    buildSource.OperatingSystemRestriction |> shouldEqual None
+
+    let nupkgtestSource = cfg.Groups.[GroupName "Dev"].Sources.Tail.Head
     nupkgtestSource.Url |> shouldEqual "paket-files/dev/github.com/nupkgtest/source"

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -737,3 +737,25 @@ let ``should parse local git lock file``() =
     lockFile.Head.RemoteUrl |> shouldEqual (Some "file:///c:/code/Paket.VisualStudio")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "528024723f314aa1011499a122258167b53699f7"
     lockFile.Head.SourceFiles.Head.Project |> shouldEqual "Paket.VisualStudio"
+    lockFile.Head.SourceFiles.Head.Command |> shouldEqual None
+
+
+let localGitLockFileWithBuild = """
+NUGET
+  remote: paket-files/github.com/nupkgtest/source
+  specs:
+    Argu (1.1.3)
+GIT
+  remote: https://github.com/forki/nupkgtest.git
+  specs:
+     (2942d23fcb13a2574b635194203aed7610b21903)
+      build: build.cmd Test
+"""
+
+[<Test>]
+let ``should parse local git lock file with build``() = 
+    let lockFile = LockFileParser.Parse(toLines localGitLockFileWithBuild)
+    lockFile.Head.RemoteUrl |> shouldEqual (Some "https://github.com/forki/nupkgtest.git")
+    lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
+    lockFile.Head.SourceFiles.Head.Project |> shouldEqual "nupkgtest"
+    lockFile.Head.SourceFiles.Head.Command |> shouldEqual (Some "build.cmd Test")

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -52,7 +52,7 @@ let ``SelectiveUpdate does not update any package when it is neither updating al
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
     
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -77,7 +77,7 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -103,7 +103,7 @@ let ``SelectiveUpdate updates all packages constraining version``() =
     nuget Castle.Core ~> 3.2
     nuget FAKE = 4.0.0""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -128,7 +128,7 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -153,7 +153,7 @@ let ``SelectiveUpdate updates a single package``() =
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "FAKE" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
@@ -180,7 +180,7 @@ let ``SelectiveUpdate updates a single constrained package``() =
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
@@ -208,7 +208,7 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
     nuget Castle.Core ~> 3.2
     nuget FAKE""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
@@ -236,7 +236,7 @@ let ``SelectiveUpdate installs new packages``() =
     nuget FAKE
     nuget Newtonsoft.Json""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
     
     let result = 
         lockFile.GetGroupedResolution()
@@ -262,7 +262,7 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
@@ -290,7 +290,7 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
     nuget Castle.Core = 3.2.0
     nuget FAKE""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
     let result = 
@@ -317,7 +317,7 @@ let ``SelectiveUpdate considers package name case difference``() =
     nuget castle.core = 3.2.0
     nuget FAKE""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
@@ -361,7 +361,7 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
     nuget Castle.Core
     nuget FAKE""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
     
@@ -397,7 +397,7 @@ let ``SelectiveUpdate does not update when package conflicts with a transitive d
 
     let packageFilter = PackageName "log4net" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
     
@@ -468,7 +468,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     
     let packageFilter = PackageName "log4f" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
     
@@ -499,7 +499,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph2) (PackageDetailsFromGraph graph2) lockFile2 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
     
@@ -555,7 +555,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
     
@@ -588,7 +588,7 @@ let ``SelectiveUpdate does not conflict with a transitive dependency of another 
     
     let packageFilter = PackageName "Ninject" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
 
@@ -620,7 +620,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     
     let packageFilter = PackageName "Ninject.Extensions.Interception" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph3) (PackageDetailsFromGraph graph3) lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
     
@@ -672,7 +672,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net.Deep" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph4) (PackageDetailsFromGraph graph4) lockFile4 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
     
@@ -722,7 +722,7 @@ let ``SelectiveUpdate updates package that conflicts with transitive dependency 
     
     let packageFilter = PackageName "Ninject.Extensions.Logging" |> PackageFilter.ofName
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph5) (PackageDetailsFromGraph graph5) lockFile5 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
     
@@ -761,7 +761,7 @@ let ``SelectiveUpdate updates all packages from all groups if no group is specif
 
         nuget Castle.Core-log4net ~> 4.0""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile
 
@@ -812,7 +812,7 @@ let ``SelectiveUpdate updates only packages from specific group if group is spec
 
         nuget Castle.Core-log4net""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup) SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup) SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile |> Seq.toList
 
@@ -844,7 +844,7 @@ let ``SelectiveUpdate updates only packages from specified group``() =
 
         nuget Castle.Core-log4net""")
 
-    let lockFile = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group")) SemVerUpdateMode.NoRestriction
+    let lockFile,_ = selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group")) SemVerUpdateMode.NoRestriction
     
     let result = groupMap lockFile
 
@@ -899,7 +899,7 @@ let ``SelectiveUpdate updates package from a specific group``() =
         nuget Castle.Core-log4net
         nuget FAKE""")
 
-    let lockFile =
+    let lockFile,_ =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
     
@@ -935,7 +935,7 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
         nuget FAKE
         nuget log4net""")
 
-    let lockFile =
+    let lockFile,_ =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
     
@@ -970,7 +970,7 @@ let ``SelectiveUpdate updates package from main group``() =
         nuget Castle.Core-log4net
         nuget FAKE""")
 
-    let lockFile =
+    let lockFile,_ =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
     
@@ -1015,7 +1015,7 @@ let ``SelectiveUpdate updates package that has a new dependent package that also
     nuget Newtonsoft.Json
     nuget Package""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile7 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Package" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
@@ -1049,7 +1049,7 @@ let ``SelectiveUpdate updates early package that has a new dependent package tha
     nuget Newtonsoft.Json
     nuget APackage""")
 
-    let lockFile = 
+    let lockFile,_ = 
         selectiveUpdate true noSha1 (VersionsFromGraph graph7) (PackageDetailsFromGraph graph7) lockFile8 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "APackage" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
@@ -1081,7 +1081,7 @@ let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specifi
         nuget Castle.Core-log4net
         nuget FAKE""")
 
-    let lockFile =
+    let lockFile,_ =
         selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.KeepMinor
     


### PR DESCRIPTION
Paket v3 alpha versions already support git repos as dependencies (see http://fsprojects.github.io/Paket/git-dependencies.html), but we should go one step further and allow to build the referenced repos. After the build we can use whatever NuGet package the build produced.

The paket.dependencies file might look like:

    source https://nuget.org/api/v2

    nuget Newtonsoft.Json
    nuget FSharp.Core

    group Dev

        git https://github.com/fsprojects/Paket.git master build:"build.cmd NuGet", Packages: /temp/ OS: windows

        nuget Paket.Core

- [x] parse build command and nupkgs output folder from git source feed definition
- [ ] allow to use SemVer git tags
- [ ] restrict checkouts to the specified OS (if OS was specified) see up-for-grabs: #1355
- [x] execute the build command when on checkout of the git source feed
- [x] use output folder als NuGet source feed
- [x] docs