### PR TITLE
Add new option --max-file-age

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -1,10 +1,10 @@
 # paket.bootstrapper.exe
 
-Downloads the latest stable paket.exe. By default, the bootstrapper caches downloaded versions of paket.exe for the current user across all projects. If the requested version is not present in the cache, it is downloaded from github.com. If the download from github.com fails it tries to download the version from nuget.org instead. 
+Downloads the latest stable paket.exe. By default, the bootstrapper caches downloaded versions of paket.exe for the current user across all projects. If the requested version is not present in the cache, it is downloaded from github.com. If the download from github.com fails it tries to download the version from nuget.org instead.
 
 Cached paket.exe versions are removed when the NuGet cache folder is [cleared](paket-clear-cache.html).
 
-`Ctrl+C` interrupts the download process. The return value of the bootstrapper is 0 when a paket.exe already exists, so that any subsequent scripts can continue. 
+`Ctrl+C` interrupts the download process. The return value of the bootstrapper is 0 when a paket.exe already exists, so that any subsequent scripts can continue.
 
     [lang=batchfile]
     $ paket.bootstrapper.exe [prerelease|version] [--prefer-nuget] [--self] [-s] [-f]
@@ -19,6 +19,8 @@ Options:
 
   `--force-nuget`: As with the `--prefer-nuget` option, downloads paket.exe from nuget.org instead of github.com, but does *not* use github.com as a fallback.
 
+  `--max-file-age=120`: if the paket.exe already exists, and it is not older than `120` minutes all checks will be skipped.
+
   `--nuget-source`: When specified as `--nuget-source=http://local.site/path/here`, the specified path is used instead of nuget.org when trying to fetch paket.exe as a nuget package. Combine this with either `--prefer-nuget` or `--force-nuget` to get paket.exe from a custom source.
 
   `--self`: Self updating the paket.bootstrapper.exe. When this option is used the download of paket.exe will be skipped. (Can be combined with `--prefer-nuget`)
@@ -31,6 +33,6 @@ Options:
 
 Environment Variables:
 
-  `PAKET.VERSION`: The requested version can also be set using this environment variable. Above options take precedence over the environment variable 
+  `PAKET.VERSION`: The requested version can also be set using this environment variable. Above options take precedence over the environment variable
 
 

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -20,6 +20,7 @@ namespace Paket.Bootstrapper
             public const string SelfUpdate = "--self";
             public const string Silent = "-s";
             public const string IgnoreCache = "-f";
