### PR TITLE
install mvvmlightlibs first time with wpav8.1 framework in lock file

### DIFF
--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -377,11 +377,16 @@ let ``#1552 install mvvmlightlibs again``() =
         |> normalizeLineEndings |> shouldEqual expected
 
     prepare scenarioName
-    ["install -f"
-     "update -f"
-     "install"
-     "update"]
-    |> List.iter lockFileShouldBeConsistentAfterCommand
+    let commands =
+        ["install -f"
+         "update -f"
+         "install"
+         "update"]
+    let rnd = new Random((int)DateTime.Now.Ticks)
+    for _ in [1..10] do
+        let ind = rnd.Next(commands.Length)
+        let command = commands.[ind]
+        lockFileShouldBeConsistentAfterCommand command
 
     let newFile = Path.Combine(scenarioPath,"CSharp","CSharp.csproj")
     let oldFile = Path.Combine(originalScenarioPath scenarioName,"CSharp","CSharp.csprojtemplate")

--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -370,11 +370,19 @@ let ``#1552 install mvvmlightlibs again``() =
     let oldLockFile = LockFile.LoadFrom(Path.Combine(originalScenarioPath scenarioName,"paket.lock"))
     let expected = oldLockFile.ToString() |> normalizeLineEndings
 
+    let oldProjectFile = Path.Combine(originalScenarioPath scenarioName,"CSharp","CSharp.csprojtemplate")
+    let oldProjectFileText = File.ReadAllText oldProjectFile |> normalizeLineEndings
+
     let newLockFilePath = Path.Combine(scenarioPath,"paket.lock")
     let lockFileShouldBeConsistentAfterCommand command =
         directPaketInPath command scenarioPath |> ignore
+
         LockFile.LoadFrom(newLockFilePath).ToString()
         |> normalizeLineEndings |> shouldEqual expected
+
+        let newProjectFile = Path.Combine(scenarioPath,"CSharp","CSharp.csproj")
+        File.ReadAllText newProjectFile
+        |> normalizeLineEndings |> shouldEqual oldProjectFileText
 
     prepare scenarioName
     let commands =
@@ -383,16 +391,10 @@ let ``#1552 install mvvmlightlibs again``() =
          "install"
          "update"]
     let rnd = new Random((int)DateTime.Now.Ticks)
-    for _ in [1..10] do
-        let ind = rnd.Next(commands.Length)
+    for x in [1..10] do
+        let ind = if x<=4 then x-1 else rnd.Next(commands.Length)
         let command = commands.[ind]
         lockFileShouldBeConsistentAfterCommand command
-
-    let newFile = Path.Combine(scenarioPath,"CSharp","CSharp.csproj")
-    let oldFile = Path.Combine(originalScenarioPath scenarioName,"CSharp","CSharp.csprojtemplate")
-    let s1 = File.ReadAllText oldFile |> normalizeLineEndings
-    let s2 = File.ReadAllText newFile |> normalizeLineEndings
-    s2 |> shouldEqual s1
 
 [<Test>]
 let ``#1552 install mvvmlightlibs first time``() =

--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -388,3 +388,13 @@ let ``#1552 install mvvmlightlibs again``() =
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
     let s2 = File.ReadAllText newFile |> normalizeLineEndings
     s2 |> shouldEqual s1
+
+[<Test>]
+let ``#1552 install mvvmlightlibs first time``() =
+    let scenarioName = "i001552-install-mvvmlightlibs-first-time"
+
+    let oldLockFile = LockFile.LoadFrom(Path.Combine(originalScenarioPath scenarioName,"paket.locktemplate"))
+    let expected = oldLockFile.ToString() |> normalizeLineEndings
+
+    let newLockFile = install scenarioName
+    newLockFile.ToString() |> normalizeLineEndings |> shouldEqual expected

--- a/integrationtests/scenarios/i001552-install-mvvmlightlibs-first-time/before/paket.dependencies
+++ b/integrationtests/scenarios/i001552-install-mvvmlightlibs-first-time/before/paket.dependencies
@@ -1,0 +1,3 @@
+source https://nuget.org/api/v2
+
+nuget MvvmLightLibs

--- a/integrationtests/scenarios/i001552-install-mvvmlightlibs-first-time/before/paket.locktemplate
+++ b/integrationtests/scenarios/i001552-install-mvvmlightlibs-first-time/before/paket.locktemplate
@@ -1,0 +1,7 @@
+NUGET
+  remote: https://www.nuget.org/api/v2
+  specs:
+    CommonServiceLocator (1.3) - framework: >= net40, monoandroid, portable-net45+wp80+wpa81+win+MonoAndroid10+xamarinios10, xamarinios, winv4.5, winv4.5.1, wpv8.0, wpv8.1, wpav8.1, sl50
+    MvvmLightLibs (5.2)
+      CommonServiceLocator (>= 1.0) - framework: net35, sl40
+      CommonServiceLocator (>= 1.3) - framework: >= net40, monoandroid, portable-net45+wp80+wpa81+win+MonoAndroid10+xamarinios10, xamarinios, winv4.5, winv4.5.1, wpv8.0, wpv8.1, wpav8.1, sl50


### PR DESCRIPTION
This test work on my machine and produce lock file with `wpav8.1`
![image](https://cloud.githubusercontent.com/assets/1197905/14121747/5a33486e-f601-11e5-8ee9-0e98242c88ee.png)
