### PR TITLE
generate-include-scripts: fix edge case of nuget package with mscorlib dep

### DIFF
--- a/integrationtests/scenarios/loading-scripts/mscorlib/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/mscorlib/before/paket.dependencies
@@ -1,0 +1,3 @@
+source http://nuget.org/api/v2
+
+nuget Microsoft.Azure.Management.ResourceManager = 1.1.1-preview

--- a/src/Paket.Core/ScriptGeneration.fs
+++ b/src/Paket.Core/ScriptGeneration.fs
@@ -96,6 +96,14 @@ module ScriptGeneration =
 
     let frameworkRefLines =
       input.FrameworkReferences
+      |> List.filter (
+          function 
+          | "mscorlib" ->
+              // we never want to reference mscorlib directly (some nuget package state it as a dependency)
+              // reason is that having it referenced more than once fails in FSI
+              false 
+          | _ -> true
+      )
       |> List.map (sprintf """#r "%s" """)
 
     let dllLines =


### PR DESCRIPTION
FSI can't have that reference added more than once and it doesn't need it AFAIK

With this change, we do not generate `#r "mscorlib"` in F# scripts anymore.