### PR TITLE
Paket should import build targets from packages in dependency groups

### DIFF
--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -300,8 +300,8 @@ let ``#1505 should install conditionals``() =
 [<Test>]
 let ``#1663 should install google apis``() = 
     install "i001663-google-apis" |> ignore
-    let newFile = Path.Combine(scenarioTempPath "i001505-conditionals","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
-    let oldFile = Path.Combine(originalScenarioPath "i001505-conditionals","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
+    let newFile = Path.Combine(scenarioTempPath "i001663-google-apis","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
+    let oldFile = Path.Combine(originalScenarioPath "i001663-google-apis","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
     let s2 = File.ReadAllText newFile |> normalizeLineEndings
     s2 |> shouldEqual s1
@@ -453,6 +453,15 @@ let ``#1592 install source content without CopyToOutputDirectory``() =
     let newLockFile = install "i001592-source-content"
     let newFile = Path.Combine(scenarioTempPath "i001592-source-content","xUnitTests","xUnitTests.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001592-source-content","xUnitTests","xUnitTests.expected.csprojtemplate")
+    let s1 = File.ReadAllText oldFile |> normalizeLineEndings
+    let s2 = File.ReadAllText newFile |> normalizeLineEndings
+    s2 |> shouldEqual s1
+
+[<Test>]
+let ``#1663 should import build targets``() =
+    install "i001663-build-targets" |> ignore
+    let newFile = Path.Combine(scenarioTempPath "i001663-build-targets","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
+    let oldFile = Path.Combine(originalScenarioPath "i001663-build-targets","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
     let s2 = File.ReadAllText newFile |> normalizeLineEndings
     s2 |> shouldEqual s1

--- a/integrationtests/scenarios/i001663-build-targets/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
+++ b/integrationtests/scenarios/i001663-build-targets/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{2C1B4A0C-A56A-46C1-B550-598A2B75F50C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DIPS.Infrastructure</RootNamespace>
+    <AssemblyName>DIPS.Infrastructure</AssemblyName>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.65</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>612, 618</WarningsAsErrors>
+    <OutputPath>..\..\bin\$(TargetFrameworkVersion)\$(Platform)\$(Configuration)</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DefineConstants>TRACE;DEBUG;$(DefineConstants)</DefineConstants>
+    <Optimize>false</Optimize>
+    <DebugType>full</DebugType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>612, 618</WarningsAsErrors>
+    <OutputPath>..\..\bin\$(TargetFrameworkVersion)\$(Platform)\$(Configuration)</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>False</SignAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Data" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Call.cs" />
+    <Compile Include="IProfilerStorage.cs" />
+    <Compile Include="IProfilingExecutor.cs" />
+    <Compile Include="ProfilingConstants.cs" />
+    <Compile Include="Profiler.cs">
+      <ExcludeFromStyleCop>False</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="IProfiler.cs" />
+    <Compile Include="ProfilingExecutor.cs" />
+    <Compile Include="LogicalContextProfilerStorage.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\manual_reference\DIPS.Infrastructure.Services.csproj">
+      <Project>{479F0088-3377-4A96-9729-DD1A2B0434E1}</Project>
+      <Name>DIPS.Infrastructure.Services</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\..\.paket\paket.targets" />
+  <Import Project="..\packages\build\BuildBundlerMinifier\build\BuildBundlerMinifier.targets" Condition="Exists('..\packages\build\BuildBundlerMinifier\build\BuildBundlerMinifier.targets')" Label="Paket" />
+  <Import Project="..\packages\build\BuildWebCompiler\build\BuildWebCompiler.targets" Condition="Exists('..\packages\build\BuildWebCompiler\build\BuildWebCompiler.targets')" Label="Paket" />
+</Project>

--- a/integrationtests/scenarios/i001663-build-targets/before/MyClassLibrary/MyClassLibrary/paket.references
+++ b/integrationtests/scenarios/i001663-build-targets/before/MyClassLibrary/MyClassLibrary/paket.references
@@ -1,0 +1,3 @@
+group Build
+	BuildBundlerMinifier
+	BuildWebCompiler

--- a/integrationtests/scenarios/i001663-build-targets/before/paket.dependencies
+++ b/integrationtests/scenarios/i001663-build-targets/before/paket.dependencies
@@ -1,0 +1,7 @@
+source https://nuget.org/api/v2
+
+group Build
+	source https://nuget.org/api/v2
+
+	nuget BuildBundlerMinifier 1.8.154
+	nuget BuildWebCompiler 1.10.310


### PR DESCRIPTION
Not sure it is directly related to #1663
But after `paket.exe update` with version `2.64.2`, paket removed by build targets from project file
![image](https://cloud.githubusercontent.com/assets/1197905/15137741/456a2796-1694-11e6-9f56-f0043d2ddf66.png)
