### PR TITLE
Bring back a parameter to clean the redirects - fixes #1665

### DIFF
--- a/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
+++ b/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
@@ -80,8 +80,8 @@ let ``#1195 should report broken app.config``() =
     | exn when exn.Message.Contains("Project1") && exn.Message.Contains("app.config") -> ()
 
 [<Test>]
-let ``#1218 install should replace all assembly redirects with required only``() = 
-    paket "install --redirects --createnewbindingfiles" "i001218-binding-redirect" |> ignore
+let ``#1218 install hard should replace all assembly redirects with required only``() = 
+    paket "install --redirects --createnewbindingfiles --clean-redirects" "i001218-binding-redirect" |> ignore
 
     let path = Path.Combine(scenarioTempPath "i001218-binding-redirect")
     let config1Path = Path.Combine(path, "Project1", "app.config")
@@ -141,10 +141,88 @@ let ``#1218 install should replace all assembly redirects with required only``()
     config4.Contains ``xunit.extensions`` |> shouldEqual false
     config4 |> shouldContainText ``Castle.Core``
     config4.Contains ``Castle.Windsor`` |> shouldEqual false
+    
+[<Test>]
+let ``#1218 install should replace paket's binding redirects with required only``() = 
+    paket "install --redirects --createnewbindingfiles" "i001218-binding-redirect" |> ignore
+
+    let path = Path.Combine(scenarioTempPath "i001218-binding-redirect")
+    let config1Path = Path.Combine(path, "Project1", "app.config")
+    let config2Path = Path.Combine(path, "Project2", "app.config")
+    let config3Path = Path.Combine(path, "Project3", "app.config")
+    let config4Path = Path.Combine(path, "Project4", "app.config")
+
+    let config1 = File.ReadAllText(config1Path)
+    let config2 = File.ReadAllText(config2Path)
+    let config3 = File.ReadAllText(config3Path)
+    let config4 = File.ReadAllText(config4Path)
+
+    let paketMark = "<Paket>True</Paket>\s*"
+
+    let Albedo = """<assemblyIdentity name="Ploeh.Albedo" publicKeyToken="179ef6dd03497bbd" culture="neutral" />"""
+    let AutoFixture = """<assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let ``AutoFixture.Idioms`` = """<assemblyIdentity name="Ploeh.AutoFixture.Idioms" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let ``AutoFixture.Xunit`` = """<assemblyIdentity name="Ploeh.AutoFixture.Xunit" publicKeyToken="b24654c590009d4f" culture="neutral" />"""
+    let log4net = """<assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />"""
+    let ``Newtonsoft.Json`` = """<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+    let ``Newtonsoft.Json.Schema`` = """<assemblyIdentity name="Newtonsoft.Json.Schema" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
+    let xunit = """<assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
+    let ``xunit.extensions`` = """<assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />"""
+    let ``Castle.Core`` = """<assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
+    let ``Castle.Windsor`` = """<assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />"""
+
+    Regex.IsMatch(config1, paketMark + Albedo) |> shouldEqual true
+    Regex.IsMatch(config1, paketMark + AutoFixture) |> shouldEqual true
+    config1.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config1.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config1.Contains log4net |> shouldEqual false
+    Regex.IsMatch(config1, paketMark + ``Newtonsoft.Json``) |> shouldEqual true
+    config1.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config1.Contains xunit |> shouldEqual false
+    Regex.IsMatch(config1, paketMark + ``xunit.extensions``) |> shouldEqual true
+    Regex.IsMatch(config1, paketMark + ``Castle.Core``) |> shouldEqual true
+    config1.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config2.Contains Albedo |> shouldEqual false
+    config2.Contains AutoFixture |> shouldEqual false
+    config2.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config2.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config2.Contains log4net |> shouldEqual false
+    config2 |> shouldContainText ``Newtonsoft.Json``
+    config2.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config2.Contains xunit |> shouldEqual false
+    config2.Contains ``xunit.extensions`` |> shouldEqual false
+    config2.Contains ``Castle.Core`` |> shouldEqual false
+    config2.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config3.Contains Albedo |> shouldEqual false
+    config3 |> shouldContainText AutoFixture
+    config3.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config3.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config3.Contains log4net |> shouldEqual false
+    Regex.IsMatch(config3, paketMark + ``Newtonsoft.Json``) |> shouldEqual true
+    config3.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config3.Contains xunit |> shouldEqual false
+    config3.Contains ``xunit.extensions`` |> shouldEqual false
+    Regex.IsMatch(config3, paketMark + ``Castle.Core``) |> shouldEqual true
+    config3.Contains ``Castle.Windsor`` |> shouldEqual false
+
+    config4.Contains Albedo |> shouldEqual false
+    config4.Contains AutoFixture |> shouldEqual false
+    config4.Contains ``AutoFixture.Idioms`` |> shouldEqual false
+    config4.Contains ``AutoFixture.Xunit`` |> shouldEqual false
+    config4.Contains log4net |> shouldEqual false
+    config4 |> shouldContainText ``Newtonsoft.Json``
+    config4.Contains ``Newtonsoft.Json.Schema`` |> shouldEqual false
+    config4.Contains xunit |> shouldEqual false
+    config4.Contains ``xunit.extensions`` |> shouldEqual false
+    Regex.IsMatch(config4, paketMark + ``Castle.Core``) |> shouldEqual true
+    config4.Contains ``Castle.Windsor`` |> shouldEqual false
+
 
 [<Test>]
 let ``#1248 install should replace paket's binding redirects with required only and keep stable``() = 
