### PR TITLE
fix debuggerdisplay commands that were broken and add comments

### DIFF
--- a/src/Paket.Core/Domain.fs
+++ b/src/Paket.Core/Domain.fs
@@ -4,7 +4,7 @@ open System.IO
 open System.Text.RegularExpressions
 
 /// Represents a NuGet package name
-[<System.Diagnostics.DebuggerDisplay("{Item}")>]
+[<System.Diagnostics.DebuggerDisplay("{ToString()}")>]
 [<CustomEquality;CustomComparison>]
 type PackageName =
 | PackageName of string * string
@@ -34,7 +34,7 @@ type PackageName =
 let PackageName(name:string) = PackageName.PackageName(name.Trim(),name.ToLowerInvariant().Trim())
 
 // Represents a filter of normalized package names
-[<System.Diagnostics.DebuggerDisplay("{Item}")>]
+[<System.Diagnostics.DebuggerDisplay("{ToString()}")>]
 type PackageFilter =
 | PackageName of PackageName
 | PackageFilter of string

--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -209,6 +209,8 @@ type FrameworkIdentifier =
         | XamariniOS _, XamariniOS _ -> true
         | Native _, Native _ -> true
         | _ -> false
+    
+    /// TODO: some notion of an increasing/decreasing sequence of FrameworkIdentitifers, so that Between(bottom, top) constraints can enumerate the list
 
     member x.IsCompatible y = 
         x = y || 

--- a/src/Paket.Core/InstallModel.fs
+++ b/src/Paket.Core/InstallModel.fs
@@ -69,7 +69,6 @@ module InstallFiles =
             References = Set.union that.References installFiles.References
             ContentFiles = Set.union that.ContentFiles installFiles.ContentFiles }
 
-
 type InstallFiles with
     member this.AddReference lib = InstallFiles.addReference  lib this
     member this.AddTargetsFile targetsFile = InstallFiles.addTargetsFile targetsFile this
@@ -77,6 +76,7 @@ type InstallFiles with
     member this.GetFrameworkAssemblies() = InstallFiles.getFrameworkAssemblies this
     member this.MergeWith that = InstallFiles.mergeWith that this
 
+/// Represents a subfolder of a nuget package that provides files (content, references, etc) for one or more Target Profiles.  This is a logical representation of the 'net45' folder in a NuGet package, for example.
 type LibFolder =
     { Name : string
       Targets : TargetProfile list
@@ -106,13 +106,13 @@ type AnalyzerLib =
         Path : string
         /// Target language for the analyzer
         Language : AnalyzerLanguage }
-
     static member FromFile(file : FileInfo) =
         {
             Path = file.FullName
             Language = AnalyzerLanguage.FromDirectory(file.Directory)
         }
 
+/// Represents the contents of a particular package at a particular version.  Any install-specific actions like Content files, References, Roslyn Analyzers, MsBuild targets are represented here.
 type InstallModel = 
     { PackageName : PackageName
       PackageVersion : SemVerInfo


### PR DESCRIPTION
Found a few broken debuggerdisplays while working on the script generation feature so I thought I'd fix them up.
Also added a few comments to some domain types are a result of me asking what the particular type was supposed to represent.