### PR TITLE
Fixed missing src files when packing with symbols on Linux

### DIFF
--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -73,16 +73,14 @@ let private convertToNormal (symbols : bool) templateFile =
         let includePdbs = optional.IncludePdbs
         { templateFile with Contents = ProjectInfo(core, { optional with IncludePdbs = (if symbols then false else includePdbs) }) }
 
-let private convertToSymbols (projectFile : ProjectFile) (includeReferencedProjects : bool) templateFile =
+let private convertToSymbols (projectFile: ProjectFile) (includeReferencedProjects: bool) templateFile =
     let sourceFiles =
         let getTarget compileItem =
-            let item = match compileItem.Link with
-                       | Some link -> Path.Combine(Path.GetFileName(compileItem.BaseDir), link)
-                       | None -> createRelativePath compileItem.BaseDir compileItem.Include
-            Path.Combine("src", Path.GetDirectoryName(item))
+            let projectName = Path.GetFileName(compileItem.BaseDir)
+            Path.Combine("src", projectName, compileItem.DestinationPath)
 
         projectFile.GetCompileItems(includeReferencedProjects)
-        |> Seq.map (fun c -> c.Include, getTarget c)
+        |> Seq.map (fun c -> c.SourceFile, getTarget c)
         |> Seq.toList
 
     match templateFile.Contents with


### PR DESCRIPTION
Packing with symbols never correctly added source files when running on Linux due to DirectorySeparatorChar issues.

This PR fixes that and makes the integration test from #1538 pass.