### PR TITLE
Fix for #1718 : paket update fails on silverlight projects

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -897,10 +897,31 @@ module ProjectFile =
 
     let getTargetFrameworkProfile (project:ProjectFile) = getProperty "TargetFrameworkProfile" project
 
+    let getTargetProfile (project:ProjectFile) =
+        match getTargetFrameworkProfile project with
+        | Some profile when profile = "Client" ->
+            SinglePlatform (DotNetFramework FrameworkVersion.V4_Client)
+        | Some profile when String.IsNullOrWhiteSpace profile |> not ->
+            KnownTargetProfiles.FindPortableProfile profile
+        | _ ->
+            let prefix =
+                match getTargetFrameworkIdentifier project with
+                | None -> "net"
+                | Some x -> x
+            let framework = getProperty "TargetFrameworkVersion" project
+            let defaultResult = SinglePlatform (DotNetFramework FrameworkVersion.V4)
+            match framework with
+            | None -> defaultResult
+            | Some s ->
+                match FrameworkDetection.Extract(prefix + s.Replace("v","")) with
+                | None -> defaultResult
+                | Some x -> SinglePlatform x
+
     let getTargetFramework (project:ProjectFile) = 
-        match getProperty "TargetFrameworkVersion" project with
-        | None -> None
-        | Some v -> FrameworkDetection.Extract(v.Replace("v","net"))
+        match getTargetProfile project with
+        | SinglePlatform x -> Some x
+        | PortableProfile (_, x::_) -> Some x
+        | _ -> None
 
     let updateReferences
             (completeModel: Map<GroupName*PackageName,_*InstallModel>) 
@@ -1161,26 +1182,6 @@ module ProjectFile =
                 | "WinExe" -> ProjectOutputType.Exe
                 | _        -> ProjectOutputType.Library }
         |> Seq.head
-
-    let getTargetProfile (project:ProjectFile) =
-        match getTargetFrameworkProfile project with
-        | Some profile when profile = "Client" ->
-            SinglePlatform (DotNetFramework FrameworkVersion.V4_Client)
-        | Some profile when String.IsNullOrWhiteSpace profile |> not ->
-            KnownTargetProfiles.FindPortableProfile profile
-        | _ ->
-            let prefix =
-                match getTargetFrameworkIdentifier project with
-                | None -> "net"
-                | Some x -> x
-            let framework = getProperty "TargetFrameworkVersion" project
-            let defaultResult = SinglePlatform (DotNetFramework FrameworkVersion.V4)
-            match framework with
-            | None -> defaultResult
-            | Some s ->
-                match FrameworkDetection.Extract(prefix + s.Replace("v","")) with
-                | None -> defaultResult
-                | Some x -> SinglePlatform x
     
     let addImportForPaketTargets relativeTargetsPath (project:ProjectFile) =
         match project.Document 

--- a/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
@@ -4,22 +4,27 @@ open Paket
 open NUnit.Framework
 open FsUnit
 
-[<Test>]
-let ``should detect TargetFramework in Project2 proj file``() =
-    ProjectFile.TryLoad("./ProjectFile/TestData/Project2.fsprojtest").Value.GetTargetProfile().ToString()
-    |> shouldEqual "net40"
+let TestData: obj[][] = 
+    [|
+        // project file name, expected TargetProfile 
+        [|"Project2.fsprojtest";
+            (SinglePlatform(DotNetFramework FrameworkVersion.V4_Client));
+            "net40"|];
+        [|"Empty.fsprojtest";
+            (SinglePlatform(DotNetFramework FrameworkVersion.V4));
+            "net40-full"|];
+        [|"NewSilverlightClassLibrary.csprojtest";
+            (SinglePlatform(Silverlight("v5.0")));
+            "sl50"|];
+        [|"FSharp.Core.Fluent-3.1.fsprojtest";
+            (PortableProfile("Profile259", [ DotNetFramework FrameworkVersion.V4_5; Windows "v4.5"; WindowsPhoneSilverlight "v8.0"; WindowsPhoneApp "v8.1" ]));
+            "portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1"|];
+    |]
 
 [<Test>]
-let ``should detect net40 in empty proj file``() =
-    ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GetTargetProfile().ToString()
-    |> shouldEqual "net40-full"
+[<TestCaseSource("TestData")>]
+let ``should detect the correct framework on test projects`` projectFile expectedProfile expectedProfileString =
+    let p = ProjectFile.TryLoad("./ProjectFile/TestData/" + projectFile).Value
+    p.GetTargetProfile() |> shouldEqual expectedProfile
+    p.GetTargetProfile().ToString() |> shouldEqual expectedProfileString
 
-[<Test>]
-let ``should detect silverlight framework in new silverlight project2``() =
-    ProjectFile.TryLoad("./ProjectFile/TestData/NewSilverlightClassLibrary.csprojtest").Value.GetTargetProfile()
-    |> shouldEqual (SinglePlatform(Silverlight("v5.0")))
-
-[<Test>]
-let ``should detect portable profile``() =
-    ProjectFile.TryLoad("./ProjectFile/TestData/FSharp.Core.Fluent-3.1.fsprojtest").Value.GetTargetProfile()
-    |> shouldEqual (PortableProfile("Profile259", [ DotNetFramework FrameworkVersion.V4_5; Windows "v4.5"; WindowsPhoneSilverlight "v8.0"; WindowsPhoneApp "v8.1" ]))

--- a/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
@@ -6,25 +6,33 @@ open FsUnit
 
 let TestData: obj[][] = 
     [|
-        // project file name, expected TargetProfile 
+        // project file name, 
+        //  expected TargetProfile 
+        //  expected TargetProfile.ToString
+        //  expected TargetFramework
         [|"Project2.fsprojtest";
             (SinglePlatform(DotNetFramework FrameworkVersion.V4_Client));
-            "net40"|];
+            "net40";
+            (Some(DotNetFramework FrameworkVersion.V4_Client))|];
         [|"Empty.fsprojtest";
             (SinglePlatform(DotNetFramework FrameworkVersion.V4));
-            "net40-full"|];
+            "net40-full";
+            (Some(DotNetFramework FrameworkVersion.V4))|];
         [|"NewSilverlightClassLibrary.csprojtest";
             (SinglePlatform(Silverlight("v5.0")));
-            "sl50"|];
+            "sl50";
+            (Some(Silverlight "v5.0"))|];
         [|"FSharp.Core.Fluent-3.1.fsprojtest";
             (PortableProfile("Profile259", [ DotNetFramework FrameworkVersion.V4_5; Windows "v4.5"; WindowsPhoneSilverlight "v8.0"; WindowsPhoneApp "v8.1" ]));
-            "portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1"|];
+            "portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1";
+            (Some(DotNetFramework FrameworkVersion.V4_5))|];
     |]
 
 [<Test>]
 [<TestCaseSource("TestData")>]
-let ``should detect the correct framework on test projects`` projectFile expectedProfile expectedProfileString =
+let ``should detect the correct framework on test projects`` projectFile expectedProfile expectedProfileString expectedTargetFramework =
     let p = ProjectFile.TryLoad("./ProjectFile/TestData/" + projectFile).Value
     p.GetTargetProfile() |> shouldEqual expectedProfile
     p.GetTargetProfile().ToString() |> shouldEqual expectedProfileString
+    p.GetTargetFramework() |> shouldEqual expectedTargetFramework
 


### PR DESCRIPTION
Some refactoring of the tests in TargetFrameworkSpecs.fs.

Implemented getTargetFramework by using getTargetProfile.