### PR TITLE
Adds Paket syntax coloring tag

### DIFF
--- a/docs/content/commands/add.md
+++ b/docs/content/commands/add.md
@@ -1,6 +1,6 @@
 ## Adding to a single project
 
-It's also possible to add a package to a specified project only: 
+It's also possible to add a package to a specified project only:
 
     [lang=batchfile]
     $ paket add nuget PACKAGENAME [version VERSION] [project PROJECT] [--force] [--hard]
@@ -11,9 +11,10 @@ See also [paket remove](paket-remove.html).
 
 Consider the following paket.dependencies file:
 
-	source https://nuget.org/api/v2
+    [lang=paket]
+    source https://nuget.org/api/v2
 
-	nuget FAKE
+    nuget FAKE
 
 Now we run `paket add nuget xunit --interactive` to install the package:
 
@@ -21,7 +22,8 @@ Now we run `paket add nuget xunit --interactive` to install the package:
 
 This will add the package to the selected paket.references files and also to the paket.dependencies file:
 
-	source https://nuget.org/api/v2
+    [lang=paket]
+    source https://nuget.org/api/v2
 
-	nuget FAKE
-	nuget xunit
+    nuget FAKE
+    nuget xunit

--- a/docs/content/commands/outdated.md
+++ b/docs/content/commands/outdated.md
@@ -2,13 +2,15 @@
 
 Consider the following paket.dependencies file:
 
+    [lang=paket]
     source https://nuget.org/api/v2
-    
+
     nuget Castle.Core
     nuget Castle.Windsor
 
-and the following paket.lock file: 
+and the following paket.lock file:
 
