### PR TITLE
Removed "specs:" from paket.lock 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 3.0.0-alpha113 - 13.04.2016
+#### 3.0.0-alpha114 - 13.04.2016
 * Allow to reference git repositories - http://fsprojects.github.io/Paket/git-dependencies.html
 * Allow to run build commands on git repositories - http://fsprojects.github.io/Paket/git-dependencies.html#Running-a-build-in-git-repositories
 * Allow to use git repositories as NuGet source - http://fsprojects.github.io/Paket/git-dependencies.html#Using-Git-repositories-as-NuGet-source
@@ -6,6 +6,7 @@
 * Garbage collection in packages folder - https://github.com/fsprojects/Paket/pull/1491
 * Allows to exclude dll references from a NuGet package - http://fsprojects.github.io/Paket/references-files.html#Excluding-libraries
 * Allows to use aliases for libraries - http://fsprojects.github.io/Paket/references-files.html#Library-aliases
+* USABILITY: Removed "specs:" from paket.lock since it was copied from Bundler and had no meaning in Paket
 * BREAKING CHANGE: Removed --hard parameter from all commands. Paket threads all commands as if --hard would have been set - https://github.com/fsprojects/Paket/pull/1567
 
 #### 2.60.2 - 13.04.2016

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 * Garbage collection in packages folder - https://github.com/fsprojects/Paket/pull/1491
 * Allows to exclude dll references from a NuGet package - http://fsprojects.github.io/Paket/references-files.html#Excluding-libraries
 * Allows to use aliases for libraries - http://fsprojects.github.io/Paket/references-files.html#Library-aliases
-* USABILITY: Removed "specs:" from paket.lock since it was copied from Bundler and had no meaning in Paket
+* USABILITY: Removed "specs:" from paket.lock since it was copied from Bundler and had no meaning in Paket - https://github.com/fsprojects/Paket/pull/1608
 * BREAKING CHANGE: Removed --hard parameter from all commands. Paket threads all commands as if --hard would have been set - https://github.com/fsprojects/Paket/pull/1567
 
 #### 2.60.2 - 13.04.2016

