### PR TITLE
prevent packing of sources from doubling up on the project directory …

### DIFF
--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -81,7 +81,9 @@ let private convertToSymbols (projectFile : ProjectFile) (includeReferencedProje
                        | None -> compileItem.Include
             
             let tld = Path.GetFileName(compileItem.BaseDir)
-            Path.Combine("src", tld, Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(item))))
+            let fileDir = Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(item)))
+            if tld = fileDir then Path.Combine("src", tld)
+            else Path.Combine("src", tld, Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(item))))
 
         projectFile.GetCompileItems(includeReferencedProjects)
         |> Seq.map (fun c -> c.Include, getTarget c)


### PR DESCRIPTION
…when adding files in the root of the project

Example. we are packing project A with source tree like so
```
projectA
    + SubDir
        + class1.cs
        + class2.cs
    + class3.cs
    + class4.cs

```
when packed it should look exactly the same, but currently the following directory structure is produced
```
projectA
    + SubDir
        + class1.cs
        + class2.cs
    + projectA
        + class3.cs
        + class4.cs
```

This is obviously incorrect.