+    [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
       specs:

--- a/docs/content/commands/pack.md
+++ b/docs/content/commands/pack.md
@@ -2,6 +2,7 @@
 
 Consider the following [`paket.dependencies` file][depfile] in your project's root:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget Castle.Windsor ~> 3.2
@@ -9,10 +10,12 @@ Consider the following [`paket.dependencies` file][depfile] in your project's ro
 
 And one of your projects having a [`paket.references` file][reffile] like this:
 
+    [lang=paket]
     Castle.Windsor
 
 Now, when you run `paket install`, your [`paket.lock` file][lockfile] would look like this:
 
+    [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
       specs:
@@ -45,7 +48,7 @@ Depending on which command you issue, Paket creates different version requiremen
       <td><code>[3.2,4.0)</code></td>
       <td><code>[3.3.0]</code></td>
     </tr>
-  </tbody> 
+  </tbody>
 </table>
 
 As you see here, the first command (without the `lock-dependencies` parameter) creates version requirements as specified in your [`paket.dependencies` file][depfile]. The second command takes the currently resolved versions from your [`paket.lock` file][lockfile] and "locks" them to these specific versions.

--- a/docs/content/commands/simplify.md
+++ b/docs/content/commands/simplify.md
@@ -15,8 +15,9 @@ When you install `Castle.Windsor` package in NuGet to a project, it will generat
 
 After converting to Paket with [`paket convert-from-nuget command`](paket-convert-from-nuget.html), you should get a following paket.dependencies file:
 
+    [lang=paket]
     source https://nuget.org/api/v2
-    
+
     nuget Castle.Core 3.3.1
     nuget Castle.Windsor 3.3.0
 
@@ -30,8 +31,9 @@ Paket by default (without [strict](dependencies-file.html#Strict-references) mod
 In other words, you still get the same result if you remove `Castle.Core` from your paket.references file.
 And this is exactly what happens after executing `paket simplify` command:
 
+    [lang=paket]
     source https://nuget.org/api/v2
-    
+
     nuget Castle.Windsor 3.3.0
 
 will be the content of your paket.dependencies file, and:
@@ -55,13 +57,15 @@ It is possible through the use of simplify to make unintended changes to your pa
 
 Imagine a paket.dependencies file with the following contents:
 
+    [lang=paket]
     source https://nuget.org/api/v2
-    
+
     nuget Foo 1.0.0
     nuget Bar 1.0.0
 
 Let us imagine that package Bar has a dependency on package Foo for any version from 1.0 through 2.0. The paket.lock file that results for this combination is:
 
+    [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
       specs:
@@ -71,8 +75,9 @@ Let us imagine that package Bar has a dependency on package Foo for any version 
 
 In this situation, if simplify is run, the Foo dependency will be removed, resulting in a paket.dependencies of:
 
+    [lang=paket]
     source https://nuget.org/api/v2
-    
+
     nuget Bar 1.0.0
 
 like we expect.  But now, if an install is run, the Foo dependency will be free to update to the maximum allowed by the Bar dependency, which could have unforseen consequences if the author of Foo has introduced a breaking change.

--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -4,6 +4,7 @@ The `paket.dependencies` file is used to specify rules regarding your applicatio
 
 To give you an overview, consider the following `paket.dependencies` file:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     // NuGet packages
@@ -50,6 +51,7 @@ Paket supports the following source types:
 Paket usually references all direct and transitive dependencies that are listed in your [`paket.references` files](references-files.md) to your project file.
 In `strict` mode it will **only** reference *direct* dependencies.
 
+    [lang=paket]
     references: strict
     source https://nuget.org/api/v2
 
@@ -60,6 +62,7 @@ In `strict` mode it will **only** reference *direct* dependencies.
 
 Sometimes you don't want to generate dependencies for older framework versions. You can control this in the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     framework: net35, net40
     source https://nuget.org/api/v2
 
@@ -69,6 +72,7 @@ Sometimes you don't want to generate dependencies for older framework versions. 
 
 This option disables the installation of any content files:
 
+    [lang=paket]
     content: none
     source https://nuget.org/api/v2
 
@@ -79,6 +83,7 @@ This option disables the installation of any content files:
 
 If you don't want to import `.targets` and `.props` files you can disable it via the `import_targets` switch:
 
+    [lang=paket]
     import_targets: false
     source https://nuget.org/api/v2
 
@@ -89,6 +94,7 @@ If you don't want to import `.targets` and `.props` files you can disable it via
 
 It's possible to influence the `Private` property for references via the `copy_local` switch:
 
+    [lang=paket]
     copy_local: false
     source https://nuget.org/api/v2
 
@@ -98,6 +104,7 @@ It's possible to influence the `Private` property for references via the `copy_l
 
 This option tells paket to create [Assembly Binding Redirects](https://msdn.microsoft.com/en-us/library/433ysdt1(v=vs.110).aspx) for all referenced libraries.
 
+    [lang=paket]
     redirects: on
     source https://nuget.org/api/v2
 
@@ -105,6 +112,7 @@ This option tells paket to create [Assembly Binding Redirects](https://msdn.micr
 
 On the other hand, you can instruct Paket to create no [Assembly Binding Redirects](https://msdn.microsoft.com/en-us/library/433ysdt1(v=vs.110).aspx), regardless a package instructs otherwise.
 
+    [lang=paket]
     redirects: off
     source https://nuget.org/api/v2
 
@@ -113,6 +121,7 @@ On the other hand, you can instruct Paket to create no [Assembly Binding Redirec
 
 If you're using multiple groups, you must set `redirects: off` for each one of them.
 
+    [lang=paket]
     redirects: off
     source https://nuget.org/api/v2
 
@@ -122,17 +131,18 @@ If you're using multiple groups, you must set `redirects: off` for each one of t
     group Build
         redirects: off
 	    source https://nuget.org/api/v2
-		
+
         nuget FAKE redirects: on
 
 ### Strategy option
 
-This option tells Paket what resolver strategy it will use by default. 
+This option tells Paket what resolver strategy it will use by default.
 
 NuGet's dependency syntax led to a lot of incompatible packages on Nuget.org. To make your transition to Paket easier and to allow package authors to correct their version constraints you can have Paket behave like NuGet when resolving transitive dependencies (i.e. defaulting to lowest matching versions).
 
 The strategy can be either `min` or `max`.
 
+    [lang=paket]
     strategy: min
     source https://nuget.org/api/v2
 
@@ -140,7 +150,7 @@ The strategy can be either `min` or `max`.
 
 A `min` strategy means you get the *lowest matching version* of your transitive dependencies (i.e. NuGet-style). In constrast, a `max` strategy will get you the *highest matching version*.
 
-Note, however, that all direct dependencies still get their *lastest matching versions*, no matter the value of the `strategy` option. 
+Note, however, that all direct dependencies still get their *lastest matching versions*, no matter the value of the `strategy` option.
 
 The only exception is when you are updating a single package and one of your direct dependencies is a transitive dependency for that specific package. In this case, only the updating package will get its *latest matching version* and the dependency is treated as transitive.
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -22,9 +22,9 @@ If you really need to have the version in the path for certain packages (like xu
 
 ## NuGet allows to use multiple versions of the same package. Can I do that with Paket?
 
-Usually you don't want that to happen. Most solutions that have multiple versions of the same package installed did this by accident. 
+Usually you don't want that to happen. Most solutions that have multiple versions of the same package installed did this by accident.
 Since NuGet has no global lock file and stores version information in packages.config (per project), it's hard to keep all projects consolidated.
-Paket on the other gives you a global/consolidated view of all your dependencies in the [`paket.lock` file](lock-file.html). 
+Paket on the other gives you a global/consolidated view of all your dependencies in the [`paket.lock` file](lock-file.html).
 
 In the very rare cases when you really need to maintain different versions of the same package you can use the [dependency groups feature](http://fsprojects.github.io/Paket/groups.html).
 Every dependency group gets resolved independently so it also deals with the conflict resolution of indirect dependencies, but the most important difference is that using groups is a deliberate action.
@@ -69,9 +69,9 @@ Instead we encourage the .NET community to use a declarative install process and
 
 Committing the [`paket.lock` file](lock-file.html) to your version control system guarantees that other developers and/or build servers will always end up with a reliable and consistent set of packages regardless of where or when [`paket install`](paket-install.html) is run.
 
-If your *project is an application* you should always commit the [`paket.lock` file](lock-file.html). 
+If your *project is an application* you should always commit the [`paket.lock` file](lock-file.html).
 
-If your *project is a library* then you probably want to commit it as well. There are rare cases where you always want to test your lib against the latest version of your dependencies, 
+If your *project is a library* then you probably want to commit it as well. There are rare cases where you always want to test your lib against the latest version of your dependencies,
 but we recommend to set up a second CI build instead. This new build should be run regularly (maybe once a day) and execute [`paket update`](paket-update.html) at the beginning.
 This will ensure that you get notified whenever a dependency update breaks your library.
 
@@ -108,6 +108,7 @@ If your proxy uses custom credentials, you need to set the following environment
 
 For example:
 
+    [lang=paket]
     set HTTP_PROXY=http://user:password@proxy.company.com:port/
     set HTTPS_PROXY=https://user:password@proxy.company.com:port/
     set NO_PROXY=.company.com,localhost

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -27,6 +27,7 @@ Create a [`paket.dependencies` file](dependencies-file.html) in your project's r
 You can use [NuGet packages](nuget-dependencies.html), [GitHub files](github-dependencies.html) and [HTTP dependencies](http-dependencies.html).
 The file might look like this:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget Castle.Windsor-log4net >= 3.2
@@ -47,6 +48,7 @@ Install all of the required packages from the specified sources:
 
 The [`paket install` command](paket-install.html) will analyze your dependencies and automatically generate a [`paket.lock` file](lock-file.html) like:
 
+	[lang=paket]
 	NUGET
 	  remote: https://nuget.org/api/v2
 	  specs:
@@ -79,6 +81,7 @@ In the last paragraph you learned how to install packages into your repository, 
 In order to do so you need a [`paket.references` files](references-files.html) alongside your Visual Studio project files.
 By listing the direct dependencies in a `paket.references` file, Paket will automatically sync references to the corresponding projects whenever an `install` or `update` takes place.
 
+    [lang=paket]
     Castle.Windsor-log4net
     NUnit
 

--- a/docs/content/git-dependencies.md
+++ b/docs/content/git-dependencies.md
@@ -11,6 +11,7 @@ If you don't have git installed then Paket still allows you to <a href="github-d
 
 You can also reference a complete git repository by specifying the clone url in the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     git https://github.com/fsprojects/Paket.git
     git git@github.com:fsharp/FAKE.git
 
@@ -18,6 +19,7 @@ This will clone the repository, checkout the latest version of the default branc
 
 If you want to restrict Paket to a special branch, tag or a concrete commit then this is also possible:
 
+    [lang=paket]
     git https://github.com/fsprojects/Paket.git master
     git http://github.com/forki/AskMe.git 97ee5ae7074bdb414a3e5dd7d2f2d752547d0542
     git http://github.com/forki/AskMe.git 97ee5ae7074b // short hash
@@ -28,11 +30,12 @@ If you want to restrict Paket to a special branch, tag or a concrete commit then
 
 Paket allows you to specify version ranges for git tags similar to [NuGet version ranges](nuget-dependencies.html#Version-constraints):
 
+    [lang=paket]
     git https://github.com/fsprojects/Paket.git >= 1.0 // at least 1.0
     git http://github.com/forki/AskMe.git < 3.0        // lower than version 3.0
     git http://github.com/forki/AskMe.git ~> 2.0       // 2.0 <= x < 3.0
     git https://github.com/forki/FsUnit.git 1.0        // exactly 1.0
-	git file:///C:\Users\Steffen\AskMe >= 1 alpha      // at least 1.0 including alpha versions
+    git file:///C:\Users\Steffen\AskMe >= 1 alpha      // at least 1.0 including alpha versions
     git file:///C:\Users\Steffen\AskMe >= 1 prerelease // at least 1.0 including prereleases
 
 You can read more about the version range details in the corresponding [NuGet reference section](nuget-dependencies.html#Version-constraints).
@@ -41,6 +44,7 @@ You can read more about the version range details in the corresponding [NuGet re
 
 If your referenced git repository contains a build script then Paket can execute this scipt after restore:
 
+    [lang=paket]
     git https://github.com/forki/nupkgtest.git build build:"build.cmd"
 
 This allows you to excute arbitray commands after restore.
@@ -49,12 +53,14 @@ This allows you to excute arbitray commands after restore.
 
 If you have NuGet packages inside a git repository you can easily use the repository as a NuGet source from the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     git https://github.com/forki/nupkgtest.git master Packages: /source/
- 
+
     nuget Argu
 
 The generated [`paket.lock` file](lock-file.html) will look like this:
 
+    [lang=paket]
     NUGET
       remote: paket-files/github.com/forki/nupkgtest/source
       specs:
@@ -66,9 +72,10 @@ The generated [`paket.lock` file](lock-file.html) will look like this:
 
 It's also possible to [run build scripts](git-dependencies.html#Running-a-build-in-git-repositories) to create the NuGet packages:
 
+    [lang=paket]
     git https://github.com/forki/nupkgtest.git master build:"build.cmd", Packages: /source/, OS:windows
     git https://github.com/forki/nupkgtest.git master build:"build.sh", Packages: /source/, OS:mono
-    
+
     nuget Argu
 
 In this sample we have different build scripts for mono and windows.

--- a/docs/content/github-dependencies.md
+++ b/docs/content/github-dependencies.md
@@ -9,10 +9,12 @@ If you have git installed then Paket also allows you to [reference files from ot
 
 You can reference a single file from [github.com](http://www.github.com) simply by specifying the source repository and the file name in the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     github forki/FsUnit FsUnit.fs
 
 If you run the [`paket update` command](paket-update.html), it will download the file to a sub folder in ``paket-files`` and also add a new section to your [`paket.lock` file](lock-file.html):
 
+    [lang=paket]
     GITHUB
       remote: forki/FsUnit
       specs:
@@ -22,11 +24,13 @@ As you can see the file is pinned to a concrete commit. This allows you to relia
 
 By default the `master` branch is used to determine the commit to reference, you can specify the desired branch or commit in the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     github fsharp/fsfoundation:gh-pages img/logo/fsharp.svg
     github forki/FsUnit:7623fc13439f0e60bd05c1ed3b5f6dcb937fe468 FsUnit.fs
 
 If you want to reference the file in one of your project files then add an entry to the project's [`paket.references` file.](references-files.html):
-    
+
+    [lang=paket]
     File:FsUnit.fs
 
 and run [`paket install` command](paket-install.html). This will reference the linked file directly into your project and by default, be visible under ``paket-files`` folder in project.
@@ -35,12 +39,14 @@ and run [`paket install` command](paket-install.html). This will reference the l
 
 You can specify custom folder for the file:
 
+    [lang=paket]
     File:FsUnit.fs Tests\FsUnit
 
 ![alt text](img/github_ref_custom_link.png "GitHub file referenced in project with custom link")
 
 Or if you use ``.`` for the directory, the file will be placed under the root of the project:
-    
+
+    [lang=paket]
     File:FsUnit.fs .
 
 ![alt text](img/github_ref_root.png "GitHub file referenced in project under root of project")
@@ -49,6 +55,7 @@ Or if you use ``.`` for the directory, the file will be placed under the root of
 
 You can also reference a complete [github.com](http://www.github.com) repository by specifying the repository id in the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     github hakimel/reveal.js                                          // master branch
     github hakimel/reveal.js:2.6.2                                    // version 2.6.2
     github hakimel/reveal.js:822a9c937c902807e376713760e1f07845951d5a // specific commit 822a9c937c902807e376713760e1f07845951d5a
@@ -57,8 +64,8 @@ This will download the given repository and put it into your `paket-files` folde
 
 ## Recognizing Build Action
 
-Paket will recognize build action for referenced file based on the project type. 
-As example, for a ``*.csproj`` project file, it will use ``Compile`` Build Action if you reference ``*.cs`` file 
+Paket will recognize build action for referenced file based on the project type.
+As example, for a ``*.csproj`` project file, it will use ``Compile`` Build Action if you reference ``*.cs`` file
 and ``Content`` Build Action if you reference file with any other extension.
 
 ## Remote dependencies
@@ -70,11 +77,13 @@ Let's look at a sample:
 
 And we reference this in our own [`paket.dependencies` file.](dependencies-file.html):
 
+    [lang=paket]
     github fsharp/FAKE modules/Octokit/Octokit.fsx
 
 
 This generates the following [`paket.lock` file](lock-file.html):
 
+    [lang=paket]
 	NUGET
 	  remote: https://nuget.org/api/v2
 	  specs:
@@ -99,19 +108,22 @@ As you can see Paket also resolved the Octokit dependency.
 To reference a private github repository the syntax is identical to
 above and supports the same branch and file definitions the only extra
 item to add is an identifier which defines which credential key to
-use (see [`paket config`](paket-config.html)). 
+use (see [`paket config`](paket-config.html)).
 
-     github fsharp/private src/myprivate/file.fs githubAuthKey
+    [lang=paket]
+    github fsharp/private src/myprivate/file.fs githubAuthKey
 
 ## Gist
 
 Gist works the same way. You can fetch single files or multi-file-gists as well:
 
+    [lang=paket]
     gist Thorium/1972308 gistfile1.fs
     gist Thorium/6088882
 
 If you run the [`paket update` command](paket-update.html), it will add a new section to your [`paket.lock` file](lock-file.html):
 
+    [lang=paket]
     GIST
       remote: Thorium/1972308
       specs:

--- a/docs/content/groups.md
+++ b/docs/content/groups.md
@@ -3,30 +3,31 @@
 *Groups* allow for better organization of dependencies and also enable [easier conflict resolution](groups.html#Conflict-resolution-with-groups).
 Let's consider a small example:
 
+    [lang=paket]
     source https://nuget.org/api/v2
-    
+
     nuget Newtonsoft.Json
     nuget UnionArgParser
     nuget FSharp.Core
-    
+
     github forki/FsUnit FsUnit.fs
     github fsharp/FAKE src/app/FakeLib/Globbing/Globbing.fs
     github fsprojects/Chessie src/Chessie/ErrorHandling.fs
-    
+
     group Build
 
         source https://nuget.org/api/v2
-    
+
         nuget FAKE
         nuget FSharp.Formatting
         nuget ILRepack
-    
+
         github fsharp/FAKE modules/Octokit/Octokit.fsx
-    
+
     group Test
 
         source https://nuget.org/api/v2
-    
+
         nuget NUnit.Runners
         nuget NUnit
 
@@ -35,8 +36,9 @@ The first one is the default group (internally called "Main") and the other two 
 
 <blockquote>Notice the indentation in groups is optional.</blockquote>
 
-After [`paket install`](paket-install.html) the generated [`paket.lock` file](lock-file.html) looks like the following: 
+After [`paket install`](paket-install.html) the generated [`paket.lock` file](lock-file.html) looks like the following:
 
+    [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
       specs:
@@ -86,12 +88,13 @@ After [`paket install`](paket-install.html) the generated [`paket.lock` file](lo
       specs:
         NUnit (2.6.4)
         NUnit.Runners (2.6.4)
-        
+
 As you can see every group is listed separately and it's possible to let Paket [restore only specific groups](paket-restore.html).
 If you want to reference dependencies from projects you can do this via the following syntax in the [`paket.references` file.](references-files.html):
 
+    [lang=paket]
     FSharp.Core
-    
+
     group Test
       NUnit
       NUnit.Runners
@@ -100,30 +103,33 @@ If you want to reference dependencies from projects you can do this via the foll
 
 Paket's group feature allows you to use multiple versions of the same package. Let consider the following [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     source https://nuget.org/api/v2
-    
+
     nuget Newtonsoft.Json
-    
+
     group Legacy
         source https://nuget.org/api/v2
-    
+
         nuget Newtonsoft.Json ~> 6
 
 Every group will be resolved independently to the following [`paket.lock` file](lock-file.html):
 
+    [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
       specs:
         Newtonsoft.Json (7.0.1)
-    
+
     GROUP Legacy
     NUGET
       remote: https://nuget.org/api/v2
       specs:
         Newtonsoft.Json (6.0.8)
-        
+
 Paket is downloading both version. You will get `packages/Newtonsoft.Json` with version 7.0.1 and `packages/legacy/Newtonsoft.Json` with the 6.0.8 bits.
 In your  [`paket.references` file.](references-files.html) you can now decide which version you want to use:
 
+    [lang=paket]
     group Legacy
     Newtonsoft.Json // uses 6.0.8

--- a/docs/content/http-dependencies.md
+++ b/docs/content/http-dependencies.md
@@ -6,10 +6,12 @@ Paket allows one to automatically manage the linking of files from HTTP resource
 
 You can reference a single file from a HTTP resource simply by specifying the url in the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     http http://www.fssnip.net/raw/1M/test1.fs
 
 If you run the [`paket install` command](paket-install.html), it will add a new section to your [`paket.lock` file](lock-file.html):
 
+    [lang=paket]
     HTTP
       remote: http://www.fssnip.net/raw/1M/test1.fs
       specs:
@@ -17,7 +19,8 @@ If you run the [`paket install` command](paket-install.html), it will add a new 
 
 
 If you want to reference the file in one of your project files then add an entry to the project's [`paket.references` file.](references-files.html):
-    
+
+    [lang=paket]
     File:test1.fs
 
 This will reference the linked file directly into your project.
@@ -33,18 +36,20 @@ The build action is determined depending on the file extension:
 
 ## Options on http dependencies
 
-When referencing a file using a http dependency, there are several options that help you to deal with things like authentication and file name. 
-The pattern expected is 
+When referencing a file using a http dependency, there are several options that help you to deal with things like authentication and file name.
+The pattern expected is
 
-	http url [FileSpec] [SourceName]
+    [lang=paket]
+    http url [FileSpec] [SourceName]
 
 * **FileSpec** - This allows you to define the path to which the file that is downloaded will be written to. For example specfying the following
 
+    [lang=paket]
 		http http://www.fssnip.net/raw/1M/test1.fs src/test1.fs
 
-	will write the file to `paket-files\www.fssnip.net\src\test.fs` 
+	will write the file to `paket-files\www.fssnip.net\src\test.fs`
 
-* **SourceName** - The source name allows you to override the folder which the downloaded file is written to and also acts as a key to lookup any authentication 
+* **SourceName** - The source name allows you to override the folder which the downloaded file is written to and also acts as a key to lookup any authentication
 that maybe assoicated for that key. For example if I had added an authentication source using [``paket config add-authentication MySource``](commands\config.html)
 then each time paket extracts a HTTP dependency with `MySource` as a `SourceName` the credentails will be made part of the HTTP request. If no keys exist in the authentication store
 then the request will be made without any authentication headers.
@@ -55,11 +60,11 @@ All `http`, `https` and `file protocol` `URIs` are allowed. Examples:
 
 * http https://raw.githubusercontent.com/fsprojects/Paket/master/src/Paket.Core/ProjectFile.fs
 
-	will write the file to `paket-files\raw.githubusercontent.com\ProjectFile.fs` 
+	will write the file to `paket-files\raw.githubusercontent.com\ProjectFile.fs`
 
 * http file:///c:/projects/library.dll
 
-	will write the file to `paket-files\localhost\library.dll` 
+	will write the file to `paket-files\localhost\library.dll`
 
 ## Updating http dependencies
 

--- a/docs/content/lock-file.md
+++ b/docs/content/lock-file.md
@@ -3,6 +3,7 @@ The paket.lock file
 
 Consider the following [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget Castle.Windsor-log4net !~> 3.2
@@ -12,6 +13,7 @@ Here we [specify dependencies](dependencies-file.html) on the default NuGet feed
 
 The [`paket.lock` file](lock-file.html) records the concrete dependency resolution of all direct *and transitive* dependencies of your project:
 
+    [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
       specs:

--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -16,16 +16,19 @@ Paket supports NuGet feeds like those provided by [nuget.org](http://www.nuget.o
 
 Please note that you need to specify all NuGet sources, including the default feed from [nuget.org](http://www.nuget.org). Paket does not take the current machine's NuGet Package Sources configuration (that you set up e.g. using Visual Studio) into account.
 
+    [lang=paket]
     source https://nuget.org/api/v2     // nuget.org
     source http://myserver/nuget/api/v2 // custom feed
 
 <div id="plaintext-credentials"></div>
 It's also possible to provide login information for private NuGet feeds:
 
+    [lang=paket]
     source http://myserver/nuget/api/v2 username: "my user" password: "my pw"
 
 If you don't want to check your username and password into source control, you can use environment variables instead:
 
+    [lang=paket]
     source http://myserver/nuget/api/v2 username: "%PRIVATE_FEED_USER%" password: "%PRIVATE_FEED_PASS%"
 
 `%PRIVATE_FEED_USER%` and `%PRIVATE_FEED_PASS%` will be expanded with the contents of your `PRIVATE_FEED_USER` and `PRIVATE_FEED_PASS` environment variables.
@@ -36,11 +39,13 @@ The [`paket.lock` file](lock-file.html) will also reflect these settings.
 
 Paket also supports file paths such as local directories or references to UNC shares:
 
+    [lang=paket]
     source C:\Nugets
     source ~/project/nugets
-    
-As well Paket supports the source directory to be specified relative to the `paket.dependencies` file: 
 
+As well Paket supports the source directory to be specified relative to the `paket.dependencies` file:
+
+    [lang=paket]
     source ext/nugets
 
 ## Dependencies
@@ -64,6 +69,7 @@ You can also [influence the resolution of transitive dependencies](#Paket-s-NuGe
 
 #### Pinned version constraint
 
+    [lang=paket]
     nuget Example = 1.2.3
     nuget Example 1.2.3   // same as above
 
@@ -75,18 +81,21 @@ This is the strictest version constraint. Use the `=` operator to specify an exa
 
 If you omit the version constraint then Paket will assume `>= 0`:
 
+    [lang=paket]
     nuget Example
 
 #### "Use exactly this version" constraint
 
 If your transitive dependencies result in a version conflict you might want to instruct Paket to use a specific version. The `==` operator allows you to manually resolve the conflict:
 
+    [lang=paket]
     nuget Example == 1.2.3 // take exactly this version
 
 <blockquote>Important: If you want to restrict the version to a specific version then use the [= operator](nuget-dependencies.html#Pinned-version-constraint). The == operator should only be used if you need to overwrite a dependency resultion due to a conflict.</blockquote>
 
 #### Further version constraints
 
+    [lang=paket]
     nuget Example >= 1.2.3        // at least 1.2.3
     nuget Example > 1.2.3         // greater than 1.2.3
     nuget Example <= 1.2.3        // less than or equal to 1.2.3
@@ -95,6 +104,7 @@ If your transitive dependencies result in a version conflict you might want to i
 
 #### Pessimistic version constraint
 
+    [lang=paket]
     nuget Example ~> 1.2.3
 
 The `~>` "twiddle-wakka" operator is borrowed from [bundler](http://bundler.io/). It is used to specify a version range.
@@ -138,6 +148,7 @@ Let us illustrate:
 
 If want to allow newer backward-compatible versions but also need a specific fix version within the allowed range, use a compound constraint.
 
+    [lang=paket]
     nuget Example ~> 1.2 >= 1.2.3
 
 The example above translates to `1.2.3 <= x < 2.0`.
@@ -146,6 +157,7 @@ The example above translates to `1.2.3 <= x < 2.0`.
 
 If you want to dependend on prereleases then Paket can assist you. In contrast to NuGet, Paket allows you to depend on different prerelease channels:
 
+    [lang=paket]
     nuget Example >= 1.2.3 alpha      // at least 1.2.3 including alpha versions
     nuget Example >= 2 beta rc        // at least 2.0 including rc and beta versions
     nuget Example >= 3 rc             // at least 3.0 but including rc versions
@@ -155,13 +167,15 @@ If you want to dependend on prereleases then Paket can assist you. In contrast t
 
 Sometimes you don't want to generate dependencies for older framework versions. You can control this in the [`paket.dependencies` file](dependencies-file.html):
 
+    [lang=paket]
     nuget Example >= 2.0 framework: net35, net40  // .NET 3.5 and .NET 4.0
     nuget Example >= 2.0 framework: >= net45      // .NET 4.5 and above
 
 ### Putting the version no. into the path
 
 If you need to be NuGet compatible and want to have the version no. in the package path you can do the following:
-    
+
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget xunit.runners.visualstudio >= 2.0 version_in_path: true
@@ -170,12 +184,13 @@ If you need to be NuGet compatible and want to have the version no. in the packa
 ### No content option
 
 This option disables the installation of any content files:
-    
+
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget jQuery content: none // we don't install jQuery content files
-	nuget Fody   content: once // install content files but don't overwrite
-	nuget ServiceStack.Swagger content: true // install content and always override
+    nuget Fody   content: once // install content files but don't overwrite
+    nuget ServiceStack.Swagger content: true // install content and always override
     nuget UnionArgParser ~> 0.7
 
 The default is `content: true`.
@@ -184,6 +199,7 @@ The default is `content: true`.
 
 It's possible to influence the `Private` property for references in project files:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget Newtonsoft.Json copy_local: false
@@ -192,18 +208,21 @@ It's possible to influence the `Private` property for references in project file
 
 You can instruct Paket to create assembly binding redirects for NuGet packages:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget FSharp.Core redirects: on
 
 Redirects are created only if they are required. However, you can instruct Paket to create it regardless:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget FSharp.Core redirects: force
 
 In constract, you have the option to force Paket to not create a redirect:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget FSharp.Core redirects: off
@@ -214,6 +233,7 @@ You can also override the redirects settings per project, from its [references f
 
 If you don't want to import `.targets` and `.props` files you can disable it via the `import_targets` switch:
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget Microsoft.Bcl.Build import_targets: false // we don't import .targets and .props
@@ -227,6 +247,7 @@ To override a [strategy option](dependencies-file.html#Strategy-option) or the d
 
 To request Paket to override the resolver strategy for the transitive dependencies of a package, use the `@` operator in your version constraint.
 
+    [lang=paket]
     strategy: min
     source https://nuget.org/api/v2
 
@@ -238,6 +259,7 @@ This effectively will get you the *lastest matching versions* of `Example`'s dep
 
 To request Paket to override the resolver strategy for the transitive dependencies of a package, use the `!` operator in your version constraint.
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget Example !~> 1.2 // use "min" version resolution strategy
@@ -246,6 +268,7 @@ This effectively will get you the *lowest matching versions* of `Example`'s depe
 
 The `!` and `@` modifiers are applicable to all [version constraints](#Version-constraints):
 
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget Example-A @> 0 // use "max" version resolution strategy
@@ -255,7 +278,8 @@ The `!` and `@` modifiers are applicable to all [version constraints](#Version-c
 ### Specifying multiple targeting options
 
 It is possible to apply more than one of the options above to a particular package.  To do so, simply separate them by commas, like so:
-    
+
+    [lang=paket]
     source https://nuget.org/api/v2
 
     nuget ClearScript.Installer import_targets: false, content: none // we don't import .targets and .props, and also don't add any content

--- a/docs/content/references-files.md
+++ b/docs/content/references-files.md
@@ -16,11 +16,12 @@ Paket looks for `paket.references` files underneath the folder where [`paket.dep
 
 The file whitelists any dependencies from the [`paket.lock` file](lock-file.html) set that are to be referenced within the projects alongside it in a given directory:
 
+    [lang=paket]
     Newtonsoft.Json
     UnionArgParser
     DotNetZip
     RestSharp
-    
+
     group Test
         NUnit
 
@@ -34,39 +35,46 @@ Any [roslyn based analyzer](analyzers.html) present in the packages will also be
 
 It's possible to influence the `Private` property for references in project files:
 
+    [lang=paket]
     Newtonsoft.Json copy_local:false
 
 ## import_targets settings
 
 If you don't want to import `.targets` and `.props` files you can disable it via the `import_targets` switch:
 
+    [lang=paket]
     Microsoft.Bcl.Build import_targets:false
 
 ## No content option
 
 This option disables the installation of any content files for the given package:
-    
+
+    [lang=paket]
     jQuery content: none
 
 ## Framework restrictions
 
 Sometimes you don't want to generate dependencies for older framework versions. You can control this in the [`paket.dependencies` file](nuget-dependencies.html#Framework-restrictions) or via the `framework` switch:
 
-    Newtonsoft.Json framework: net35, net40 
+    [lang=paket]
+    Newtonsoft.Json framework: net35, net40
     DotNetZip framework: >= net45           
 
 ## Redirects settings
 
 You can instruct Paket to create assembly binding redirects for NuGet packages:
 
+    [lang=paket]
     FSharp.Core redirects: on
 
 Redirects are created only if they are required. However, you can instruct Paket to create it regardless:
 
+    [lang=paket]
     FSharp.Core redirects: force
 
 In constract, you have the option to force Paket to not create a redirect:
 
+    [lang=paket]
     FSharp.Core redirects: off
 
 Redirects settings in [references files](references-files.html#Redirects-settings) takes precedence over settings in [dependencies file](nuget-dependencies.html#redirects-settings).

--- a/paket.lock
+++ b/paket.lock
@@ -19,7 +19,7 @@ NUGET
   specs:
     FAKE (4.15.1)
     FSharp.Compiler.Service (1.4.2.3)
-    FSharp.Formatting (2.13.2)
+    FSharp.Formatting (2.13.4)
       FSharp.Compiler.Service (>= 1.4.2 < 1.5.0)
       FSharpVSPowerTools.Core (>= 2.2.0 < 2.3.0)
     FSharpVSPowerTools.Core (2.2.0)
@@ -36,7 +36,7 @@ NUGET
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (474eb69504fd0a904fc66305d962049fab1c857d)
+    modules/Octokit/Octokit.fsx (627d68727518ef0c013d0dfbb0260aba84de98e1)
       Octokit
 GROUP Test
 NUGET


### PR DESCRIPTION
This PR:
 - Updates FSharp.Formatting version to 2.13.4 which contains tpetricek/FSharp.Formatting#379
 - Adds the [lang=paket] command to all code blocks that contain paket code to use the new Paket syntax coloring.

The documentation will look like this:
![image](https://cloud.githubusercontent.com/assets/403823/12455250/088af1d4-bf9b-11e5-92ab-df7e80035385.png)

![image](https://cloud.githubusercontent.com/assets/403823/12455265/1d522754-bf9b-11e5-9ac5-d7e692f3922e.png)

