### PR TITLE
Local file: support comments

### DIFF
--- a/docs/content/local-file.md
+++ b/docs/content/local-file.md
@@ -95,3 +95,17 @@ Format of git source is the same as used in `paket.dependencies` for specifying 
 The Format of the source is the same as in [path sources](nuget-dependencies.html#Path-sources).
 
 > Note: In case of source override, `paket restore` assumes the NuGet package **already exists** in   pointed directory - no build is going to be triggered.
+
+### Comments
+
+All lines starting with with `//` or `#` are considered comments.
+
+    [lang=paket]
+    // this line is treated as comment
+    nuget Fake -> source c:\github\FAKE\bin
+
+Comments might prove helpful if you use `paket.local` override on regular basis - instead of typing the override by hand, you can just comment/uncomment relevant line:
+
+    [lang=paket]
+    // uncomment below to override FAKE package
+    // nuget FAKE -> source C:\github\FAKE\bin

--- a/src/Paket.Core/LocalFile.fs
+++ b/src/Paket.Core/LocalFile.fs
@@ -36,7 +36,10 @@ module LocalFile =
             Trial.fail (sprintf "Cannot parse line '%s'" line)
 
     let parse =
-        List.filter (not << String.IsNullOrWhiteSpace)
+        List.map String.trim
+        >> List.filter (not << String.IsNullOrWhiteSpace)
+        >> List.filter (not << String.startsWithIgnoreCase @"//")
+        >> List.filter (not << String.startsWithIgnoreCase @"#")
         >> List.map parseLine
         >> Trial.collect
         >> Trial.lift LocalFile

--- a/tests/Paket.Tests/LocalFile/LocalFileSpecs.fs
+++ b/tests/Paket.Tests/LocalFile/LocalFileSpecs.fs
@@ -24,3 +24,21 @@ let ``should parse single dev source override``() =
     let actual = LocalFile.parse (toLines contents |> Array.toList)
 
     actual |> shouldEqual expected
+
+
+[<Test>]
+let ``should ignore comments``() = 
+    let contents = """
+        // override NUnit with nupkg from local directory
+        nuget NUnit -> source ./local_source
+        # override FAKE with nupkg built from git repository
+        nuget FAKE -> git file:\\\c:/github/FAKE fature_branch build:"build.cmd", Packages: /bin/
+        """
+    
+    let actual = LocalFile.parse (toLines contents |> Array.toList)
+
+    match actual with
+    | Ok (LocalFile overrides, _) ->
+        overrides |> shouldHaveLength 2
+    | Bad msgs ->
+        Assert.Fail (msgs |> String.concat System.Environment.NewLine)


### PR DESCRIPTION
can use `//` or `#`, just as in `paket.dependencies`