### PR TITLE
Prevent paket holding locks on assemblies during binding redirects

### DIFF
--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -213,7 +213,8 @@ let private applyBindingRedirects (loadedLibs:Dictionary<_,_>) isFirstGroup crea
                             match loadedLibs.TryGetValue key with
                             | true,v -> v
                             | _ -> 
-                                let v = Assembly.ReflectionOnlyLoadFrom library
+                                let ass = File.ReadAllBytes library
+                                let v = Assembly.ReflectionOnlyLoad ass
                                 loadedLibs.Add(key,v)
                                 v
 


### PR DESCRIPTION
solves issue https://github.com/fsprojects/Paket/issues/1477