### PR TITLE
added support for including projecturl for pack

### DIFF
--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -47,3 +47,10 @@ let ``#1375 pack specific dependency``() =
     paket ("pack -v output \"" + outPath + "\"") "i001375-pack-specific" |> ignore
 
     File.Delete(Path.Combine(scenarioTempPath "i001375-pack-specific","PaketBug","paket.template"))
+
+[<Test>]
+let ``#1375 pack with projectUrl commandline``() = 
+    let outPath = Path.Combine(scenarioTempPath "i001375-pack-specific","out")
+    paket ("pack -v output \"" + outPath + "\" project-url \"http://localhost\"") "i001375-pack-specific" |> ignore
+
+    File.Delete(Path.Combine(scenarioTempPath "i001375-pack-specific","PaketBug","paket.template"))

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -86,7 +86,7 @@ let private convertToSymbols (projectFile : ProjectFile) (includeReferencedProje
         let augmentedFiles = optional.Files |> List.append sourceFiles
         { templateFile with Contents = ProjectInfo({ core with Symbols = true }, { optional with Files = augmentedFiles }) }
 
-let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, symbols, includeReferencedProjects) =
+let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, symbols, includeReferencedProjects, projectUrl) =
     let buildConfig = defaultArg buildConfig "Release"
     let buildPlatform = defaultArg buildPlatform ""
     let packageOutputPath = if Path.IsPathRooted(packageOutputPath) then packageOutputPath else Path.Combine(workingDir,packageOutputPath)
@@ -166,8 +166,14 @@ let Pack(workingDir,dependencies : DependenciesFile, packageOutputPath, buildCon
             let excluded = set excluded
             allTemplates |> List.filter (fun t -> match t with CompleteTemplate(c,_) -> not (excluded.Contains c.Id) | _ -> true)
     
+    // set projectUrl
+    let templatesWithProjectUrl = 
+        match projectUrl with
+        | None -> excludedTemplates
+        | Some url -> excludedTemplates |> List.map (TemplateFile.setProjectUrl url)
+
     // set version
-    let templatesWithVersion = excludedTemplates |> List.map (TemplateFile.setVersion version specificVersions)
+    let templatesWithVersion = templatesWithProjectUrl |> List.map (TemplateFile.setVersion version specificVersions)
 
     // set release notes
     let processedTemplates =

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -488,14 +488,15 @@ type Dependencies(dependenciesFileName: string) =
         FindReferences.FindReferencesForPackage (GroupName group) (PackageName package) |> this.Process
 
     // Packs all paket.template files.
-    member this.Pack(outputPath, ?buildConfig, ?buildPlatform, ?version, ?specificVersions, ?releaseNotes, ?templateFile, ?workingDir, ?excludedTemplates, ?lockDependencies, ?symbols, ?includeReferencedProjects) =
+    member this.Pack(outputPath, ?buildConfig, ?buildPlatform, ?version, ?specificVersions, ?releaseNotes, ?templateFile, ?workingDir, ?excludedTemplates, ?lockDependencies, ?symbols, ?includeReferencedProjects, ?projectUrl) =
         let dependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
         let specificVersions = defaultArg specificVersions Seq.empty
         let workingDir = defaultArg workingDir (dependenciesFile.FileName |> Path.GetDirectoryName)
         let lockDependencies = defaultArg lockDependencies false
         let symbols = defaultArg symbols false
         let includeReferencedProjects = defaultArg includeReferencedProjects false
-        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, symbols, includeReferencedProjects)
+        let projectUrl = defaultArg (Some(projectUrl)) None
+        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, symbols, includeReferencedProjects, projectUrl)
 
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =

--- a/src/Paket.Core/TemplateFile.fs
+++ b/src/Paket.Core/TemplateFile.fs
@@ -197,6 +197,13 @@ module internal TemplateFile =
             | ProjectInfo(core, optional) -> ProjectInfo(core, { optional with ReleaseNotes = Some releaseNotes })
         { templateFile with Contents = contents }
 
+    let setProjectUrl url templateFile = 
+        let contents =
+            match templateFile.Contents with
+            | CompleteInfo(core, optional) -> CompleteInfo(core, { optional with ProjectUrl = Some url })
+            | ProjectInfo(core, optional) -> ProjectInfo(core, { optional with ProjectUrl = Some url })
+        { templateFile with Contents = contents }
+
     let private failP file str = fail <| PackagingConfigParseError(file,str)
 
     type private PackageConfigType =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -310,6 +310,7 @@ type PackArgs =
     | [<CustomCommandLine("lock-dependencies")>] LockDependencies
     | [<CustomCommandLine("symbols")>] Symbols
     | [<CustomCommandLine("include-referenced-projects")>] IncludeReferencedProjects
+    | [<CustomCommandLine("project-url")>] ProjectUrl of string
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -325,6 +326,7 @@ with
             | LockDependencies -> "Get the version requirements from paket.lock instead of paket.dependencies."
             | Symbols -> "Build symbol/source packages in addition to library/content packages."
             | IncludeReferencedProjects -> "Include symbol/source from referenced projects."
+            | ProjectUrl(_) -> "Url to the projects home page."
 
 type PushArgs =
     | [<CustomCommandLine("url")>][<Mandatory>] Url of string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -227,7 +227,8 @@ let pack (results : ParseResults<_>) =
                       workingDir = Environment.CurrentDirectory,
                       lockDependencies = results.Contains <@ PackArgs.LockDependencies @>,
                       symbols = results.Contains <@ PackArgs.Symbols @>,
-                      includeReferencedProjects = results.Contains <@ PackArgs.IncludeReferencedProjects @>)
+                      includeReferencedProjects = results.Contains <@ PackArgs.IncludeReferencedProjects @>,
+                      ?projectUrl = results.TryGetResult <@ PackArgs.ProjectUrl @>)
 
 let findPackages (results : ParseResults<_>) =
     let maxResults = defaultArg (results.TryGetResult <@ FindPackagesArgs.MaxResults @>) 10000


### PR DESCRIPTION
for background, this is particularly useful when packing on build systems internal to a company, and you want the project url to be that of the build configuration, which is best set by the build agent.