### PR TITLE
[V3] Garbage collection

### DIFF
--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -32,6 +32,7 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
 
         if installAfter then
             InstallProcess.Install(options, hasChanged, dependenciesFile, lockFile, updatedGroups)
+            GarbageCollectionProcess.DeleteUnusedPackages(Path.GetDirectoryName(dependenciesFileName), lockFile)
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, groupName, package, version, options : InstallerOptions, projectName, installAfter) =

--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -32,7 +32,7 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
 
         if installAfter then
             InstallProcess.Install(options, hasChanged, dependenciesFile, lockFile, updatedGroups)
-            GarbageCollectionProcess.DeleteUnusedPackages(Path.GetDirectoryName(dependenciesFileName), lockFile)
+            GarbageCollection.CleanUp(Path.GetDirectoryName dependenciesFileName, lockFile)
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, groupName, package, version, options : InstallerOptions, projectName, installAfter) =

--- a/src/Paket.Core/GarbageCollection.fs
+++ b/src/Paket.Core/GarbageCollection.fs
@@ -1,5 +1,5 @@
 ﻿/// Contains methods for the garbage collection of no longer needed files.
-module Paket.GarbageCollectionProcess
+module Paket.GarbageCollection
 
 open Paket
 open Paket.Domain
@@ -34,8 +34,8 @@ let discoverExtractedPackages root : ExtractedPackage list =
         packagesFolder.GetDirectories() |> Array.collect (fun dir -> findGroupPackages (GroupName dir.Name) dir)
     ] |> Array.concat |> List.ofArray
 
-/// Remove all packages from the packages folder which are not part pf the lock file.
-let DeleteUnusedPackages(root, lockFile:LockFile) =
+/// Remove all packages from the packages folder which are not part of the lock file.
+let deleteUnusedPackages root (lockFile:LockFile) =
 
     let resolutionKey package = package.GroupName, package.PackageName
     let delete package =
@@ -49,3 +49,7 @@ let DeleteUnusedPackages(root, lockFile:LockFile) =
     discoverExtractedPackages root
     |> List.filter (fun p -> resolutions |> Map.containsKey (resolutionKey p) |> not)
     |> List.iter delete
+
+/// Remove all packages from the packages folder which are not part of the lock file.
+let CleanUp(root, lockFile) =
+    deleteUnusedPackages root lockFile

--- a/src/Paket.Core/GarbageCollectionProcess.fs
+++ b/src/Paket.Core/GarbageCollectionProcess.fs
@@ -1,0 +1,51 @@
+﻿/// Contains methods for the garbage collection of no longer needed files.
+module Paket.GarbageCollectionProcess
+
+open Paket
+open Paket.Domain
+open Paket.Logging
+open System.IO
+
+type ExtractedPackage = {
+    GroupName: GroupName
+    PackageName: PackageName
+    Path: DirectoryInfo
+}
+
+/// Discover all packages currently available in the packages folder
+let discoverExtractedPackages root : ExtractedPackage list =
+    let packageInDir groupName (dir:DirectoryInfo) =
+        match dir.GetFiles("*.nuspec") with
+        | [| nuspec |] ->
+            Some {
+                GroupName = groupName
+                PackageName = PackageName (Path.GetFileNameWithoutExtension nuspec.Name)
+                Path = dir
+            }
+        | _ -> None
+
+    let findGroupPackages groupName (groupDir:DirectoryInfo) =
+        groupDir.GetDirectories()
+        |> Array.choose (packageInDir groupName)
+
+    let packagesFolder = DirectoryInfo(Path.Combine(root, Constants.PackagesFolderName))
+    [
+        findGroupPackages Constants.MainDependencyGroup packagesFolder
+        packagesFolder.GetDirectories() |> Array.collect (fun dir -> findGroupPackages (GroupName dir.Name) dir)
+    ] |> Array.concat |> List.ofArray
+
+/// Remove all packages from the packages folder which are not part pf the lock file.
+let DeleteUnusedPackages(root, lockFile:LockFile) =
+
+    let resolutionKey package = package.GroupName, package.PackageName
+    let delete package =
+        try
+            Utils.deleteDir package.Path
+        with
+        | exn -> traceWarnfn "Could not delete no longer needed directory '%s'. %s." package.Path.FullName exn.Message
+
+    let resolutions = lockFile.GetGroupedResolution()
+
+    discoverExtractedPackages root
+    |> List.filter (fun p -> resolutions |> Map.containsKey (resolutionKey p) |> not)
+    |> List.iter delete

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -117,12 +117,12 @@
     <Compile Include="ProjectFile.fs" />
     <Compile Include="DependencyModel.fs" />
     <Compile Include="DependencyChangeDetection.fs" />