+            public const string MaxFileAge = "--max-file-age=";
         }
         public static class AppSettingKeys
         {
@@ -76,6 +77,7 @@ namespace Paket.Bootstrapper
             bool doSelfUpdate = false;
             var ignoreCache = false;
             var commandArgs = args.ToList();
+            int? maxFileAgeInMinutes = null;
 
             if (commandArgs.Contains(CommandArgs.SelfUpdate))
             {
@@ -93,6 +95,22 @@ namespace Paket.Bootstrapper
                 commandArgs.Remove(CommandArgs.IgnoreCache);
                 ignoreCache = true;
             }
+
+            var maxFileAgeArg = commandArgs.SingleOrDefault(x => x.StartsWith(CommandArgs.MaxFileAge, StringComparison.Ordinal));
+            if (maxFileAgeArg != null)
+            {
+                var parts = maxFileAgeArg.Split("=".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2)
+                {
+                    var maxFileAgeInMinutesCommandArg = parts[1];
+                    int parsedMaxFileAgeInMinutesCommandArg;
+                    if (int.TryParse(maxFileAgeInMinutesCommandArg, out parsedMaxFileAgeInMinutesCommandArg))
+                        maxFileAgeInMinutes = parsedMaxFileAgeInMinutesCommandArg;
+                }
+
+                commandArgs.Remove(maxFileAgeArg);
+            }
+
             if (commandArgs.Count >= 1)
             {
                 if (commandArgs[0] == CommandArgs.Prerelease)
@@ -115,6 +133,7 @@ namespace Paket.Bootstrapper
             downloadArguments.DoSelfUpdate = doSelfUpdate;
             downloadArguments.Target = target;
             downloadArguments.Folder = folder;
+            downloadArguments.MaxFileAgeInMinutes = maxFileAgeInMinutes;
             return commandArgs;
         }
 

--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -18,6 +18,8 @@ Options:
 --force-nuget                  only use nuget as source
 --nuget-source=<NUGET_SOURCE>  uses <NUGET_SOURCE> to download latest paket.
                                NUGET_SOURCE can also be a filepath
+--max-file-age=<IN MINUTES>    if the paket.exe already exists, and it is not 
+                               older than <IN MINUTES> all checks will be skipped.
 --self                         downloads and updates paket.bootstrapper
 -f                             don't use local cache; always downloads
 -s                             silent mode; no output";

--- a/src/Paket.Bootstrapper/DownloadArguments.cs
+++ b/src/Paket.Bootstrapper/DownloadArguments.cs
@@ -11,14 +11,16 @@ namespace Paket.Bootstrapper
         public string LatestVersion { get; set; }
         public bool IgnorePrerelease { get; set; }
         public bool IgnoreCache { get; set; }
+        public int? MaxFileAgeInMinutes { get; set; }
 
         public DownloadArguments()
         {
             IgnorePrerelease = true;
             LatestVersion = String.Empty;
+            MaxFileAgeInMinutes = null;
         }
 
-        public DownloadArguments(string latestVersion, bool ignorePrerelease, string folder, string target, bool doSelfUpdate, string nugetSource, bool ignoreCache)
+        public DownloadArguments(string latestVersion, bool ignorePrerelease, string folder, string target, bool doSelfUpdate, string nugetSource, bool ignoreCache, int? maxFileAgeInMinutes)
         {
             LatestVersion = latestVersion;
             IgnorePrerelease = ignorePrerelease;
@@ -27,6 +29,7 @@ namespace Paket.Bootstrapper
             DoSelfUpdate = doSelfUpdate;
             NugetSource = nugetSource;
             IgnoreCache = ignoreCache;
+            MaxFileAgeInMinutes = maxFileAgeInMinutes;
         }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
@@ -6,7 +6,7 @@ using Paket.Bootstrapper.HelperProxies;
 
 namespace Paket.Bootstrapper.DownloadStrategies
 {
-    internal class CacheDownloadStrategy : ICachedDownloadStrategy
+    internal class CacheDownloadStrategy : IHaveEffectiveStrategy
     {
         public string Name { get { return String.Format("{0} - cached", EffectiveStrategy.Name); } }
         public IDownloadStrategy FallbackStrategy { get; set; }

--- a/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
@@ -9,7 +9,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
         void SelfUpdate(string latestVersion);
     }
 
-    public interface ICachedDownloadStrategy : IDownloadStrategy
+    public interface IHaveEffectiveStrategy : IDownloadStrategy
     {
         IDownloadStrategy EffectiveStrategy { get; }
     }

--- a/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using Paket.Bootstrapper.HelperProxies;
+
+namespace Paket.Bootstrapper.DownloadStrategies
+{
+    internal class TemporarilyIgnoreUpdatesDownloadStrategy : IHaveEffectiveStrategy
+    {
+        private readonly int _maxFileAgeOfPaketExeInMinutes;
+        private readonly string _target;
+        private readonly IFileProxy _fileProxy;
+
+        public TemporarilyIgnoreUpdatesDownloadStrategy(
+            IDownloadStrategy effectiveStrategy, 
+            IFileProxy fileProxy,
+            string target,
+            int maxFileAgeOfPaketExeInMinutes)
+        {
+            if (effectiveStrategy == null)
+                throw new ArgumentException("TemporarilyIgnoreUpdatesDownloadStrategy needs a non-null effective strategy");
+
+            if (string.IsNullOrEmpty(target))
+                throw new ArgumentException("TemporarilyIgnoreUpdatesDownloadStrategy needs a non-empty target");
+            
+            _effectiveStrategy = effectiveStrategy;
+            _maxFileAgeOfPaketExeInMinutes = maxFileAgeOfPaketExeInMinutes;
+            _fileProxy = fileProxy;
+
+            _target = target;
+        }
+
+        public string GetLatestVersion (bool ignorePrerelease)
+        {
+            var targetVersion = string.Empty;
+            try 
+            {
+                targetVersion = _fileProxy.GetLocalFileVersion(_target);
+            } 
+            catch (FileNotFoundException) 
+            {
+                targetVersion = string.Empty;
+            }
+
+            if (!IsOlderThanMaxFileAge())
+            {
+                ConsoleImpl.WriteDebug("Don't looking for new version, as last version is not older tha {0} minutes", _maxFileAgeOfPaketExeInMinutes);
+                return targetVersion;
+            }
+            
+            var latestVersion = _effectiveStrategy.GetLatestVersion(ignorePrerelease);
+            if (latestVersion == targetVersion)
+                TouchTarget(_target);
+
+            return latestVersion;
+        }
+
+        public void DownloadVersion (string latestVersion, string target)
+        {
+            _effectiveStrategy.DownloadVersion(latestVersion, target);
+            TouchTarget(target);
+        }
+
+        public void SelfUpdate (string latestVersion)
+        {
+            _effectiveStrategy.SelfUpdate (latestVersion);
+        }
+
+        public string Name { get { return string.Format("{0} (temporarily ignore updates)", EffectiveStrategy.Name); } }
+
+        public IDownloadStrategy FallbackStrategy { get; set; }
+
+        public IDownloadStrategy EffectiveStrategy {
+            get { return _effectiveStrategy; }
+            set {
+                if (value == null)
+                    throw new ArgumentException("TemporarilyIgnoreUpdatesDownloadStrategy needs a non-null EffecitveStrategy");
+
+                _effectiveStrategy = value;
+            }
+        }
+            
+        private IDownloadStrategy _effectiveStrategy;
+
+        private bool IsOlderThanMaxFileAge()
+        {
+            if (_maxFileAgeOfPaketExeInMinutes <= 0)
+                return true;
+            
+            try 
+            {
+                var lastModification = _fileProxy.GetLastWriteTime(_target);
+
+                return DateTimeProxy.Now > lastModification.AddMinutes(_maxFileAgeOfPaketExeInMinutes);
+            } 
+            catch (FileNotFoundException) 
+            {
+                return true;
+            }
+        }
+
+        private void TouchTarget(string target)
+        {
+            try
+            {
+                _fileProxy.Touch(target);
+            }
+            catch (FileNotFoundException)
+            {
+                ConsoleImpl.WriteDebug("Could not update the timestamps. File {0} not found!", _target);
+            }
+            catch (Exception)
+            {
+                ConsoleImpl.WriteDebug("Could not update the timestamps.");
+            }
+        }
+    }
+}
+

--- a/src/Paket.Bootstrapper/HelperProxies/DateTimeProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/DateTimeProxy.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Paket.Bootstrapper
+{
+    public static class DateTimeProxy
+    {
+        public static Func<DateTime> GetNow 
+        { 
+            get { return _getNow ?? (_getNow = () => DateTime.Now); }
+            set { _getNow = value;}
+        }
+
+        private static Func<DateTime> _getNow = null;
+
+        public static DateTime Now { get { return GetNow(); } }
+    }
+}
+

--- a/src/Paket.Bootstrapper/HelperProxies/FileProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/FileProxy.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.IO.Compression;
+using System;
 
 namespace Paket.Bootstrapper.HelperProxies
 {
@@ -39,6 +40,17 @@ namespace Paket.Bootstrapper.HelperProxies
         {
             ZipFile.ExtractToDirectory(zipFile, targetLocation);
         }
-        
+
+        public DateTime GetLastWriteTime(string filename)
+        {
+            var fileInfo = new FileInfo(filename);
+            return fileInfo.LastWriteTime;
+        }
+
+        public void Touch(string filename)
+        {
+            var fileInfo = new FileInfo(filename);
+            fileInfo.LastWriteTime = fileInfo.LastAccessTime = DateTimeProxy.Now;
+        }
     }
 }

--- a/src/Paket.Bootstrapper/HelperProxies/IFileProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/IFileProxy.cs
@@ -12,5 +12,7 @@ namespace Paket.Bootstrapper.HelperProxies
         string GetLocalFileVersion(string filename);
         void FileMove(string fromFile, string toFile);
         void ExtractToDirectory(string zipFile, string targetLocation);
+        DateTime GetLastWriteTime(string filename);
+        void Touch(string filename);
     }
 }

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SemVer.cs" />
+    <Compile Include="DownloadStrategies\TemporarilyIgnoreUpdatesDownloadStrategy.cs" />
+    <Compile Include="HelperProxies\DateTimeProxy.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.template" />

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -149,7 +149,7 @@ namespace Paket.Bootstrapper
                 gitHubDownloadStrategy.FallbackStrategy = nugetDownloadStrategy;
             }
 
