### PR TITLE
Automatic framework detection - references #1440

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 #### 2.49.0-alpha001 - 03.02.2016
 * Automatic framework detection - http://fsprojects.github.io/Paket/dependencies-file.html#Automatic-framework-detection
-* Work around auth issues with VSTS feed - https://github.com/fsprojects/Paket/issues/1453
-* Show warning if a dependency is installed for wrong target framework - https://github.com/fsprojects/Paket/pull/1445
+* BUGFIX: Work around auth issues with VSTS feed - https://github.com/fsprojects/Paket/issues/1453
+* USABILITY: Show warning if a dependency is installed for wrong target framework - https://github.com/fsprojects/Paket/pull/1445
 
 #### 2.48.0 - 28.01.2016
 * New lowest_matching option that allows to use lowest matching version of direct dependencies - http://fsprojects.github.io/Paket/dependencies-file.html#Lowest-matching-option

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,6 @@
-#### 2.48.2 - 03.02.2016
+#### 2.49.0-alpha001 - 03.02.2016
+* Automatic framework detection - http://fsprojects.github.io/Paket/dependencies-file.html#Automatic-framework-detection
 * Work around auth issues with VSTS feed - https://github.com/fsprojects/Paket/issues/1453
-
-#### 2.48.1 - 29.01.2016
 * Show warning if a dependency is installed for wrong target framework - https://github.com/fsprojects/Paket/pull/1445
 
 #### 2.48.0 - 28.01.2016

--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -68,6 +68,18 @@ Sometimes you don't want to generate dependencies for older framework versions. 
 
     nuget Example >= 2.0 // only .NET 3.5 and .NET 4.0
 
+#### Automatic framework detection
+
+Paket can detect the target frameworks from your project and then limit the installation to these target frameworks. You can control this in the [`paket.dependencies` file](dependencies-file.html):
+
+    [lang=paket]
+    framework: auto-detect
+    source https://nuget.org/api/v2
+
+    nuget Example >= 2.0 // only the target frameworks that are used in projects
+
+If you change the target frameworks in the projects then you need to run `paket install` again.
+
 ### No content option
 
 This option disables the installation of any content files:

--- a/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
@@ -44,13 +44,13 @@ let ``#1225 should convert simple C# project with non-matching framework restric
     requirement.Name |> shouldEqual (PackageName "Castle.Core")
     requirement.VersionRequirement.ToString() |> shouldEqual "3.3.3"
     requirement.ResolverStrategyForTransitives |> shouldEqual None
-    requirement.Settings.FrameworkRestrictions |> shouldEqual [FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))]
+    requirement.Settings.FrameworkRestrictions  |> getRestrictionList |> shouldEqual [FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))]
 
     let requirement2 = depsFile.GetGroup(Constants.MainDependencyGroup).Packages.Tail.Head
     requirement2.Name |> shouldEqual (PackageName "Newtonsoft.Json")
     requirement2.VersionRequirement.ToString() |> shouldEqual "7.0.1"
     requirement2.ResolverStrategyForTransitives |> shouldEqual None
-    requirement2.Settings.FrameworkRestrictions |> shouldEqual [FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))]
+    requirement2.Settings.FrameworkRestrictions  |> getRestrictionList |> shouldEqual [FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))]
 
 [<Test>]
 let ``#1217 should replace packages.config files in project``() = 

--- a/integrationtests/Paket.IntegrationTests/FrameworkRestrictionsSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/FrameworkRestrictionsSpecs.fs
@@ -1,5 +1,4 @@
 module Paket.IntegrationTests.FrameworkRestrictionsSpecs
-
 open Fake
 open Paket
 open System
@@ -14,6 +13,7 @@ open Paket.Requirements
 let ``#140 windsor should resolve framework dependent dependencies``() =
     let lockFile = update "i000140-resolve-framework-restrictions"
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "TaskParallelLibrary"].Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldEqual [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V3_5))]
 
 [<Test>]
@@ -29,6 +29,7 @@ let ``#1190 paket add nuget should handle transitive dependencies``() =
     
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001190-transitive-dependencies-with-restr","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "xunit.abstractions"].Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldContain (FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5)))
     
 [<Test>]
@@ -37,6 +38,7 @@ let ``#1190 paket add nuget should handle transitive dependencies with restricti
     
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001190-transitive-deps","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "xunit.abstractions"].Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldEqual []
     
     
@@ -53,6 +55,7 @@ let ``#1213 framework dependencies propagate``() =
     let lockFile = update "i001213-framework-propagation"
     
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Newtonsoft.Json"].Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldEqual []
 
 [<Test>]
@@ -60,6 +63,7 @@ let ``#1215 framework dependencies propagate``() =
     let lockFile = update "i001215-framework-propagation-no-restriction"
     
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Microsoft.Bcl.Async"].Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldEqual []
 
 [<Test>]
@@ -67,4 +71,5 @@ let ``#1232 framework dependencies propagate``() =
     let lockFile = update "i001232-sql-lite"
     
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "System.Data.SQLite.Core"].Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldContain (FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client)))

--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -128,6 +128,15 @@ let ``#1427 won't install content when content:none``() =
     s1 |> shouldEqual s2 // we do not touch it
 
 [<Test>]
+let ``#1440 auto-detect framework``() = 
+    let newLockFile = install "i001440-auto-detect"
+    let newFile = Path.Combine(scenarioTempPath "i001440-auto-detect","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
+    let oldFile = Path.Combine(originalScenarioPath "i001440-auto-detect","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
+    let s1 = File.ReadAllText oldFile |> normalizeLineEndings
+    let s2 = File.ReadAllText newFile |> normalizeLineEndings
+    s1 |> shouldEqual s2
+
+[<Test>]
 let ``#1442 warn if install finds no libs``() = 
     let result = paket "install" "i001442-warn-if-empty"
     result |> shouldContainText "contains libraries, but not for the selected TargetFramework"

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary.sln
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{673951A0-5216-4FBD-BA08-7FA057D5CC0D}"
+	ProjectSection(SolutionItems) = preProject
+		..\paket.dependencies = ..\paket.dependencies
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyClassLibrary", "MyClassLibrary\MyClassLibrary.csproj", "{CD678800-8DFC-4BB1-911A-7234F492EA29}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD678800-8DFC-4BB1-911A-7234F492EA29}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/Class1.cs
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CD678800-8DFC-4BB1-911A-7234F492EA29}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MyClassLibrary</RootNamespace>
+    <AssemblyName>MyClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')">
+      <ItemGroup>
+        <Reference Include="Newtonsoft.Json">
+          <HintPath>..\..\packages\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/Properties/AssemblyInfo.cs
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MyClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MyClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cd678800-8dfc-4bb1-911a-7234f492ea29")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/paket.references
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary/paket.references
@@ -1,0 +1,1 @@
+Newtonsoft.Json

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/Class1.cs
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyClassLibrary
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/MyClassLibrary.csprojtemplate
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/MyClassLibrary.csprojtemplate
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CD678800-8DFC-4BB1-911A-7234F492EA29}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MyClassLibrary</RootNamespace>
+    <AssemblyName>MyClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.5.3</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.2'">
+      <ItemGroup>
+        <Reference Include="Newtonsoft.Json">
+          <HintPath>..\..\packages\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/Properties/AssemblyInfo.cs
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MyClassLibrary")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MyClassLibrary")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cd678800-8dfc-4bb1-911a-7234f492ea29")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/paket.references
+++ b/integrationtests/scenarios/i001440-auto-detect/before/MyClassLibrary/MyClassLibrary2/paket.references
@@ -1,0 +1,1 @@
+Newtonsoft.Json

