### PR TITLE
Updated message when paket.dependencies cannot be found

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -45,7 +45,7 @@ type Dependencies(dependenciesFileName: string) =
                 match parent with
                 | null ->
                     if withError then
-                        failwithf "Could not find '%s'. To use Paket with this solution, please run 'paket init' first.\nIf you have already run 'packet.init' then ensure that '%s' is located in the source directory.\nLike this:\nMySourceDir\n  .paket\n  paket.dependencies" Constants.DependenciesFileName Constants.DependenciesFileName
+                        failwithf "Could not find '%s'. To use Paket with this solution, please run 'paket init' first.\nIf you have already run 'paket.init' then ensure that '%s' is located in the source directory.\nLike this:\nMySourceDir\n  .paket\n  paket.dependencies" Constants.DependenciesFileName Constants.DependenciesFileName
                     else
                         Constants.DependenciesFileName
                 | _ -> findInPath(parent, withError)

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -45,7 +45,7 @@ type Dependencies(dependenciesFileName: string) =
                 match parent with
                 | null ->
                     if withError then
-                        failwithf "Could not find '%s'. To use Paket with this solution, please run 'paket init' first." Constants.DependenciesFileName
+                        failwithf "Could not find '%s'. To use Paket with this solution, please run 'paket init' first.\nIf you have already run 'packet.init' then ensure that '%s' is located in the source directory.\nLike this:\nMySourceDir\n  .paket\n  paket.dependencies" Constants.DependenciesFileName Constants.DependenciesFileName
                     else
                         Constants.DependenciesFileName
                 | _ -> findInPath(parent, withError)


### PR DESCRIPTION
The new message would look like:

"Could not find 'paket.dependencies'. To use Paket with this solution, please run 'paket init' first.
If you have already run 'packet.init' then ensure that 'paket.dependencies' is located in the source directory.
Like this:
MySourceDir
  .paket
  paket.dependencies"