### PR TITLE
Property Definitions: placed after non-paket imports if they directly follow the top property groups

### DIFF
--- a/integrationtests/scenarios/i001233-props-files/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
+++ b/integrationtests/scenarios/i001233-props-files/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
@@ -29,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5.1'">
       <PropertyGroup>
@@ -68,7 +69,6 @@
     <Compile Include="Class1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/integrationtests/scenarios/i001233-props-fw-files/before/xUnitTests/xUnitTests.csprojtemplate
+++ b/integrationtests/scenarios/i001233-props-fw-files/before/xUnitTests/xUnitTests.csprojtemplate
@@ -30,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,7 +44,6 @@
     <None Include="packages.config" />
     <None Include="paket.references" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/integrationtests/scenarios/i001233-props-fw-files/before/xUnitTests/xUnitTests.expected.csprojtemplate
+++ b/integrationtests/scenarios/i001233-props-fw-files/before/xUnitTests/xUnitTests.expected.csprojtemplate
@@ -51,7 +51,6 @@
     <None Include="packages.config" />
     <None Include="paket.references" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/integrationtests/scenarios/i001233-props-fw-files/before/xUnitTests/xUnitTests.expected.csprojtemplate
+++ b/integrationtests/scenarios/i001233-props-fw-files/before/xUnitTests/xUnitTests.expected.csprojtemplate
@@ -29,6 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <PropertyGroup>

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -947,7 +947,11 @@ module ProjectFile =
                 incr j
 
             let k = ref !j
-            while !k < project.ProjectNode.ChildNodes.Count && String.startsWithIgnoreCase  "<PropertyGroup" (project.ProjectNode.ChildNodes.[!k].OuterXml.ToString()) do
+            while !k < project.ProjectNode.ChildNodes.Count &&
+                (String.startsWithIgnoreCase  "<PropertyGroup" (project.ProjectNode.ChildNodes.[!k].OuterXml.ToString()) ||
+                 (String.startsWithIgnoreCase  "<import" (project.ProjectNode.ChildNodes.[!k].OuterXml.ToString()) &&
+                  not (String.containsIgnoreCase "label" (project.ProjectNode.ChildNodes.[!k].OuterXml.ToString()) &&
+                       String.containsIgnoreCase "paket" (project.ProjectNode.ChildNodes.[!k].OuterXml.ToString())))) do
                 incr k
 
             let addProps() =


### PR DESCRIPTION
Related to #1537

If in a project file there are non-paket imports right after the top property groups, then place the property definitions right after them (instead of before them). This makes sure that imports like `Microsoft.CSharp.targets` can be moved up before them, to make sure`TargetFrameworkIdentifier` is actually defined. Note that it does *not* move `Microsoft.CSharp.targets` up manually if it is further down (which it is by default).