--- a/integrationtests/scenarios/i001440-auto-detect/before/paket.dependencies
+++ b/integrationtests/scenarios/i001440-auto-detect/before/paket.dependencies
@@ -1,0 +1,4 @@
+source https://www.nuget.org/api/v2/
+framework auto-detect
+
+nuget Newtonsoft.Json

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -4,11 +4,11 @@ using System.Reflection;
 [assembly: AssemblyTitleAttribute("Paket.Bootstrapper")]
 [assembly: AssemblyProductAttribute("Paket")]
 [assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")]
-[assembly: AssemblyVersionAttribute("2.48.2")]
-[assembly: AssemblyFileVersionAttribute("2.48.2")]
-[assembly: AssemblyInformationalVersionAttribute("2.48.2")]
+[assembly: AssemblyVersionAttribute("2.49.0")]
+[assembly: AssemblyFileVersionAttribute("2.49.0")]
+[assembly: AssemblyInformationalVersionAttribute("2.49.0-alpha001")]
 namespace System {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.48.2";
+        internal const string Version = "2.49.0";
     }
 }

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.48.2")>]
-[<assembly: AssemblyFileVersionAttribute("2.48.2")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.48.2")>]
+[<assembly: AssemblyVersionAttribute("2.49.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.49.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.49.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.48.2"
+    let [<Literal>] Version = "2.49.0"

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -202,6 +202,7 @@ module DependenciesFileParser =
     | ReferencesMode of bool
     | OmitContent of ContentCopySettings
     | FrameworkRestrictions of FrameworkRestrictions
+    | AutodetectFrameworkRestrictions
     | ImportTargets of bool
     | CopyLocal of bool
     | ReferenceCondition of string
@@ -260,9 +261,18 @@ module DependenciesFileParser =
 
             ParserOptions(ParserOption.ResolverStrategyForDirectDependencies(setting))
         | String.StartsWith "framework" trimmed -> 
-            let text = trimmed.Replace(":","").Trim() 
-            let restriction = Requirements.parseRestrictions text
-            ParserOptions(ParserOption.FrameworkRestrictions restriction)
+            let text = trimmed.Replace(":", "").Trim()
+            
+            if text = "auto-detect" then 
+                ParserOptions(ParserOption.AutodetectFrameworkRestrictions)
+            else 
+                let restrictions = Requirements.parseRestrictions text
+                if String.IsNullOrWhiteSpace text |> not && List.isEmpty restrictions then 
+                    failwithf "Could not parse framework restriction \"%s\"" text
+
+                let options = ParserOption.FrameworkRestrictions(FrameworkRestrictionList restrictions)
+                ParserOptions options
+
         | String.StartsWith "content" trimmed -> 
             let setting =
                 match trimmed.Replace(":","").Trim().ToLowerInvariant() with
@@ -337,6 +347,8 @@ module DependenciesFileParser =
         | CopyLocal mode -> { current.Options with Settings = { current.Options.Settings with CopyLocal = Some mode } }
         | ImportTargets mode -> { current.Options with Settings = { current.Options.Settings with ImportTargets = Some mode } }
         | FrameworkRestrictions r -> { current.Options with Settings = { current.Options.Settings with FrameworkRestrictions = r } }
+        | AutodetectFrameworkRestrictions ->
+            { current.Options with Settings = { current.Options.Settings with FrameworkRestrictions = AutoDetectFramework } }
         | OmitContent omit -> { current.Options with Settings = { current.Options.Settings with OmitContent = Some omit } }
         | ReferenceCondition condition -> { current.Options with Settings = { current.Options.Settings with ReferenceCondition = Some condition } }
 
@@ -473,13 +485,14 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
 
     member this.SimplifyFrameworkRestrictions() = 
         let transform (dependenciesFile:DependenciesFile) (group:DependenciesGroup) =
-            if group.Options.Settings.FrameworkRestrictions <> [] then dependenciesFile else
+            if group.Options.Settings.FrameworkRestrictions |> getRestrictionList <> [] then dependenciesFile else
             match group.Packages with
             | [] -> dependenciesFile
             | package::rest ->
                 let commonRestrictions =
                     package.Settings.FrameworkRestrictions
-                    |> List.filter (fun r -> rest |> Seq.forall (fun p' -> p'.Settings.FrameworkRestrictions |> List.contains r))
+                    |> getRestrictionList
+                    |> List.filter (fun r -> rest |> Seq.forall (fun p' -> p'.Settings.FrameworkRestrictions |> getRestrictionList |> List.contains r))
 
                 match commonRestrictions with
                 | [] -> dependenciesFile
@@ -487,11 +500,11 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
                     let newDependenciesFile = dependenciesFile.AddFrameworkRestriction(group.Name,commonRestrictions)
                     group.Packages
                      |> List.fold (fun (d:DependenciesFile) package ->
-                            let oldRestrictions = package.Settings.FrameworkRestrictions
+                            let oldRestrictions = package.Settings.FrameworkRestrictions |> getRestrictionList
                             let newRestrictions = oldRestrictions |> List.filter (fun r -> commonRestrictions |> List.contains r |> not)
                             if oldRestrictions = newRestrictions then d else
                             let (d:DependenciesFile) = d.Remove(group.Name,package.Name)
-                            d.Add(group.Name,package.Name,package.VersionRequirement.ToString(),{ package.Settings with FrameworkRestrictions = newRestrictions })) newDependenciesFile
+                            d.Add(group.Name,package.Name,package.VersionRequirement.ToString(),{ package.Settings with FrameworkRestrictions = FrameworkRestrictionList newRestrictions })) newDependenciesFile
 
         this.Groups
         |> Seq.map (fun kv -> kv.Value)
@@ -555,7 +568,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
         |> Map.map resolveGroup 
 
 
-    member private this.AddFrameworkRestriction(groupName, frameworkRestrictions:FrameworkRestrictions) =
+    member private this.AddFrameworkRestriction(groupName, frameworkRestrictions:FrameworkRestriction list) =
         if frameworkRestrictions = [] then this else
         let restrictionString = sprintf "framework %s" (String.Join(", ",frameworkRestrictions))
 

--- a/src/Paket.Core/FindOutdated.fs
+++ b/src/Paket.Core/FindOutdated.fs
@@ -44,6 +44,8 @@ let FindOutdated strict includingPrereleases environment = trial {
         | ResolverStrategy.Min -> List.sort versions
         |> List.toSeq
 
+    let dependenciesFile = UpdateProcess.detectProjectFrameworksForDependenciesFile dependenciesFile
+
     let newResolution = dependenciesFile.Resolve(force, getSha1, getVersionsF, NuGetV2.GetPackageDetails root true, dependenciesFile.Groups, PackageResolver.UpdateMode.UpdateAll)
 
     let changed = 

--- a/src/Paket.Core/InstallModel.fs
+++ b/src/Paket.Core/InstallModel.fs
@@ -236,9 +236,9 @@ module InstallModel =
             TargetsFileFolders = addFileToFolder path file installModel.TargetsFileFolders InstallFiles.addTargetsFile
         }
 
-    let addFrameworkAssemblyReference (installModel:InstallModel) (reference:FrameworkAssemblyReference)  : InstallModel =
+    let addFrameworkAssemblyReference (installModel:InstallModel) (reference:FrameworkAssemblyReference) : InstallModel =
         let referenceApplies (folder : LibFolder) =
-            match reference.FrameworkRestrictions with
+            match reference.FrameworkRestrictions |> getRestrictionList with
             | [] -> true
             | restrictions ->
                 restrictions
@@ -300,7 +300,7 @@ module InstallModel =
                 mapFiles (fun files -> { files with References = Set.filter f files.References }) model)
                 installModel
 
-    let applyFrameworkRestrictions (restrictions:FrameworkRestrictions) (installModel:InstallModel) =
+    let applyFrameworkRestrictions (restrictions:FrameworkRestriction list) (installModel:InstallModel) =
         match restrictions with
         | [] -> installModel
         | restrictions ->
@@ -402,5 +402,5 @@ type InstallModel with
 
     member this.RemoveIfCompletelyEmpty() = InstallModel.removeIfCompletelyEmpty this
     
-    static member CreateFromLibs(packageName, packageVersion, frameworkRestrictions:FrameworkRestrictions, libs, targetsFiles, analyzerFiles, nuspec : Nuspec) = 
+    static member CreateFromLibs(packageName, packageVersion, frameworkRestrictions:FrameworkRestriction list, libs, targetsFiles, analyzerFiles, nuspec : Nuspec) = 
         InstallModel.createFromLibs packageName packageVersion frameworkRestrictions libs targetsFiles analyzerFiles nuspec 

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -136,7 +136,7 @@ let CreateInstallModel(root, groupName, sources, force, package) =
         let files = files |> Array.map (fun fi -> fi.FullName)
         let targetsFiles = targetsFiles |> Array.map (fun fi -> fi.FullName)
         let analyzerFiles = analyzerFiles |> Array.map (fun fi -> fi.FullName)
-        let model = InstallModel.CreateFromLibs(package.Name, package.Version, package.Settings.FrameworkRestrictions, files, targetsFiles, analyzerFiles, nuspec)
+        let model = InstallModel.CreateFromLibs(package.Name, package.Version, package.Settings.FrameworkRestrictions |> getRestrictionList, files, targetsFiles, analyzerFiles, nuspec)
         return (groupName,package.Name), (package,model)
     }
 

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -48,9 +48,9 @@ module LockFileSerializer =
         | Some condition -> yield "CONDITION: " + condition.ToUpper()
         | None -> ()
 
-        match options.Settings.FrameworkRestrictions with
+        match options.Settings.FrameworkRestrictions |> getRestrictionList with
         | [] -> ()
