### PR TITLE
make exit code 0 when help is explicitly requested

### DIFF
--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -354,6 +354,9 @@ let main() =
 
             handler command args
             ()
+        | [] when results.IsUsageRequested ->
+            Environment.ExitCode <- 0
+            parser.Usage ("Help was requested:") |> trace
         | [] ->
             Environment.ExitCode <- 1
             traceError "Command was:"


### PR DESCRIPTION
This just patches a tiny inconsistency.  When --help is passed for sub-commands the exit code is zero, but when it is passed for the main paket exe we get 1.