### PR TITLE
Find packages is now case-insensitive #93

### DIFF
--- a/integrationtests/Paket.IntegrationTests/paket.references
+++ b/integrationtests/Paket.IntegrationTests/paket.references
@@ -6,3 +6,4 @@ group Test
   NUnit
   NUnit.Runners.Net4
   File:FsUnit.fs .
+  FAKE

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -22,6 +22,7 @@ group Test
 
   source https://nuget.org/api/v2
 
+  nuget FAKE
   nuget NUnit.Runners.Net4
   nuget NUnit ~> 2
   github forki/FsUnit FsUnit.fs

--- a/paket.lock
+++ b/paket.lock
@@ -42,6 +42,7 @@ GROUP Test
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
+    FAKE (4.14.9)
     NUnit (2.6.4)
     NUnit.Runners.Net4 (2.6.4)
 GITHUB

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -546,7 +546,7 @@ let getVersionsCached key f (source, auth, nugetURL, package) =
 let FindPackages(auth, nugetURL, packageNamePrefix, maxResults) =
     async {
         try 
-            let url = sprintf "%s/Packages()?$filter=IsLatestVersion and IsAbsoluteLatestVersion and substringof('%s',Id)" nugetURL packageNamePrefix
+            let url = sprintf "%s/Packages()?$filter=IsLatestVersion and IsAbsoluteLatestVersion and substringof('%s',Id)" nugetURL packageNamePrefix 
             let! raw = getFromUrl(auth |> Option.map toBasicAuth,url,acceptXml)
             let doc = XmlDocument()
             doc.LoadXml raw

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -546,7 +546,7 @@ let getVersionsCached key f (source, auth, nugetURL, package) =
 let FindPackages(auth, nugetURL, packageNamePrefix, maxResults) =
     async {
         try 
-            let url = sprintf "%s/Packages()?$filter=IsLatestVersion and IsAbsoluteLatestVersion and substringof('%s',tolower(Id))" nugetURL ((packageNamePrefix:string).ToLowerInvariant())
+            let url = sprintf "%s/Packages()?$filter=IsLatestVersion and IsAbsoluteLatestVersion and substringof('%s',Id)" nugetURL packageNamePrefix
             let! raw = getFromUrl(auth |> Option.map toBasicAuth,url,acceptXml)
             let doc = XmlDocument()
             doc.LoadXml raw

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -546,7 +546,7 @@ let getVersionsCached key f (source, auth, nugetURL, package) =
 let FindPackages(auth, nugetURL, packageNamePrefix, maxResults) =
     async {
         try 
-            let url = sprintf "%s/Packages()?$filter=IsLatestVersion and IsAbsoluteLatestVersion and substringof('%s',Id)" nugetURL packageNamePrefix 
+            let url = sprintf "%s/Packages()?$filter=IsLatestVersion and IsAbsoluteLatestVersion and substringof('%s',tolower(Id))" nugetURL ((packageNamePrefix:string).ToLowerInvariant())
             let! raw = getFromUrl(auth |> Option.map toBasicAuth,url,acceptXml)
             let doc = XmlDocument()
             doc.LoadXml raw


### PR DESCRIPTION
I am F# virgin so I'm not sure if the code is "optimal", but it seems to work. I've created a unit test to poke our private nuget server and with my fix it does return all packages that contain the words, case insensitive.