### PR TITLE
Touch: disabled by default in Add, Update, Install; enabled with --touch-affected-refs #1484

### DIFF
--- a/src/Paket.Core/AddProcess.fs
+++ b/src/Paket.Core/AddProcess.fs
@@ -32,7 +32,8 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
         addToProjectsF projects groupName package
 
         if installAfter then
-            InstallProcess.Install(options, hasChanged, dependenciesFile, lockFile)
+            let forceTouch = hasChanged && options.TouchAffectedRefs
+            InstallProcess.Install(options, forceTouch, dependenciesFile, lockFile)
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, groupName, package, version, options : InstallerOptions, projectName, installAfter) =

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -32,13 +32,14 @@ type InstallerOptions =
           OnlyReferenced = false
           TouchAffectedRefs = false }
 
-    static member CreateLegacyOptions(force, hard, redirects, createNewBindingFiles, semVerUpdateMode) =
+    static member CreateLegacyOptions(force, hard, redirects, createNewBindingFiles, semVerUpdateMode, touchAffectedRefs) =
         { InstallerOptions.Default with
             Force = force
             Hard = hard
             CreateNewBindingFiles = createNewBindingFiles
-            Redirects = redirects 
-            SemVerUpdateMode = semVerUpdateMode }
+            Redirects = redirects
+            SemVerUpdateMode = semVerUpdateMode
+            TouchAffectedRefs = touchAffectedRefs }
 
 type UpdaterOptions =
     { Common : InstallerOptions

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -8,18 +8,20 @@ type SemVerUpdateMode =
     | KeepPatch
 
 // Options for UpdateProcess and InstallProcess.
-/// Force          - Force the download and reinstallation of all packages
-/// Hard           - Replace package references within project files even if they are not yet adhering
-///                  to the Paket's conventions (and hence considered manually managed)
-/// Redirects      - Create binding redirects for the NuGet packages
-/// OnlyReferenced - Only install packages that are referenced in paket.references files.
+/// Force             - Force the download and reinstallation of all packages
+/// Hard              - Replace package references within project files even if they are not yet adhering
+///                     to the Paket's conventions (and hence considered manually managed)
+/// Redirects         - Create binding redirects for the NuGet packages
+/// OnlyReferenced    - Only install packages that are referenced in paket.references files.
+/// TouchAffectedRefs - Touch projects referencing installed packages even if the project file does not change.
 type InstallerOptions =
     { Force : bool
       Hard : bool
       SemVerUpdateMode : SemVerUpdateMode
       Redirects : bool
       CreateNewBindingFiles : bool
-      OnlyReferenced : bool }
+      OnlyReferenced : bool
+      TouchAffectedRefs : bool }
 
     static member Default =
         { Force = false
@@ -27,7 +29,8 @@ type InstallerOptions =
           Redirects = false
           SemVerUpdateMode = SemVerUpdateMode.NoRestriction
           CreateNewBindingFiles = false
-          OnlyReferenced = false }
+          OnlyReferenced = false
+          TouchAffectedRefs = false }
 
     static member CreateLegacyOptions(force, hard, redirects, createNewBindingFiles, semVerUpdateMode) =
         { InstallerOptions.Default with

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -43,7 +43,7 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
         dependenciesFile,UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,SemVerUpdateMode.NoRestriction,force)
     
     if installAfter then
-        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), hasChanged, dependenciesFile, lockFile)
+        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), false, dependenciesFile, lockFile)
 
 /// Removes a package with the option to remove it from a specified project.
 let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -43,7 +43,7 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
         dependenciesFile,UpdateProcess.SelectiveUpdate(dependenciesFile,PackageResolver.UpdateMode.Install,SemVerUpdateMode.NoRestriction,force)
     
     if installAfter then
-        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction), false, dependenciesFile, lockFile)
+        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, hard, false, false, SemVerUpdateMode.NoRestriction, false), false, dependenciesFile, lockFile)
 
 /// Removes a package with the option to remove it from a specified project.
 let RemoveFromProject(dependenciesFileName, groupName, packageName:PackageName, force, hard, projectName, installAfter) =

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -226,7 +226,8 @@ let SmartInstall(dependenciesFile, updateMode, options : UpdaterOptions) =
     let projectsAndReferences = InstallProcess.findAllReferencesFiles root |> returnOrFail
 
     if not options.NoInstall then