-    paket "install --redirects --createnewbindingfiles" "i001248-stable-redirect" |> ignore
+    paket "install --redirects --clean-redirects --createnewbindingfiles" "i001248-stable-redirect" |> ignore
 
     let originalConfig2Path = Path.Combine(originalScenarioPath "i001248-stable-redirect", "Project2", "app.config")
     
@@ -251,7 +329,7 @@ let ``#1544 redirects off``() =
 
 [<Test>]
 let ``#1574 redirects GAC``() = 
-    paket "install"  "i001574-redirect-gac" |> ignore
+    paket "install --clean-redirects"  "i001574-redirect-gac" |> ignore
     let path = Path.Combine(scenarioTempPath "i001574-redirect-gac")
     let configPath = Path.Combine(path, "BindingRedirectPaketBug", "App.config")
     let originalConfigPath = Path.Combine(path, "BindingRedirectPaketBug", "App.config.expected")

--- a/integrationtests/scenarios/i001544-redirects/before/BindingRedirectPaketBug/App.config.expected
+++ b/integrationtests/scenarios/i001544-redirects/before/BindingRedirectPaketBug/App.config.expected
@@ -4,13 +4,9 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
 
-  
-<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
-  </dependentAssembly>
+  <runtime>
+    
+  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
@@ -19,6 +15,11 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Common.Logging.NLog20" publicKeyToken="af08829b84f0328e" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
   </dependentAssembly>
   <dependentAssembly>
@@ -36,4 +37,5 @@
     <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="8.0.0.0" />
   </dependentAssembly>
-</assemblyBinding></runtime></configuration>
+</assemblyBinding></runtime>
+</configuration>

--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -123,7 +123,7 @@ let private addConfigFileToProject project =
         project.Save(false))
 
 /// Applies a set of binding redirects to a single configuration file.
-let private applyBindingRedirects isFirstGroup (allKnownLibs:Reference seq) bindingRedirects (configFilePath:string) =
+let private applyBindingRedirects isFirstGroup cleanBindingRedirects (allKnownLibs:Reference seq) bindingRedirects (configFilePath:string) =
     let config = 
         try
             XDocument.Load(configFilePath, LoadOptions.PreserveWhitespace)
@@ -132,6 +132,11 @@ let private applyBindingRedirects isFirstGroup (allKnownLibs:Reference seq) bind
 
     use originalContents = new StringReader(config.ToString())
     let original = XDocument.Load(originalContents, LoadOptions.None).ToString()
