### PR TITLE
fix the debugger label for Groupname

### DIFF
--- a/src/Paket.Core/Domain.fs
+++ b/src/Paket.Core/Domain.fs
@@ -56,7 +56,7 @@ type PackageFilter =
         | PackageFilter filter -> filter
 
 /// Represents a normalized group name
-[<System.Diagnostics.DebuggerDisplay("{Item}")>]
+[<System.Diagnostics.DebuggerDisplay("{Item2}")>]
 [<CustomEquality;CustomComparison>]
 type GroupName =
 | GroupName of string * string


### PR DESCRIPTION
tiny change so that debuggerdisplay of groupnames works instead of throwing a 'member not found 'Item'' exception.