### PR TITLE
Added ability to include partials in the paket.template

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -196,3 +196,9 @@ This only works for paket.template files of type `project`.
 ### Comments
 
 A line starting with a # or // is considered a comment and will be ignored by the parser.
+
+### Includes
+
+A line with the format `#load "<filename>"` will be replaced with the content of the given file.
+
+The file must exist relative to the root file. If the file is not found, the line will be deleted.


### PR DESCRIPTION
You can now include partials via `#load "<filename>"`

This is meant for having a base template and then just generating the version info and the release notes for example as include file via FAKE. So I don't have to generate everything via FAKE.