### PR TITLE
If Paket bootstrapper fails, suggest common fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,18 @@ else
   mono .paket/paket.bootstrapper.exe prerelease
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
+    certificate_count=$(certmgr -list -c Trust | grep X.509 | wc -l)
+    if [ $certificate_count -le 1 ]; then
+      echo "Couldn't download Paket. This might be because your Mono installation"
+      echo "doesn't have the right SSL root certificates installed. One way"
+      echo "to fix this would be to download the list of SSL root certificates"
+      echo "from the Mozilla project by running the following command:"
+      echo ""
+      echo "    mozroots --import --sync"
+      echo ""
+      echo "This will import over 100 SSL root certificates into your Mono"
+      echo "certificate repository. Then try running the build script again."
+    fi
   	exit $exit_code
   fi
 


### PR DESCRIPTION
One of the most common reasons for the Paket bootstrapper to fail on Linux is if the Mono installation is brand-new -- because out of the box, Mono does not trust *any* X.509 root certificates. Therefore, GitHub's SSL certificate won't be trusted and Paket won't be downloaded.

The fix most often recommended is to run:

    mozroots --import --sync

which imports the entire root SSL certificate store trusted by the Mozilla project. This is over 100 certificates, so not everyone will want to run this command. (And we certainly shouldn't be running it for them.) But for someone who is new to F# and Mono, this suggestion might save them hours of frustrated Google searches.

Note that we try to only print this message if it looks like it is actually true for the user's situation, by using Mono's certificate manager to count the number of trusted X.509 certificates. We compare to 1 rather than 0 because the word "X.509" will appear once in the header of certmgr's output even on a system with no trusted root certs.