### PR TITLE
Apply any saved api key credentials to the push operation

### DIFF
--- a/docs/content/paket-push.md
+++ b/docs/content/paket-push.md
@@ -1,0 +1,20 @@
+# paket push
+
+Pushes the given `.nupkg` file.
+
+    [lang=msh]
+    paket push url <string> file <string> [apikey <string>] [endpoint <string>]
+
+### Options:
+
+  `url <string>`: Url of the NuGet feed.
+
+  `file <string>`: Path to the package.
+
+  `apikey <string>`: Optionally specify your API key on the command line. Otherwise uses the value of the `nugetkey` environment variable, or the api key stored in the [`paket.config` file](paket-config.html) for this url.
+
+  `endpoint <string>`: Optionally specify a custom api endpoint to push to. Defaults to `/api/v2/package`.
+
+If you add the `-v` flag, then Paket will run in verbose mode and show detailed information.
+
+With `--log-file [FileName]` you can trace the logged information into a file.

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -542,11 +542,20 @@ type Dependencies(dependenciesFileName: string) =
     /// Pushes a nupkg file.
     static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?maxTrials) =
         let urlWithEndpoint = RemoteUpload.GetUrlWithEndpoint url endPoint
-        let apiKey = defaultArg apiKey (Environment.GetEnvironmentVariable("nugetkey"))
-        if String.IsNullOrEmpty apiKey then
-            failwithf "Could not push package %s. Please specify a NuGet API key via environment variable \"nugetkey\"." packageFileName
-        let maxTrials = defaultArg maxTrials 5
-        RemoteUpload.Push maxTrials urlWithEndpoint apiKey packageFileName
+        let envKey = Environment.GetEnvironmentVariable("nugetkey") |> Option.ofObj 
+        let configKey = url |> Option.bind ConfigFile.GetAuthentication |> Option.bind (fun a -> match a with Token t -> Some t | _ -> None )
+        let firstPresentKey = 
+            [apiKey; envKey; configKey]
+            |> List.choose id
+            |> List.where (String.IsNullOrEmpty >> not)
+            |> List.tryHead
+
+        match firstPresentKey with
+        | None -> 
+            failwithf "Could not push package %s due to missing credentials for the url %s. Please specify a NuGet API key via the command line, the environment variable \"nugetkey\", or by using 'paket config add-token'." packageFileName urlWithEndpoint
+        | Some apiKey -> 
+            let maxTrials = defaultArg maxTrials 5
+            RemoteUpload.Push maxTrials urlWithEndpoint apiKey packageFileName
 
     /// Lists all paket.template files in the current solution.
     member this.ListTemplateFiles() : TemplateFile list =


### PR DESCRIPTION
Addresses #1568 by roping in a call to the Paket config for a token for the given url and deferring to that only when there is non command-line or env variable for the token.