-            return effectiveStrategy;
+            return effectiveStrategy.AsTemporarilyIgnored(dlArgs.MaxFileAgeInMinutes, dlArgs.Target);
         }
 
         private static IDownloadStrategy AsCached(this IDownloadStrategy effectiveStrategy, bool ignoreCache)
@@ -159,5 +159,11 @@ namespace Paket.Bootstrapper
             return new CacheDownloadStrategy(effectiveStrategy, new DirectoryProxy(), new FileProxy());
         }
 
+        private static IDownloadStrategy AsTemporarilyIgnored(this IDownloadStrategy effectiveStrategy, int? maxFileAgeInMinutes, string target)
+        {
+            if (maxFileAgeInMinutes.HasValue)
+                return new TemporarilyIgnoreUpdatesDownloadStrategy(effectiveStrategy, new FileProxy(), target, maxFileAgeInMinutes.Value);
+            return effectiveStrategy;
+        }
     }
 }

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace Paket.Bootstrapper.Tests
 {
@@ -41,9 +42,10 @@ namespace Paket.Bootstrapper.Tests
             Assert.That(result.DownloadArguments.LatestVersion, Is.Empty);
             Assert.That(result.DownloadArguments.NugetSource, Is.Null);
             Assert.That(result.DownloadArguments.Target, Does.EndWith("paket.exe"));
+            Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.Null);
             Assert.That(result.ShowHelp, Is.False);
 