-        | _  -> yield "FRAMEWORK: " + (String.Join(", ",options.Settings.FrameworkRestrictions)).ToUpper()]
+        | list  -> yield "FRAMEWORK: " + (String.Join(", ",list)).ToUpper()]
 
     /// [omit]
     let serializePackages options (resolved : PackageResolution) = 
@@ -86,7 +86,7 @@ module LockFileSerializer =
 
                       let settings =
                         if package.Settings.FrameworkRestrictions = options.Settings.FrameworkRestrictions then
-                            { package.Settings with FrameworkRestrictions = [] }
+                            { package.Settings with FrameworkRestrictions = FrameworkRestrictionList [] }
                         else
                             package.Settings
                       let s = settings.ToString()
@@ -101,8 +101,8 @@ module LockFileSerializer =
                               let s = v.ToString()
                               if s = "" then s else "(" + s + ")"
 
-                          let restrictions = filterRestrictions options.Settings.FrameworkRestrictions restrictions
-                          if List.isEmpty restrictions || restrictions = options.Settings.FrameworkRestrictions then
+                          let restrictions = filterRestrictions options.Settings.FrameworkRestrictions restrictions |> getRestrictionList
+                          if List.isEmpty restrictions || restrictions = getRestrictionList options.Settings.FrameworkRestrictions then
                             yield sprintf "      %O %s" name versionStr
                           else
                             yield sprintf "      %O %s - framework: %s" name versionStr (String.Join(", ",restrictions))]
@@ -204,7 +204,7 @@ module LockFileParser =
             InstallOption(Redirects(setting))
         | _, String.StartsWith "IMPORT-TARGETS:" trimmed -> InstallOption(ImportTargets(trimmed.Trim() = "TRUE"))
         | _, String.StartsWith "COPY-LOCAL:" trimmed -> InstallOption(CopyLocal(trimmed.Trim() = "TRUE"))
-        | _, String.StartsWith "FRAMEWORK:" trimmed -> InstallOption(FrameworkRestrictions(trimmed.Trim() |> Requirements.parseRestrictions))
+        | _, String.StartsWith "FRAMEWORK:" trimmed -> InstallOption(FrameworkRestrictions(FrameworkRestrictionList (trimmed.Trim() |> Requirements.parseRestrictions)))
         | _, String.StartsWith "CONDITION:" trimmed -> InstallOption(ReferenceCondition(trimmed.Trim().ToUpper()))
         | _, String.StartsWith "CONTENT:" trimmed -> 
             let setting =

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -313,7 +313,11 @@ let getDetailsFromLocalNuGetPackage root localNugetPath (packageName:PackageName
         return 
             { PackageName = nuspec.OfficialName
               DownloadUrl = packageName.ToString()
-              Dependencies = Requirements.optimizeDependencies nuspec.Dependencies
+              Dependencies = 
+                nuspec.Dependencies
+                |> List.map (fun (a,b,c) -> a,b, getRestrictionList c)
+                |> Requirements.optimizeDependencies 
+
               SourceUrl = di.FullName
               CacheVersion = NuGetPackageCache.CurrentCacheVersion
               LicenseUrl = nuspec.LicenseUrl

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -260,7 +260,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
     let read() =
         let addPackages dependenciesFile = 
             packages
-            |> List.map (fun (name, v, restrictions) -> Constants.MainDependencyGroup, PackageName name, v, { InstallSettings.Default with FrameworkRestrictions = restrictions})
+            |> List.map (fun (name, v, restrictions) -> Constants.MainDependencyGroup, PackageName name, v, { InstallSettings.Default with FrameworkRestrictions = FrameworkRestrictionList restrictions})
             |> List.fold (fun (dependenciesFile:DependenciesFile) (groupName, packageName,version,installSettings) -> dependenciesFile.Add(groupName, packageName,version,installSettings)) dependenciesFile
         try 
             DependenciesFile.ReadFromFile dependenciesFileName
@@ -289,7 +289,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
             let packageLines = 
                 packages 
                 |> List.map (fun (name,v,restr) -> 
-                    let vr = createPackageRequirement (name, v, restr) dependenciesFileName
+                    let vr = createPackageRequirement (name, v, FrameworkRestrictionList restr) dependenciesFileName
                     DependenciesFileSerializer.packageString vr.Name vr.VersionRequirement vr.ResolverStrategyForTransitives vr.Settings)
 
             let newLines = sourceLines @ [""] @ packageLines |> Seq.toArray

--- a/src/Paket.Core/Nuspec.fs
+++ b/src/Paket.Core/Nuspec.fs
@@ -44,13 +44,13 @@ module internal NuSpecParserHelper =
         let targetFrameworks = node |> getAttribute "targetFramework"
         match name,targetFrameworks with
         | Some name, Some targetFrameworks when targetFrameworks = "" ->
-            [{ AssemblyName = name; FrameworkRestrictions = [] }]
+            [{ AssemblyName = name; FrameworkRestrictions = FrameworkRestrictionList [] }]
         | Some name, None ->
-            [{ AssemblyName = name; FrameworkRestrictions = [] }]
+            [{ AssemblyName = name; FrameworkRestrictions = FrameworkRestrictionList [] }]
         | Some name, Some targetFrameworks ->
             targetFrameworks.Split([|','; ' '|],System.StringSplitOptions.RemoveEmptyEntries)
             |> Array.choose FrameworkDetection.Extract
-            |> Array.map (fun fw -> { AssemblyName = name; FrameworkRestrictions = [FrameworkRestriction.Exactly fw] })
+            |> Array.map (fun fw -> { AssemblyName = name; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly fw] })
             |> Array.toList
         | _ -> []
 
@@ -89,7 +89,7 @@ type Nuspec =
                     match node |> getAttribute "targetFramework" with
                     | Some framework ->
                         match FrameworkDetection.Extract framework with
-                        | Some x -> [PackageName "",VersionRequirement.NoRestriction,[FrameworkRestriction.Exactly x]]
+                        | Some x -> [PackageName "",VersionRequirement.NoRestriction, [FrameworkRestriction.Exactly x]]
                         | None -> []
                     | _ -> [])
                 |> List.concat
@@ -129,4 +129,4 @@ type Nuspec =
 
                 [for name,restrictions in grouped do
                     yield { AssemblyName = name
-                            FrameworkRestrictions = List.collect (fun x -> x.FrameworkRestrictions) restrictions } ] }
+                            FrameworkRestrictions = FrameworkRestrictionList(List.collect (fun x -> x.FrameworkRestrictions |> getRestrictionList) restrictions) } ] }

--- a/src/Paket.Core/ReferencesFile.fs
+++ b/src/Paket.Core/ReferencesFile.fs
@@ -140,7 +140,7 @@ type ReferencesFile =
 
                 { this with Groups = newGroups }
 
-    member this.AddNuGetReference(groupName, packageName : PackageName) = this.AddNuGetReference(groupName, packageName, true, true, [], false, false, None, null)
+    member this.AddNuGetReference(groupName, packageName : PackageName) = this.AddNuGetReference(groupName, packageName, true, true, FrameworkRestrictionList [], false, false, None, null)
 
     member this.RemoveNuGetReference(groupName, packageName : PackageName) =
         let group = this.Groups.[groupName]

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -157,13 +157,35 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
     
     LockFile(lockFile.FileName, groups)
 
+let detectProjectFrameworksForDependenciesFile (dependenciesFile:DependenciesFile) =
+    let root = Path.GetDirectoryName dependenciesFile.FileName
+    let groups =
+        let targetFrameworks = lazy (
+            InstallProcess.findAllReferencesFiles root |> returnOrFail
+            |> List.map (fun (p,_) -> 
+                match p.GetTargetFramework() with
+                | Some fw -> Requirements.FrameworkRestriction.Exactly fw
+                | None -> failwithf "Could not detect target framework for project %s" p.FileName))
+
+        dependenciesFile.Groups
+        |> Map.map (fun groupName group -> 
+            let restrictions =
+                match group.Options.Settings.FrameworkRestrictions with
+                | Requirements.FrameworkRestrictions.AutoDetectFramework ->
+                    Requirements.FrameworkRestrictions.FrameworkRestrictionList (targetFrameworks.Force())
+                | x -> x
+
+            let settings = { group.Options.Settings with FrameworkRestrictions = restrictions }
+            let options = { group.Options with Settings = settings }
+            { group with Options = options })
+
+    DependenciesFile(dependenciesFile.FileName,groups,dependenciesFile.Lines)
+
 let SelectiveUpdate(dependenciesFile : DependenciesFile, updateMode, semVerUpdateMode, force) =
     let lockFileName = DependenciesFile.FindLockfile dependenciesFile.FileName
     let oldLockFile,updateMode =
