### PR TITLE
Remove --hard flag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,10 @@
-#### 3.0.0-alpha095 - 31.03.2016
+#### 3.0.0-alpha096 - 04.04.2016
 * Allow to reference git repositories - http://fsprojects.github.io/Paket/git-dependencies.html
 * Allow to run build commands on git repositories - http://fsprojects.github.io/Paket/git-dependencies.html#Running-a-build-in-git-repositories
 * Allow to use git repositories as NuGet source - http://fsprojects.github.io/Paket/git-dependencies.html#Using-Git-repositories-as-NuGet-source
 * Additional local caches - http://fsprojects.github.io/Paket/caches.html
 * Garbage collection in packages folder - https://github.com/fsprojects/Paket/pull/1491
+* BREAKING CHANGE: Removed --hard parameter from all commands. Paket threads all commands as if --hard would have been set - https://github.com/fsprojects/Paket/pull/1567
 
 #### 2.57.1 - 30.03.2016
 * BUGFIX: Property Definitions: placed after csharp targets - https://github.com/fsprojects/Paket/pull/1522

--- a/docs/content/commands/add.md
+++ b/docs/content/commands/add.md
@@ -3,7 +3,7 @@
 It's also possible to add a package to a specified project only:
 
     [lang=batchfile]
-    $ paket add nuget PACKAGENAME [version VERSION] [project PROJECT] [--force] [--hard]
+    $ paket add nuget PACKAGENAME [version VERSION] [project PROJECT] [--force]
 
 See also [paket remove](paket-remove.html).
 

--- a/docs/content/commands/remove.md
+++ b/docs/content/commands/remove.md
@@ -3,6 +3,6 @@
 It's also possible to remove a package from a specified project only: 
 
     [lang=batchfile]
-    $ paket remove nuget PACKAGENAME [project PROJECT] [--force] [--hard]
+    $ paket remove nuget PACKAGENAME [project PROJECT] [--force]
 
 See also [paket add](paket-add.html).

--- a/docs/content/commands/update.md
+++ b/docs/content/commands/update.md
@@ -3,7 +3,7 @@
 If you do not specify a package, then all packages from paket.dependencies are updated.
 
     [lang=batchfile]
-    paket update [--force|-f] [--hard] [--redirects] [--no-install]
+    paket update [--force|-f] [--redirects] [--no-install]
 
 First, the current [`paket.lock` file](lock-file.html) is deleted. `paket update` then recomputes the current dependency resolution,
 as explained under [Package resolution algorithm](http://fsprojects.github.io/Paket/resolver.html), and writes it to paket.lock.
@@ -15,11 +15,9 @@ Please see [`paket install`](paket-install.html) if you want to keep the current
 
   `--force [-f]`: Forces the download and reinstallation of all packages.
 
-  `--hard`: Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed). See [convert from NuGet](paket-convert-from-nuget.html).
-
   `--redirects`: Creates binding redirects for the NuGet packages.
 
-  `--no-install`: Skips paket install --hard process afterward generation of [`paket.lock` file](lock-file.html).
+  `--no-install`: Skips paket install process afterward generation of [`paket.lock` file](lock-file.html).
 
 
 ## Updating a single package, or packages matching a pattern
@@ -27,7 +25,7 @@ Please see [`paket install`](paket-install.html) if you want to keep the current
 It's also possible to update only specified packages and to keep all other dependencies fixed:
 
     [lang=batchfile]
-    paket update nuget PACKAGENAME [version VERSION] [group GROUPNAME] [--force|-f] [--hard] [--redirects] [--no-install]
+    paket update nuget PACKAGENAME [version VERSION] [group GROUPNAME] [--force|-f] [--redirects] [--no-install]
 
 ### Options:
 
@@ -39,11 +37,9 @@ It's also possible to update only specified packages and to keep all other depen
 
   `--force [-f]`: Forces the download and reinstallation of all packages.
 
-  `--hard`: Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed). See [convert from NuGet](paket-convert-from-nuget.html).
-
   `--redirects`: Creates binding redirects for the NuGet packages.
 
-  `--no-install`: Skips paket install --hard process afterward generation of [`paket.lock` file](lock-file.html).
+  `--no-install`: Skips paket install process afterward generation of [`paket.lock` file](lock-file.html).
 
   `--filter`: Treat PACKAGENAME as a regex pattern to match against, rather than a single package. Enforces a "total" match (i.e. an implicit ^ and $ at beginning and end of PACKAGENAME)
 
@@ -52,7 +48,7 @@ It's also possible to update only specified packages and to keep all other depen
 If you want to update a single group you can use the following command:
 
     [lang=batchfile]
-    paket update group GROUPNAME [--force|-f] [--hard] [--redirects] [--no-install]
+    paket update group GROUPNAME [--force|-f] [--redirects] [--no-install]
 
 ### Options:
 
@@ -60,11 +56,9 @@ If you want to update a single group you can use the following command:
 
   `--force [-f]`: Forces the download and reinstallation of all packages.
 
-  `--hard`: Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed). See [convert from NuGet](paket-convert-from-nuget.html).
-
   `--redirects`: Creates binding redirects for the NuGet packages.
 
-  `--no-install`: Skips paket install --hard process afterward generation of [`paket.lock` file](lock-file.html).
+  `--no-install`: Skips paket install process afterward generation of [`paket.lock` file](lock-file.html).
 
 ## Updating http dependencies
 