-        InstallProcess.InstallIntoProjects(options.Common, hasChanged, dependenciesFile, lockFile, projectsAndReferences)
+        let forceTouch = hasChanged && options.Common.TouchAffectedRefs
+        InstallProcess.InstallIntoProjects(options.Common, forceTouch, dependenciesFile, lockFile, projectsAndReferences)
 
 /// Update a single package command
 let UpdatePackage(dependenciesFileName, groupName, packageName : PackageName, newVersion, options : UpdaterOptions) =

--- a/src/Paket.Core/VSIntegration.fs
+++ b/src/Paket.Core/VSIntegration.fs
@@ -20,7 +20,7 @@ let TurnOnAutoRestore environment =
         |> List.iter (fun project ->
             let relativePath = createRelativePath project.FileName paketTargetsPath
             project.AddImportForPaketTargets(relativePath)
-            project.Save(true)
+            project.Save(false)
         )
     } 
 
@@ -37,6 +37,6 @@ let TurnOffAutoRestore environment =
         |> List.iter (fun project ->
             let relativePath = createRelativePath project.FileName paketTargetsPath
             project.RemoveImportForPaketTargets(relativePath)
-            project.Save(true)
+            project.Save(false)
         )
     }

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -68,6 +68,7 @@ type AddArgs =
     | Keep_Major
     | Keep_Minor
     | Keep_Patch
+    | Touch_Affected_Refs
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -85,7 +86,7 @@ with
             | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
             | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
             | Keep_Patch -> "Allows only updates that are not changing the patch version of the NuGet packages."
-     
+            | Touch_Affected_Refs -> "Touches project files referencing packages which are affected, to help incremental build tools detecting the change."
 
 type ConfigArgs =
     | [<CustomCommandLine("add-credentials")>] AddCredentials of string
@@ -146,6 +147,7 @@ type InstallArgs =
     | Keep_Minor
     | Keep_Patch
     | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
+    | Touch_Affected_Refs
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -158,6 +160,7 @@ with
             | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
             | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
             | Keep_Patch -> "Allows only updates that are not changing the patch version of the NuGet packages."
+            | Touch_Affected_Refs -> "Touches project files referencing packages which are affected, to help incremental build tools detecting the change."
 
 type OutdatedArgs =
     | Ignore_Constraints
@@ -233,6 +236,7 @@ type UpdateArgs =
     | Keep_Minor
     | Keep_Patch
     | Filter
+    | Touch_Affected_Refs
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -249,7 +253,8 @@ with
             | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
             | Keep_Patch -> "Allows only updates that are not changing the patch version of the NuGet packages."
             | Filter -> "Treat the nuget parameter as a regex to filter packages rather than an exact match."
-            
+            | Touch_Affected_Refs -> "Touches project files referencing packages which are affected, to help incremental build tools detecting the change."
+
 type FindPackagesArgs =
     | [<CustomCommandLine("searchtext")>] SearchText of string
     | [<CustomCommandLine("source")>] Source of string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -76,7 +76,7 @@ let add (results : ParseResults<_>) =
         if results.Contains <@ AddArgs.Keep_Minor @> then SemVerUpdateMode.KeepMinor else
         if results.Contains <@ AddArgs.Keep_Major @> then SemVerUpdateMode.KeepMajor else
         SemVerUpdateMode.NoRestriction
-    let touchAffectedRefs = false
+    let touchAffectedRefs = results.Contains <@ AddArgs.Touch_Affected_Refs @>
 
     match results.TryGetResult <@ AddArgs.Project @> with
     | Some projectName ->
@@ -152,7 +152,7 @@ let install (results : ParseResults<_>) =
         if results.Contains <@ InstallArgs.Keep_Minor @> then SemVerUpdateMode.KeepMinor else
         if results.Contains <@ InstallArgs.Keep_Major @> then SemVerUpdateMode.KeepMajor else
         SemVerUpdateMode.NoRestriction
-    let touchAffectedRefs = false
+    let touchAffectedRefs = results.Contains <@ InstallArgs.Touch_Affected_Refs @>
 
     Dependencies.Locate().Install(force, hard, withBindingRedirects, createNewBindingFiles, installOnlyReferenced, semVerUpdateMode, touchAffectedRefs)
 
