### PR TITLE
ProjectFile.save with forceTouch to only modify the last write time without content if unchanged

### DIFF
--- a/src/Paket.Core/FindReferences.fs
+++ b/src/Paket.Core/FindReferences.fs
@@ -39,7 +39,7 @@ let TouchReferencesOfPackages packages environment = trial {
     |> List.distinctBy (fun project-> project.FileName)
     |> List.iter (fun project ->
         verbosefn "Touching project %s" project.FileName
-        ProjectFile.save true project)
+        ProjectFile.touch project)
 }
 
 let ShowReferencesFor packages environment = trial {

--- a/src/Paket.Core/FindReferences.fs
+++ b/src/Paket.Core/FindReferences.fs
@@ -39,7 +39,7 @@ let TouchReferencesOfPackages packages environment = trial {
     |> List.distinctBy (fun project-> project.FileName)
     |> List.iter (fun project ->
         verbosefn "Touching project %s" project.FileName
-        ProjectFile.touch project)
+        ProjectFile.save true project)
 }
 
 let ShowReferencesFor packages environment = trial {

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -941,6 +941,9 @@ module ProjectFile =
                 project.ProjectNode.AppendChild analyzersNode |> ignore
             )
 
+    let touch (project:ProjectFile) =
+        if File.Exists(project.FileName) then
+            File.SetLastWriteTimeUtc(project.FileName, DateTime.UtcNow)
 
     let save forceTouch project =
         if forceTouch then 
@@ -1305,7 +1308,9 @@ type ProjectFile with
     member this.RemovePaketNodes () = ProjectFile.removePaketNodes this 
 
     member this.UpdateReferences (completeModel, usedPackages, hard) = ProjectFile.updateReferences completeModel usedPackages hard this
-         
+
+    member this.Touch () = ProjectFile.touch this
+
     member this.Save(forceTouch) = ProjectFile.save forceTouch this
 
     member this.GetPaketFileItems () = ProjectFile.getPaketFileItems this

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -941,16 +941,17 @@ module ProjectFile =
                 project.ProjectNode.AppendChild analyzersNode |> ignore
             )
 
-    let touch (project:ProjectFile) =
-        if File.Exists(project.FileName) then
-            File.SetLastWriteTimeUtc(project.FileName, DateTime.UtcNow)
-
     let save forceTouch project =
         if forceTouch then 
             project.Document.Save(project.FileName)
         elif Utils.normalizeXml project.Document <> project.OriginalText then 
             verbosefn "Project %s changed" project.FileName
             project.Document.Save(project.FileName)
+
+    let touch (project:ProjectFile) =
+        if File.Exists(project.FileName) then
+            File.SetLastWriteTimeUtc(project.FileName, DateTime.UtcNow)
+        else save true project
 
     let getPaketFileItems project =
         findPaketNodes "Content" project

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -942,16 +942,11 @@ module ProjectFile =
             )
 
     let save forceTouch project =
-        if forceTouch then 
-            project.Document.Save(project.FileName)
-        elif Utils.normalizeXml project.Document <> project.OriginalText then 
+        if Utils.normalizeXml project.Document <> project.OriginalText || not (File.Exists(project.FileName)) then
             verbosefn "Project %s changed" project.FileName
             project.Document.Save(project.FileName)
-
-    let touch (project:ProjectFile) =
-        if File.Exists(project.FileName) then
+        elif forceTouch then
             File.SetLastWriteTimeUtc(project.FileName, DateTime.UtcNow)
-        else save true project
 
     let getPaketFileItems project =
         findPaketNodes "Content" project
@@ -1309,8 +1304,6 @@ type ProjectFile with
     member this.RemovePaketNodes () = ProjectFile.removePaketNodes this 
 
     member this.UpdateReferences (completeModel, usedPackages, hard) = ProjectFile.updateReferences completeModel usedPackages hard this
-
-    member this.Touch () = ProjectFile.touch this
 
     member this.Save(forceTouch) = ProjectFile.save forceTouch this
 


### PR DESCRIPTION
This is a follow up to #1485 which introduced the optional --touch-affected-refs
parameter on restore. In the original implementation this caused the
project file to be saved forcefully, which could in some cases cause the
file content to change slightly (e.g. minor xml formatting).

With this change, save with forceTouch=true only saves the content if it has actually changed. Otherwise it only sets the last-write-time to now.