### PR TITLE
Update: support combining filter with specific version

### DIFF
--- a/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
@@ -93,6 +93,17 @@ let ``#1178 update with [MN].* and without filter should fail``() =
     | exn when exn.Message.Contains "Package [MN].* was not found in paket.dependencies in group Main" -> ()
 
 [<Test>]
+let ``#1178 update with NUn.* filter to specific version``() =
+    paket "update nuget NUn.* --filter version 2.6.2" "i001178-update-with-regex" |> ignore
+    let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001178-update-with-regex","paket.lock"))
+    lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor"].Version
+    |> shouldEqual (SemVer.Parse "2.5.1")
+    lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "NUnit"].Version
+    |> shouldEqual (SemVer.Parse "2.6.2")
+    lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Microsoft.AspNet.WebApi.SelfHost"].Version
+    |> shouldEqual (SemVer.Parse "5.0.1")
+
+[<Test>]
 let ``#1413 doesn't take symbols``() =
     update "i001413-symbols" |> ignore
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001413-symbols","paket.lock"))

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -255,8 +255,8 @@ let UpdateFilteredPackages(dependenciesFileName, groupName, packageName : string
 
     let dependenciesFile =
         match newVersion with
-        | Some v -> dependenciesFile.UpdatePackageVersion(groupName,PackageName packageName, v)
-        | None -> 
+        | Some v -> dependenciesFile.UpdateFilteredPackageVersion(groupName, filter, v)
+        | None ->
             tracefn "Updating %O in %s group %O" packageName dependenciesFileName groupName
             dependenciesFile
 


### PR DESCRIPTION
Update supports updating all packages matching a regex. It also supports providing a specific version to update to. What it did not support before is combining these two, i.e. updating all packages matching a regex to the same specific version. This PR adds the missing piece to support this combination.