### PR TITLE
Readme: Fix invalid link to "http-resource".

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Even more importantly: If two packages reference conflicting versions of a packa
 Paket on the other hand maintains this information on a consistent and stable basis within the [`paket.lock` file][7] in the solution root.
 This file, together with the [`paket.dependencies` file][8] enables you to determine exactly what's happening with your dependencies.
 
-Paket also enables you to [reference files directly from GitHub (and Gist)][9] repositories or any [http-resource](11).
+Paket also enables you to [reference files directly from GitHub (and Gist)][9] repositories or any [http-resource][11].
 
 For more reasons see the [FAQ][10].
 


### PR DESCRIPTION
The link used to lead to `https://github.com/fsprojects/Paket/blob/master/11` because of invalid syntax used.