+
+    let isMarked e =
+        match tryGetElement (Some bindingNs) "Paket" e with
+        | Some e -> String.equalsIgnoreCase (e.Value.Trim()) "true"
+        | None -> false
 
     let libIsContained e =
         let haystack = e.ToString().ToLower()
@@ -145,7 +150,7 @@ let private applyBindingRedirects isFirstGroup (allKnownLibs:Reference seq) bind
     config.XPathSelectElements("//bindings:assemblyBinding", nsManager)
     |> Seq.collect (fun e -> e.Elements(XName.Get("dependentAssembly", bindingNs)))
     |> List.ofSeq
-    |> List.filter (fun e -> isFirstGroup && libIsContained e)
+    |> List.filter (fun e -> isFirstGroup && (cleanBindingRedirects || isMarked e) && libIsContained e)
     |> List.iter (fun e -> e.Remove())
 
     let config = Seq.fold setRedirect config bindingRedirects
@@ -156,7 +161,7 @@ let private applyBindingRedirects isFirstGroup (allKnownLibs:Reference seq) bind
         config.Save(configFilePath, SaveOptions.DisableFormatting)
 
 /// Applies a set of binding redirects to all .config files in a specific folder.
-let applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles rootPath allKnownLibs bindingRedirects =
+let applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles cleanBindingRedirects rootPath allKnownLibs bindingRedirects =
     let applyBindingRedirects projectFile =
         let bindingRedirects = bindingRedirects projectFile
         let path = Path.GetDirectoryName projectFile.FileName
@@ -169,7 +174,7 @@ let applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles rootPath al
                 addConfigFileToProject projectFile
                 Some config
             | _ -> None
-        |> Option.iter (applyBindingRedirects isFirstGroup allKnownLibs bindingRedirects)
+        |> Option.iter (applyBindingRedirects isFirstGroup cleanBindingRedirects allKnownLibs bindingRedirects)
 
     rootPath
     |> getProjectFilesWithPaketReferences Directory.GetFiles

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -196,7 +196,7 @@ let inline private getOrAdd (key: 'key) (getValue: 'key -> 'value) (d: Dictionar
         value
 
 /// Applies binding redirects for all strong-named references to all app. and web.config files.
-let private applyBindingRedirects isFirstGroup createNewBindingFiles redirects 
+let private applyBindingRedirects isFirstGroup createNewBindingFiles redirects cleanBindingRedirects
                                   root groupName findDependencies allKnownLibs 
                                   (projectCache: Dictionary<string, ProjectFile option>) 
                                   extractedPackages =
@@ -289,7 +289,7 @@ let private applyBindingRedirects isFirstGroup createNewBindingFiles redirects
               Culture = None })
         |> Seq.sort
 
-    applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles root allKnownLibs bindingRedirects
+    applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles cleanBindingRedirects root allKnownLibs bindingRedirects
 
 let findAllReferencesFiles root =
     let findRefFile (p:ProjectFile) =
@@ -457,7 +457,6 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
             | true -> Some true
             | false -> None
 
-
         let allKnownLibs =
             model
             |> Seq.map (fun kv -> (snd kv.Value).GetLibReferencesLazy.Force())
@@ -478,6 +477,7 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
                 !first 
                 options.CreateNewBindingFiles
                 (g.Value.Options.Redirects ++ redirects) 
+                options.CleanBindingRedirects
                 (FileInfo project.FileName).Directory.FullName 
                 g.Key 
                 lockFile.GetAllDependenciesOf 

--- a/src/Paket.Core/ProcessOptions.fs
+++ b/src/Paket.Core/ProcessOptions.fs
@@ -16,6 +16,7 @@ type InstallerOptions =
     { Force : bool
       SemVerUpdateMode : SemVerUpdateMode
       Redirects : bool
+      CleanBindingRedirects : bool
       CreateNewBindingFiles : bool
       OnlyReferenced : bool
       TouchAffectedRefs : bool }
@@ -26,12 +27,14 @@ type InstallerOptions =
           SemVerUpdateMode = SemVerUpdateMode.NoRestriction
           CreateNewBindingFiles = false
           OnlyReferenced = false