-        if (updateMode = UpdateMode.UpdateAll && semVerUpdateMode = SemVerUpdateMode.NoRestriction) ||
-           not lockFileName.Exists
-        then
-            LockFile.Parse(lockFileName.FullName, [||]),UpdateAll // Change updateMode to UpdateAll
+        if (updateMode = UpdateMode.UpdateAll && semVerUpdateMode = SemVerUpdateMode.NoRestriction) || not lockFileName.Exists then
+            LockFile.Parse(lockFileName.FullName, [||]),UpdateAll
         else
             LockFile.LoadFrom lockFileName.FullName,updateMode
 
@@ -174,6 +196,8 @@ let SelectiveUpdate(dependenciesFile : DependenciesFile, updateMode, semVerUpdat
         match resolverStrategy with
         | ResolverStrategy.Max -> List.sortDescending versions
         | ResolverStrategy.Min -> List.sort versions
+
+    let dependenciesFile = detectProjectFrameworksForDependenciesFile dependenciesFile
 
     let lockFile = 
         selectiveUpdate

--- a/src/Paket.PowerShell/AssemblyInfo.fs
+++ b/src/Paket.PowerShell/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.48.2")>]
-[<assembly: AssemblyFileVersionAttribute("2.48.2")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.48.2")>]
+[<assembly: AssemblyVersionAttribute("2.49.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.49.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.49.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.48.2"
+    let [<Literal>] Version = "2.49.0"

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -5,10 +5,10 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A package dependency manager for .NET with support for NuGet packages and GitHub repositories.")>]
-[<assembly: AssemblyVersionAttribute("2.48.2")>]
-[<assembly: AssemblyFileVersionAttribute("2.48.2")>]
-[<assembly: AssemblyInformationalVersionAttribute("2.48.2")>]
+[<assembly: AssemblyVersionAttribute("2.49.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.49.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.49.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.48.2"
+    let [<Literal>] Version = "2.49.0"

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -49,6 +49,7 @@
     <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001270-net461\temp</StartWorkingDirectory>
     <StartWorkingDirectory>C:\code\restore</StartWorkingDirectory>
     <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001450-twiddle-wakka\temp</StartWorkingDirectory>
+    <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001440-auto-detect\temp</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -616,7 +616,7 @@ let ``should read config with local source``() =
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Nancy.Owin")
     p.VersionRequirement.Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "0.22.2"))
-    p.Settings.FrameworkRestrictions |> shouldEqual []
+    p.Settings.FrameworkRestrictions |> getRestrictionList |> shouldEqual []
 
 
 [<Test>]
@@ -637,7 +637,7 @@ let ``should read config with single framework restriction``() =
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Foobar")
     p.VersionRequirement.Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "1.2.3"))
-    p.Settings.FrameworkRestrictions |> shouldEqual [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))]
+    p.Settings.FrameworkRestrictions |> getRestrictionList |> shouldEqual [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))]
     p.Settings.ImportTargets |> shouldEqual None
 
 
@@ -650,7 +650,7 @@ let ``should read config with framework restriction``() =
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Foobar")
     p.VersionRequirement.Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "1.2.3"))
-    p.Settings.FrameworkRestrictions |> shouldEqual [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V3_5)); FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))]
+    p.Settings.FrameworkRestrictions |> getRestrictionList |> shouldEqual [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V3_5)); FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))]
     p.Settings.ImportTargets |> shouldEqual None
     p.Settings.CopyLocal |> shouldEqual None
 
@@ -663,7 +663,7 @@ let ``should read config with no targets import``() =
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Foobar")
     p.VersionRequirement.Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "1.2.3"))
-    p.Settings.FrameworkRestrictions |> shouldEqual []
+    p.Settings.FrameworkRestrictions |> getRestrictionList |> shouldEqual []
     p.Settings.ImportTargets |> shouldEqual (Some false)
     p.Settings.CopyLocal |> shouldEqual (Some false)
     p.Settings.OmitContent |> shouldEqual None
@@ -677,7 +677,7 @@ let ``should read config with content none``() =
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Foobar")
     p.VersionRequirement.Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "1.2.3"))
-    p.Settings.FrameworkRestrictions |> shouldEqual []
+    p.Settings.FrameworkRestrictions  |> getRestrictionList |> shouldEqual []
     p.Settings.ImportTargets |> shouldEqual None
     p.Settings.CopyLocal |> shouldEqual (Some false)
     p.Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
@@ -994,6 +994,7 @@ let ``should read config with target framework``() =
     let cfg = DependenciesFile.FromCode(configTargetFramework)
 
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldEqual [FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))]
 
 [<Test>]

--- a/tests/Paket.Tests/DependencySetSpecs.fs
+++ b/tests/Paket.Tests/DependencySetSpecs.fs
@@ -18,8 +18,8 @@ let ``should optimize 2 restriction set with only exactly``() =
          PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
 
     let expected =
-        [PackageName("P1"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-         PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
+        [PackageName("P1"), VersionRequirement.AllReleases,FrameworkRestrictionList  [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+         PackageName("P2"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
 
     original
     |> optimizeDependencies
@@ -34,8 +34,8 @@ let ``should optimize 2 restriction set with only exactly and client framework``
          PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
 
     let expected =
-        [PackageName("P1"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-         PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
+        [PackageName("P1"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+         PackageName("P2"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
 
     original
     |> optimizeDependencies
@@ -50,8 +50,8 @@ let ``should optimize 2 restriction sets with between``() =
          PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_Client))]]
 
     let expected =
-        [PackageName("P1"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-         PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_Client))]]
+        [PackageName("P1"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+         PackageName("P2"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_Client))]]
 
     original
     |> optimizeDependencies
@@ -60,109 +60,109 @@ let ``should optimize 2 restriction sets with between``() =
 [<Test>]
 let ``empty set filtered with empty restrictions should give empty set``() = 
     Set.empty
-    |> DependencySetFilter.filterByRestrictions []
+    |> DependencySetFilter.filterByRestrictions (FrameworkRestrictionList [])
     |> shouldEqual Set.empty
 
 [<Test>]
 let ``filtered with empty restrictions should give full set``() = 
     let set = 
-      [PackageName("P1"), VersionRequirement.AllReleases, []
-       PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P3"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]]
+      [PackageName("P1"), VersionRequirement.AllReleases, FrameworkRestrictionList []
+       PackageName("P2"), VersionRequirement.AllReleases, FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P3"), VersionRequirement.AllReleases, FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]]
       |> Set.ofList
 
     set
-    |> DependencySetFilter.filterByRestrictions []
+    |> DependencySetFilter.filterByRestrictions (FrameworkRestrictionList [])
     |> shouldEqual set
 
 
 [<Test>]
 let ``filtered with concrete restriction should filter non-matching``() = 
     let original = 
-      [PackageName("P1"), VersionRequirement.AllReleases, []
-       PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P3"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P4"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P5"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P7"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]]
+      [PackageName("P1"), VersionRequirement.AllReleases,FrameworkRestrictionList []
+       PackageName("P2"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P3"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P4"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P5"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P6"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P7"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]]
       |> Set.ofList
 
     let expected = 
-      [PackageName("P1"), VersionRequirement.AllReleases, []
-       PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]]
+      [PackageName("P1"), VersionRequirement.AllReleases,FrameworkRestrictionList []
+       PackageName("P2"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P6"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]]
       |> Set.ofList
 
 
     original
-    |> DependencySetFilter.filterByRestrictions [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]
+    |> DependencySetFilter.filterByRestrictions (FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))])
     |> shouldEqual expected
 
 [<Test>]
 let ``filtered with AtLeast restriction should filter non-matching``() = 
     let original = 
-      [PackageName("P1"), VersionRequirement.AllReleases, []
-       PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P3"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P4"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P5"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P7"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P9"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
+      [PackageName("P1"), VersionRequirement.AllReleases,FrameworkRestrictionList []
+       PackageName("P2"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P3"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P4"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P5"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P6"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P7"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P8"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P9"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
       |> Set.ofList
 
     let expected = 
-      [PackageName("P1"), VersionRequirement.AllReleases, []
-       PackageName("P2"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P3"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P4"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P5"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P6"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P8"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P9"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
+      [PackageName("P1"), VersionRequirement.AllReleases,FrameworkRestrictionList []
+       PackageName("P2"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P3"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P4"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P5"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P6"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P8"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P9"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]]
       |> Set.ofList
 
 
     original
-    |> DependencySetFilter.filterByRestrictions [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+    |> DependencySetFilter.filterByRestrictions ( FrameworkRestrictionList[FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))])
     |> shouldEqual expected
 
 [<Test>]
 let ``filtered with Between restriction should filter non-matching`` () =
     let original =
-      [PackageName("P01"), VersionRequirement.AllReleases, []
-       PackageName("P02"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P03"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P04"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P05"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P06"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P07"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P10"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5_1),DotNetFramework(FrameworkVersion.V4_6))]
-       PackageName("P11"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5_1))]
-       PackageName("P12"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P13"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P14"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5_1))]]
+      [PackageName("P01"), VersionRequirement.AllReleases,FrameworkRestrictionList []
+       PackageName("P02"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P03"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P04"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P05"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P06"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P07"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3),DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P08"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P09"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P10"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5_1),DotNetFramework(FrameworkVersion.V4_6))]
+       PackageName("P11"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5_1))]
+       PackageName("P12"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P13"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P14"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5_1))]]
       |> Set.ofList
 
     let expected =
