### PR TITLE
ensuring that dependent dll's are not included in the package when us…

### DIFF
--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -137,7 +137,11 @@ let findDependencies (dependenciesFile : DependenciesFile) config platform (temp
         | _ -> PreReleaseStatus.All
     
     let deps, files = 
-        project.GetAllInterProjectDependenciesWithProjectTemplates |> Seq.toList
+        let interProjectDeps = if includeReferencedProjects then project.GetAllInterProjectDependenciesWithoutProjectTemplates 
+                               else project.GetAllInterProjectDependenciesWithProjectTemplates 
+
+        interProjectDeps
+        |> Seq.toList
         |> List.filter (fun proj -> proj <> project)
         |> List.fold (fun (deps, files) p -> 
             match Map.tryFind p.FileName map with


### PR DESCRIPTION
…ing include-referenced-projects

as per requested in (https://github.com/fsprojects/Paket/pull/1540).  Separate PR in order to keep the history clean.