--- a/docs/content/convert-from-nuget-tutorial.md
+++ b/docs/content/convert-from-nuget-tutorial.md
@@ -65,7 +65,7 @@ The `paket convert-from-nuget` command:
 1. Finds all `packages.config` files, generates a paket.dependencies file in the solution root and replaces each `packages.config` with an equivalent paket.references file. 
 2. If there is a solution-level `packages.config`, then it will be removed and its dependencies will be included into the paket.dependencies file.
 3. If you use NuGet Package Restore ([MSBuild-Integrated or Automatic Visual Studio Package Restore](http://docs.nuget.org/docs/workflows/migrating-to-automatic-package-restore)), then the [`paket auto-restore`](paket-auto-restore.html) command will be invoked.
-4. Next (unless `--no-install` is specified), the [paket install](paket-install.html) process with the `--hard` flag will be executed. This will:
+4. Next (unless `--no-install` is specified), the [paket install](paket-install.html) process will be executed. This will:
 
   - analyze the dependencies.
   - generate a paket.lock file.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -108,7 +108,7 @@ In case of the command's failure, you can fallback to manual approach:
 
 1. Analyse your `packages.config` files and extract the referenced packages into a paket.dependencies file.
 2. Convert each `packages.config` file to a paket.references file. This is very easy - you just have to remove all the XML and keep the package names.
-3. Run [paket install](paket-install.html) with the `--hard` flag. This will analyze the dependencies, generate a paket.lock file, remove all the old package references from your project files and replace them with equivalent `Reference`s in a syntax that can be managed automatically by Paket.
+3. Run [paket install](paket-install.html). This will analyze the dependencies, generate a paket.lock file, remove all the old package references from your project files and replace them with equivalent `Reference`s in a syntax that can be managed automatically by Paket.
 4. (Optional) Raise corresponding issue [here](https://github.com/fsprojects/Paket/issues) so that we can make the command even better.
 
 ## How do I convert a new project to Paket when my solution is already using Paket

--- a/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
+++ b/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
@@ -80,8 +80,8 @@ let ``#1195 should report broken app.config``() =
     | exn when exn.Message.Contains("Project1") && exn.Message.Contains("app.config") -> ()
 
 [<Test>]
-let ``#1218 install hard should replace all assembly redirects with required only``() = 
-    paket "install --redirects --createnewbindingfiles --hard" "i001218-binding-redirect" |> ignore
+let ``#1218 install should replace all assembly redirects with required only``() = 
+    paket "install --redirects --createnewbindingfiles" "i001218-binding-redirect" |> ignore
 
     let path = Path.Combine(scenarioTempPath "i001218-binding-redirect")
     let config1Path = Path.Combine(path, "Project1", "app.config")
@@ -143,88 +143,10 @@ let ``#1218 install hard should replace all assembly redirects with required onl
     config4.Contains ``xunit.extensions`` |> shouldEqual false
     config4 |> shouldContainText ``Castle.Core``
     config4.Contains ``Castle.Windsor`` |> shouldEqual false
-    
-[<Test>]
-let ``#1218 install should replace paket's binding redirects with required only``() = 
-    paket "install --redirects --createnewbindingfiles" "i001218-binding-redirect" |> ignore
-
-    let path = Path.Combine(scenarioTempPath "i001218-binding-redirect")
-    let config1Path = Path.Combine(path, "Project1", "app.config")
-    let config2Path = Path.Combine(path, "Project2", "app.config")
-    let config3Path = Path.Combine(path, "Project3", "app.config")
-    let config4Path = Path.Combine(path, "Project4", "app.config")
-
-    let config1 = File.ReadAllText(config1Path)
-    let config2 = File.ReadAllText(config2Path)
-    let config3 = File.ReadAllText(config3Path)
-    let config4 = File.ReadAllText(config4Path)
-
-    let paketMark = "<Paket>True</Paket>\s*"
-
-    let Albedo = """<assemblyIdentity name="Ploeh.Albedo" publicKeyToken="179ef6dd03497bbd" culture="neutral" />"""
-    let AutoFixture = """<assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
-    let ``AutoFixture.Idioms`` = """<assemblyIdentity name="Ploeh.AutoFixture.Idioms" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
-    let ``AutoFixture.Xunit`` = """<assemblyIdentity name="Ploeh.AutoFixture.Xunit" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
-    let log4net = """<assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />"""
-    let ``Newtonsoft.Json`` = """<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
-    let ``Newtonsoft.Json.Schema`` = """<assemblyIdentity name="Newtonsoft.Json.Schema" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
-    let xunit = """<assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
-    let ``xunit.extensions`` = """<assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
-    let ``Castle.Core`` = """<assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
-    let ``Castle.Windsor`` = """<assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
-
-    Regex.IsMatch(config1, paketMark + Albedo) |> shouldEqual true
-    Regex.IsMatch(config1, paketMark + AutoFixture) |> shouldEqual true
-    config1.Contains ``AutoFixture.Idioms`` |> shouldEqual false
-    config1.Contains ``AutoFixture.Xunit`` |> shouldEqual false
-    config1.Contains log4net |> shouldEqual false
-    Regex.IsMatch(config1, paketMark + ``Newtonsoft.Json``) |> shouldEqual true
-    config1.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
-    config1.Contains xunit |> shouldEqual false
-    Regex.IsMatch(config1, paketMark + ``xunit.extensions``) |> shouldEqual true
-    Regex.IsMatch(config1, paketMark + ``Castle.Core``) |> shouldEqual true
-    config1.Contains ``Castle.Windsor`` |> shouldEqual false
-
-    config2.Contains Albedo |> shouldEqual false
-    config2.Contains AutoFixture |> shouldEqual false
-    config2.Contains ``AutoFixture.Idioms`` |> shouldEqual false
-    config2.Contains ``AutoFixture.Xunit`` |> shouldEqual false
-    config2.Contains log4net |> shouldEqual false
-    config2 |> shouldContainText ``Newtonsoft.Json``
-    config2.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
-    config2.Contains xunit |> shouldEqual false
-    config2.Contains ``xunit.extensions`` |> shouldEqual false
-    config2.Contains ``Castle.Core`` |> shouldEqual false
-    config2.Contains ``Castle.Windsor`` |> shouldEqual false
-
-    config3.Contains Albedo |> shouldEqual false
-    config3 |> shouldContainText AutoFixture
-    config3.Contains ``AutoFixture.Idioms`` |> shouldEqual false
-    config3.Contains ``AutoFixture.Xunit`` |> shouldEqual false
-    config3.Contains log4net |> shouldEqual false
-    Regex.IsMatch(config3, paketMark + ``Newtonsoft.Json``) |> shouldEqual true
-    config3.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
-    config3.Contains xunit |> shouldEqual false
-    config3.Contains ``xunit.extensions`` |> shouldEqual false
-    Regex.IsMatch(config3, paketMark + ``Castle.Core``) |> shouldEqual true
-    config3.Contains ``Castle.Windsor`` |> shouldEqual false
-
-    config4.Contains Albedo |> shouldEqual false
-    config4.Contains AutoFixture |> shouldEqual false
-    config4.Contains ``AutoFixture.Idioms`` |> shouldEqual false
-    config4.Contains ``AutoFixture.Xunit`` |> shouldEqual false
-    config4.Contains log4net |> shouldEqual false
-    config4 |> shouldContainText ``Newtonsoft.Json``
-    config4.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
-    config4.Contains xunit |> shouldEqual false
-    config4.Contains ``xunit.extensions`` |> shouldEqual false
-    Regex.IsMatch(config4, paketMark + ``Castle.Core``) |> shouldEqual true
-    config4.Contains ``Castle.Windsor`` |> shouldEqual false
-
 
 [<Test>]
 let ``#1248 install should replace paket's binding redirects with required only and keep stable``() = 
-    paket "install --redirects --hard --createnewbindingfiles" "i001248-stable-redirect" |> ignore
+    paket "install --redirects --createnewbindingfiles" "i001248-stable-redirect" |> ignore
 
     let originalConfig2Path = Path.Combine(originalScenarioPath "i001248-stable-redirect", "Project2", "app.config")
     
@@ -335,7 +257,7 @@ let ``#1477 assembly redirects lock files``() =
     let scenario =  "i001474-restore-no-locks"
     prepare scenario
     let p = Paket.Dependencies.Locate (Path.Combine(scenarioTempPath scenario, "paket.dependencies"))
-    p.Install(true,true)
+    p.Install(true)
     p.Restore()
 
     try

--- a/integrationtests/scenarios/i001544-redirects/before/BindingRedirectPaketBug/App.config.expected
+++ b/integrationtests/scenarios/i001544-redirects/before/BindingRedirectPaketBug/App.config.expected
@@ -4,9 +4,13 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
 
-  <runtime>
-    
-  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
+  </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
@@ -15,11 +19,6 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Common.Logging.NLog20" publicKeyToken="af08829b84f0328e" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
   </dependentAssembly>
   <dependentAssembly>
@@ -37,5 +36,4 @@
     <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="8.0.0.0" />
   </dependentAssembly>
-</assemblyBinding></runtime>
-</configuration>
+</assemblyBinding></runtime></configuration>

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -137,7 +137,7 @@ let processContentFiles root project (usedPackages:Map<_,_>) gitRemoteItems opti
 
     removeCopiedFiles project
 
-    project.UpdateFileItems(gitRemoteItems @ nuGetFileItems, options.Hard)
+    project.UpdateFileItems(gitRemoteItems @ nuGetFileItems)
 
 
 let CreateInstallModel(root, groupName, sources, caches, force, package) =
@@ -194,7 +194,7 @@ module private LoadAssembliesSafe =
 
 
 /// Applies binding redirects for all strong-named references to all app. and web.config files.
-let private applyBindingRedirects isFirstGroup createNewBindingFiles cleanBindingRedirects redirects root groupName findDependencies extractedPackages =
+let private applyBindingRedirects isFirstGroup createNewBindingFiles redirects root groupName findDependencies extractedPackages =
     let dependencyGraph = ConcurrentDictionary<_,Set<_>>()
     let projects = ConcurrentDictionary<_,ProjectFile option>();
     let referenceFiles = ConcurrentDictionary<_,ReferencesFile option>();
@@ -268,7 +268,7 @@ let private applyBindingRedirects isFirstGroup createNewBindingFiles cleanBindin
               Culture = None })
         |> Seq.sort
 
-    applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles cleanBindingRedirects root bindingRedirects
+    applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles root bindingRedirects
 
 let findAllReferencesFiles root =
     let findRefFile (p:ProjectType) =
@@ -392,7 +392,7 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
             NuGet.NuGetConfig.writeNuGetConfig dir sources
 
         | ProjectType.Project project ->
-            project.UpdateReferences(model, usedPackages, options.Hard)
+            project.UpdateReferences(model, usedPackages)
         
             Path.Combine(FileInfo(project.FileName).Directory.FullName, Constants.PackagesConfigFile)
             |> updatePackagesConfigFile usedPackages 
@@ -466,7 +466,7 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
                         |> Option.bind (fun p -> p.Settings.CreateBindingRedirects)
 
                     (snd kv.Value,packageRedirects))
-                |> applyBindingRedirects !first options.CreateNewBindingFiles options.Hard (g.Value.Options.Redirects ++ redirects) (FileInfo project.FileName).Directory.FullName g.Key lockFile.GetAllDependenciesOf
+                |> applyBindingRedirects !first options.CreateNewBindingFiles (g.Value.Options.Redirects ++ redirects) (FileInfo project.FileName).Directory.FullName g.Key lockFile.GetAllDependenciesOf
                 first := false
 
 

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -445,4 +445,4 @@ let replaceNuGetWithPaket initAutoRestore installAfter result =
     if installAfter then
         UpdateProcess.Update(
             result.PaketEnv.DependenciesFile.FileName,
-            { UpdaterOptions.Default with Common = { InstallerOptions.Default with Force = true; Hard = true; Redirects = true }})
+            { UpdaterOptions.Default with Common = { InstallerOptions.Default with Force = true; Redirects = true }})

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -9,13 +9,11 @@ type SemVerUpdateMode =
 
 // Options for UpdateProcess and InstallProcess.
 /// Force          - Force the download and reinstallation of all packages
-/// Hard           - Replace package references within project files even if they are not yet adhering
 ///                  to the Paket's conventions (and hence considered manually managed)
 /// Redirects      - Create binding redirects for the NuGet packages
 /// OnlyReferenced - Only install packages that are referenced in paket.references files.
 type InstallerOptions =
     { Force : bool
-      Hard : bool
       SemVerUpdateMode : SemVerUpdateMode
       Redirects : bool
       CreateNewBindingFiles : bool
@@ -23,16 +21,14 @@ type InstallerOptions =
 
     static member Default =
         { Force = false
-          Hard = false
           Redirects = false
           SemVerUpdateMode = SemVerUpdateMode.NoRestriction
           CreateNewBindingFiles = false
           OnlyReferenced = false }
 
-    static member CreateLegacyOptions(force, hard, redirects, createNewBindingFiles, semVerUpdateMode) =
+    static member CreateLegacyOptions(force, redirects, createNewBindingFiles, semVerUpdateMode) =
         { InstallerOptions.Default with
             Force = force
-            Hard = hard
             CreateNewBindingFiles = createNewBindingFiles
             Redirects = redirects 
             SemVerUpdateMode = semVerUpdateMode }

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -116,22 +116,22 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Adds the given package with the given version to the dependencies file.
     member this.Add(groupName: string option, package: string,version: string): unit =
-        this.Add(groupName, package, version, force = false, hard = false, withBindingRedirects = false,  createNewBindingFiles = false, interactive = false, installAfter = true, semVerUpdateMode = SemVerUpdateMode.NoRestriction)
+        this.Add(groupName, package, version, force = false, withBindingRedirects = false,  createNewBindingFiles = false, interactive = false, installAfter = true, semVerUpdateMode = SemVerUpdateMode.NoRestriction)
 
     /// Adds the given package with the given version to the dependencies file.
-    member this.Add(groupName: string option, package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool, createNewBindingFiles:bool, interactive: bool,installAfter: bool, semVerUpdateMode): unit =
+    member this.Add(groupName: string option, package: string,version: string,force: bool,withBindingRedirects: bool, createNewBindingFiles:bool, interactive: bool,installAfter: bool, semVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.Add(dependenciesFileName, groupName, PackageName(package.Trim()), version,
-                                     InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode),
+                                     InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, createNewBindingFiles, semVerUpdateMode),
                                      interactive, installAfter))
 
    /// Adds the given package with the given version to the dependencies file.
-    member this.AddToProject(groupName, package: string,version: string,force: bool,hard: bool,withBindingRedirects: bool, createNewBindingFiles:bool, projectName: string,installAfter: bool, semVerUpdateMode): unit =
+    member this.AddToProject(groupName, package: string,version: string,force: bool,withBindingRedirects: bool, createNewBindingFiles:bool, projectName: string,installAfter: bool, semVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.AddToProject(dependenciesFileName, groupName, PackageName package, version,
-                                              InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode),
+                                              InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, createNewBindingFiles, semVerUpdateMode),
                                               projectName, installAfter))
 
     /// Adds credentials for a Nuget feed
@@ -145,15 +145,15 @@ type Dependencies(dependenciesFileName: string) =
         Utils.RunInLockedAccessMode(this.RootPath, fun () -> ConfigFile.AddToken(source, token) |> returnOrFail)
 
     /// Installs all dependencies.
-    member this.Install(force: bool, hard: bool) = this.Install(force, hard, false, false, SemVerUpdateMode.NoRestriction)
+    member this.Install(force: bool) = this.Install(force, false, false, SemVerUpdateMode.NoRestriction)
 
     /// Installs all dependencies.
-    member this.Install(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, semVerUpdateMode): unit =
-        this.Install(force, hard, withBindingRedirects, createNewBindingFiles, false, semVerUpdateMode)
+    member this.Install(force: bool, withBindingRedirects: bool, createNewBindingFiles:bool, semVerUpdateMode): unit =
+        this.Install(force, withBindingRedirects, createNewBindingFiles, false, semVerUpdateMode)
 
     /// Installs all dependencies.
-    member this.Install(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, onlyReferenced: bool, semVerUpdateMode): unit =
-        this.Install({ InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode) with OnlyReferenced = onlyReferenced })
+    member this.Install(force: bool, withBindingRedirects: bool, createNewBindingFiles:bool, onlyReferenced: bool, semVerUpdateMode): unit =
+        this.Install({ InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, createNewBindingFiles, semVerUpdateMode) with OnlyReferenced = onlyReferenced })
 
     /// Installs all dependencies.
     member private this.Install(options: InstallerOptions): unit =
@@ -165,48 +165,47 @@ type Dependencies(dependenciesFileName: string) =
                             { UpdaterOptions.Default with Common = options }))
 
     /// Creates a paket.dependencies file with the given text in the current directory and installs it.
-    static member Install(dependencies, ?path: string, ?force, ?hard, ?withBindingRedirects, ?createNewBindingFiles, ?semVerUpdateMode) =
+    static member Install(dependencies, ?path: string, ?force, ?withBindingRedirects, ?createNewBindingFiles, ?semVerUpdateMode) =
         let path = defaultArg path Environment.CurrentDirectory
         let fileName = Path.Combine(path, Constants.DependenciesFileName)
         File.WriteAllText(fileName, dependencies)
         let dependencies = Dependencies.Locate(path)
         dependencies.Install(
             force = defaultArg force false,
-            hard = defaultArg hard false,
             withBindingRedirects = defaultArg withBindingRedirects false,
             createNewBindingFiles = defaultArg createNewBindingFiles false, 
             semVerUpdateMode = defaultArg semVerUpdateMode SemVerUpdateMode.NoRestriction)
 
     /// Updates all dependencies.
-    member this.Update(force: bool, hard: bool): unit = this.Update(force, hard, false, false)
+    member this.Update(force: bool): unit = this.Update(force, false, false)
 
     /// Updates all dependencies.
-    member this.Update(force: bool, hard: bool, withBindingRedirects:bool, createNewBindingFiles:bool): unit =
-        this.Update(force, hard, withBindingRedirects, createNewBindingFiles, true, SemVerUpdateMode.NoRestriction)
+    member this.Update(force: bool, withBindingRedirects:bool, createNewBindingFiles:bool): unit =
+        this.Update(force, withBindingRedirects, createNewBindingFiles, true, SemVerUpdateMode.NoRestriction)
 
     /// Updates all dependencies.
-    member this.Update(force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
+    member this.Update(force: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> UpdateProcess.Update(
                         dependenciesFileName,
                         { UpdaterOptions.Default with
-                            Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
+                            Common = InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
                             NoInstall = installAfter |> not }))
 
     /// Updates dependencies in single group.
-    member this.UpdateGroup(groupName, force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode:SemVerUpdateMode): unit =
+    member this.UpdateGroup(groupName, force: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode:SemVerUpdateMode): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () -> UpdateProcess.UpdateGroup(
                             dependenciesFileName,
                             GroupName groupName,
                             { UpdaterOptions.Default with
-                                Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
+                                Common = InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
                                 NoInstall = installAfter |> not }))
 
     /// Update a filtered set of packages
-    member this.UpdateFilteredPackages(groupName: string option, package: string, version: string option, force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
+    member this.UpdateFilteredPackages(groupName: string option, package: string, version: string option, force: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
         let groupName = 
             match groupName with
             | None -> Constants.MainDependencyGroup
@@ -216,15 +215,15 @@ type Dependencies(dependenciesFileName: string) =
             this.RootPath,
             fun () -> UpdateProcess.UpdateFilteredPackages(dependenciesFileName, groupName, package, version,
                                                   { UpdaterOptions.Default with
-                                                      Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
+                                                      Common = InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
                                                       NoInstall = installAfter |> not }))
 
     /// Updates the given package.
-    member this.UpdatePackage(groupName, package: string, version: string option, force: bool, hard: bool, semVerUpdateMode): unit =
-        this.UpdatePackage(groupName, package, version, force, hard, false, false, true, semVerUpdateMode)
+    member this.UpdatePackage(groupName, package: string, version: string option, force: bool, semVerUpdateMode): unit =
+        this.UpdatePackage(groupName, package, version, force, false, false, true, semVerUpdateMode)
 
     /// Updates the given package.
-    member this.UpdatePackage(groupName: string option, package: string, version: string option, force: bool, hard: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
+    member this.UpdatePackage(groupName: string option, package: string, version: string option, force: bool, withBindingRedirects: bool, createNewBindingFiles:bool, installAfter: bool, semVerUpdateMode): unit =
         let groupName = 
             match groupName with
             | None -> Constants.MainDependencyGroup
@@ -234,7 +233,7 @@ type Dependencies(dependenciesFileName: string) =
             this.RootPath,
             fun () -> UpdateProcess.UpdatePackage(dependenciesFileName, groupName, PackageName package, version,
                                                   { UpdaterOptions.Default with
-                                                      Common = InstallerOptions.CreateLegacyOptions(force, hard, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
+                                                      Common = InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, createNewBindingFiles, semVerUpdateMode)
                                                       NoInstall = installAfter |> not }))
 
     /// Restores all dependencies.
@@ -420,19 +419,19 @@ type Dependencies(dependenciesFileName: string) =
     member this.Remove(package: string): unit = this.Remove(None, package)
 
     /// Removes the given package from dependencies file.
-    member this.Remove(groupName, package: string): unit = this.Remove(groupName, package, false, false, false, true)
+    member this.Remove(groupName, package: string): unit = this.Remove(groupName, package, false, false, true)
 
     /// Removes the given package from dependencies file.
-    member this.Remove(groupName, package: string, force: bool,hard: bool,interactive: bool,installAfter: bool): unit =
+    member this.Remove(groupName, package: string, force: bool, interactive: bool, installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> RemoveProcess.Remove(dependenciesFileName, groupName, PackageName package, force, hard, interactive, installAfter))
+            fun () -> RemoveProcess.Remove(dependenciesFileName, groupName, PackageName package, force, interactive, installAfter))
 
     /// Removes the given package from the specified project
-    member this.RemoveFromProject(groupName,package: string,force: bool,hard: bool,projectName: string,installAfter: bool): unit =
+    member this.RemoveFromProject(groupName,package: string,force: bool, projectName: string,installAfter: bool): unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
-            fun () -> RemoveProcess.RemoveFromProject(dependenciesFileName, groupName, PackageName package, force, hard, projectName, installAfter))
+            fun () -> RemoveProcess.RemoveFromProject(dependenciesFileName, groupName, PackageName package, force, projectName, installAfter))
 
     /// Shows all references files where the given package is referenced.
     member this.ShowReferencesFor(packages: (string * string) list): unit =

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -12,7 +12,7 @@ let private removePackageFromProject (project : ProjectType) groupName package =
         .RemoveNuGetReference(groupName,package)
         .Save()
 
-let private remove removeFromProjects dependenciesFileName groupName (package: PackageName) force hard installAfter = 
+let private remove removeFromProjects dependenciesFileName groupName (package: PackageName) force installAfter = 
     let root = Path.GetDirectoryName dependenciesFileName
     let allProjects = ProjectType.FindAllProjects root
     
@@ -46,11 +46,11 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
     
     if installAfter then
         let updatedGroups = Map.add groupName 0 Map.empty
-        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), hasChanged, dependenciesFile, lockFile, updatedGroups)
+        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, false, false, SemVerUpdateMode.NoRestriction), hasChanged, dependenciesFile, lockFile, updatedGroups)
         GarbageCollection.CleanUp(root, dependenciesFile, lockFile)
 
 /// Removes a package with the option to remove it from a specified project.
-let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =
+let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, projectName, installAfter) =
     let groupName = 
         match groupName with
         | None -> Constants.MainDependencyGroup
@@ -65,10 +65,10 @@ let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, 
         | None ->
             traceErrorfn "Could not remove package %O from specified project %s. Project not found" packageName projectName
 
-    remove removeFromSpecifiedProject dependenciesFileName groupName packageName force hard installAfter
+    remove removeFromSpecifiedProject dependenciesFileName groupName packageName force installAfter
 
 /// Remove a package with the option to interactively remove it from multiple projects.
-let Remove(dependenciesFileName, groupName, packageName:PackageName, force, hard, interactive, installAfter) =
+let Remove(dependenciesFileName, groupName, packageName:PackageName, force, interactive, installAfter) =
     let groupName = 
         match groupName with
         | None -> Constants.MainDependencyGroup
@@ -80,4 +80,4 @@ let Remove(dependenciesFileName, groupName, packageName:PackageName, force, hard
                 if (not interactive) || Utils.askYesNo(sprintf "  Remove from %s (group %O)?" project.FileName groupName) then
                     removePackageFromProject project groupName packageName
 
-    remove removeFromProjects dependenciesFileName groupName packageName force hard installAfter
+    remove removeFromProjects dependenciesFileName groupName packageName force installAfter

--- a/src/Paket.PowerShell/PowerShell.fs
+++ b/src/Paket.PowerShell/PowerShell.fs
@@ -62,7 +62,6 @@ type Add() =
     [<Parameter>] member val Project = "" with get, set
     [<Parameter>] member val Force = SwitchParameter() with get, set
     [<Parameter>] member val Interactive = SwitchParameter() with get, set
-    [<Parameter>] member val Hard = SwitchParameter() with get, set
     [<Parameter>] member val NoInstall = SwitchParameter() with get, set
 
     override x.ProcessRecord() =
@@ -79,8 +78,6 @@ type Add() =
                     yield AddArgs.Force
                 if x.Interactive.IsPresent then
                     yield AddArgs.Interactive
-                if x.Hard.IsPresent then
-                    yield AddArgs.Hard
                 if x.NoInstall.IsPresent then
                     yield AddArgs.No_Install
             ]
@@ -238,7 +235,6 @@ type InstallCmdlet() =
     inherit PSCmdlet()
 
     [<Parameter>] member val Force = SwitchParameter() with get, set
-    [<Parameter>] member val Hard = SwitchParameter() with get, set
     [<Parameter>] member val Redirects = SwitchParameter() with get, set
 
     override x.ProcessRecord() =
@@ -246,9 +242,7 @@ type InstallCmdlet() =
             let parser = ArgumentParser.Create<InstallArgs>()
             [
                 if x.Force.IsPresent then
-                    yield InstallArgs.Force
-                if x.Hard.IsPresent then
-                    yield InstallArgs.Hard             
+                    yield InstallArgs.Force       
                 if x.Redirects.IsPresent then
                     yield InstallArgs.Redirects
             ]
@@ -310,7 +304,6 @@ type RemoveCmdlet() =
     [<Parameter>] member val Project = "" with get, set
     [<Parameter>] member val Force = SwitchParameter() with get, set
     [<Parameter>] member val Interactive = SwitchParameter() with get, set
-    [<Parameter>] member val Hard = SwitchParameter() with get, set
     [<Parameter>] member val NoInstall = SwitchParameter() with get, set
 
     override x.ProcessRecord() =
@@ -325,8 +318,6 @@ type RemoveCmdlet() =
                     yield RemoveArgs.Force
                 if x.Interactive.IsPresent then
                     yield RemoveArgs.Interactive
-                if x.Hard.IsPresent then
-                    yield RemoveArgs.Hard
                 if x.NoInstall.IsPresent then
                     yield RemoveArgs.No_Install
             ]
@@ -414,7 +405,6 @@ type UpdateCmdlet() =
     [<Parameter(Position=1)>][<ValidateNotNullOrEmpty>] member val NuGet = "" with get, set
     [<Parameter(Position=2)>] member val Version = "" with get, set
     [<Parameter>] member val Force = SwitchParameter() with get, set
-    [<Parameter>] member val Hard = SwitchParameter() with get, set
     [<Parameter>] member val Redirects = SwitchParameter() with get, set
 
     override x.ProcessRecord() =
@@ -427,8 +417,6 @@ type UpdateCmdlet() =
                     yield UpdateArgs.Version x.Version
                 if x.Force.IsPresent then
                     yield UpdateArgs.Force
-                if x.Hard.IsPresent then
-                    yield UpdateArgs.Hard
                 if x.Redirects.IsPresent then
                     yield UpdateArgs.Redirects
             ]

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -61,7 +61,6 @@ type AddArgs =
     | [<CustomCommandLine("group")>] Group of string
     | [<AltCommandLine("-f")>] Force
     | [<AltCommandLine("-i")>] Interactive
-    | Hard
     | Redirects
     | CreateNewBindingFiles
     | No_Install
@@ -78,7 +77,6 @@ with
             | Project(_) -> "Allows to add the package to a single project only."
             | Force -> "Forces the download and reinstallation of all packages."
             | Interactive -> "Asks the user for every project if he or she wants to add the package to the projects's paket.references file."
-            | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
             | No_Install -> "Skips paket install process (patching of csproj, fsproj, ... files) after the generation of paket.lock file."
@@ -139,7 +137,6 @@ with
 
 type InstallArgs =
     | [<AltCommandLine("-f")>] Force
-    | Hard
     | Redirects
     | CreateNewBindingFiles
     | Keep_Major
@@ -151,7 +148,6 @@ with
         member this.Usage =
             match this with
             | Force -> "Forces the download and reinstallation of all packages."
-            | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
             | Install_Only_Referenced -> "Only install packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
@@ -175,7 +171,6 @@ type RemoveArgs =
     | [<CustomCommandLine("group")>] Group of string
     | [<AltCommandLine("-f")>] Force
     | [<AltCommandLine("-i")>] Interactive
-    | Hard
     | No_Install
 with
     interface IArgParserTemplate with
@@ -186,7 +181,6 @@ with
             | Project(_) -> "Allows to remove the package from a single project only."
             | Force -> "Forces the download and reinstallation of all packages."
             | Interactive -> "Asks the user for every project if he or she wants to remove the package from the projects's paket.references file. By default every installation of the package is removed."
-            | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."
             | No_Install -> "Skips paket install process (patching of csproj, fsproj, ... files) after the generation of paket.lock file."
 
 
@@ -225,7 +219,6 @@ type UpdateArgs =
     | [<CustomCommandLine("version")>] Version of string
     | [<CustomCommandLine("group")>] Group of string
     | [<AltCommandLine("-f")>] Force
-    | Hard
     | Redirects
     | CreateNewBindingFiles
     | No_Install
@@ -241,7 +234,6 @@ with
             | Group(_) -> "Allows to specify the dependency group."
             | Version(_) -> "Allows to specify version of the package."
             | Force -> "Forces the download and reinstallation of all packages."
-            | Hard -> "Replaces package references within project files even if they are not yet adhering to the Paket's conventions (and hence considered manually managed)."
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
             | No_Install -> "Skips paket install process (patching of csproj, fsproj, ... files) after the generation of paket.lock file."

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -66,7 +66,6 @@ let add (results : ParseResults<_>) =
     let packageName = results.GetResult <@ AddArgs.Nuget @>
     let version = defaultArg (results.TryGetResult <@ AddArgs.Version @>) ""
     let force = results.Contains <@ AddArgs.Force @>
-    let hard = results.Contains <@ AddArgs.Hard @>
     let redirects = results.Contains <@ AddArgs.Redirects @>
     let createNewBindingFiles = results.Contains <@ AddArgs.CreateNewBindingFiles @>
     let group = results.TryGetResult <@ AddArgs.Group @>
@@ -79,10 +78,10 @@ let add (results : ParseResults<_>) =
 
     match results.TryGetResult <@ AddArgs.Project @> with
     | Some projectName ->
-        Dependencies.Locate().AddToProject(group, packageName, version, force, hard, redirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode)
+        Dependencies.Locate().AddToProject(group, packageName, version, force, redirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode)
     | None ->
         let interactive = results.Contains <@ AddArgs.Interactive @>
-        Dependencies.Locate().Add(group, packageName, version, force, hard, redirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode)
+        Dependencies.Locate().Add(group, packageName, version, force, redirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode)
 
 let validateConfig (results : ParseResults<_>) =
     let credential = results.Contains <@ ConfigArgs.AddCredentials @>
@@ -142,7 +141,6 @@ let clearCache (results : ParseResults<ClearCacheArgs>) =
 
 let install (results : ParseResults<_>) =
     let force = results.Contains <@ InstallArgs.Force @>
-    let hard = results.Contains <@ InstallArgs.Hard @>
     let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
     let createNewBindingFiles = results.Contains <@ InstallArgs.CreateNewBindingFiles @>
     let installOnlyReferenced = results.Contains <@ InstallArgs.Install_Only_Referenced @>
@@ -152,7 +150,7 @@ let install (results : ParseResults<_>) =
         if results.Contains <@ InstallArgs.Keep_Major @> then SemVerUpdateMode.KeepMajor else
         SemVerUpdateMode.NoRestriction
 
-    Dependencies.Locate().Install(force, hard, withBindingRedirects, createNewBindingFiles, installOnlyReferenced, semVerUpdateMode)
+    Dependencies.Locate().Install(force, withBindingRedirects, createNewBindingFiles, installOnlyReferenced, semVerUpdateMode)
 
 let outdated (results : ParseResults<_>) =
     let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
@@ -162,16 +160,15 @@ let outdated (results : ParseResults<_>) =
 let remove (results : ParseResults<_>) =
     let packageName = results.GetResult <@ RemoveArgs.Nuget @>
     let force = results.Contains <@ RemoveArgs.Force @>
-    let hard = results.Contains <@ RemoveArgs.Hard @>
     let noInstall = results.Contains <@ RemoveArgs.No_Install @>
     let group = results.TryGetResult <@ RemoveArgs.Group @>
     match results.TryGetResult <@ RemoveArgs.Project @> with
     | Some projectName ->
         Dependencies.Locate()
-                    .RemoveFromProject(group, packageName, force, hard, projectName, noInstall |> not)
+                    .RemoveFromProject(group, packageName, force, projectName, noInstall |> not)
     | None ->
         let interactive = results.Contains <@ RemoveArgs.Interactive @>
-        Dependencies.Locate().Remove(group, packageName, force, hard, interactive, noInstall |> not)
+        Dependencies.Locate().Remove(group, packageName, force, interactive, noInstall |> not)
 
 let restore (results : ParseResults<_>) =
     let force = results.Contains <@ RestoreArgs.Force @>
@@ -187,7 +184,6 @@ let simplify (results : ParseResults<_>) =
     Dependencies.Locate().Simplify(interactive)
 
 let update (results : ParseResults<_>) =
-    let hard = results.Contains <@ UpdateArgs.Hard @>
     let force = results.Contains <@ UpdateArgs.Force @>
     let noInstall = results.Contains <@ UpdateArgs.No_Install @>
     let group = results.TryGetResult <@ UpdateArgs.Group @>
@@ -204,15 +200,15 @@ let update (results : ParseResults<_>) =
     | Some packageName ->
         let version = results.TryGetResult <@ UpdateArgs.Version @>
         if filter then
-            Dependencies.Locate().UpdateFilteredPackages(group, packageName, version, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().UpdateFilteredPackages(group, packageName, version, force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
         else
-            Dependencies.Locate().UpdatePackage(group, packageName, version, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().UpdatePackage(group, packageName, version, force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
     | _ ->
         match group with
         | Some groupName -> 
-            Dependencies.Locate().UpdateGroup(groupName, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().UpdateGroup(groupName, force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
         | None ->
-            Dependencies.Locate().Update(force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().Update(force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
 
 let pack (results : ParseResults<_>) =
     let outputPath = results.GetResult <@ PackArgs.Output @>

--- a/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
@@ -66,7 +66,7 @@ let ``should generate full Xml for Fantomas 1.5``() =
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value
     let completeModel = [(Constants.MainDependencyGroup, (PackageName "Fantomas")),(model,model)] |> Map.ofSeq
     let used = [(Constants.MainDependencyGroup, (PackageName "fantoMas")), (InstallSettings.Default,InstallSettings.Default)] |> Map.ofSeq
-    project.UpdateReferences(completeModel,used,false)
+    project.UpdateReferences(completeModel,used)
     
     project.Document.OuterXml
     |> normalizeXml
@@ -87,7 +87,7 @@ let ``should not generate full Xml for Fantomas 1.5 if not referenced``() =
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value
     let completeModel = [(Constants.MainDependencyGroup, (PackageName "Fantomas")),(model,model)] |> Map.ofSeq
     let used = [(Constants.MainDependencyGroup, (PackageName "blub")), (InstallSettings.Default,InstallSettings.Default) ] |> Map.ofSeq
-    project.UpdateReferences(completeModel,used,false)
+    project.UpdateReferences(completeModel,used)
     
     project.Document.OuterXml
     |> normalizeXml
@@ -126,7 +126,7 @@ let ``should generate full Xml with reference condition for Fantomas 1.5``() =
         { InstallSettings.Default 
             with ReferenceCondition = Some "LEGACY" }
     let used = [(Constants.MainDependencyGroup, (PackageName "fantoMas")), (InstallSettings.Default,settings)] |> Map.ofSeq
-    project.UpdateReferences(completeModel,used,false)
+    project.UpdateReferences(completeModel,used)
     
     project.Document.OuterXml
     |> normalizeXml
@@ -167,7 +167,7 @@ let ``should generate full Xml with reference condition and framework restrictio
         { InstallSettings.Default
             with ReferenceCondition = Some "LEGACY" }
     let used = [(Constants.MainDependencyGroup, (PackageName "fantoMas")), (InstallSettings.Default,settings)] |> Map.ofSeq
-    project.UpdateReferences(completeModel,used,false)
+    project.UpdateReferences(completeModel,used)
 
     project.Document.OuterXml
     |> normalizeXml

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -73,7 +73,7 @@ let ``should maintain order when updating project file items`` () =
         { BuildAction = BuildAction.Compile; WithPaketSubNode = true; CopyToOutputDirectory = None; Include = "ProvidedTypes.fs"; Link = None }
         { BuildAction = BuildAction.Content; WithPaketSubNode = true; CopyToOutputDirectory = None; Include = "ProvidedTypes.fsi"; Link = None }
     ]
-    projFile.UpdateFileItems(fileItems, false)
+    projFile.UpdateFileItems(fileItems)
 
     let rec nodes node = 
         seq {
@@ -115,7 +115,7 @@ let ``should remove missing files that exist in the project`` () =
         { BuildAction = BuildAction.Compile; WithPaketSubNode = true; CopyToOutputDirectory = None; Include = "ProvidedTypes.fs"; Link = None }
         { BuildAction = BuildAction.Content; WithPaketSubNode = true; CopyToOutputDirectory = None; Include = "ProvidedTypes.fsi"; Link = None }
     ]
-    projFile.UpdateFileItems(fileItems, false)
+    projFile.UpdateFileItems(fileItems)
 
     let rec nodes node = 
         seq {


### PR DESCRIPTION
## Background

    --hard: Replaces package references within project files 
              even if they are not yet adhering to the Paket's conventions 
              (and hence considered manually managed).

### Sample

in default mode paket 2.0 will not change references to libraries if they are not already controlled by paket. A common case is "file/ enw F# project" creates a fsproj file that already references FSharp.Core. If you then add FSharp.Core as nuget package, then Paket will not replace the reference unless you specify --hard parameter. 

## Suggestion

I suggest we remove the --hard flag in paket v3 and thread all calls as if --hard would have been set.

- [x] removed flag from all commands 
- [x] fixed tests
- [x] update docs

We will not create a --soft flag to restore old behaviour, but if you really need to keep that existing reference you can manually add a 

    <paket>false</paket>