-            var knownProps = new[] { "DownloadArguments.Folder", "DownloadArguments.Target", "DownloadArguments.NugetSource", "DownloadArguments.DoSelfUpdate", "DownloadArguments.LatestVersion", "DownloadArguments.IgnorePrerelease", "DownloadArguments.IgnoreCache", "Silent", "ForceNuget", "PreferNuget", "UnprocessedCommandArgs", "ShowHelp" };
+            var knownProps = new[] { "DownloadArguments.MaxFileAgeInMinutes", "DownloadArguments.Folder", "DownloadArguments.Target", "DownloadArguments.NugetSource", "DownloadArguments.DoSelfUpdate", "DownloadArguments.LatestVersion", "DownloadArguments.IgnorePrerelease", "DownloadArguments.IgnoreCache", "Silent", "ForceNuget", "PreferNuget", "UnprocessedCommandArgs", "ShowHelp" };
             var allProperties = GetAllProperties(result);
             Assert.That(allProperties, Is.Not.Null.And.Count.EqualTo(knownProps.Length));
             Assert.That(allProperties, Is.EquivalentTo(knownProps));
@@ -189,6 +191,45 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             Assert.That(result.DownloadArguments.DoSelfUpdate, Is.True);
+        }
+
+        [Test]
+        public void MaxFileAgeInMinutes()
+        {
+            //arrange
+
+            //act
+            var result = ArgumentParser.ParseArgumentsAndConfigurations(new[] { ArgumentParser.CommandArgs.MaxFileAge + "10" }, null, null);
+
+            //assert
+            Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.EqualTo(10));
+            Assert.That(result.UnprocessedCommandArgs, Is.Empty);
+        }
+
+        [Test]
+        public void MaxFileAgeInMinutes_No_Value()
+        {
+            //arrange
+
+            //act
+            var result = ArgumentParser.ParseArgumentsAndConfigurations(new[] { ArgumentParser.CommandArgs.MaxFileAge }, null, null);
+
+            //assert
+            Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.Null);
+            Assert.That(result.UnprocessedCommandArgs, Is.Empty);
+        }
+
+        [Test]
+        public void MaxFileAgeInMinutes_Non_Integer_Value()
+        {
+            //arrange
+
+            //act
+            var result = ArgumentParser.ParseArgumentsAndConfigurations(new[] { ArgumentParser.CommandArgs.MaxFileAge+"FOO" }, null, null);
+
+            //assert
+            Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.Null);
+            Assert.That(result.UnprocessedCommandArgs, Is.Empty);
         }
 
         [Test]

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
@@ -1,0 +1,176 @@
+using System;
+using Moq;
+using NUnit.Framework;
+using Paket.Bootstrapper.DownloadStrategies;
+using Paket.Bootstrapper.HelperProxies;
+using System.IO;
+
+namespace Paket.Bootstrapper.Tests.DownloadStrategies
+{
+    [TestFixture]
+    public class TemporarilyIgnoreUpdatesDownloadStrategyTest
+    {
+        private const string Target = @"C:\Test\paket.exe";
+        private TemporarilyIgnoreUpdatesDownloadStrategy _sut;
+        private Mock<IDownloadStrategy> _mockEffectiveStrategy;
+        private Mock<IFileProxy> _mockFileProxy;
+        private static readonly DateTime Now = new DateTime(2016, 1, 20, 10, 0, 0);
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockEffectiveStrategy = new Mock<IDownloadStrategy>();
+            _mockFileProxy = new Mock<IFileProxy>();
+            DateTimeProxy.GetNow = () => Now;
+
+            _sut = new TemporarilyIgnoreUpdatesDownloadStrategy(
+                _mockEffectiveStrategy.Object, 
+                _mockFileProxy.Object,
+                Target,
+                10);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            DateTimeProxy.GetNow = null;
+        }
+
+        [Test]
+        public void CreateStrategy_With_NoEffective()
+        {
+            //arrange
+            //act
+            //assert
+            Assert.Throws<ArgumentException>(() => new TemporarilyIgnoreUpdatesDownloadStrategy(null, _mockFileProxy.Object, Target, 10));
+        }
+
+        [Test]
+        public void CreateStrategy_Without_Target()
+        {
+            //arrange
+            //act
+            //assert
+            Assert.Throws<ArgumentException>(() => new TemporarilyIgnoreUpdatesDownloadStrategy(_mockEffectiveStrategy.Object, _mockFileProxy.Object, string.Empty, 10));
+        }
+
+        [Test]
+        public void Name()
+        {
+            //arrange
+            _mockEffectiveStrategy.SetupGet(x => x.Name).Returns("any");
+
+            //act
+            //assert
+            Assert.That(_sut.Name, Is.EqualTo("any (temporarily ignore updates)"));
+        }
+
+        [Test]
+        public void GetLatestVersion_Target_Does_Not_Exist()
+        {
+            //arrange
+            _mockFileProxy
+                .Setup(fp => fp.GetLastWriteTime(Target))
+                .Throws<FileNotFoundException>();
+
+            _mockFileProxy
+                .Setup(fp => fp.GetLocalFileVersion(Target))
+                .Throws<FileNotFoundException>();
+
+            _mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Returns("any");
+
+            //act
+            var result = _sut.GetLatestVersion(true);
+
+            //assert
+            Assert.That(result, Is.EqualTo("any"));
+            _mockFileProxy.Verify();
+            _mockEffectiveStrategy.Verify();
+        }
+
+        [Test]
+        public void GetLatestVersion_Target_Is_Newer_Than_Threshold()
+        {
+            //arrange
+            _mockFileProxy.Setup(fp => fp.GetLastWriteTime(Target)).Returns(Now.AddMinutes(-9));
+            _mockFileProxy.Setup(fp => fp.GetLocalFileVersion(Target)).Returns("any");
+            _mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Returns("new");
+
+            //act
+            var result = _sut.GetLatestVersion(true);
+
+            //assert
+            Assert.That(result, Is.EqualTo("any"));
+
+            _mockFileProxy.Verify();
+            _mockEffectiveStrategy.Verify(es => es.GetLatestVersion(true), Times.Never());
+        }
+
+        [Test]
+        public void GetLatestVersion_Target_Is_Older_Than_Threshold()
+        {
+            //arrange
+            _mockFileProxy.Setup(fp => fp.GetLastWriteTime(Target)).Returns(Now.AddMinutes(-11));
+            _mockFileProxy.Setup(fp => fp.GetLocalFileVersion(Target)).Returns("any");
+            _mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Returns("new");
+
+            //act
+            var result = _sut.GetLatestVersion(true);
+
+            //assert
+            Assert.That(result, Is.EqualTo("new"));
+
+            _mockFileProxy.Verify();
+            _mockFileProxy.Verify(fp => fp.Touch(Target), Times.Never());
+            _mockEffectiveStrategy.Verify();
+        }
+
+        [Test]
+        public void GetLatestVersion_Target_Is_Older_Than_Threshold_Same_Version()
+        {
+            //arrange
+            _mockFileProxy.Setup(fp => fp.GetLastWriteTime(Target)).Returns(Now.AddMinutes(-11));
+            _mockFileProxy.Setup(fp => fp.GetLocalFileVersion(Target)).Returns("any");
+            _mockFileProxy.Setup(fp => fp.Touch(Target)).Verifiable();
+            _mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Returns("any");
+
+            //act
+            var result = _sut.GetLatestVersion(true);
+
+            //assert
+            Assert.That(result, Is.EqualTo("any"));
+
+            _mockFileProxy.Verify();
+            _mockEffectiveStrategy.Verify();
+        }
+            
+        [Test]
+        public void SelfUpdate()
+        {
+            //arrange
+            _mockEffectiveStrategy.Setup(x => x.SelfUpdate("any")).Verifiable();
+
+            //act
+            _sut.SelfUpdate("any");
+
+            //assert
+            _mockEffectiveStrategy.Verify();
+        }
+
+        [Test]
+        public void DownloadVersion_Touches_Target()
+        {
+            //arrange
+            _mockFileProxy.Setup(fp => fp.Touch(Target)).Verifiable();
+            _mockEffectiveStrategy.Setup(x => x.DownloadVersion("any", Target)).Verifiable();
+
+            //act
+            _sut.DownloadVersion("any", Target);
+
+            //assert
+            _mockEffectiveStrategy.Verify();
+            _mockFileProxy.Verify();
+        }
+    }
+}
+