+          CleanBindingRedirects = false
           TouchAffectedRefs = false }
 
-    static member CreateLegacyOptions(force, redirects, createNewBindingFiles, semVerUpdateMode, touchAffectedRefs) =
+    static member CreateLegacyOptions(force, redirects, cleanBindingRedirects, createNewBindingFiles, semVerUpdateMode, touchAffectedRefs) =
         { InstallerOptions.Default with
             Force = force
             CreateNewBindingFiles = createNewBindingFiles
+            CleanBindingRedirects = cleanBindingRedirects
             Redirects = redirects
             SemVerUpdateMode = semVerUpdateMode
             TouchAffectedRefs = touchAffectedRefs }

--- a/src/Paket.Core/RemoveProcess.fs
+++ b/src/Paket.Core/RemoveProcess.fs
@@ -46,7 +46,7 @@ let private remove removeFromProjects dependenciesFileName groupName (package: P
     
     if installAfter then
         let updatedGroups = Map.add groupName 0 Map.empty
-        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, false, false, SemVerUpdateMode.NoRestriction, false), false, dependenciesFile, lockFile, updatedGroups)
+        InstallProcess.Install(InstallerOptions.CreateLegacyOptions(force, false, false, false, SemVerUpdateMode.NoRestriction, false), false, dependenciesFile, lockFile, updatedGroups)
         GarbageCollection.CleanUp(root, dependenciesFile, lockFile)
 
 /// Removes a package with the option to remove it from a specified project.

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -64,6 +64,7 @@ type AddArgs =
     | [<AltCommandLine("-i")>] Interactive
     | Redirects
     | CreateNewBindingFiles
+    | Clean_Redirects
     | No_Install
     | Keep_Major
     | Keep_Minor
@@ -81,6 +82,7 @@ with
             | Interactive -> "Asks the user for every project if he or she wants to add the package to the projects's paket.references file."
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
+            | Clean_Redirects -> "Removes all binding redirects that are not specified by Paket."
             | No_Install -> "Skips paket install process (patching of csproj, fsproj, ... files) after the generation of paket.lock file."
             | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
             | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
@@ -141,6 +143,7 @@ type InstallArgs =
     | [<AltCommandLine("-f")>] Force
     | Redirects
     | CreateNewBindingFiles
+    | Clean_Redirects
     | Keep_Major
     | Keep_Minor
     | Keep_Patch
@@ -153,6 +156,7 @@ with
             | Force -> "Forces the download and reinstallation of all packages."
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
+            | Clean_Redirects -> "Removes all binding redirects that are not specified by Paket."
             | Install_Only_Referenced -> "Only install packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
             | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
             | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."
@@ -225,6 +229,7 @@ type UpdateArgs =
     | [<AltCommandLine("-f")>] Force
     | Redirects
     | CreateNewBindingFiles
+    | Clean_Redirects
     | No_Install
     | Keep_Major
     | Keep_Minor
@@ -241,6 +246,7 @@ with
             | Force -> "Forces the download and reinstallation of all packages."
             | Redirects -> "Creates binding redirects for the NuGet packages."
             | CreateNewBindingFiles -> "Creates binding redirect files if needed."
+            | Clean_Redirects -> "Removes all binding redirects that are not specified by Paket."
             | No_Install -> "Skips paket install process (patching of csproj, fsproj, ... files) after the generation of paket.lock file."
             | Keep_Major -> "Allows only updates that are not changing the major version of the NuGet packages."
             | Keep_Minor -> "Allows only updates that are not changing the minor version of the NuGet packages."

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -68,6 +68,7 @@ let add (results : ParseResults<_>) =
     let force = results.Contains <@ AddArgs.Force @>
     let redirects = results.Contains <@ AddArgs.Redirects @>
     let createNewBindingFiles = results.Contains <@ AddArgs.CreateNewBindingFiles @>
