### PR TITLE
removed unnecessary memory allocations

### DIFF
--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -134,7 +134,7 @@ let private applyBindingRedirects isFirstGroup cleanBindingRedirects bindingRedi
 
     let isMarked e =
         match tryGetElement (Some bindingNs) "Paket" e with
-        | Some e -> e.Value.Trim().ToLower() = "true"
+        | Some e -> String.equalsIgnoreCase (e.Value.Trim()) "true"
         | None -> false
 
     let nsManager = XmlNamespaceManager(NameTable());

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -91,7 +91,7 @@ module DependenciesFileParser =
             let inline parsePrerelease (texts : string list) = 
                 match texts |> List.filter ((<>) "") with
                 | [] -> PreReleaseStatus.No
-                | [x] when x.ToLower() = "prerelease" -> PreReleaseStatus.All
+                | [x] when String.equalsIgnoreCase x "prerelease" -> PreReleaseStatus.All
                 | _ -> PreReleaseStatus.Concrete texts
 
             if String.IsNullOrWhiteSpace text then VersionRequirement(VersionRange.AtLeast("0"),PreReleaseStatus.No) else
@@ -627,8 +627,8 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
                     | Some found -> 
                         let pos = ref (found + 1)
                         let skipped = ref false
-                        while !pos < textRepresentation.Length - 1 && (String.IsNullOrWhiteSpace textRepresentation.[!pos] || textRepresentation.[!pos].ToLower().StartsWith("source")) do
-                            if textRepresentation.[!pos].ToLower().StartsWith("source") then
+                        while !pos < textRepresentation.Length - 1 && (String.IsNullOrWhiteSpace textRepresentation.[!pos] || String.startsWithIgnoreCase "source" textRepresentation.[!pos]) do
+                            if String.startsWithIgnoreCase "source" textRepresentation.[!pos] then
                                 skipped := true
                             pos := !pos + 1
                             

--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -216,10 +216,10 @@ module FrameworkDetection =
         let path = path.Replace("\\", "/").ToLower()
         let fi = new FileInfo(path)
         
-        if path.Contains("lib/" + fi.Name.ToLower()) then Some(DotNetFramework(FrameworkVersion.V1))
+        if String.containsIgnoreCase ("lib/" + fi.Name) path then Some(DotNetFramework(FrameworkVersion.V1))
         else 
             let startPos = path.LastIndexOf("lib/")
-            let endPos = path.LastIndexOf(fi.Name.ToLower())
+            let endPos = path.LastIndexOf(fi.Name,StringComparison.OrdinalIgnoreCase)
             if startPos < 0 || endPos < 0 then None
             else 
                 path.Substring(startPos + 4, endPos - startPos - 5) 

--- a/src/Paket.Core/InstallModel.fs
+++ b/src/Paket.Core/InstallModel.fs
@@ -275,18 +275,18 @@ module InstallModel =
         references |> Seq.fold (addFrameworkAssemblyReference) (installModel:InstallModel) 
 
     let filterBlackList  (installModel:InstallModel)  = 
-        let inline checkExt str ext = str |>  toLower |> endsWith ext
+
         let includeReferences = function
-            | Reference.Library lib -> not (checkExt lib ".dll" || checkExt lib ".exe")
+            | Reference.Library lib -> not (String.endsWithIgnoreCase ".dll" lib || String.endsWithIgnoreCase ".exe" lib )
             | Reference.TargetsFile targetsFile -> 
-                (not (checkExt targetsFile ".props" || checkExt targetsFile ".targets"))
+                (not (String.endsWithIgnoreCase ".props" targetsFile|| String.endsWithIgnoreCase ".targets" targetsFile))
             | _ -> false
 
         let excludeSatelliteAssemblies = function
             | Reference.Library lib -> lib.EndsWith ".resources.dll"
             | _ -> false
 