+    <Compile Include="GarbageCollectionProcess.fs" />
     <Compile Include="RestoreProcess.fs" />
     <Compile Include="BindingRedirects.fs" />
     <Compile Include="NupkgWriter.fs" />
     <Compile Include="ProcessOptions.fs" />
     <Compile Include="PackagesConfigFile.fs" />
-    <Compile Include="GarbageCollectionProcess.fs" />
     <Compile Include="InstallProcess.fs" />
     <Compile Include="UpdateProcess.fs" />
     <Compile Include="RemoveProcess.fs" />

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -117,7 +117,7 @@
     <Compile Include="ProjectFile.fs" />
     <Compile Include="DependencyModel.fs" />
     <Compile Include="DependencyChangeDetection.fs" />
-    <Compile Include="GarbageCollectionProcess.fs" />
+    <Compile Include="GarbageCollection.fs" />
     <Compile Include="RestoreProcess.fs" />
     <Compile Include="BindingRedirects.fs" />
     <Compile Include="NupkgWriter.fs" />

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -122,6 +122,7 @@
     <Compile Include="NupkgWriter.fs" />
     <Compile Include="ProcessOptions.fs" />
     <Compile Include="PackagesConfigFile.fs" />
+    <Compile Include="GarbageCollectionProcess.fs" />
     <Compile Include="InstallProcess.fs" />
     <Compile Include="UpdateProcess.fs" />
     <Compile Include="RemoveProcess.fs" />

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -46,6 +46,7 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
     if installAfter then
         let updatedGroups = Map.add groupName 0 Map.empty
         InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), hasChanged, dependenciesFile, lockFile, updatedGroups)
+        GarbageCollectionProcess.DeleteUnusedPackages(root, lockFile)
 
 /// Removes a package with the option to remove it from a specified project.
 let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -46,7 +46,7 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
     if installAfter then
         let updatedGroups = Map.add groupName 0 Map.empty
         InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), hasChanged, dependenciesFile, lockFile, updatedGroups)
-        GarbageCollectionProcess.DeleteUnusedPackages(root, lockFile)
+        GarbageCollection.CleanUp(root, lockFile)
 
 /// Removes a package with the option to remove it from a specified project.
 let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -110,4 +110,4 @@ let Restore(dependenciesFileName,force,group,referencesFileNames) =
         |> Async.RunSynchronously
         |> ignore
 
-    GarbageCollectionProcess.DeleteUnusedPackages(root, lockFile)
+    GarbageCollection.CleanUp(root, lockFile)

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -109,3 +109,5 @@ let Restore(dependenciesFileName,force,group,referencesFileNames) =
         restore(root, kv.Key, dependenciesFile.Groups.[kv.Value.Name].Sources, force, lockFile,Set.ofSeq packages)
         |> Async.RunSynchronously
         |> ignore
+
+    GarbageCollectionProcess.DeleteUnusedPackages(root, lockFile)

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -221,7 +221,7 @@ let SmartInstall(dependenciesFile, updateMode, options : UpdaterOptions) =
 
     if not options.NoInstall then
         InstallProcess.InstallIntoProjects(options.Common, hasChanged, dependenciesFile, lockFile, projectsAndReferences, updatedGroups)
-        GarbageCollectionProcess.DeleteUnusedPackages(root, lockFile)
+        GarbageCollection.CleanUp(root, lockFile)
 
 /// Update a single package command
 let UpdatePackage(dependenciesFileName, groupName, packageName : PackageName, newVersion, options : UpdaterOptions) =

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -221,6 +221,7 @@ let SmartInstall(dependenciesFile, updateMode, options : UpdaterOptions) =
 
     if not options.NoInstall then
         InstallProcess.InstallIntoProjects(options.Common, hasChanged, dependenciesFile, lockFile, projectsAndReferences, updatedGroups)
+        GarbageCollectionProcess.DeleteUnusedPackages(root, lockFile)
 
 /// Update a single package command
 let UpdatePackage(dependenciesFileName, groupName, packageName : PackageName, newVersion, options : UpdaterOptions) =


### PR DESCRIPTION
*PR #1482 but rebased on v3*

I've started on a proposal how we could implement garbage collection to clean up packages no longer needed in the `packages` folder (and if possible the same for `paket-files`). Addresses #1416.

Since the packages folder is typically excluded from version control, we do not always have explicit information about a package being removed. What we do know is what packages are currently extracted in the packages folder, and what packages we actually expect to be there according to the lock file.

The proposed algorithm essentially goes through the subdirs of the packages folder, tries to imply group and package names, and drops all of these folders which we identify as a extracted package but are *not* known by the lock file (ignoring the version).

Questions:
* Is it safe to assume that the name of the extracted nuspec file matches the package id, or do we need to parse it to be sure? We could also interpret the folder name instead, which we do construct ourselves (with or without version).
* When/where would we want to do this? Should it be explicit? Only on demand? Currently it is rather aggressive: always after add, remove and install, unless --no-install is set, and always after restore. I expect this to be too aggressive in practice.
