### PR TITLE
Local Git deps - better error message when git hash not found

### DIFF
--- a/src/Paket.Core/RemoteDownload.fs
+++ b/src/Paket.Core/RemoteDownload.fs
@@ -57,12 +57,15 @@ let getSHA1OfBranch origin owner project (versionRestriction:VersionRestriction)
                 return ""
         | ModuleResolver.Origin.GitLink (LocalGitOrigin path) ->
             let path = path.Replace(@"file:///", "")
-            return 
+            let branch = 
                 match versionRestriction with
-                | VersionRestriction.NoVersionRestriction -> Git.Handling.getHash path ""
-                | VersionRestriction.Concrete branch      -> Git.Handling.getHash path branch
-                | _                                       -> None
-                |> Option.get
+                | VersionRestriction.NoVersionRestriction -> "master"
+                | VersionRestriction.Concrete branch      -> branch
+                | _ -> failwith "unexpected version restriction"
+            
+            match Git.Handling.getHash path branch with
+                | Some hash -> return hash
+                | None -> return failwithf "Could not find hash for %s in '%s'" branch path
         | ModuleResolver.Origin.GitLink (RemoteGitOrigin url) ->
             return
                 match versionRestriction with


### PR DESCRIPTION
From

```
λ .paket\paket.exe restore
Paket version 3.0.0.0
paket.local override: nuget FsCheck.Xunit -> file:///c:\github\FsCheck 2.5.1 build:"build.cmd PaketPack", Packages: /bin/
Paket failed with:
        The option value was None
Parameter name: option
```

To

```
λ c:\github\Paket\bin\paket.exe restore
Paket version 3.0.0.0
paket.local override: nuget FsCheck.Xunit -> file:///c:\github\FsCheck 2.5.1 build:"build.cmd PaketPack", Packages: /bin/
Paket failed with:
        Could not find hash for 2.5.1 in 'c:\github\FsCheck'
```