### PR TITLE
Support for explicit filenames in paket.references, fixes #1641

### DIFF
--- a/docs/content/github-dependencies.md
+++ b/docs/content/github-dependencies.md
@@ -51,6 +51,12 @@ Or if you use ``.`` for the directory, the file will be placed under the root of
 
 ![alt text](img/github_ref_root.png "GitHub file referenced in project under root of project")
 
+The file can be renamed for your project by providing an explicit filename:
+
+    [lang=paket]
+    File:FsUnit.fs ./tests.fs
+    File:FsUnit.fs Tests\FsUnit\tests.fs
+
 ## Referencing a GitHub repository
 
 You can also reference a complete [github.com](http://www.github.com) repository by specifying the repository id in the [`paket.dependencies` file](dependencies-file.html):

--- a/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
@@ -159,3 +159,15 @@ let ``#1635 should tell about auth issue``() =
         failwith "error expected"
     with
     | exn when exn.Message.Contains("Could not find versions for package Argu") -> ()
+       
+[<Test>]
+let ``#1641 explicit custom file paths are respected``() =
+    let scenario = "i001641-rename-file-dependencies"
+
+    update scenario |> ignore
+
+    let projFile = Path.Combine(scenarioTempPath scenario, @"Src\MyService\MyService.csproj")
+    let projXml = File.ReadAllText(projFile)
+
+    projXml |> shouldContainText "<Content Include=\"..\\..\\paket-files\\forki\\FsUnit\\FsUnit.fs\">"
+    projXml |> shouldContainText "<Link>customname.fs</Link>"

--- a/integrationtests/scenarios/i001641-rename-file-dependencies/before/PaketDemo.sln
+++ b/integrationtests/scenarios/i001641-rename-file-dependencies/before/PaketDemo.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{1D5837E3-232C-4F67-92CF-2903D7AAC725}"
+	ProjectSection(SolutionItems) = preProject
+		paket.dependencies = paket.dependencies
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyService", "Src\MyService\MyService.csproj", "{379D1079-01CD-4F27-85C8-EE5E1B694D83}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{171DD95A-16B9-4C0C-A7DB-6550FDE808DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{171DD95A-16B9-4C0C-A7DB-6550FDE808DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{171DD95A-16B9-4C0C-A7DB-6550FDE808DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{171DD95A-16B9-4C0C-A7DB-6550FDE808DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{379D1079-01CD-4F27-85C8-EE5E1B694D83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{379D1079-01CD-4F27-85C8-EE5E1B694D83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{379D1079-01CD-4F27-85C8-EE5E1B694D83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{379D1079-01CD-4F27-85C8-EE5E1B694D83}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/Bar.cs
+++ b/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/Bar.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MyLibrary;
+
+namespace MyService {
+    public class Bar {
+
+        Bar() {
+            var foo = new Foo();
+        }
+    }
+}

--- a/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/MyService.csprojtemplate
+++ b/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/MyService.csprojtemplate
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{379D1079-01CD-4F27-85C8-EE5E1B694D83}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MyService</RootNamespace>
+    <AssemblyName>MyService</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Bar.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="paket.references" />
+    <None Include="paket.template" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/Properties/AssemblyInfo.cs
+++ b/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MyService")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MyService")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("379d1079-01cd-4f27-85c8-ee5e1b694d83")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/paket.references
+++ b/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/paket.references
@@ -1,0 +1,1 @@
+﻿File:FsUnit.fs ./customname.fs

--- a/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/paket.templatetemplate
+++ b/integrationtests/scenarios/i001641-rename-file-dependencies/before/Src/MyService/paket.templatetemplate
@@ -1,0 +1,8 @@
+type project
+id PaketDemo.MyService
+version 1.0
+authors Michael Baker
+description
+    Provides some kind of service
+#files
+#    bin\Debug\MyService.dll ==> lib

--- a/integrationtests/scenarios/i001641-rename-file-dependencies/before/paket.dependencies
+++ b/integrationtests/scenarios/i001641-rename-file-dependencies/before/paket.dependencies
@@ -1,0 +1,1 @@
+github forki/FsUnit:7623fc13439f0e60bd05c1ed3b5f6dcb937fe468 FsUnit.fs

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -397,10 +397,15 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
             |> Seq.map (fun kv ->
                 kv.Value.RemoteFiles
                 |> List.map (fun file ->
-                    let link = if file.Link = "." then Path.GetFileName file.Name else Path.Combine(file.Link, Path.GetFileName file.Name)
+                    let fileName = Path.GetFileName <| if Path.HasExtension(file.Link) then file.Link else file.Name
+                    let link = 
+                        let linkIsRelative = file.Link.StartsWith(".")
+                        let addPath path = Path.Combine(Path.GetDirectoryName(file.Link), path)
+                        if linkIsRelative then fileName else addPath fileName
+
                     let remoteFilePath = 
                         if verbose then
-                            tracefn "FileName: %s " file.Name 
+                            tracefn "FileName: %s " fileName 
     
                         let lockFileReference =
                             match lockFile.Groups |> Map.tryFind kv.Key with

--- a/tests/Paket.Tests/ReferencesFile/ReferencesFileSpecs.fs
+++ b/tests/Paket.Tests/ReferencesFile/ReferencesFileSpecs.fs
@@ -50,6 +50,18 @@ let ``should parse custom path correctly``() =
     refFile.RemoteFiles.Head.Name |> shouldEqual "FsUnit.fs"
     refFile.RemoteFiles.Head.Link |> shouldEqual "Tests\Common"
 
+let refFileWithExplicitCustomPath = """
+File:FsUnit.fs Tests\Common\ExplicitName.fs
+"""
+
+[<Test>]
+let ``should parse custom path with explicit target filename correctly``() = 
+    let refFile = ReferencesFile.FromLines(toLines refFileWithExplicitCustomPath).Groups.[Constants.MainDependencyGroup]
+    refFile.NugetPackages.Length |> shouldEqual 0
+    refFile.RemoteFiles.Length |> shouldEqual 1
+    refFile.RemoteFiles.Head.Name |> shouldEqual "FsUnit.fs"
+    refFile.RemoteFiles.Head.Link |> shouldEqual "Tests\Common\ExplicitName.fs"
+
 [<Test>]
 let ``should serialize customPath correctly``() = 
     let refFile = 


### PR DESCRIPTION
### PR Content

Fixes #1641, allows for specifying the linked filename in paket.references with the following formats:

````
File:src/FootballLibrary/Helpers.fs ./Helpers.fs
File:src/SuaveHost/Helpers.fs Custom\Folder\SuaveHelpers.fs
````

Includes tests for command parsing and generation of the correct link in the project file.

### Possible issues before merge

  1. Currently the integration test is downloading a file from github...  I didn't find any other integration tests using paket.references for an example of a workaround during testing

  1. I'm uncertain if UpdatePackageSpecs.fs is the right location for the integration test for a paket.references edit