-      [PackageName("P01"), VersionRequirement.AllReleases, []
-       PackageName("P02"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
-       PackageName("P03"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P04"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
-       PackageName("P05"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P06"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P08"), VersionRequirement.AllReleases, [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-       PackageName("P09"), VersionRequirement.AllReleases, [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
-       PackageName("P13"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]]
+      [PackageName("P01"), VersionRequirement.AllReleases,FrameworkRestrictionList []
+       PackageName("P02"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4))]
+       PackageName("P03"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P04"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V4_5))]
+       PackageName("P05"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P06"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P08"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
+       PackageName("P09"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V3_5),DotNetFramework(FrameworkVersion.V4_5_2))]
+       PackageName("P13"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]]
       |> Set.ofList
 
 
     original
-    |> DependencySetFilter.filterByRestrictions [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_1))]
+    |> DependencySetFilter.filterByRestrictions (FrameworkRestrictionList [FrameworkRestriction.Between (DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5_1))])
     |> shouldEqual expected
 
 [<Test>]
@@ -177,10 +177,11 @@ let ``should optimize ZendeskApi_v2 ``() =
 
     let expected =
         [PackageName("Newtonsoft.Json"), VersionRequirement.AllReleases, 
+          FrameworkRestrictionList
             [FrameworkRestriction.Portable "portable-net45+sl40+wp71+win80"
              FrameworkRestriction.AtLeast (DotNetFramework(FrameworkVersion.V3_5))]
-         PackageName("AsyncCTP"), VersionRequirement.AllReleases, [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]
-         PackageName("Microsoft.Bcl.Async"), VersionRequirement.AllReleases, [FrameworkRestriction.Portable "portable-net45+sl40+wp71+win80"]]
+         PackageName("AsyncCTP"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4))]
+         PackageName("Microsoft.Bcl.Async"), VersionRequirement.AllReleases,FrameworkRestrictionList [FrameworkRestriction.Portable "portable-net45+sl40+wp71+win80"]]
 
     original
     |> optimizeDependencies
@@ -197,6 +198,7 @@ let ``should optimize real world restrictions``() =
 
     let expected =
         [PackageName("P1"), VersionRequirement.AllReleases, 
+          FrameworkRestrictionList
            [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V2))
             FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))
             FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))
@@ -217,6 +219,7 @@ let ``should optimize real world restrictions 2``() =
 
     let expected =
         [PackageName("P1"), VersionRequirement.AllReleases, 
+          FrameworkRestrictionList
            [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V2))
             FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_Client))
             FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V4_5))

--- a/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
@@ -105,10 +105,10 @@ let ``should generate Xml for Rx-XAML 2.2.4 with correct framework assembly refe
                  LicenseUrl = ""
                  IsDevelopmentDependency = false
                  FrameworkAssemblyReferences =
-                 [{ AssemblyName = "WindowsBase"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework FrameworkVersion.V4_5)] }
-                  { AssemblyName = "WindowsBase"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework FrameworkVersion.V4)] }
-                  { AssemblyName = "System.Windows"; FrameworkRestrictions = [FrameworkRestriction.Exactly(Silverlight "v5.0")] }
-                  { AssemblyName = "System.Windows"; FrameworkRestrictions = [FrameworkRestriction.Exactly(WindowsPhoneSilverlight "v7.1")] }]})
+                 [{ AssemblyName = "WindowsBase"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework FrameworkVersion.V4_5)] }
+                  { AssemblyName = "WindowsBase"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework FrameworkVersion.V4)] }
+                  { AssemblyName = "System.Windows"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(Silverlight "v5.0")] }
+                  { AssemblyName = "System.Windows"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(WindowsPhoneSilverlight "v7.1")] }]})
 
     let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
@@ -66,8 +66,8 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                  LicenseUrl = ""
                  IsDevelopmentDependency = false
                  FrameworkAssemblyReferences =
-                 [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }
-                  { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
+                 [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }
+                  { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
 
     let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/FrameworkAssemblies.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
@@ -74,8 +74,8 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                  LicenseUrl = ""
                  IsDevelopmentDependency = false
                  FrameworkAssemblyReferences =
-                 [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))] }
-                  { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
+                 [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))] }
+                  { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
 
     let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model,true,true,None)
     chooseNode.OuterXml

--- a/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
@@ -157,11 +157,13 @@ NUGET
     let cfg = DependenciesFile.FromCode(config)
     let group = cfg.Groups.[Constants.MainDependencyGroup]
     group.Packages.Head.Settings.FrameworkRestrictions 
+    |> getRestrictionList
     |> shouldEqual [FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client)) ]
 
     let resolved = ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     getVersion resolved.[PackageName "NLog"] |> shouldEqual "1.0.1"
     resolved.[PackageName "NLog"].Settings.FrameworkRestrictions 
+    |> getRestrictionList
     |> shouldEqual [FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client)) ]
 
     resolved

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -47,12 +47,12 @@ let ``should parse lock file``() =
     packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[1].Name |> shouldEqual (PackageName "Castle.Windsor-log4net")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.3")
-    packages.[1].Dependencies |> shouldEqual (Set.ofList [PackageName "Castle.Windsor", VersionRequirement(Minimum(SemVer.Parse "2.0"), PreReleaseStatus.No), []; PackageName "log4net", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), []])
+    packages.[1].Dependencies |> shouldEqual (Set.ofList [PackageName "Castle.Windsor", VersionRequirement(Minimum(SemVer.Parse "2.0"), PreReleaseStatus.No), FrameworkRestrictionList []; PackageName "log4net", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), FrameworkRestrictionList []])
     
     packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
-    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), []])
+    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), FrameworkRestrictionList []])
 
     let sourceFiles = List.rev lockFile.SourceFiles
     sourceFiles|> shouldEqual
@@ -105,7 +105,7 @@ let ``should parse strict lock file``() =
     packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
-    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), []])
+    packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), FrameworkRestrictionList []])
 
 let redirectsLockFile = """REDIRECTS: ON
 IMPORT-TARGETS: TRUE
@@ -218,7 +218,7 @@ let ``should parse own lock file``() =
     packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[1].Name |> shouldEqual (PackageName "FAKE")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.5.5")
-    packages.[1].Settings.FrameworkRestrictions |> shouldEqual []
+    packages.[1].Settings.FrameworkRestrictions |> shouldEqual (FrameworkRestrictionList [])
 
     lockFile.SourceFiles.[0].Name |> shouldEqual "modules/Octokit/Octokit.fsx"
 
@@ -268,7 +268,7 @@ let ``should parse own lock file2``() =
     packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[1].Name |> shouldEqual (PackageName "FAKE")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.5.5")
-    packages.[3].Settings.FrameworkRestrictions |> shouldEqual []
+    packages.[3].Settings.FrameworkRestrictions |> shouldEqual (FrameworkRestrictionList [])
 
     lockFile.SourceFiles.[0].Name |> shouldEqual "modules/Octokit/Octokit.fsx"
 
@@ -300,20 +300,25 @@ let ``should parse framework restricted lock file``() =
 
     packages.[0].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
     |> List.item 2
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
 
     packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
-    packages.[3].Settings.FrameworkRestrictions |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
+    packages.[3].Settings.FrameworkRestrictions 
+    |> getRestrictionList
+    |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
     packages.[3].Settings.ImportTargets |> shouldEqual None
 
     let dependencies4 =
         packages.[4].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
 
     dependencies4.Head
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2), FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
     dependencies4.Tail.Head
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
                      FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
@@ -321,7 +326,8 @@ let ``should parse framework restricted lock file``() =
     packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[5].Name |> shouldEqual (PackageName "ReadOnlyCollectionInterfaces")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.0.0")
-    packages.[5].Settings.FrameworkRestrictions 
+    packages.[5].Settings.FrameworkRestrictions
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
                      FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
@@ -353,12 +359,15 @@ let ``should parse framework restricted lock file in new syntax``() =
 
     packages.[0].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
     |> List.item 2
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
 
     packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
-    packages.[3].Settings.FrameworkRestrictions |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
+    packages.[3].Settings.FrameworkRestrictions
+    |> getRestrictionList 
+    |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
     packages.[3].Settings.CopyLocal |> shouldEqual None
     packages.[3].Settings.ImportTargets |> shouldEqual (Some false)
     packages.[3].Settings.IncludeVersionInPath |> shouldEqual (Some true)
@@ -368,8 +377,10 @@ let ``should parse framework restricted lock file in new syntax``() =
         packages.[4].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
 
     dependencies4.Head
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2), FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))])
     dependencies4.Tail.Head
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
                      FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
@@ -382,6 +393,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[5].Settings.OmitContent |> shouldEqual None
     packages.[5].Settings.IncludeVersionInPath |> shouldEqual None
     packages.[5].Settings.FrameworkRestrictions 
+    |> getRestrictionList
     |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
                      FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_Client))])
@@ -446,7 +458,7 @@ let ``should parse portable lockfile``() =
     
     packages.[1].Name |> shouldEqual (PackageName "Zlib.Portable")
     packages.[1].Version |> shouldEqual (SemVer.Parse "1.10.0")
-    packages.[1].Settings.FrameworkRestrictions.ToString() |> shouldEqual "[portable-net40+sl50+wp80+win80]"
+    (packages.[1].Settings.FrameworkRestrictions |> getRestrictionList).ToString() |> shouldEqual "[portable-net40+sl50+wp80+win80]"
 
 let reactiveuiLockFile = """NUGET
   remote: https://www.nuget.org/api/v2