--- a/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
+++ b/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="DownloadStrategies\GitHubDownloadStrategyTest.cs" />
     <Compile Include="SemVerTests.cs" />
     <Compile Include="StartPaketBootstrappingTests.cs" />
+    <Compile Include="DownloadStrategies\TemporarilyIgnoreUpdatesDownloadStrategyTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.paket\paket.targets" />

--- a/tests/Paket.Bootstrapper.Tests/ProgramTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ProgramTests.cs
@@ -14,7 +14,7 @@ namespace Paket.Bootstrapper.Tests
             //arrange
 
             //act
-            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false);
+            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
             var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false);
 
             //assert
@@ -31,7 +31,7 @@ namespace Paket.Bootstrapper.Tests
             //arrange
 
             //act
-            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false);
+            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
             var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, false);
 
             //assert
@@ -47,7 +47,7 @@ namespace Paket.Bootstrapper.Tests
             //arrange
 
             //act
-            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false);
+            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
             var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true);
 
             //assert
@@ -62,7 +62,7 @@ namespace Paket.Bootstrapper.Tests
             //arrange
 
             //act
-            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false);
+            var downloadArguments =  new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
             var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, true);
 
             //assert
@@ -77,13 +77,47 @@ namespace Paket.Bootstrapper.Tests
             //arrange
 
             //act
