### PR TITLE
[V3] Remove lock-dependencies functionality

### DIFF
--- a/docs/content/commands/pack.md
+++ b/docs/content/commands/pack.md
@@ -31,6 +31,11 @@ Or, you could run:
     [lang=batch]
     paket pack output nugets version 1.0.0 lock-dependencies
 
+<blockquote>
+Note that the `lock-dependencies` parameter will be removed in Version 3 of Paket.
+</blockqoute>
+
+
 Depending on which command you issue, Paket creates different version requirements of the packages you depend on in the resulting `.nuspec` file of your package:
 
 <table>

--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -128,8 +128,8 @@ let addFile (source : string) (target : string) (templateFile : TemplateFile) =
     | IncompleteTemplate -> 
         failwith "You should only try and add files to template files with complete metadata."
 
-let findDependencies (dependencies : DependenciesFile) config platform (template : TemplateFile) (project : ProjectFile) lockDependencies (map : Map<string, TemplateFile * ProjectFile>) =
-    let targetDir = 
+let findDependencies (dependencies : DependenciesFile) config platform (template : TemplateFile) (project : ProjectFile) (map : Map<string, TemplateFile * ProjectFile>) =
+    let targetDir =
         match project.OutputType with
         | ProjectOutputType.Exe -> "tools/"
         | ProjectOutputType.Library -> sprintf "lib/%O/" (project.GetTargetProfile())
@@ -182,7 +182,7 @@ let findDependencies (dependencies : DependenciesFile) config platform (template
             | CompleteTemplate(core, opt) -> 
                 match core.Version with
                 | Some v ->
-                    let versionConstraint = if not lockDependencies then Minimum v else Specific v
+                    let versionConstraint = Minimum v
                     PackageName core.Id, VersionRequirement(versionConstraint, getPreReleaseStatus v)
                 | None -> failwithf "There was no version given for %s." templateFile.FileName
             | IncompleteTemplate -> failwithf "You cannot create a dependency on a template file (%s) with incomplete metadata." templateFile.FileName)
@@ -224,35 +224,27 @@ let findDependencies (dependencies : DependenciesFile) config platform (template
             | _ -> true)
         |> List.map (fun (groupName,np) ->
                 let dependencyVersionRequirement =
-                    if not lockDependencies then
-                        match dependencies.Groups |> Map.tryFind groupName with
-                        | None -> None
-                        | Some group ->
-                            let deps = 
-                                group.Packages 
-                                |> Seq.map (fun p -> p.Name, p.VersionRequirement)
-                                |> Map.ofSeq
+                    match dependencies.Groups |> Map.tryFind groupName with
+                    | None -> None
+                    | Some group ->
+                        let deps =
+                            group.Packages
+                            |> Seq.map (fun p -> p.Name, p.VersionRequirement)
+                            |> Map.ofSeq
 
-                            Map.tryFind np.Name deps
-                            |> function
-                                | Some direct -> Some direct
-                                | None ->
-                                    match lockFile.Groups |> Map.tryFind groupName with
-                                    | None -> None
-                                    | Some group ->
-                                        // If it's a transient dependency, try to
-                                        // find it in `paket.lock` and set min version
-                                        // to current locked version
-                                        group.Resolution
-                                        |> Map.tryFind np.Name
-                                        |> Option.map (fun transient -> VersionRequirement(Minimum transient.Version, getPreReleaseStatus transient.Version))
-                        else
-                            match lockFile.Groups |> Map.tryFind groupName with
-                            | None -> None
-                            | Some group ->
-                                Map.tryFind np.Name group.Resolution
-                                |> Option.map (fun resolvedPackage -> resolvedPackage.Version)
-                                |> Option.map (fun version -> VersionRequirement(Specific version, getPreReleaseStatus version))
+                        Map.tryFind np.Name deps
+                        |> function
+                            | Some direct -> Some direct
+                            | None ->
+                                match lockFile.Groups |> Map.tryFind groupName with
+                                | None -> None
+                                | Some group ->
+                                    // If it's a transient dependency, try to
+                                    // find it in `paket.lock` and set min version
+                                    // to current locked version
+                                    group.Resolution
+                                    |> Map.tryFind np.Name
+                                    |> Option.map (fun transient -> VersionRequirement(Minimum transient.Version, getPreReleaseStatus transient.Version))
                 let dep =
                     match dependencyVersionRequirement with
                     | Some installed -> installed

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -85,7 +85,7 @@ let private convertToSymbols (projectFile : ProjectFile) templateFile =
         let augmentedFiles = optional.Files |> List.append sourceFiles 
         { templateFile with Contents = ProjectInfo({ core with Symbols = true }, { optional with Files = augmentedFiles }) }
 
-let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, symbols) =
+let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, symbols) =
     let buildConfig = defaultArg buildConfig "Release"
     let buildPlatform = defaultArg buildPlatform ""
     let packageOutputPath = if Path.IsPathRooted(packageOutputPath) then packageOutputPath else Path.Combine(workingDir,packageOutputPath)