+    let cleanBindingRedirects = results.Contains <@ AddArgs.Clean_Redirects @>
     let group = results.TryGetResult <@ AddArgs.Group @>
     let noInstall = results.Contains <@ AddArgs.No_Install @>
     let semVerUpdateMode =
@@ -79,10 +80,10 @@ let add (results : ParseResults<_>) =
 
     match results.TryGetResult <@ AddArgs.Project @> with
     | Some projectName ->
-        Dependencies.Locate().AddToProject(group, packageName, version, force, redirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
+        Dependencies.Locate().AddToProject(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
     | None ->
         let interactive = results.Contains <@ AddArgs.Interactive @>
-        Dependencies.Locate().Add(group, packageName, version, force, redirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
+        Dependencies.Locate().Add(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
 
 let validateConfig (results : ParseResults<_>) =
     let credential = results.Contains <@ ConfigArgs.AddCredentials @>
@@ -144,6 +145,7 @@ let install (results : ParseResults<_>) =
     let force = results.Contains <@ InstallArgs.Force @>
     let withBindingRedirects = results.Contains <@ InstallArgs.Redirects @>
     let createNewBindingFiles = results.Contains <@ InstallArgs.CreateNewBindingFiles @>
+    let cleanBindingRedirects = results.Contains <@ InstallArgs.Clean_Redirects @>
     let installOnlyReferenced = results.Contains <@ InstallArgs.Install_Only_Referenced @>
     let semVerUpdateMode =
         if results.Contains <@ InstallArgs.Keep_Patch @> then SemVerUpdateMode.KeepPatch else
@@ -152,7 +154,7 @@ let install (results : ParseResults<_>) =
         SemVerUpdateMode.NoRestriction
     let touchAffectedRefs = results.Contains <@ InstallArgs.Touch_Affected_Refs @>
 
-    Dependencies.Locate().Install(force, withBindingRedirects, createNewBindingFiles, installOnlyReferenced, semVerUpdateMode, touchAffectedRefs)
+    Dependencies.Locate().Install(force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, installOnlyReferenced, semVerUpdateMode, touchAffectedRefs)
 
 let outdated (results : ParseResults<_>) =
     let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
@@ -190,6 +192,7 @@ let update (results : ParseResults<_>) =
     let noInstall = results.Contains <@ UpdateArgs.No_Install @>
     let group = results.TryGetResult <@ UpdateArgs.Group @>
     let withBindingRedirects = results.Contains <@ UpdateArgs.Redirects @>
+    let cleanBindingRedirects = results.Contains <@ UpdateArgs.Clean_Redirects @>
     let createNewBindingFiles = results.Contains <@ UpdateArgs.CreateNewBindingFiles @>
     let semVerUpdateMode =
         if results.Contains <@ UpdateArgs.Keep_Patch @> then SemVerUpdateMode.KeepPatch else
@@ -203,15 +206,15 @@ let update (results : ParseResults<_>) =
     | Some packageName ->
         let version = results.TryGetResult <@ UpdateArgs.Version @>
         if filter then
-            Dependencies.Locate().UpdateFilteredPackages(group, packageName, version, force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
+            Dependencies.Locate().UpdateFilteredPackages(group, packageName, version, force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
         else
-            Dependencies.Locate().UpdatePackage(group, packageName, version, force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
+            Dependencies.Locate().UpdatePackage(group, packageName, version, force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
     | _ ->
         match group with
         | Some groupName -> 
-            Dependencies.Locate().UpdateGroup(groupName, force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
+            Dependencies.Locate().UpdateGroup(groupName, force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
         | None ->
-            Dependencies.Locate().Update(force, withBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
+            Dependencies.Locate().Update(force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, noInstall |> not, semVerUpdateMode, touchAffectedRefs)
 
 let pack (results : ParseResults<_>) =
     let outputPath = results.GetResult <@ PackArgs.Output @>


### PR DESCRIPTION
it was parameter --hard in v2.
This parameter was removed, but --clean-redirects brings the functionality back for the redirects.
This also changes the default back to what paket 2 did and doesn't automatically clean the manual redirects.

@mrinaldi @isaacabraham @konste 