### PR TITLE
change from wget to curl in install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ echo "Installing $LATEST ..."
 
 rm -rf $TMP
 mkdir -p $TMP
-wget -nc -q -4 -O $TMP/paket.zip $LATEST
+curl -L $LATEST -o $TMP/paket.zip
 unzip -qq -o -d $TMP/ $TMP/paket.zip
 
 rm -rf $LIB/paket


### PR DESCRIPTION
Cause the OSX does not contains `wget` native, I changed the download of paket.exe in install.sh script to curl. In my tests (existing and not existing paket.exe) everything works fine.