@@ -152,7 +152,7 @@ let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildCon
             | _ -> seq { yield templateFile }
 
         projectTemplates
-        |> Map.map (fun _ (t, p) -> p,findDependencies dependencies buildConfig buildPlatform t p lockDependencies projectTemplates)
+        |> Map.map (fun _ (t, p) -> p, findDependencies dependencies buildConfig buildPlatform t p projectTemplates)
         |> Map.toList
         |> Seq.collect (fun (_,(p,t)) -> t |> optWithSymbols p)
         |> Seq.append (allTemplateFiles |> Seq.collect convertRemainingTemplate)

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -460,13 +460,12 @@ type Dependencies(dependenciesFileName: string) =
         FindReferences.FindReferencesForPackage (GroupName group) (PackageName package) |> this.Process
 
     // Packs all paket.template files.
-    member this.Pack(outputPath, ?buildConfig, ?buildPlatform, ?version, ?specificVersions, ?releaseNotes, ?templateFile, ?workingDir, ?excludedTemplates, ?lockDependencies, ?symbols) =
+    member this.Pack(outputPath, ?buildConfig, ?buildPlatform, ?version, ?specificVersions, ?releaseNotes, ?templateFile, ?workingDir, ?excludedTemplates, ?symbols) =
         let dependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
         let specificVersions = defaultArg specificVersions Seq.empty
         let workingDir = defaultArg workingDir (dependenciesFile.FileName |> Path.GetDirectoryName)
-        let lockDependencies = defaultArg lockDependencies false
         let symbols = defaultArg symbols false
-        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, symbols)
+        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, symbols)
 
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -307,7 +307,6 @@ type PackArgs =
     | [<CustomCommandLine("exclude")>] ExcludedTemplate of string
     | [<CustomCommandLine("specific-version")>] SpecificVersion of templateId:string * version:string
     | [<CustomCommandLine("releaseNotes")>] ReleaseNotes of string
-    | [<CustomCommandLine("lock-dependencies")>] LockDependencies
     | [<CustomCommandLine("symbols")>] Symbols
 with
     interface IArgParserTemplate with
@@ -321,7 +320,6 @@ with
             | ExcludedTemplate(_) -> "Exclude template file by id."
             | SpecificVersion(_) -> "Specifies a version number for template with given id."
             | ReleaseNotes(_) -> "Specify relase notes for the package."
-            | LockDependencies -> "Get the version requirements from paket.lock instead of paket.dependencies."
             | Symbols -> "Build symbol/source packages in addition to library/content packages."
 
 type PushArgs =

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -225,7 +225,6 @@ let pack (results : ParseResults<_>) =
                       ?templateFile = results.TryGetResult <@ PackArgs.TemplateFile @>,
                       excludedTemplates = results.GetResults <@ PackArgs.ExcludedTemplate @>,
                       workingDir = Environment.CurrentDirectory,
-                      lockDependencies = results.Contains <@ PackArgs.LockDependencies @>,
                       symbols = results.Contains <@ PackArgs.Symbols @>)
 
 let findPackages (results : ParseResults<_>) =


### PR DESCRIPTION
I would propose to remove the `lock-dependencies` functionality from Version 3 of Paket. I realized that this doesn't make much sense in it's current form and can be achieved with a custom `paket.template` while being much more fine grained.

If this is going to be accepted, I would prepare a PR for removing the complete section about this in the documentation.