@@ -200,7 +200,7 @@ let update (results : ParseResults<_>) =
         if results.Contains <@ UpdateArgs.Keep_Minor @> then SemVerUpdateMode.KeepMinor else
         if results.Contains <@ UpdateArgs.Keep_Major @> then SemVerUpdateMode.KeepMajor else
         SemVerUpdateMode.NoRestriction
-    let touchAffectedRefs = false
+    let touchAffectedRefs = results.Contains <@ UpdateArgs.Touch_Affected_Refs @>
     let filter = results.Contains <@ UpdateArgs.Filter @>
 
     match results.TryGetResult <@ UpdateArgs.Nuget @> with

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -76,13 +76,14 @@ let add (results : ParseResults<_>) =
         if results.Contains <@ AddArgs.Keep_Minor @> then SemVerUpdateMode.KeepMinor else
         if results.Contains <@ AddArgs.Keep_Major @> then SemVerUpdateMode.KeepMajor else
         SemVerUpdateMode.NoRestriction
+    let touchAffectedRefs = false
 
     match results.TryGetResult <@ AddArgs.Project @> with
     | Some projectName ->
-        Dependencies.Locate().AddToProject(group, packageName, version, force, hard, redirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode)
+        Dependencies.Locate().AddToProject(group, packageName, version, force, hard, redirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
     | None ->
         let interactive = results.Contains <@ AddArgs.Interactive @>
-        Dependencies.Locate().Add(group, packageName, version, force, hard, redirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode)
+        Dependencies.Locate().Add(group, packageName, version, force, hard, redirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
 
 let validateConfig (results : ParseResults<_>) =
     let credential = results.Contains <@ ConfigArgs.AddCredentials @>
@@ -151,8 +152,9 @@ let install (results : ParseResults<_>) =
         if results.Contains <@ InstallArgs.Keep_Minor @> then SemVerUpdateMode.KeepMinor else
         if results.Contains <@ InstallArgs.Keep_Major @> then SemVerUpdateMode.KeepMajor else
         SemVerUpdateMode.NoRestriction
+    let touchAffectedRefs = false
 
-    Dependencies.Locate().Install(force, hard, withBindingRedirects, createNewBindingFiles, installOnlyReferenced, semVerUpdateMode)
+    Dependencies.Locate().Install(force, hard, withBindingRedirects, createNewBindingFiles, installOnlyReferenced, semVerUpdateMode, touchAffectedRefs)
 
 let outdated (results : ParseResults<_>) =
     let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
@@ -198,21 +200,22 @@ let update (results : ParseResults<_>) =
         if results.Contains <@ UpdateArgs.Keep_Minor @> then SemVerUpdateMode.KeepMinor else
         if results.Contains <@ UpdateArgs.Keep_Major @> then SemVerUpdateMode.KeepMajor else
         SemVerUpdateMode.NoRestriction
+    let touchAffectedRefs = false
     let filter = results.Contains <@ UpdateArgs.Filter @>
 
     match results.TryGetResult <@ UpdateArgs.Nuget @> with
     | Some packageName ->
         let version = results.TryGetResult <@ UpdateArgs.Version @>
         if filter then
-            Dependencies.Locate().UpdateFilteredPackages(group, packageName, version, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().UpdateFilteredPackages(group, packageName, version, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
         else
-            Dependencies.Locate().UpdatePackage(group, packageName, version, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().UpdatePackage(group, packageName, version, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
     | _ ->
         match group with
         | Some groupName -> 
-            Dependencies.Locate().UpdateGroup(groupName, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().UpdateGroup(groupName, force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
         | None ->
-            Dependencies.Locate().Update(force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode)
+            Dependencies.Locate().Update(force, hard, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
 
 let pack (results : ParseResults<_>) =
     let outputPath = results.GetResult <@ PackArgs.Output @>


### PR DESCRIPTION
Related to #1484 

While force touch has already been disabled by default on `restore`, it was always enabled in `add`, `remove`, `update` and `install`.

This PR changes it to disabled by default for `add`, `update` and `install`, where it can optionally be enabled with --touch-affected-refs (just like in `restore`). For `remove` it is always disabled.