### PR TITLE
Restore: optional --touch-affected-refs to touch refs affected by a restore

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -334,6 +334,11 @@ let inline isExtracted fileName =
     di.EnumerateFileSystemInfos()
     |> Seq.exists (fun f -> f.FullName <> fi.FullName)
 
+let IsPackageVersionExtracted(root, groupName, packageName:PackageName, version:SemVerInfo, includeVersionInPath) =
+    let targetFolder = DirectoryInfo(getTargetFolder root groupName packageName version includeVersionInPath).FullName
+    let targetFileName = Path.Combine(targetFolder, packageName.ToString() + "." + version.Normalize() + ".nupkg")
+    isExtracted targetFileName
+
 /// Extracts the given package to the ./packages folder
 let ExtractPackage(fileName:string, targetFolder, packageName:PackageName, version:SemVerInfo, detailed) =
     async {

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -240,22 +240,26 @@ type Dependencies(dependenciesFileName: string) =
                                                       NoInstall = installAfter |> not }))
 
     /// Restores all dependencies.
-    member this.Restore(): unit = this.Restore(false,None,[])
+    member this.Restore(): unit = this.Restore(false,None,[],false)
 
     /// Restores the given paket.references files.
-    member this.Restore(group: string option, files: string list): unit = this.Restore(false, group, files)
+    member this.Restore(group: string option, files: string list): unit = this.Restore(false, group, files, false)
 
     /// Restores the given paket.references files.
-    member this.Restore(force: bool, group: string option, files: string list): unit =
+    member this.Restore(force: bool, group: string option, files: string list, touchAffectedRefs: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> RestoreProcess.Restore(dependenciesFileName,force,Option.map GroupName group,files))
+            fun () ->
+                if touchAffectedRefs then
+                    let packagesToTouch = RestoreProcess.FindPackagesNotExtractedYet(dependenciesFileName)
+                    this.Process (FindReferences.TouchReferencesOfPackages packagesToTouch)
+                RestoreProcess.Restore(dependenciesFileName,force,Option.map GroupName group,files))
 
     /// Restores packages for all available paket.references files
     /// (or all packages if onlyReferenced is false)
-    member this.Restore(force: bool, group: string option, onlyReferenced: bool): unit =
+    member this.Restore(force: bool, group: string option, onlyReferenced: bool, touchAffectedRefs: bool): unit =
         if not onlyReferenced then 
-            this.Restore(force,group,[]) 
+            this.Restore(force,group,[],touchAffectedRefs) 
         else
             let referencesFiles =
                 this.RootPath
@@ -264,7 +268,7 @@ type Dependencies(dependenciesFileName: string) =
             if Array.isEmpty referencesFiles then
                 traceWarnfn "No paket.references files found for which packages could be installed."
             else 
-                this.Restore(force, group, Array.toList referencesFiles)
+                this.Restore(force, group, Array.toList referencesFiles, touchAffectedRefs)
 
     /// Lists outdated packages.
     member this.ShowOutdated(strict: bool,includePrereleases: bool): unit =

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -10,6 +10,17 @@ open Paket.PackageSources
 open FSharp.Polyfill
 open System
 
+// Find packages which would be affected by a restore, i.e. not extracted yet or with the wrong version
+let FindPackagesNotExtractedYet(dependenciesFileName) =
+    let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
+    let lockFile = LockFile.LoadFrom(lockFileName.FullName)
+    let root = lockFileName.Directory.FullName
+
+    lockFile.GetGroupedResolution()
+    |> Map.toList
+    |> List.filter (fun ((group,package),resolved) -> NuGetV2.IsPackageVersionExtracted(root, group, package, resolved.Version, defaultArg resolved.Settings.IncludeVersionInPath false) |> not)
+    |> List.map fst
+
 let private extractPackage package root source groupName version includeVersionInPath force =
     let downloadAndExtract force detailed = async {
         let! folder = NuGetV2.DownloadPackage(root, source, groupName, package.Name, version, includeVersionInPath, force, detailed)

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -199,6 +199,7 @@ with
 type RestoreArgs =
     | [<AltCommandLine("-f")>] Force
     | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
+    | [<CustomCommandLine("--touch-affected-refs")>] Touch_Affected_Refs
     | [<CustomCommandLine("group")>] Group of string
     | [<Rest>] References_Files of string
 with
@@ -208,6 +209,7 @@ with
             | Force -> "Forces the download of all packages."
             | Group(_) -> "Allows to restore a single group."
             | Install_Only_Referenced -> "Allows to restore packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
+            | Touch_Affected_Refs -> "Touches project files referencing packages which are being restored, to help incremental build tools detecting the change."
             | References_Files(_) -> "Allows to restore all packages from the given paket.references files. This implies --only-referenced."
 
 type SimplifyArgs =

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -178,8 +178,9 @@ let restore (results : ParseResults<_>) =
     let files = results.GetResults <@ RestoreArgs.References_Files @>
     let group = results.TryGetResult <@ RestoreArgs.Group @>
     let installOnlyReferenced = results.Contains <@ RestoreArgs.Install_Only_Referenced @>
-    if List.isEmpty files then Dependencies.Locate().Restore(force, group, installOnlyReferenced)
-    else Dependencies.Locate().Restore(force, group, files)
+    let touchAffectedRefs = results.Contains <@ RestoreArgs.Touch_Affected_Refs @>
+    if List.isEmpty files then Dependencies.Locate().Restore(force, group, installOnlyReferenced, touchAffectedRefs)
+    else Dependencies.Locate().Restore(force, group, files, touchAffectedRefs)
 
 let simplify (results : ParseResults<_>) =
     let interactive = results.Contains <@ SimplifyArgs.Interactive @>


### PR DESCRIPTION
Proposal how  #1471 could be addressed, to help incremental build tools like MsBuild to detect the need to rebuild selective projects.

I'm not convinced `Project.save true` is the right approach though, since it could also affect the content of the project file. Maybe we should specifically add a `Project.touch` instead which guarantees the project file content remains exactly the same?