### PR TITLE
Fix for SolutoinDir in ProjectReference element

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -889,7 +889,7 @@ type ProjectFile =
 
         [for node in this.Document |> getDescendants "ProjectReference" -> 
             { Path = 
-                let p = node.Attributes.["Include"].Value |> normalizePath
+                let p = node.Attributes.["Include"].Value |> expandVariables |> normalizePath
                 if Path.IsPathRooted p then Path.GetFullPath p else 
                 let di = FileInfo(normalizePath this.FileName).Directory
                 Path.Combine(di.FullName,p) |> Path.GetFullPath

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -311,6 +311,8 @@ let askYesNo question =
 
 let inline normalizePath(path:string) = path.Replace("\\",Path.DirectorySeparatorChar.ToString()).Replace("/",Path.DirectorySeparatorChar.ToString()).TrimEnd(Path.DirectorySeparatorChar)
 
+let inline expandVariables(path:string) = path.Replace("$(SolutionDir)", Environment.CurrentDirectory + Path.DirectorySeparatorChar.ToString())
+
 /// Gets all files with the given pattern
 let inline FindAllFiles(folder, pattern) = DirectoryInfo(folder).GetFiles(pattern, SearchOption.AllDirectories)
 

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -38,7 +38,7 @@
     <StartArguments>pack output D:\code\paketbug\output</StartArguments>
     <StartArguments>install</StartArguments>
     <StartArguments>restore</StartArguments>
-    <StartArguments>pack -v output D:\code\Paket\integrationtests\scenarios\i001375-pack-specific\temp\out</StartArguments>
+    <StartArguments>install --hard -v</StartArguments>
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartWorkingDirectory>c:\code\Paketkopie</StartWorkingDirectory>
@@ -48,7 +48,7 @@
     <StartWorkingDirectory>d:\code\paketrepro</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001270-net461\temp</StartWorkingDirectory>
     <StartWorkingDirectory>C:\code\restore</StartWorkingDirectory>
-    <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001375-pack-specific\temp</StartWorkingDirectory>
+    <StartWorkingDirectory>C:\Work\ManagedCodeGit\CrossPoint.Database</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Proposal for fix for resolving $(SolutionDir) macro/variable in ProjectReference include attribute.
When proposed solution is accepted I will add some tests before merging.