### PR TITLE
Fix small typo and use constants

### DIFF
--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -121,7 +121,11 @@ let Restore(dependenciesFileName,force,group,referencesFileNames) =
 
         match dependenciesFile.Groups |> Map.tryFind kv.Value.Name with
         | None ->
-            failwithf "The group %O was not found in the paket.lock file but not in the paket.dependencies file. Please run \"paket install\" again." kv.Value.Name
+            failwithf 
+                "The group %O was found in the %s file but not in the %s file. Please run \"paket install\" again." 
+                kv.Value
+                Constants.LockFileName
+                Constants.DependenciesFileName
         | Some depFileGroup ->        
             restore(root, kv.Key, depFileGroup.Sources, force, lockFile,Set.ofSeq packages)
             |> Async.RunSynchronously


### PR DESCRIPTION
"The group was not found" ==> "The group was found"