-            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, true);
+            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, true, null);
             var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false);
 
             //assert
             Assert.That(strategy, Is.TypeOf<GitHubDownloadStrategy>());
             Assert.That(strategy.FallbackStrategy, Is.TypeOf<NugetDownloadStrategy>());
             Assert.That(strategy.FallbackStrategy.FallbackStrategy, Is.Null);
+        }
+
+        [Test]
+        public void GetDownloadStrategy_NotCached_TemporarilyIgnored()
+        {
+            //arrange
+
+            //act
+            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, true, 10);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false);
+
+            //assert
+            Assert.That(strategy, Is.TypeOf<TemporarilyIgnoreUpdatesDownloadStrategy>());
+            var effectiveStrategy = ((TemporarilyIgnoreUpdatesDownloadStrategy)strategy).EffectiveStrategy;
+            Assert.That(effectiveStrategy, Is.TypeOf<GitHubDownloadStrategy>());
+            Assert.That(effectiveStrategy.FallbackStrategy, Is.TypeOf<NugetDownloadStrategy>());
+            Assert.That(effectiveStrategy.FallbackStrategy.FallbackStrategy, Is.Null);
+            Assert.That(strategy.FallbackStrategy, Is.Null);
+        }
+
+        [Test]
+        public void GetDownloadStrategy_TemporarilyIgnored_Cached_Nuget_Nothing()
+        {
+            //arrange
+
+            //act
+            var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, 10);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true);
+
+            //assert
+            Assert.That(strategy, Is.TypeOf<TemporarilyIgnoreUpdatesDownloadStrategy>());
+            Assert.That(((TemporarilyIgnoreUpdatesDownloadStrategy)strategy).EffectiveStrategy, Is.TypeOf<CacheDownloadStrategy>());
+            Assert.That(((CacheDownloadStrategy)((TemporarilyIgnoreUpdatesDownloadStrategy)strategy).EffectiveStrategy).EffectiveStrategy, Is.TypeOf<NugetDownloadStrategy>());
+            Assert.That(strategy.FallbackStrategy, Is.Null);
         }
     }
 }


### PR DESCRIPTION
for temporarily preventing a delay while checking the new file version.

**this is a reapply of PR #1617, as that one was accidentally rebased**

Use case:
The internet on my workplace is occasionally very slow. My build scripts call the bootstrapper on every call (in case paket.exe is missing). This leads usually to a hit to "GetNewVersion", which sometimes slows the build process down, as I build very often via command line.
With this command line parameter it is possible to delay this check for a new version so it will be checked for example only every 4 hours. If the paket.exe exists and the last write time of the paket.exe is not older than the given threshold, the bootstrapper will not check the version, so the network hit is not there anymore.