@@ -493,11 +505,11 @@ let ``should parse reactiveui lockfile``() =
     
     packages.[8].Name |> shouldEqual (PackageName "Rx-WindowStoreApps")
     packages.[8].Version |> shouldEqual (SemVer.Parse "2.2.5")
-    packages.[8].Settings.FrameworkRestrictions.ToString() |> shouldEqual "[winv4.5]"
+    (packages.[8].Settings.FrameworkRestrictions |> getRestrictionList).ToString() |> shouldEqual "[winv4.5]"
 
     packages.[10].Name |> shouldEqual (PackageName "Rx-Xaml")
     packages.[10].Version |> shouldEqual (SemVer.Parse "2.2.5")
-    packages.[10].Settings.FrameworkRestrictions.ToString() |> shouldEqual "[winv4.5; wpv8.0; >= net45]"
+    (packages.[10].Settings.FrameworkRestrictions |> getRestrictionList).ToString() |> shouldEqual "[winv4.5; wpv8.0; >= net45]"
 
 let multipleFeedLockFile = """NUGET
   remote: http://internalfeed/NugetWebFeed/nuget
@@ -531,7 +543,6 @@ let ``should parse lockfile with multiple feeds``() =
     
     packages.[3].Name |> shouldEqual (PackageName "Microsoft.AspNet.WebApi")
     packages.[3].Version |> shouldEqual (SemVer.Parse "5.2.3")
-    packages.[3].Settings.FrameworkRestrictions.ToString() |> shouldEqual "[]"
     packages.[3].Source.ToString() |> shouldEqual "https://www.nuget.org/api/v2"
 
 [<Test>]

--- a/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
+++ b/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
@@ -21,7 +21,7 @@ let ``can detect explicit dependencies for Fantomas``() =
     |> shouldEqual 
         { PackageName = "Fantomas"
           DownloadUrl = "http://www.nuget.org/api/v2/package/Fantomas/1.6.0"
-          Dependencies = [PackageName "FSharp.Compiler.Service",DependenciesFileParser.parseVersionRequirement(">= 0.0.73"), []]
+          Dependencies = [PackageName "FSharp.Compiler.Service",DependenciesFileParser.parseVersionRequirement(">= 0.0.73"), FrameworkRestrictionList []]
           Unlisted = false
           LicenseUrl = "http://github.com/dungpa/fantomas/blob/master/LICENSE.md"
           CacheVersion = NuGet.NuGetPackageCache.CurrentCacheVersion
@@ -35,8 +35,8 @@ let ``can detect explicit dependencies for Rx-PlaformServices``() =
         { PackageName = "Rx-PlatformServices"
           DownloadUrl = "https://www.nuget.org/api/v2/package/Rx-PlatformServices/2.3.0"
           Dependencies = 
-                [PackageName "Rx-Interfaces",DependenciesFileParser.parseVersionRequirement(">= 2.2"), []
-                 PackageName "Rx-Core",DependenciesFileParser.parseVersionRequirement(">= 2.2"), []]
+                [PackageName "Rx-Interfaces",DependenciesFileParser.parseVersionRequirement(">= 2.2"), FrameworkRestrictionList []
+                 PackageName "Rx-Core",DependenciesFileParser.parseVersionRequirement(">= 2.2"), FrameworkRestrictionList []]
           Unlisted = true
           LicenseUrl = "http://go.microsoft.com/fwlink/?LinkID=261272"
           Version = "2.3.0"
@@ -50,7 +50,7 @@ let ``can detect explicit dependencies for EasyNetQ``() =
         { PackageName = "EasyNetQ"
           DownloadUrl = "https://www.nuget.org/api/v2/package/EasyNetQ/0.40.3.352"
           Dependencies = 
-                [PackageName "RabbitMQ.Client",DependenciesFileParser.parseVersionRequirement(">= 3.4.3"), []]
+                [PackageName "RabbitMQ.Client",DependenciesFileParser.parseVersionRequirement(">= 3.4.3"),FrameworkRestrictionList []]
           Unlisted = false
           LicenseUrl = "https://github.com/mikehadlow/EasyNetQ/blob/master/licence.txt"
           CacheVersion = NuGet.NuGetPackageCache.CurrentCacheVersion
@@ -68,10 +68,10 @@ let ``can detect explicit dependencies for Fleece``() =
           LicenseUrl = "https://raw.github.com/mausch/Fleece/master/LICENSE"
           Version = "0.4.0"
           Dependencies = 
-            [PackageName "FSharpPlus",DependenciesFileParser.parseVersionRequirement(">= 0.0.4"), []
-             PackageName "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"), []
-             PackageName "ReadOnlyCollectionExtensions",DependenciesFileParser.parseVersionRequirement(">= 1.2.0"), []
-             PackageName "System.Json",DependenciesFileParser.parseVersionRequirement(">= 4.0.20126.16343"), []]
+            [PackageName "FSharpPlus",DependenciesFileParser.parseVersionRequirement(">= 0.0.4"),FrameworkRestrictionList []
+             PackageName "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"),FrameworkRestrictionList []
+             PackageName "ReadOnlyCollectionExtensions",DependenciesFileParser.parseVersionRequirement(">= 1.2.0"),FrameworkRestrictionList []
+             PackageName "System.Json",DependenciesFileParser.parseVersionRequirement(">= 4.0.20126.16343"),FrameworkRestrictionList []]
           SourceUrl = fakeUrl }
 
 [<Test>]
@@ -85,8 +85,9 @@ let ``can detect explicit dependencies for ReadOnlyCollectionExtensions``() =
           LicenseUrl = "https://github.com/mausch/ReadOnlyCollections/blob/master/license.txt"
           Version = "1.2.0"
           Dependencies = 
-            [PackageName "LinqBridge",DependenciesFileParser.parseVersionRequirement(">= 1.3.0"), [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V2))]
+            [PackageName "LinqBridge",DependenciesFileParser.parseVersionRequirement(">= 1.3.0"),FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V2))]
              PackageName "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"), 
+              FrameworkRestrictionList
                [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V2))
                 FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V3_5))]]
           SourceUrl = fakeUrl }
@@ -102,7 +103,7 @@ let ``can detect explicit dependencies for Math.Numerics``() =
           LicenseUrl = "http://numerics.mathdotnet.com/docs/License.html"
           CacheVersion = NuGet.NuGetPackageCache.CurrentCacheVersion
           Dependencies = 
-            [PackageName "TaskParallelLibrary",DependenciesFileParser.parseVersionRequirement(">= 1.0.2856"), [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
+            [PackageName "TaskParallelLibrary",DependenciesFileParser.parseVersionRequirement(">= 1.0.2856"), FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))]]
           SourceUrl = fakeUrl }
 
 [<Test>]
@@ -110,7 +111,7 @@ let ``can detect explicit dependencies for Math.Numerics.FSharp``() =
     (parse "NuGetOData/Math.Numerics.FSharp.xml").Dependencies |> Seq.head
     |> shouldEqual 
         (PackageName "MathNet.Numerics",
-         DependenciesFileParser.parseVersionRequirement("3.3.0"),[])
+         DependenciesFileParser.parseVersionRequirement("3.3.0"),FrameworkRestrictionList [])
 
 [<Test>]
 let ``can calculate v3 path``() = 
@@ -125,10 +126,10 @@ let ``can detect explicit dependencies for Microsoft.AspNet.WebApi.Client``() =
     let dependencies = odata.Dependencies |> Array.ofList
     dependencies.[0] |> shouldEqual 
         (PackageName "Newtonsoft.Json", DependenciesFileParser.parseVersionRequirement(">= 6.0.4"), 
-                [FrameworkRestriction.Portable("portable-wp80+win+net45+wp81+wpa81"); FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))])
+            FrameworkRestrictionList [FrameworkRestriction.Portable("portable-wp80+win+net45+wp81+wpa81"); FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))])
     dependencies.[1] |> shouldEqual
         (PackageName "Microsoft.Net.Http", DependenciesFileParser.parseVersionRequirement(">= 2.2.22"), 
-                [FrameworkRestriction.Portable("portable-wp80+win+net45+wp81+wpa81")])
+            FrameworkRestrictionList [FrameworkRestriction.Portable("portable-wp80+win+net45+wp81+wpa81")])
 
 [<Test>]
 let ``can detect explicit dependencies for WindowsAzure.Storage``() = 
@@ -138,7 +139,7 @@ let ``can detect explicit dependencies for WindowsAzure.Storage``() =
     let dependencies = odata.Dependencies |> Array.ofList
     dependencies.[0] |> shouldEqual 
         (PackageName "Microsoft.Data.OData", DependenciesFileParser.parseVersionRequirement(">= 5.6.3"), 
-                [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))])
+           FrameworkRestrictionList [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))])
 
     let vr,pr = 
         match DependenciesFileParser.parseVersionRequirement(">= 4.0.0-beta-22231") with
@@ -146,8 +147,8 @@ let ``can detect explicit dependencies for WindowsAzure.Storage``() =
 
     dependencies.[18] |> shouldEqual 
         (PackageName "System.Net.Http", VersionRequirement(vr,PreReleaseStatus.All), 
-                [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))])
+           FrameworkRestrictionList [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))])
 
     dependencies.[44] |> shouldEqual 
         (PackageName "Newtonsoft.Json", DependenciesFileParser.parseVersionRequirement(">= 6.0.8"), 
-                [FrameworkRestriction.Exactly(WindowsPhoneSilverlight("v8.0")); FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))])
+            FrameworkRestrictionList [FrameworkRestriction.Exactly(WindowsPhoneSilverlight("v8.0")); FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))])

--- a/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
+++ b/tests/Paket.Tests/Nuspec/NuspecSpecs.fs
@@ -72,26 +72,27 @@ let ``can detect framework assemblies for Microsoft.Net.Http``() =
     |> shouldEqual 
         [{ AssemblyName = "System.Net.Http"
            FrameworkRestrictions = 
+            FrameworkRestrictionList
              [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))
               FrameworkRestriction.Exactly(MonoTouch)
               FrameworkRestriction.Exactly(MonoAndroid)] }
          { AssemblyName = "System.Net.Http.WebRequest"
            FrameworkRestrictions = 
-             [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]
+             FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]
 
 [<Test>]
 let ``can detect framework assemblies for FluentAssertions``() = 
     Nuspec.Load("Nuspec/FluentAssertions.nuspec").FrameworkAssemblyReferences
     |> shouldEqual 
-        [{ AssemblyName = "System.Xml"; FrameworkRestrictions = [] }
-         { AssemblyName = "System.Xml.Linq"; FrameworkRestrictions = [] } ]
+        [{ AssemblyName = "System.Xml"; FrameworkRestrictions = FrameworkRestrictionList [] }
+         { AssemblyName = "System.Xml.Linq"; FrameworkRestrictions = FrameworkRestrictionList [] } ]
 
 [<Test>]
 let ``can detect framework assemblies for SqlCLient``() = 
     Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec").FrameworkAssemblyReferences
     |> shouldEqual 
-        [{ AssemblyName = "System.Data"; FrameworkRestrictions = [] }
-         { AssemblyName = "System.Xml"; FrameworkRestrictions = [] } ]
+        [{ AssemblyName = "System.Data"; FrameworkRestrictions = FrameworkRestrictionList [] }
+         { AssemblyName = "System.Xml"; FrameworkRestrictions = FrameworkRestrictionList [] } ]
 
 [<Test>]
 let ``can detect license for SqlCLient``() = 
@@ -102,7 +103,7 @@ let ``can detect license for SqlCLient``() =
 let ``can detect dependencies for SqlCLient``() = 
     Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec").Dependencies
     |> shouldEqual 
-        [PackageName "Microsoft.SqlServer.Types",DependenciesFileParser.parseVersionRequirement(">= 11.0.0"), []]
+        [PackageName "Microsoft.SqlServer.Types",DependenciesFileParser.parseVersionRequirement(">= 11.0.0"), FrameworkRestrictionList []]
 
 [<Test>]
 let ``can detect reference files for SqlCLient``() = 
@@ -115,15 +116,16 @@ let ``can detect framework assemblies for Octokit``() =
     |> shouldEqual 
         [{ AssemblyName = "System.Net.Http"
            FrameworkRestrictions = 
-            [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))
-             FrameworkRestriction.Exactly(Windows "v4.5")] }]
+            FrameworkRestrictionList
+              [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))
+               FrameworkRestriction.Exactly(Windows "v4.5")] }]
 
 [<Test>]
 let ``can detect framework assemblies for FSharp.Data.SqlEnumProvider``() = 
     Nuspec.Load("Nuspec/FSharp.Data.SqlEnumProvider.nuspec").FrameworkAssemblyReferences
     |> shouldEqual 
-        [{ AssemblyName = "System.Data"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))] }
-         { AssemblyName = "System.Xml"; FrameworkRestrictions = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))] }]
+        [{ AssemblyName = "System.Data"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))] }
+         { AssemblyName = "System.Xml"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))] }]
 
 [<Test>]
 let ``can detect empty framework assemblies for ReadOnlyCollectionExtensions``() = 
@@ -138,17 +140,18 @@ let ``can detect empty dependencies for log4net``() =
 [<Test>]
 let ``can detect explicit dependencies for Fantomas``() = 
     Nuspec.Load("Nuspec/Fantomas.nuspec").Dependencies
-    |> shouldEqual [PackageName "FSharp.Compiler.Service",DependenciesFileParser.parseVersionRequirement(">= 0.0.57"), []]
+    |> shouldEqual [PackageName "FSharp.Compiler.Service",DependenciesFileParser.parseVersionRequirement(">= 0.0.57"), FrameworkRestrictionList []]
 
 [<Test>]
 let ``can detect explicit dependencies for ReadOnlyCollectionExtensions``() = 
     Nuspec.Load("Nuspec/ReadOnlyCollectionExtensions.nuspec").Dependencies
     |> shouldEqual 
         [PackageName "LinqBridge",DependenciesFileParser.parseVersionRequirement(">= 1.3.0"), 
-            [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V2))]
+            FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V2))]
          PackageName "ReadOnlyCollectionInterfaces",DependenciesFileParser.parseVersionRequirement("1.0.0"),
-            [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V2))
-             FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V3_5))]]
+            FrameworkRestrictionList
+             [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V2))
+              FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V3_5))]]
 
 [<Test>]
 let ``can detect framework assemblies for MathNet.Numerics``() = 
@@ -156,11 +159,12 @@ let ``can detect framework assemblies for MathNet.Numerics``() =
     |> shouldEqual 
         [{ AssemblyName = "System.Numerics"
            FrameworkRestrictions = 
-            [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))
-             FrameworkRestriction.Exactly(Windows("v4.5"))
-             FrameworkRestriction.Exactly(Silverlight("v5.0"))
-             FrameworkRestriction.Exactly(MonoAndroid)
-             FrameworkRestriction.Exactly(MonoTouch)] }]
+             FrameworkRestrictionList
+                [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))
+                 FrameworkRestriction.Exactly(Windows("v4.5"))
+                 FrameworkRestriction.Exactly(Silverlight("v5.0"))
+                 FrameworkRestriction.Exactly(MonoAndroid)
+                 FrameworkRestriction.Exactly(MonoTouch)] }]
 
 
 [<Test>]
@@ -169,7 +173,7 @@ let ``can detect dependencies for MathNet.Numerics``() =
     |> shouldEqual 
         [ PackageName "TaskParallelLibrary",
           DependenciesFileParser.parseVersionRequirement(">= 1.0.2856.0"),
-            [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))] ]
+            FrameworkRestrictionList [FrameworkRestriction.Exactly (DotNetFramework(FrameworkVersion.V3_5))] ]
 
 [<Test>]
 let ``can detect dependencies for MathNet.Numerics.FSharp``() = 
@@ -177,7 +181,7 @@ let ``can detect dependencies for MathNet.Numerics.FSharp``() =
     |> Seq.head
     |> shouldEqual 
         (PackageName "MathNet.Numerics",
-         DependenciesFileParser.parseVersionRequirement("3.3.0"),[])
+         DependenciesFileParser.parseVersionRequirement("3.3.0"),FrameworkRestrictionList [])
 
 [<Test>]
 let ``can detect explicit dependencies for WindowsAzure.Storage``() = 
@@ -187,27 +191,27 @@ let ``can detect explicit dependencies for WindowsAzure.Storage``() =
     |> shouldEqual 
         (PackageName "Newtonsoft.Json",
           DependenciesFileParser.parseVersionRequirement(">= 5.0.8"),
-          [FrameworkRestriction.Exactly(WindowsPhoneSilverlight("v8.0"))
-           FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))])
+          FrameworkRestrictionList
+            [FrameworkRestriction.Exactly(WindowsPhoneSilverlight("v8.0"))
+             FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))])
 
 [<Test>]
 let ``can detect framework assemblies for Microsoft.Framework.Logging``() = 
     let nuspec = Nuspec.Load("Nuspec/Microsoft.Framework.Logging.nuspec")
     nuspec.FrameworkAssemblyReferences.[0].AssemblyName |> shouldEqual "System.Collections.Concurrent"
     nuspec.FrameworkAssemblyReferences.[0].FrameworkRestrictions 
-        |> shouldEqual         
-            [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))
-             FrameworkRestriction.Exactly(DNX(FrameworkVersion.V4_5_1))]
+        |> shouldEqual
+            (FrameworkRestrictionList
+              [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))
+               FrameworkRestriction.Exactly(DNX(FrameworkVersion.V4_5_1))])
 
     let name,_,restrictions = nuspec.Dependencies.[0]
     name  |> shouldEqual (PackageName "Microsoft.Framework.DependencyInjection.Interfaces")
-    restrictions|> shouldEqual []
+    restrictions|> shouldEqual (FrameworkRestrictionList [])
 
     let name,_,restrictions = nuspec.Dependencies.[2]
     name  |> shouldEqual (PackageName "System.Collections.Concurrent")
-    restrictions |> shouldEqual  [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))]
-
-
+    restrictions |> shouldEqual (FrameworkRestrictionList [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))])
 
 [<Test>]
 let ``can detect explicit dependencies for FluentAssertions 4``() = 
@@ -217,4 +221,4 @@ let ``can detect explicit dependencies for FluentAssertions 4``() =
     |> shouldEqual 
         (PackageName "System.Collections",
           DependenciesFileParser.parseVersionRequirement(">= 4.0.10"),
-          [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))])
+          FrameworkRestrictionList [FrameworkRestriction.Exactly(DNXCore(FrameworkVersion.V5_0))])

--- a/tests/Paket.Tests/RestrictionFilterSpecs.fs
+++ b/tests/Paket.Tests/RestrictionFilterSpecs.fs
@@ -11,113 +11,113 @@ open Paket.Requirements
 
 [<Test>]
 let ``should filter net45 and >= net40``() = 
-    let l1 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
-    let l2 = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
     filterRestrictions l1 l2
     |> shouldEqual l2
 
 [<Test>]
 let ``should filter >= net40 and net45``() = 
-    let l1 = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
-    let l2 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
     filterRestrictions l1 l2
     |> shouldEqual l1
 
 
 [<Test>]
 let ``should filter >= net40 and net40``() = 
-    let l1 = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))]
-    let l2 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_Client))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))]
     filterRestrictions l1 l2
     |> shouldEqual l1
 
 [<Test>]
 let ``should filter >=net40 and >= net45``() = 
-    let l1 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
-    let l2 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))]
     filterRestrictions l1 l2
     |> shouldEqual l2
 
 [<Test>]
-let ``should filter >= net40 and portable``() =     
-    let l1 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
-    let l2 = [FrameworkRestriction.Portable("abc")]
+let ``should filter >= net40 and portable``() =
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Portable("abc")]
 
     filterRestrictions l1 l2
-    |> shouldEqual []
+    |> shouldEqual (FrameworkRestrictionList [])
 
 [<Test>]
 let ``should filter >= net40 and >= net20 < net46``() = 
-    let l1 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
-    let l2 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4_6))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4_6))]
 
     filterRestrictions l1 l2
-    |> shouldEqual [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))]
+    |> shouldEqual (FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))])
 
 [<Test>]
 let ``should filter >= net40 and >= net45 < net46``() =
-    let l1 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
-    let l2 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_6))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_6))]
 
     filterRestrictions l1 l2
     |> shouldEqual l2
 
 [<Test>]
 let ``should filter >= net40 and >= net20 < net40``() = 
-    let l1 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
-    let l2 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4))]
 
     filterRestrictions l1 l2
-    |> shouldEqual []
+    |> shouldEqual (FrameworkRestrictionList [])
 
 [<Test>]
 let ``should filter net45 and >= net40 < net46``() = 
-    let l1 = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
-    let l2 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))]
     filterRestrictions l1 l2
     |> shouldEqual l1
 
 [<Test>]
 let ``should filter net45 and >= net40 < net45``() = 
-    let l1 = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
-    let l2 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5))]
     filterRestrictions l1 l2
-    |> shouldEqual []
+    |> shouldEqual (FrameworkRestrictionList [])
 
 [<Test>]
 let ``should filter >= net40 < net46 and net45``() = 
-    let l1 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))]
-    let l2 = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
     filterRestrictions l1 l2
     |> shouldEqual l2
 
 [<Test>]
 let ``should filter >= net40 < net45 and net45``() = 
-    let l1 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5))]
-    let l2 = [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_5))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))]
     filterRestrictions l1 l2
-    |> shouldEqual []
+    |> shouldEqual (FrameworkRestrictionList [])
 
 [<Test>]
 let ``should filter >= net20 < net46 and >= net40``() = 
-    let l1 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4_6))]
-    let l2 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4_6))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
 
     filterRestrictions l1 l2
-    |> shouldEqual [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))]
+    |> shouldEqual (FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4),DotNetFramework(FrameworkVersion.V4_6))])
 
 [<Test>]
 let ``should filter >= net45 < net46 and >= net40``() =
-    let l1 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_6))]
-    let l2 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V4_5),DotNetFramework(FrameworkVersion.V4_6))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
 
     filterRestrictions l1 l2
     |> shouldEqual l1
 
 [<Test>]
 let ``should filter >= net20 < net40 and >= net40``() =
-    let l1 = [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4))]
-    let l2 = [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
+    let l1 = FrameworkRestrictionList [FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V2),DotNetFramework(FrameworkVersion.V4))]
+    let l2 = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4))]
 
     filterRestrictions l1 l2
-    |> shouldEqual []
+    |> shouldEqual (FrameworkRestrictionList [])

--- a/tests/Paket.Tests/TestHelpers.fs
+++ b/tests/Paket.Tests/TestHelpers.fs
@@ -13,7 +13,7 @@ let PackageDetailsFromGraph (graph : seq<string * string * (string * VersionRequ
     let name,dependencies = 
         graph
         |> Seq.filter (fun (p, v, _) -> (PackageName p) = package && SemVer.Parse v = version)
-        |> Seq.map (fun (n, _, d) -> PackageName n,d |> List.map (fun (x,y) -> PackageName x,y,[]))
+        |> Seq.map (fun (n, _, d) -> PackageName n,d |> List.map (fun (x,y) -> PackageName x,y,FrameworkRestrictionList []))
         |> Seq.head
 
     { Name = name
@@ -52,7 +52,7 @@ let safeResolve graph (dependencies : (string * VersionRange) list)  =
                  ResolverStrategyForTransitives = Some ResolverStrategy.Max })
         |> Set.ofList
 
-    PackageResolver.Resolve(Constants.MainDependencyGroup,[ PackageSource.NuGetV2Source "" ], VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph, None, None, [], packages, UpdateMode.UpdateAll)
+    PackageResolver.Resolve(Constants.MainDependencyGroup,[ PackageSource.NuGetV2Source "" ], VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph, None, None, FrameworkRestrictionList [], packages, UpdateMode.UpdateAll)
 
 let resolve graph dependencies = (safeResolve graph dependencies).GetModelOrFail()
 


### PR DESCRIPTION
#### Automatic framework detection

If you use only one target framework in your whole repository, then paket can detect this for you and limit the installation to that specific target framework. You can control this in the [`paket.dependencies` file](dependencies-file.html):

    framework: auto-detect
    source https://nuget.org/api/v2

    nuget Example >= 2.0 // only the target framework that is used in projects
