### PR TITLE
Add exclude projects with templates flag for pack

### DIFF
--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -123,7 +123,7 @@ let addFile (source : string) (target : string) (templateFile : TemplateFile) =
     | IncompleteTemplate -> 
         failwith "You should only try and add files to template files with complete metadata."
 
-let findDependencies (dependenciesFile : DependenciesFile) config platform (template : TemplateFile) (project : ProjectFile) lockDependencies minimumFromLockFile (map : Map<string, TemplateFile * ProjectFile>) includeReferencedProjects (version :SemVerInfo option) specificVersions =
+let findDependencies (dependenciesFile : DependenciesFile) config platform (template : TemplateFile) (project : ProjectFile) lockDependencies minimumFromLockFile (map : Map<string, TemplateFile * ProjectFile>) includeReferencedProjects (version :SemVerInfo option) specificVersions excludeProjectsWithTemplates =
     let targetDir = 
         match project.OutputType with
         | ProjectOutputType.Exe -> "tools/"
@@ -137,7 +137,10 @@ let findDependencies (dependenciesFile : DependenciesFile) config platform (temp
         | _ -> PreReleaseStatus.All
     
     let deps, files = 
-        project.GetAllInterProjectDependenciesWithProjectTemplates |> Seq.toList
+        let interProjectDeps = if excludeProjectsWithTemplates then project.GetAllInterProjectDependenciesWithoutProjectTemplates 
+                               else project.GetAllInterProjectDependenciesWithProjectTemplates 
+        interProjectDeps
+        |> Seq.toList
         |> List.filter (fun proj -> proj <> project)
         |> List.fold (fun (deps, files) p -> 
             match Map.tryFind p.FileName map with

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -95,7 +95,7 @@ let private convertToSymbols (projectFile : ProjectFile) (includeReferencedProje
         let augmentedFiles = optional.Files |> List.append sourceFiles
         { templateFile with Contents = ProjectInfo({ core with Symbols = true }, { optional with Files = augmentedFiles }) }
 
-let Pack(workingDir,dependenciesFile : DependenciesFile, packageOutputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, minimumFromLockFile, symbols, includeReferencedProjects, projectUrl) =
+let Pack(workingDir,dependenciesFile : DependenciesFile, packageOutputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, minimumFromLockFile, symbols, includeReferencedProjects, projectUrl, excludeProjectsWithTemplates) =
     let buildConfig = defaultArg buildConfig "Release"
     let buildPlatform = defaultArg buildPlatform ""
     let packageOutputPath = if Path.IsPathRooted(packageOutputPath) then packageOutputPath else Path.Combine(workingDir,packageOutputPath)
@@ -174,7 +174,7 @@ let Pack(workingDir,dependenciesFile : DependenciesFile, packageOutputPath, buil
                 }
             )
          |> Seq.map (fun (t, p) -> 
-                let deps = findDependencies dependenciesFile buildConfig buildPlatform t p lockDependencies minimumFromLockFile projectTemplates includeReferencedProjects version specificVersions
+                let deps = findDependencies dependenciesFile buildConfig buildPlatform t p lockDependencies minimumFromLockFile projectTemplates includeReferencedProjects version specificVersions excludeProjectsWithTemplates
                 deps
             )
          |> Seq.append (allTemplateFiles |> Seq.collect convertRemainingTemplate)

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -528,7 +528,7 @@ type Dependencies(dependenciesFileName: string) =
         FindReferences.FindReferencesForPackage (GroupName group) (PackageName package) |> this.Process
 
     // Packs all paket.template files.
-    member this.Pack(outputPath, ?buildConfig, ?buildPlatform, ?version, ?specificVersions, ?releaseNotes, ?templateFile, ?workingDir, ?excludedTemplates, ?lockDependencies, ?minimumFromLockFile, ?symbols, ?includeReferencedProjects, ?projectUrl) =
+    member this.Pack(outputPath, ?buildConfig, ?buildPlatform, ?version, ?specificVersions, ?releaseNotes, ?templateFile, ?workingDir, ?excludedTemplates, ?lockDependencies, ?minimumFromLockFile, ?symbols, ?includeReferencedProjects, ?projectUrl, ?excludeProjectsWithTemplates) =
         let dependenciesFile = DependenciesFile.ReadFromFile dependenciesFileName
         let specificVersions = defaultArg specificVersions Seq.empty
         let workingDir = defaultArg workingDir (dependenciesFile.FileName |> Path.GetDirectoryName)
@@ -537,7 +537,8 @@ type Dependencies(dependenciesFileName: string) =
         let symbols = defaultArg symbols false
         let includeReferencedProjects = defaultArg includeReferencedProjects false
         let projectUrl = defaultArg (Some(projectUrl)) None
-        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, minimumFromLockFile, symbols, includeReferencedProjects, projectUrl)
+        let excludeProjectsWithTemplates = defaultArg excludeProjectsWithTemplates false
+        PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, minimumFromLockFile, symbols, includeReferencedProjects, projectUrl, excludeProjectsWithTemplates)
 
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -314,6 +314,7 @@ type PackArgs =
     | [<CustomCommandLine("symbols")>] Symbols
     | [<CustomCommandLine("include-referenced-projects")>] IncludeReferencedProjects
     | [<CustomCommandLine("project-url")>] ProjectUrl of string
+    | [<CustomCommandLine("exclude-projects-with-templates")>] ExcludeProjectsWithTemplates
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -331,6 +332,7 @@ with
             | Symbols -> "Build symbol/source packages in addition to library/content packages."
             | IncludeReferencedProjects -> "Include symbol/source from referenced projects."
             | ProjectUrl(_) -> "Url to the projects home page."
+            | ExcludeProjectsWithTemplates -> "Exclude symbol/source from referenced projects that have their own templates and thus their own nuget packages."
 
 type PushArgs =
     | [<CustomCommandLine("url")>][<Mandatory>] Url of string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -230,7 +230,9 @@ let pack (results : ParseResults<_>) =
                       minimumFromLockFile = results.Contains <@ PackArgs.LockDependenciesToMinimum @>,
                       symbols = results.Contains <@ PackArgs.Symbols @>,
                       includeReferencedProjects = results.Contains <@ PackArgs.IncludeReferencedProjects @>,
-                      ?projectUrl = results.TryGetResult <@ PackArgs.ProjectUrl @>)
+                      ?projectUrl = results.TryGetResult <@ PackArgs.ProjectUrl @>,
+                      excludeProjectsWithTemplates = results.Contains <@ PackArgs.ExcludeProjectsWithTemplates @>)
+
 
 let findPackages (results : ParseResults<_>) =
     let maxResults = defaultArg (results.TryGetResult <@ FindPackagesArgs.MaxResults @>) 10000


### PR DESCRIPTION
Needed a way to exclude projects that have templates from the packing process.  This brings the output in line with how nuget behaves, and prevents problems for package consumers where they have the same dll available in multiple packages.