-        let blacklisted (blacklist:string list) (file:string) = blacklist |> List.exists (toLower >> (checkExt file ))
+        let blacklisted (blacklist:string list) (file:string) = blacklist |> List.exists (String.endsWithIgnoreCase file )
 
         let blackList = 
             [ includeReferences

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -42,7 +42,7 @@ let findPackageFolder root (groupName,packageName) (version,settings) =
     let targetFolder = getTargetFolder root groupName packageName version includeVersionInPath
     let direct = DirectoryInfo targetFolder
     if direct.Exists then direct else
-    match di.GetDirectories() |> Seq.tryFind (fun subDir -> subDir.FullName.ToLower().EndsWith lowerName) with
+    match di.GetDirectories() |> Seq.tryFind (fun subDir -> String.endsWithIgnoreCase lowerName subDir.FullName) with
     | Some x -> x
     | None -> failwithf "Package directory for package %O was not found." packageName
 

--- a/src/Paket.Core/Nuspec.fs
+++ b/src/Paket.Core/Nuspec.fs
@@ -30,8 +30,9 @@ module internal NuSpecParserHelper =
             | None ->         VersionRequirement.Parse "0"
         let restriction =
             let parent = node.ParentNode 
-            match parent.Name.ToLower(), parent |> getAttribute "targetFramework" with
-            | "group", Some framework -> 
+            match parent.Name, parent |> getAttribute "targetFramework" with
+            | name , Some framework 
+                when String.equalsIgnoreCase name "group" -> 
                 match FrameworkDetection.Extract framework with
                 | Some x -> [FrameworkRestriction.Exactly x]
                 | None -> []
@@ -117,7 +118,7 @@ type Nuspec =
                 | None -> ""
               IsDevelopmentDependency =
                 match doc |> getNode "package" |> optGetNode "metadata" |> optGetNode "developmentDependency" with
-                | Some link -> link.InnerText.ToLower() = "true"
+                | Some link -> String.equalsIgnoreCase link.InnerText "true"
                 | None -> false
               FrameworkAssemblyReferences = 
                 let grouped =

--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -179,7 +179,7 @@ let findDependencies (dependencies : DependenciesFile) config platform (template
                                                     let isSameFileName = (Path.GetFileNameWithoutExtension fi.Name) = name
                                                     let isValidExtension = 
                                                         [".xml"; ".dll"; ".exe"; ".pdb"; ".mdb"] 
-                                                        |> List.exists ((=) (fi.Extension.ToLower()))
+                                                        |> List.exists (String.equalsIgnoreCase fi.Extension)
                                                     isSameFileName && isValidExtension)
                            )
             |> Seq.toArray

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -309,7 +309,7 @@ let Resolve(groupName:GroupName, sources, getVersionsF, getPackageDetailsF, stra
                     let sources = parentSource :: sources |> List.distinct
                     Seq.singleton (v,sources)
                 | _ -> 
-                    let sources : PackageSource list = sources |> List.sortBy (fun x -> x.Url.ToLower().Contains "nuget.org" |> not) 
+                    let sources : PackageSource list = sources |> List.sortBy (fun x -> String.containsIgnoreCase "nuget.org" x.Url |> not) 
                     Seq.singleton (v,sources)
 
             availableVersions :=

--- a/src/Paket.Core/PackageSources.fs
+++ b/src/Paket.Core/PackageSources.fs
@@ -187,7 +187,7 @@ type PackageSource =
                 if uri.Scheme = System.Uri.UriSchemeFile then 
                     LocalNuGet source
                 else 
-                    if source.ToLower().EndsWith("v3/index.json") then
+                    if String.endsWithIgnoreCase "v3/index.json" source then
                         NuGetV3 { Url = source; Authentication = auth }
                     else
                         NuGetV2 { Url = source; Authentication = auth }

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -783,7 +783,7 @@ module ProjectFile =
                 let fileName = 
                     match propertyName with
                     | _ when propertyChooseNode.ChildNodes.Count = 0 -> path
-                    | name when String.endsWithIgnoreCase name "props" -> sprintf "%s$(%s).props" buildPath propertyName 
+                    | name when String.endsWithIgnoreCase "props" name  -> sprintf "%s$(%s).props" buildPath propertyName 
                     | _ -> failwithf "Unknown .props filename %s" propertyName
 
                 createNode "Import" project
@@ -801,7 +801,7 @@ module ProjectFile =
                 let fileName = 
                     match propertyName with
                     | _ when propertyChooseNode.ChildNodes.Count = 0 -> path
-                    | name when String.endsWithIgnoreCase name "targets" ->
+                    | name when String.endsWithIgnoreCase  "targets" name ->
                         sprintf "%s$(%s).targets" buildPath propertyName
                     | _ -> failwithf "Unknown .targets filename %s" propertyName
 
@@ -869,9 +869,9 @@ module ProjectFile =
             let i = ref (project.ProjectNode.ChildNodes.Count-1)
             while 
               !i >= 0 && 
-                (String.startsWithIgnoreCase (project.ProjectNode.ChildNodes.[!i].OuterXml.ToString()) "<import" && 
-                 String.containsIgnoreCase (project.ProjectNode.ChildNodes.[!i].OuterXml.ToString()) "label" &&
-                 String.containsIgnoreCase (project.ProjectNode.ChildNodes.[!i].OuterXml.ToString()) "paket")  do
+                (String.startsWithIgnoreCase "<import" (project.ProjectNode.ChildNodes.[!i].OuterXml.ToString())  && 
+                 String.containsIgnoreCase "label" (project.ProjectNode.ChildNodes.[!i].OuterXml.ToString())  &&
+                 String.containsIgnoreCase "paket" (project.ProjectNode.ChildNodes.[!i].OuterXml.ToString()) )  do
                 decr i
             
             if !i <= 0 then
@@ -883,7 +883,7 @@ module ProjectFile =
                     project.ProjectNode.InsertAfter(chooseNode,node) |> ignore
 
             let j = ref 0
-            while !j < project.ProjectNode.ChildNodes.Count && String.startsWithIgnoreCase (project.ProjectNode.ChildNodes.[!j].OuterXml.ToString()) "<import" do
+            while !j < project.ProjectNode.ChildNodes.Count && String.startsWithIgnoreCase  "<import" (project.ProjectNode.ChildNodes.[!j].OuterXml.ToString()) do
                 incr j
             
             if propertyChooseNode.ChildNodes.Count > 0 then

--- a/src/Paket.Core/SolutionFile.fs
+++ b/src/Paket.Core/SolutionFile.fs
@@ -61,7 +61,7 @@ type SolutionFile(fileName: string) =
 
     member __.RemoveNugetEntries() =
         for file in ["nuget.targets"; Constants.PackagesConfigFile; "nuget.exe"; "nuget.config"] do
-            match content |> Seq.tryFindIndex (fun line -> line.ToLower().Contains(sprintf ".nuget\\%s" file)) with
+            match content |> Seq.tryFindIndex (fun line -> String.containsIgnoreCase (sprintf ".nuget\\%s" file)line) with
             | Some(index) -> content.RemoveAt(index)
             | None -> ()            
         

--- a/src/Paket.Core/TemplateFile.fs
+++ b/src/Paket.Core/TemplateFile.fs
@@ -321,7 +321,7 @@ module internal TemplateFile =
 
         let requireLicenseAcceptance =
             match get "requireLicenseAcceptance" with
-            | Some x when x.ToLower() = "true" -> true
+            | Some x when String.equalsIgnoreCase x "true" -> true
             | _ -> false
 
         let tags =
@@ -333,7 +333,7 @@ module internal TemplateFile =
 
         let developmentDependency =
             match get "developmentDependency" with
-            | Some x when x.ToLower() = "true" -> true
+            | Some x when String.equalsIgnoreCase x "true" -> true
             | _ -> false
 
         let dependencies = getDependencies(fileName,lockFile,map,currentVersion,specificVersions)

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -381,6 +381,19 @@ module String =
             Some (input.Substring(prefix.Length))
         else None
 
+    let inline equalsIgnoreCase str1 str2 =
+        String.Compare(str1,str2,StringComparison.OrdinalIgnoreCase) = 0 
+
+    let inline containsIgnoreCase (target:string) (text:string) = 
+        text.IndexOf(target, StringComparison.OrdinalIgnoreCase) >= 0
+
+    
+    let inline startsWithIgnoreCase (target:string) (text:string) =
+        text.IndexOf(target, StringComparison.OrdinalIgnoreCase) = 0
+
+    let inline endsWithIgnoreCase (target:string) (text:string) =
+        text.IndexOf(target, StringComparison.OrdinalIgnoreCase) >= text.Length - target.Length
+
     let quoted (text:string) = (if text.Contains(" ") then "\"" + text + "\"" else text) 
 
     let inline trim (text:string) = text.Trim()


### PR DESCRIPTION
String.ToLower() allocates a new string, this is unnecessary for the purpose of comparison as using a `StringComparison.OrdinalIgnoreCase` will achieve the same effect cheaper.