### PR TITLE
fix convert-from-nuget

### DIFF
--- a/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
@@ -51,3 +51,10 @@ let ``#1225 should convert simple C# project with non-matching framework restric
     requirement2.VersionRequirement.ToString() |> shouldEqual "7.0.1"
     requirement2.ResolverStrategy |> shouldEqual None
     requirement2.Settings.FrameworkRestrictions |> shouldEqual [FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))]
+
+[<Test>]
+let ``#1217 should replace packages.config files in project``() = 
+    paket "convert-from-nuget" "i001217-convert-simple-project" |> ignore
+    let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001217-convert-simple-project","paket.lock"))
+    let projectFile = ProjectFile.loadFromFile(Path.Combine(scenarioTempPath "i001217-convert-simple-project", "ClassLibrary1", "ClassLibrary1.csproj"))
+    projectFile.Document.OuterXml.Contains("packages.config") |> shouldEqual false

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -966,7 +966,7 @@ module ProjectFile =
         let noneAndContentNodes = 
             (project.Document |> getDescendants "None") @ 
             (project.Document |> getDescendants "Content")
-
+        
         match noneAndContentNodes |> List.tryFind (withAttributeValue "Include" Constants.PackagesConfigFile) with
         | None -> ()
         | Some nugetNode ->
@@ -1296,7 +1296,7 @@ type ProjectFile with
 
     member this.GetAllInterProjectDependenciesWithProjectTemplates = ProjectFile.getAllReferencedProjects this |> ProjectFile.projectsWithTemplates this
 
-    member this.ReplaceNuGetPackagesFile () = ProjectFile.removeNuGetTargetsEntries this
+    member this.ReplaceNuGetPackagesFile () = ProjectFile.replaceNuGetPackagesFile this
 
     member this.RemoveNuGetTargetsEntries () =  ProjectFile.removeNuGetTargetsEntries this
 


### PR DESCRIPTION
found the reason the packages.configs weren't being changed to paket.references in the project files.

seems I inadvertently changed a line during one of my commits. :-s 