### PR TITLE
Fix for Issue #1676

### DIFF
--- a/integrationtests/scenarios/loading-scripts-scenarios/issue-1676/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts-scenarios/issue-1676/before/paket.dependencies
@@ -1,0 +1,3 @@
+source https://nuget.org/api/v2
+
+nuget EntityFramework = 6.1.0

--- a/src/Paket.Core/ScriptGeneration.fs
+++ b/src/Paket.Core/ScriptGeneration.fs
@@ -176,7 +176,7 @@ module ScriptGeneration =
           let scriptFile = getScriptFile groupName package.Name
           let groupName = getGroupNameAsOption groupName
           let dependencies = package.Dependencies |> Seq.map fst' |> Seq.choose knownIncludeScripts.TryFind |> List.ofSeq
-          let installModel = dependenciesFile.GetInstalledPackageModel(groupName, package.Name.GetCompareString())
+          let installModel = dependenciesFile.GetInstalledPackageModel(groupName, package.Name.ToString())
           let dllFiles = getDllsWithinPackage framework installModel |> List.map (makeRelativePath scriptFile)
 
           let scriptInfo = {


### PR DESCRIPTION
Added an integration test.

Reason of the bug: `package.Name.GetCompareString()` was used instead of `package.Name.ToString()` in `ScriptGeneration.fs`

We might consider making an overload to `dependenciesFile.GetInstalledPackageModel` taking a `PackageName` instance to avoid similar issues in future.
