### PR TITLE
Add "*.fsi" files as <Compile> by default

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -1156,6 +1156,7 @@ module ProjectFile =
         match (Path.GetExtension fileName).ToLowerInvariant() with
         | ext when Path.GetExtension project.FileName = ext + "proj"
             -> BuildAction.Compile
+        | ".fsi" -> BuildAction.Compile
         | ".xaml" -> BuildAction.Page
         | ".ttf" | ".png" | ".ico" | ".jpg" | ".jpeg"| ".bmp" | ".gif"
         | ".wav" | ".mid" | ".midi"| ".wma" | ".mp3" | ".ogg" | ".rma"

--- a/tests/Paket.Tests/ProjectFile/FileBuildActionSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/FileBuildActionSpecs.fs
@@ -16,6 +16,7 @@ let createProject name =
 let ``should recognize compilable files``() =
     (createProject "A.csproj").DetermineBuildAction "Class.cs" |> shouldEqual BuildAction.Compile
     (createProject "B.fsproj").DetermineBuildAction "Module.fs" |> shouldEqual BuildAction.Compile
+    (createProject "B.fsproj").DetermineBuildAction "Module.fsi" |> shouldEqual BuildAction.Compile
     (createProject "C.vbproj").DetermineBuildAction "Whatever.vb" |> shouldEqual BuildAction.Compile
     (createProject "D.nproj").DetermineBuildAction "Main.n" |> shouldEqual BuildAction.Compile
 


### PR DESCRIPTION
I'm [referencing F# type provider starter kit](https://github.com/BlueMountainCapital/FSharpRProvider/blob/master/src/RProvider.DesignTime/paket.references) using:

    File:ProvidedTypes.fsi
    File:ProvidedTypes.fs

And I never noticed that the [fsi file was added as `<Content>`](https://github.com/BlueMountainCapital/FSharpRProvider/blob/master/src/RProvider.DesignTime/RProvider.DesignTime.fsproj#L50) and thus ignored.

This adds an explicit case for `fsi` files.