### PR TITLE
Add support for MonoAndroid22 and MonoAndroid23.

### DIFF
--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -235,7 +235,7 @@ module FrameworkDetection =
                 | "net46" -> Some (DotNetFramework FrameworkVersion.V4_6)
                 | "net461" -> Some (DotNetFramework FrameworkVersion.V4_6_1)
                 | "monotouch" | "monotouch10" | "monotouch1" -> Some MonoTouch
-                | "monoandroid" | "monoandroid10" | "monoandroid1" | "monoandroid403" | "monoandroid41" | "monoandroid50"-> Some MonoAndroid
+                | "monoandroid" | "monoandroid10" | "monoandroid1" | "monoandroid22" | "monoandroid23" | "monoandroid403" | "monoandroid41" | "monoandroid50"-> Some MonoAndroid
                 | "monomac" | "monomac10" | "monomac1" -> Some MonoMac
                 | "xamarinios" | "xamarinios10" | "xamarinios1" | "xamarin.ios10" -> Some XamariniOS
                 | "xamarinmac" | "xamarinmac20" | "xamarin.mac20" -> Some XamarinMac


### PR DESCRIPTION
We use some libraries that have minimum targets of MonoAndroid22 and MonoAndroid23, so Paket currently doesn't pick them up.