### PR TITLE
Update FSharp.Formatting highlighter for Paket code

### DIFF
--- a/docs/content/caches.md
+++ b/docs/content/caches.md
@@ -30,7 +30,7 @@ Configuration of additional network share as caches can be done in the  [`paket.
 Many projects decide to commit all dependencies into the version control system.
 Some people argue that this bloats the version control system, but it also ensures that dependencies are always available after checkout.
 
-With a local dependencies cache you can instruct Paket to copy dependencies to a local folder. 
+With a local dependencies cache you can instruct Paket to copy dependencies to a local folder.
 This folder will then contain the `*.nupkgs files` of all dependencies and can be committed to source control.
 
 <blockquote>In contrast to the default <i>packages</i> folder this new folder will only contain the zipped dependencies. This way the <i>packages</i> folder which contains also the unzipped versions can still be gitignored.</blockquote>
@@ -39,7 +39,7 @@ The configuration can be done in the  [`paket.dependencies` file](dependencies-f
 
     [lang=paket]
     source https://nuget.org/api/v2
-	cache ./nupkgs versions:current
+	cache ./nupkgs versions: current
 
     nuget Newtonsoft.Json
     nuget UnionArgParser
@@ -57,4 +57,4 @@ Paket allows you two caching options:
 All configured caches are automatically used as additional package feeds. So if a package gets removed from the central repository even "paket update" will work.
 The fact that it's now only found in the cache will be written to the [`paket.lock` file](lock-file.html).
 
-All packages in the cache are treated as "unlisted". This means Paket's resolver will only use these packages in a new resolution if the central feed has no unlisted packages. 
+All packages in the cache are treated as "unlisted". This means Paket's resolver will only use these packages in a new resolution if the central feed has no unlisted packages.

--- a/docs/content/git-dependencies.md
+++ b/docs/content/git-dependencies.md
@@ -45,9 +45,9 @@ You can read more about the version range details in the corresponding [NuGet re
 If your referenced git repository contains a build script then Paket can execute this scipt after restore:
 
     [lang=paket]
-    git https://github.com/forki/nupkgtest.git master build:"build.cmd", OS:windows
-    git https://github.com/forki/nupkgtest.git master build:"build.sh", OS:mono
-    
+    git https://github.com/forki/nupkgtest.git master build: "build.cmd", OS: windows
+    git https://github.com/forki/nupkgtest.git master build: "build.sh", OS: mono
+
 This allows you to excute arbitray commands after restore.
 
 ## Using Git repositories as NuGet source
@@ -74,8 +74,8 @@ The generated [`paket.lock` file](lock-file.html) will look like this:
 It's also possible to [run build scripts](git-dependencies.html#Running-a-build-in-git-repositories) to create the NuGet packages:
 
     [lang=paket]
-    git https://github.com/forki/nupkgtest.git master build:"build.cmd", Packages: /source/, OS:windows
-    git https://github.com/forki/nupkgtest.git master build:"build.sh", Packages: /source/, OS:mono
+    git https://github.com/forki/nupkgtest.git master build: "build.cmd", Packages: /source/, OS: windows
+    git https://github.com/forki/nupkgtest.git master build: "build.sh", Packages: /source/, OS: mono
 
     nuget Argu
 

--- a/docs/content/github-dependencies.md
+++ b/docs/content/github-dependencies.md
@@ -31,7 +31,7 @@ By default the `master` branch is used to determine the commit to reference, you
 If you want to reference the file in one of your project files then add an entry to the project's [`paket.references` file.](references-files.html):
 
     [lang=paket]
-    File:FsUnit.fs
+    File: FsUnit.fs
 
 and run [`paket install` command](paket-install.html). This will reference the linked file directly into your project and by default, be visible under ``paket-files`` folder in project.
 
@@ -40,14 +40,14 @@ and run [`paket install` command](paket-install.html). This will reference the l
 You can specify custom folder for the file:
 
     [lang=paket]
-    File:FsUnit.fs Tests\FsUnit
+    File: FsUnit.fs Tests\FsUnit
 
 ![alt text](img/github_ref_custom_link.png "GitHub file referenced in project with custom link")
 
 Or if you use ``.`` for the directory, the file will be placed under the root of the project:
 
     [lang=paket]
-    File:FsUnit.fs .
+    File: FsUnit.fs .
 
 ![alt text](img/github_ref_root.png "GitHub file referenced in project under root of project")
 
@@ -56,8 +56,8 @@ Or if you use ``.`` for the directory, the file will be placed under the root of
 You can also reference a complete [github.com](http://www.github.com) repository by specifying the repository id in the [`paket.dependencies` file](dependencies-file.html):
 
     [lang=paket]
-    github tpetricek/FSharp.Formatting                                         // master branch 
-    github tpetricek/FSharp.Formatting:2.13.5                                  // version 2.13.5 
+    github tpetricek/FSharp.Formatting                                         // master branch
+    github tpetricek/FSharp.Formatting:2.13.5                                  // version 2.13.5
     github tpetricek/FSharp.Formatting:30cd5366a4f3f25a443ca4cd62cd592fd16ac69 // specific commit 30cd5366a4f3f25a443ca4cd62cd592fd16ac69  
 
 This will download the given repository and put it into your `paket-files` folder. In this case we download the source of [reveal.js](http://lab.hakim.se/reveal-js/#/).

--- a/docs/content/http-dependencies.md
+++ b/docs/content/http-dependencies.md
@@ -21,7 +21,7 @@ If you run the [`paket install` command](paket-install.html), it will add a new 
 If you want to reference the file in one of your project files then add an entry to the project's [`paket.references` file.](references-files.html):
 
     [lang=paket]
-    File:test1.fs
+    File: test1.fs
 
 This will reference the linked file directly into your project.
 By default the linked file will be visible under ``paket-files`` folder in project.

--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -88,11 +88,11 @@ If you omit the version constraint then Paket will assume `>= 0`:
 
 <blockquote>We consider a situation with 3 packages A, B and C.
 
-A and B are direct (or root level) dependencies, but both have a dependency on C. 
-A needs exactly C 1.0 and B wants version 1.1 of C. 
+A and B are direct (or root level) dependencies, but both have a dependency on C.
+A needs exactly C 1.0 and B wants version 1.1 of C.
 This is a version conflict and Paket will complain during resolution phase.
 
-If we specify C = 1.1 in the dependencies file then Paket still considers this as a version conflict with the version requirement in A. 
+If we specify C = 1.1 in the dependencies file then Paket still considers this as a version conflict with the version requirement in A.
 By specifying C == 1.1 we overwrite all other requirements and paket will not complain about the conflict anymore.</blockquote>
 
 If your transitive dependencies result in a version conflict you might want to instruct Paket to use a specific version. The `==` operator allows you to manually resolve the conflict:
@@ -274,7 +274,7 @@ To request Paket to override the resolver strategy for the transitive dependenci
     strategy: min
     source https://nuget.org/api/v2
 
-    nuget Example ~> 1.2 strategy:max
+    nuget Example ~> 1.2 strategy: max
 
 This effectively will get you the *latest matching versions* of `Example`'s dependencies.
 The following code is doing the same by using the `@` operator in your version constraint:
@@ -325,7 +325,7 @@ To request Paket to override the resolver strategy for a package, use the `lowes
     [lang=paket]
     source https://nuget.org/api/v2
 
-    nuget Example ~> 1.2 lowest_matching:true
+    nuget Example ~> 1.2 lowest_matching: true
 
 ### Specifying multiple targeting options
 

--- a/docs/content/references-files.md
+++ b/docs/content/references-files.md
@@ -36,14 +36,14 @@ Any [roslyn based analyzer](analyzers.html) present in the packages will also be
 It's possible to influence the `Private` property for references in project files:
 
     [lang=paket]
-    Newtonsoft.Json copy_local:false
+    Newtonsoft.Json copy_local: false
 
 ## import_targets settings
 
 If you don't want to import `.targets` and `.props` files you can disable it via the `import_targets` switch:
 
     [lang=paket]
-    Microsoft.Bcl.Build import_targets:false
+    Microsoft.Bcl.Build import_targets: false
 
 ## No content option
 

--- a/paket.lock
+++ b/paket.lock
@@ -19,7 +19,7 @@ NUGET
   specs:
     FAKE (4.25.4)
     FSharp.Compiler.Service (2.0.0.6)
-    FSharp.Formatting (2.14.2)
+    FSharp.Formatting (2.14.3)
       FSharp.Compiler.Service (2.0.0.6)
       FSharpVSPowerTools.Core (>= 2.3 < 2.4)
     FSharpVSPowerTools.Core (2.3)
@@ -32,11 +32,11 @@ NUGET
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Octokit (0.19)
-      Microsoft.Net.Http
+      Microsoft.Net.Http  - framework: net10, net11, net20, net30, net35, net40, net40-full
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (3bf706bd6058733a1a034755741076b3953aaf09)
+    modules/Octokit/Octokit.fsx (8c077f35f8cd0350485109ddd1810dafe9885d1a)
       Octokit
 GROUP Test
 NUGET


### PR DESCRIPTION
This update contains the fixes to tpetricek/FSharp.Formatting#397

Keywords have to have a space after in order to be recognized as such.