--- a/docs/content/commands/outdated.md
+++ b/docs/content/commands/outdated.md
@@ -13,7 +13,6 @@ and the following paket.lock file:
     [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         Castle.Core (2.0.0)
         Castle.Windsor (2.0.0)
           Castle.Core (>= 2.0.0)

--- a/docs/content/commands/pack.md
+++ b/docs/content/commands/pack.md
@@ -18,7 +18,6 @@ Now, when you run `paket install`, your [`paket.lock` file][lockfile] would look
     [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         Castle.Core (3.3.3)
         Castle.Windsor (3.3.0)
           Castle.Core (>= 3.3.0)

--- a/docs/content/commands/simplify.md
+++ b/docs/content/commands/simplify.md
@@ -68,7 +68,6 @@ Let us imagine that package Bar has a dependency on package Foo for any version 
     [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         Foo (1.0.0)
         Bar (1.0.0)
           Foo (<= 2.0.0)

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -51,7 +51,6 @@ The [`paket install` command](paket-install.html) will analyze your dependencies
 	[lang=paket]
 	NUGET
 	  remote: https://nuget.org/api/v2
-	  specs:
 		Castle.Core (3.3.3)
 		Castle.Core-log4net (3.3.3)
 		  Castle.Core (>= 3.3.3)
@@ -68,7 +67,6 @@ The [`paket install` command](paket-install.html) will analyze your dependencies
 		NUnit (2.6.4)
 	GITHUB
 	  remote: forki/FsUnit
-	  specs:
 		FsUnit.fs (81d27fd09575a32c4ed52eadb2eeac5f365b8348)
 
 This file shows all direct and transitive dependencies and pins every dependency to a concrete version. In most cases you want to commit this file to your version control system ([read why](faq.html#Why-should-I-commit-the-lock-file)).

--- a/docs/content/git-dependencies.md
+++ b/docs/content/git-dependencies.md
@@ -63,11 +63,9 @@ The generated [`paket.lock` file](lock-file.html) will look like this:
     [lang=paket]
     NUGET
       remote: paket-files/github.com/forki/nupkgtest/source
-      specs:
         Argu (1.1.3)
     GIT
       remote: https://github.com/forki/nupkgtest.git
-      specs:
          (05366e390e7552a569f3f328a0f3094249f3b93b)
 
 It's also possible to [run build scripts](git-dependencies.html#Running-a-build-in-git-repositories) to create the NuGet packages:

--- a/docs/content/github-dependencies.md
+++ b/docs/content/github-dependencies.md
@@ -17,7 +17,6 @@ If you run the [`paket update` command](paket-update.html), it will download the
     [lang=paket]
     GITHUB
       remote: forki/FsUnit
-      specs:
         FsUnit.fs (7623fc13439f0e60bd05c1ed3b5f6dcb937fe468)
 
 As you can see the file is pinned to a concrete commit. This allows you to reliably use the same file version in succeeding builds until you elect to perform a [`paket update` command](paket-update.html) at a time of your choosing.
@@ -86,7 +85,6 @@ This generates the following [`paket.lock` file](lock-file.html):
     [lang=paket]
 	NUGET
 	  remote: https://nuget.org/api/v2
-	  specs:
 		Microsoft.Bcl (1.1.9)
 		  Microsoft.Bcl.Build (>= 1.0.14)
 		Microsoft.Bcl.Build (1.0.21)
@@ -97,7 +95,6 @@ This generates the following [`paket.lock` file](lock-file.html):
 		  Microsoft.Net.Http (>= 0)
 	GITHUB
 	  remote: fsharp/FAKE
-	  specs:
 		modules/Octokit/Octokit.fsx (a25c2f256a99242c1106b5a3478aae6bb68c7a93)
 		  Octokit (>= 0)
 
@@ -126,8 +123,6 @@ If you run the [`paket update` command](paket-update.html), it will add a new se
     [lang=paket]
     GIST
       remote: Thorium/1972308
-      specs:
         gistfile1.fs
       remote: Thorium/6088882
-      specs:
         FULLPROJECT

--- a/docs/content/groups.md
+++ b/docs/content/groups.md
@@ -41,25 +41,20 @@ After [`paket install`](paket-install.html) the generated [`paket.lock` file](lo
     [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         FSharp.Core (4.0.0.1)
         Newtonsoft.Json (7.0.1)
         UnionArgParser (0.6.3)
     GITHUB
       remote: forki/FsUnit
-      specs:
         FsUnit.fs (81d27fd09575a32c4ed52eadb2eeac5f365b8348)
       remote: fsharp/FAKE
-      specs:
         src/app/FakeLib/Globbing/Globbing.fs (991bea743c5d5e8eec0defc7338a89281ed3f51a)
       remote: fsprojects/Chessie
-      specs:
         src/Chessie/ErrorHandling.fs (1f23b1caeb1f87e750abc96a25109376771dd090)
 
     GROUP Build
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         FAKE (4.3.1)
         FSharp.Compiler.Service (1.4.0.1)
         FSharp.Formatting (2.10.0)
@@ -78,14 +73,12 @@ After [`paket install`](paket-install.html) the generated [`paket.lock` file](lo
           Microsoft.Net.Http
     GITHUB
       remote: fsharp/FAKE
-      specs:
         modules/Octokit/Octokit.fsx (991bea743c5d5e8eec0defc7338a89281ed3f51a)
           Octokit
 
     GROUP Test
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         NUnit (2.6.4)
         NUnit.Runners (2.6.4)
 
@@ -118,13 +111,11 @@ Every group will be resolved independently to the following [`paket.lock` file](
     [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         Newtonsoft.Json (7.0.1)
 
     GROUP Legacy
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         Newtonsoft.Json (6.0.8)
 
 Paket is downloading both version. You will get `packages/Newtonsoft.Json` with version 7.0.1 and `packages/legacy/Newtonsoft.Json` with the 6.0.8 bits.

--- a/docs/content/http-dependencies.md
+++ b/docs/content/http-dependencies.md
@@ -14,7 +14,6 @@ If you run the [`paket install` command](paket-install.html), it will add a new 
     [lang=paket]
     HTTP
       remote: http://www.fssnip.net/raw/1M/test1.fs
-      specs:
         test1.fs
 
 

--- a/docs/content/lock-file.md
+++ b/docs/content/lock-file.md
@@ -16,7 +16,6 @@ The [`paket.lock` file](lock-file.html) records the concrete dependency resoluti
     [lang=paket]
     NUGET
       remote: https://nuget.org/api/v2
-      specs:
         Castle.Core (3.3.0)
         Castle.Core-log4net (3.3.0)
           Castle.Core (>= 3.3.0)

--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -448,7 +448,7 @@ let ``#1592 install source content without CopyToOutputDirectory``() =
     let s2 = File.ReadAllText newFile |> normalizeLineEndings
     s2 |> shouldEqual s1
 
-let resolvedNewPorjectJson = """{
+let resolvedNewProjectJson = """{
     "version": "1.0.0-*",
     "compilationOptions": {
         "emitEntryPoint": true
@@ -514,14 +514,14 @@ let ``#736 install into new project.json``() =
     let newLockFile = install "i000736-new-json"
     let newFile = Path.Combine(scenarioTempPath "i000736-new-json","project.json")
     let s2 = File.ReadAllText newFile |> normalizeLineEndings
-    normalizeLineEndings resolvedNewPorjectJson |> shouldEqual s2
+    normalizeLineEndings resolvedNewProjectJson |> shouldEqual s2
 
 [<Test>]
 let ``#736 install into nested project.json``() = 
     let newLockFile = install "i000736-new-json-nested"
     let newFile = Path.Combine(scenarioTempPath "i000736-new-json-nested","project1","project.json")
     let s2 = File.ReadAllText newFile |> normalizeLineEndings
-    normalizeLineEndings resolvedNewPorjectJson |> shouldEqual s2
+    normalizeLineEndings resolvedNewProjectJson |> shouldEqual s2
 
 [<Test>]
 let ``#1145 don't install excludes``() = 

--- a/integrationtests/scenarios/i001552-install-mvvmlightlibs-again/before/paket.lock
+++ b/integrationtests/scenarios/i001552-install-mvvmlightlibs-again/before/paket.lock
@@ -1,6 +1,5 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-  specs:
     CommonServiceLocator (1.3) - framework: >= net40, monoandroid, portable-net45+wp80+wpa81+win+monoandroid10+xamarinios10, xamarinios, winv4.5, winv4.5.1, wpv8.0, wpv8.1, wpav8.1, sl50
     MvvmLightLibs (5.2)
       CommonServiceLocator (>= 1.0) - framework: net35, sl40

--- a/integrationtests/scenarios/i001552-install-mvvmlightlibs-first-time/before/paket.locktemplate
+++ b/integrationtests/scenarios/i001552-install-mvvmlightlibs-first-time/before/paket.locktemplate
@@ -1,6 +1,5 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-  specs:
     CommonServiceLocator (1.3) - framework: >= net40, monoandroid, portable-net45+wp80+wpa81+win+monoandroid10+xamarinios10, xamarinios, winv4.5, winv4.5.1, wpv8.0, wpv8.1, wpav8.1, sl50
     MvvmLightLibs (5.2)
       CommonServiceLocator (>= 1.0) - framework: net35, sl40

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -81,7 +81,6 @@ module LockFileSerializer =
 
                   yield "  remote: " + String.quoted source
 
-                  yield "  specs:"
                   for _,_,package in packages |> Seq.sortBy (fun (_,_,p) -> p.Name) do
                       let versionStr = 
                           let s'' = package.Version.ToString()
@@ -128,7 +127,6 @@ module LockFileSerializer =
                         updateHasReported.Remove GistLink |> ignore
                         updateHasReported.Add GitHubLink
                     yield sprintf "  remote: %s/%s" owner project
-                    yield "  specs:"
                 | GitLink url ->
                     if not (updateHasReported.Contains(GitLink(""))) then
                         yield "GIT"
@@ -137,7 +135,6 @@ module LockFileSerializer =
                         updateHasReported.Remove (HttpLink "") |> ignore
                         updateHasReported.Add (GitLink "")
                     yield sprintf "  remote: " + url
-                    yield "  specs:"
                
                 | GistLink -> 
                     if not (updateHasReported.Contains(GistLink)) then
@@ -147,7 +144,6 @@ module LockFileSerializer =
                         updateHasReported.Remove (GitLink "") |> ignore
                         updateHasReported.Add GistLink
                     yield sprintf "  remote: %s/%s" owner project
-                    yield "  specs:"
                 | HttpLink url ->
                     if not (updateHasReported.Contains(HttpLink(""))) then
                         yield "HTTP"
@@ -156,7 +152,6 @@ module LockFileSerializer =
                         updateHasReported.Remove (GitLink "") |> ignore
                         updateHasReported.Add (HttpLink "")
                     yield sprintf "  remote: " + url
-                    yield "  specs:"
 
                 for file in files |> Seq.sortBy (fun f -> f.Owner.ToLower(),f.Project.ToLower(),f.Name.ToLower())  do
                     

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -112,7 +112,7 @@
     <DocumentationFile>
     </DocumentationFile>
     <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>D:\code\PaketKopie</StartWorkingDirectory>
+    <StartWorkingDirectory>D:\code\tempp</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
@@ -18,7 +18,6 @@ let graph = [
 
 let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]

--- a/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
@@ -25,7 +25,6 @@ COPY-LOCAL: FALSE
 FRAMEWORK: >= NET45
 NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]
@@ -52,7 +51,6 @@ let expected2 = """IMPORT-TARGETS: FALSE
 CONTENT: NONE
 NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
@@ -76,7 +74,6 @@ let graph3 = [
 let expected3 = """REDIRECTS: ON
 NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
@@ -98,7 +95,6 @@ let ``should generate strategy min lock file``() =
     let expected = """STRATEGY: MIN
 NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromCode(config)
@@ -118,7 +114,6 @@ let ``should generate strategy max lock file``() =
     let expected = """STRATEGY: MAX
 NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromCode(config)
@@ -149,7 +144,6 @@ nuget NLog.Contrib
     let expected = """FRAMEWORK: >= NET40
 NUGET
   remote: https://www.nuget.org/api/v2
-  specs:
     NLog (1.0.1)
     NLog.Contrib (1.0)
       NLog (>= 1.0.1)"""

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -32,7 +32,6 @@ let graph = [
 let ``should generate lock file for packages``() = 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)
@@ -59,7 +58,6 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 let ``should generate lock file with framework restrictions for packages``() = 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor (2.1) - framework: net35
     Castle.Windsor-log4net (3.3) - framework: net35
       Castle.Windsor (>= 2.0)
@@ -87,7 +85,6 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 let ``should generate lock file with no targets import for packages``() = 
     let expected = """NUGET
   remote: "D:\code\temp with space"
-  specs:
     Castle.Windsor (2.1) - import_targets: false, framework: net35
     Castle.Windsor-log4net (3.3) - import_targets: false, framework: net35
       Castle.Windsor (>= 2.0)
@@ -114,7 +111,6 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 let ``should generate lock file with no copy local for packages``() = 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor (2.1) - copy_local: false, import_targets: false, framework: net35
     Castle.Windsor-log4net (3.3) - copy_local: false, import_targets: false, framework: net35
       Castle.Windsor (>= 2.0)
@@ -141,7 +137,6 @@ nuget "Rx-Main" "~> 2.0" content: none, framework: >= net40 """
 let ``should generate lock file with disabled content for packages``() = 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor (2.1) - framework: net35
     Castle.Windsor-log4net (3.3) - framework: net35
       Castle.Windsor (>= 2.0)
@@ -159,11 +154,9 @@ let ``should generate lock file with disabled content for packages``() =
 
 let expectedWithGitHub = """GITHUB
   remote: owner/project1
-  specs:
     folder/file.fs (master)
     folder/file1.fs (commit1)
   remote: owner/project2
-  specs:
     folder/file.fs (commit2)
     folder/file3.fs (commit3) githubAuth"""
     
@@ -207,7 +200,6 @@ let graph2 = [
 
 let expected2 = """NUGET
   remote: https://www.myget.org/F/ravendb3
-  specs:
     RavenDB.Client (3.0.3498-Unstable)"""
 
 [<Test>]
@@ -231,7 +223,6 @@ let graph3 = [
 
 let expected3 = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     GreaterThan.Package (2.1)
       Maximum.Package (<= 3.0)
     LessThan.Package (1.9)
@@ -264,7 +255,6 @@ let trivialResolve (f:ModuleResolver.UnresolvedSource) =
 
 let expectedWithHttp = """HTTP
   remote: http://www.fssnip.net
-  specs:
     test.fs (/raw/1M)"""
     
 [<Test>]
@@ -280,17 +270,14 @@ let ``should generate lock file for http source files``() =
 
 let expectedMultiple = """HTTP
   remote: http://www.fssnip.net
-  specs:
     myFile.fs (/raw/1M)
     myFile2.fs (/raw/32)
     myFile3.fs (/raw/15)
     myFile5.fs (/raw/34) httpAuth
 GIST
   remote: Thorium/1972308
-  specs:
     gistfile1.fs
   remote: Thorium/6088882
-  specs:
     FULLPROJECT"""
     
 [<Test>]
@@ -317,10 +304,8 @@ http http://www.fssnip.net/raw/15 myFile3.fs """
 
 let expectedForStanfordNLPdotNET = """HTTP
   remote: http://www.frijters.net
-  specs:
     ikvmbin-8.0.5449.0.zip (/ikvmbin-8.0.5449.0.zip)
   remote: http://nlp.stanford.edu
-  specs:
     stanford-corenlp-full-2014-10-31.zip (/software/stanford-corenlp-full-2014-10-31.zip)
     stanford-ner-2014-10-26.zip (/software/stanford-ner-2014-10-26.zip)
     stanford-parser-full-2014-10-31.zip (/software/stanford-parser-full-2014-10-31.zip)
@@ -365,7 +350,6 @@ let ``should parse and regenerate http Stanford.NLP.NET project``() =
 let ``should generate lock file with second group``() = 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor (2.1) - copy_content_to_output_dir: preserve_newest
     Castle.Windsor-log4net (3.3) - framework: net35
       Castle.Windsor (>= 2.0)
@@ -383,7 +367,6 @@ COPY-CONTENT-TO-OUTPUT-DIR: ALWAYS
 CONDITION: LEGACY
 NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     FAKE (4.0)
 """
     let lockFile = LockFile.Parse("Test",toLines expected)

--- a/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
@@ -30,7 +30,6 @@ let graph = [
 
 let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -520,13 +520,11 @@ let ``should parse reactiveui lockfile``() =
 
 let multipleFeedLockFile = """NUGET
   remote: http://internalfeed/NugetWebFeed/nuget
-  specs:
     Internal_1 (1.2.10)
       Newtonsoft.Json (>= 6.0 < 6.1)
     log4net (1.2.10)
     Newtonsoft.Json (6.0.6)
   remote: https://www.nuget.org/api/v2
-  specs:
     Microsoft.AspNet.WebApi (5.2.3)
       Microsoft.AspNet.WebApi.WebHost (>= 5.2.3 < 5.3)
     Microsoft.AspNet.WebApi.Client (5.2.3)
@@ -566,7 +564,6 @@ COPY-LOCAL: TRUE
 IMPORT-TARGETS: TRUE
 NUGET
   remote: "D:\code\temp with space"
-  specs:
     Castle.Windsor (2.1)
 
 GROUP Build
@@ -575,7 +572,6 @@ COPY-LOCAL: TRUE
 CONDITION: LEGACY
 NUGET
   remote: "D:\code\temp with space"
-  specs:
     FAKE (4.0) - redirects: on
 """
 
@@ -624,7 +620,6 @@ let ``should parse strategy min lock file``() =
     let lockFile = """STRATEGY: MIN
 NUGET
   remote: "D:\code\temp with space"
-  specs:
     Castle.Windsor (2.1)
 """
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
@@ -663,7 +658,6 @@ let ``should parse no strategy lock file``() =
 let packageRedirectsLockFile = """REDIRECTS: ON
 NUGET
   remote: "D:\code\temp with space"
-  specs:
     Castle.Windsor (2.1)
     DotNetZip (1.9.3) - redirects: on
     FAKE (3.5.5) - redirects: off
@@ -672,14 +666,12 @@ NUGET
 GROUP Build
 NUGET
   remote: "D:\code\temp with space"
-  specs:
     FAKE (4.0) - redirects: on
 
 GROUP Test
 REDIRECTS: OFF
 NUGET
   remote: "D:\code\temp with space"
-  specs:
     xUnit (2.0.0)
 """
 
@@ -763,7 +755,6 @@ let ``should parse lock file from auto-detect settings``() =
 
 let lockFileWithManyFrameworks = """NUGET
   remote: https://www.nuget.org/api/v2
-  specs:
     CommonServiceLocator (1.3) - framework: >= net40, monoandroid, portable-net45+wp80+wpa81+win+monoandroid10+xamarinios10, xamarinios, winv4.5, winv4.5.1, wpv8.0, wpv8.1, sl50
     MvvmLightLibs (5.2)
       CommonServiceLocator (>= 1.0) - framework: net35, sl40
@@ -785,7 +776,6 @@ let ``should parse lock file many frameworks``() =
 
 let lockFileWithDependencies = """NUGET
   remote: https://www.nuget.org/api/v2
-  specs:
     Argu (2.1)
     Chessie (0.4)
       FSharp.Core
@@ -866,6 +856,26 @@ GIT
 [<Test>]
 let ``should parse local git lock file with build``() = 
     let lockFile = LockFileParser.Parse(toLines localGitLockFileWithBuild)
+    lockFile.Head.RemoteUrl |> shouldEqual (Some "https://github.com/forki/nupkgtest.git")
+    lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
+    lockFile.Head.SourceFiles.Head.Project |> shouldEqual "nupkgtest"
+    lockFile.Head.SourceFiles.Head.Command |> shouldEqual (Some "build.cmd Test")
+
+
+let localGitLockFileWithBuildAndNoSpecs = """
+NUGET
+  remote: paket-files/github.com/nupkgtest/source
+  specs:
+    Argu (1.1.3)
+GIT
+  remote: https://github.com/forki/nupkgtest.git
+     (2942d23fcb13a2574b635194203aed7610b21903)
+      build: build.cmd Test
+"""
+
+[<Test>]
+let ``should parse local git lock file with build and no specs``() = 
+    let lockFile = LockFileParser.Parse(toLines localGitLockFileWithBuildAndNoSpecs)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "https://github.com/forki/nupkgtest.git")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
     lockFile.Head.SourceFiles.Head.Project |> shouldEqual "nupkgtest"

--- a/tests/Paket.Tests/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/UpdateProcessSpecs.fs
@@ -374,7 +374,6 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
-  specs:
     Castle.Core (4.0)
     Castle.Core-log4net (3.2)
       Castle.Core (>= 3.2)


### PR DESCRIPTION
it was copied from Bundler and had no meaning in Paket

- [x] v3 will not write "specs" into lock file
- [x] v3 can still read "old" lock files
- [x] update docs