### PR TITLE
Blacklisting install.xdt and uninstall.xdt files

### DIFF
--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -50,6 +50,8 @@ let contentFileBlackList : list<(FileInfo -> bool)> = [
     fun f -> f.Name.EndsWith ".pp"
     fun f -> f.Name.EndsWith ".tt"
     fun f -> f.Name.EndsWith ".ttinclude"
+    fun f -> f.Name.EndsWith ".install.xdt"
+    fun f -> f.Name.EndsWith ".uninstall.xdt"
 ]
 
 let processContentFiles root project (usedPackages:Map<_,_>) gitRemoteItems options =


### PR DESCRIPTION
If we look at the code for how other transformation files are handled, then we see some blacklisting logic in paket. The xml transformation files mentioned in #614 are not present in the blacklisting though.
