### PR TITLE
Update documentation for Paket 3 and fix spelling and grammar mistakes

### DIFF
--- a/docs/content/analyzers.md
+++ b/docs/content/analyzers.md
@@ -63,8 +63,8 @@ project type :
 
 - There is currently no way to create analyzers for F#.
 - The `dotnet` part of the path is in fact the host platform that is targeted. The only one currently in existence
-  is the roslyn compiler and it require the `dotnet` framework.
-- The roslyn developers maintains some analyzers under the
+  is the Roslyn compiler and it require the `dotnet` framework.
+- The Roslyn developers maintains some analyzers under the
   [roslyn-analyzers](https://github.com/dotnet/roslyn-analyzers) project but others have started to appear
   like [Refactoring Essentials](http://vsrefactoringessentials.com/) or
   [Code Cracker](https://code-cracker.github.io/).

--- a/docs/content/caches.md
+++ b/docs/content/caches.md
@@ -1,6 +1,6 @@
 # Additional Caches
 
-<blockquote>This feature is only available in Paket 3.0 alpha versions.</blockquote>
+<blockquote>This feature is only available in Paket 3.0.</blockquote>
 
 Paket works well with central repositories like [nuget.org](https://www.nuget.org/) or [myget.org](http://myget.org/). Under normal circumstances these repositories are always available and allow you to retrieve all packages for the rest of all time.
 Unfortunately there are times when the central repository is not reachable or even worse: packages can be removed permanently from the feed.
@@ -50,7 +50,7 @@ The configuration can be done in the  [`paket.dependencies` file](dependencies-f
 Paket allows you two caching options:
 
 * `versions:all` - stores all currently used version of the dependencies.
-* `versions:current` - stores only currently used version of the dependencies and deletes all other version. This option should not be used with netwok shares since it might affect other projects.
+* `versions:current` - stores only currently used version of the dependencies and deletes all other version. This option should not be used with network shares since it might affect other projects.
 
 ## Caches as package feeds
 

--- a/docs/content/convert-from-nuget-tutorial.md
+++ b/docs/content/convert-from-nuget-tutorial.md
@@ -6,7 +6,7 @@ Paket comes with a command that helps to convert existing solution from NuGet's 
 If you want to use the command then:
 
   * Please start by making a **back-up of your repository**
-  * Download Paket and it's BootStrapper as described in the ["Getting started" tutorial](getting-started.html#Downloading-Paket-and-it-s-BootStrapper)
+  * Download Paket and it's bootstrapper as described in the ["Getting started" tutorial](getting-started.html#Downloading-Paket-and-it-s-BootStrapper)
   * Run the `convert-from-nuget` command:
 
 
@@ -19,9 +19,9 @@ You can read more about the details and specific parameters for `convert-from-nu
 
 Choose a folder to run the conversion from that is parent to **all** the projects to be converted.
 
-When using nuget package restore, the ``packages`` folder is alongside the solution. It is possible with a solution that the folder parent to ``packages`` is **not** also parent to all the projects in the solution.
+When using NuGet package restore, the ``packages`` folder is alongside the solution. It is possible with a solution that the folder parent to ``packages`` is **not** also parent to all the projects in the solution.
 
-A solution is in effect acting as a symlink but this indirection via the solution is not possible with paket because paket manages projects and not solutions. In the example below, it would not be possible to run the ``paket convert-from-nuget`` command from the ``Build`` folder but it would be from the root folder.
+A solution is in effect acting as a symlink but this indirection via the solution is not possible with Paket because Paket manages projects and not solutions. In the example below, it would not be possible to run the ``paket convert-from-nuget`` command from the ``Build`` folder but it would be from the root folder.
 
 <pre>
 +---Build

--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -182,7 +182,7 @@ The strategy can be either `min` or `max` with max being the default.
 
     nuget UnionArgParser ~> 0.7
 
-A `min` strategy means you get the *lowest matching version* of your transitive dependencies (i.e. NuGet-style). In constrast, a `max` strategy will get you the *highest matching version*.
+A `min` strategy means you get the *lowest matching version* of your transitive dependencies (i.e. NuGet-style). In contrast, a `max` strategy will get you the *highest matching version*.
 
 Note, however, that all direct dependencies will still get their *latest matching versions*, no matter the value of the `strategy` option.
 If you want to influence the resolution of direct dependencies then read about the [lowest_matching option](dependencies-file.html#Lowest_matching-option).
@@ -204,7 +204,7 @@ The `lowest_matching` option can be either `true` or `false` with false being th
 
     nuget UnionArgParser ~> 0.7
 
-A `lowest_matching: true` setting means you get the *lowest matching version* of your direct dependencies. In constrast, a `lowest_matching:false` will get you the *highest matching version*.
+A `lowest_matching: true` setting means you get the *lowest matching version* of your direct dependencies. In contrast, a `lowest_matching:false` will get you the *highest matching version*.
 
 Note, however, that all transitive dependencies will still get their *latest matching versions*, no matter the value of the `lowest_matching` option.
 If you want to influence the resolution of transitive dependencies then read about the [strategy option](dependencies-file.html#Strategy-option).

--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -41,6 +41,7 @@ Only direct dependencies should be listed and you can use the [`paket simplify` 
 Paket supports the following source types:
 
 * [NuGet](nuget-dependencies.html)
+* [Git](git-dependencies.html)
 * [GitHub and Gist](github-dependencies.html)
 * [HTTP](http-dependencies.html) (any single file from any site without version control)
 

--- a/docs/content/editor-support.md
+++ b/docs/content/editor-support.md
@@ -41,7 +41,7 @@
 * Features:
 	* View dependencies and referenced NuGet packages in the Solution window
 	* Execute Paket commands from the Solution window
-	* Syntax highlighting for all paket files
+	* Syntax highlighting for all Paket files
 	* Code completion whilst editing the paket.dependencies file
 	* Integrates with Xamarin Studio's unified search
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -5,7 +5,7 @@ This guide will show you
   * [how to manually setup Paket](getting-started.html#Manual-setup) in your .NET / mono solutions
   * and [how to use the automatic NuGet conversion](convert-from-nuget-tutorial.html).
 
-<blockquote>The following guide is assuming you are using the paket.exe command line tool. For information on installing the commmand line tool follow the instructions for your operating system for <a href="installation.html">installation</a>.
+<blockquote>The following guide is assuming you are using the paket.exe command line tool. For information on installing the command line tool follow the instructions for your operating system for <a href="installation.html">installation</a>.
 There are editor plugins for Visual Studio, Atom and other which can make this process easier and provide additional tooling like syntax highlighting.
 Check our <a href="editor-support.html">editor support page</a> to see if your editor has a Paket plugin.</blockquote>
 
@@ -14,7 +14,7 @@ This project helps you get started with a new .NET/Mono project solution with ev
 
 ## Manual setup
 
-### Downloading Paket and it's BootStrapper
+### Downloading Paket and its Bootstrapper
 
   * Create a `.paket` folder in the root of your solution.
   * Download the latest [paket.bootstrapper.exe](https://github.com/fsprojects/Paket/releases/latest) into that folder.
@@ -75,7 +75,7 @@ You can read more about the `paket.lock` file in the [docs](lock-file.html).
 
 ### Installing dependencies into projects
 
-In the last paragraph you learned how to install packages into your repository, but usally you want to use the dependencies in your C#, VB or F# projects.
+In the last paragraph you learned how to install packages into your repository, but usually you want to use the dependencies in your C#, VB or F# projects.
 In order to do so you need a [`paket.references` files](references-files.html) alongside your Visual Studio project files.
 By listing the direct dependencies in a `paket.references` file, Paket will automatically sync references to the corresponding projects whenever an `install` or `update` takes place.
 

--- a/docs/content/git-dependencies.md
+++ b/docs/content/git-dependencies.md
@@ -2,14 +2,14 @@
 
 Paket allows you to automatically manage the linking of files from any git repo.
 
-<blockquote>This feature is only available in Paket 3.0 prereleases.</blockquote>
+<blockquote>This feature is only available in Paket 3.0.</blockquote>
 
 <blockquote>This feature assumes that you have <a href="https://git-scm.com/">git</a> installed.
-If you don't have git installed then Paket still allows you to <a href="github-dependencies.html">reference files from github</a>.</blockquote>
+If you don't have git installed then Paket still allows you to <a href="github-dependencies.html">reference files from GitHub</a>.</blockquote>
 
 ## Referencing a Git repository
 
-You can also reference a complete git repository by specifying the clone url in the [`paket.dependencies` file](dependencies-file.html):
+You can also reference a complete git repository by specifying the clone URL in the [`paket.dependencies` file](dependencies-file.html):
 
     [lang=paket]
     git https://github.com/fsprojects/Paket.git
@@ -42,13 +42,13 @@ You can read more about the version range details in the corresponding [NuGet re
 
 ## Running a build in git repositories
 
-If your referenced git repository contains a build script then Paket can execute this scipt after restore:
+If your referenced git repository contains a build script then Paket can execute this script after restore:
 
     [lang=paket]
     git https://github.com/forki/nupkgtest.git master build: "build.cmd", OS: windows
     git https://github.com/forki/nupkgtest.git master build: "build.sh", OS: mono
 
-This allows you to excute arbitray commands after restore.
+This allows you to execute arbitrary commands after restore.
 
 ## Using Git repositories as NuGet source
 

--- a/docs/content/github-dependencies.md
+++ b/docs/content/github-dependencies.md
@@ -100,9 +100,9 @@ This generates the following [`paket.lock` file](lock-file.html):
 
 As you can see Paket also resolved the Octokit dependency.
 
-## Referencing a private github repository
+## Referencing a private GitHub repository
 
-To reference a private github repository the syntax is identical to
+To reference a private GitHub repository the syntax is identical to
 above and supports the same branch and file definitions the only extra
 item to add is an identifier which defines which credential key to
 use (see [`paket config`](paket-config.html)).

--- a/docs/content/http-dependencies.md
+++ b/docs/content/http-dependencies.md
@@ -4,7 +4,7 @@ Paket allows one to automatically manage the linking of files from HTTP resource
 
 ## Referencing a single file
 
-You can reference a single file from a HTTP resource simply by specifying the url in the [`paket.dependencies` file](dependencies-file.html):
+You can reference a single file from a HTTP resource simply by specifying the URL in the [`paket.dependencies` file](dependencies-file.html):
 
     [lang=paket]
     http http://www.fssnip.net/raw/1M/test1.fs
@@ -41,7 +41,7 @@ The pattern expected is
     [lang=paket]
     http url [FileSpec] [SourceName]
 
-* **FileSpec** - This allows you to define the path to which the file that is downloaded will be written to. For example specfying the following
+* **FileSpec** - This allows you to define the path to which the file that is downloaded will be written to. For example specifying the following
 
     [lang=paket]
 		http http://www.fssnip.net/raw/1M/test1.fs src/test1.fs
@@ -49,8 +49,8 @@ The pattern expected is
 	will write the file to `paket-files\www.fssnip.net\src\test.fs`
 
 * **SourceName** - The source name allows you to override the folder which the downloaded file is written to and also acts as a key to lookup any authentication
-that maybe assoicated for that key. For example if I had added an authentication source using [``paket config add-authentication MySource``](commands\config.html)
-then each time paket extracts a HTTP dependency with `MySource` as a `SourceName` the credentails will be made part of the HTTP request. If no keys exist in the authentication store
+that maybe associated for that key. For example if I had added an authentication source using [``paket config add-authentication MySource``](commands\config.html)
+then each time Paket extracts a HTTP dependency with `MySource` as a `SourceName` the credentials will be made part of the HTTP request. If no keys exist in the authentication store
 then the request will be made without any authentication headers.
 
 ## Allowed http schemes

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -4,11 +4,11 @@ This guide will show you
 
   * How to set up Paket for a specific repository.
   * How to install Paket for Windows, Linux, or OS-X.
-  * How to ensure `paket` is available via commmand line and other methods of use.
+  * How to ensure `paket` is available via command line and other methods of use.
 
 ## Installation per repository
 
-The most common use of Paket is as a command line tool inside your project repostiory.
+The most common use of Paket is as a command line tool inside your project repository.
 
   * Create a `.paket` folder in the root of your solution.
   * Download the latest [paket.bootstrapper.exe](https://github.com/fsprojects/Paket/releases/latest) into that folder.
@@ -45,7 +45,7 @@ The install.sh script will add Paket as a command line option into bash and most
 
 ### Installation on OS-X
 
-For OS-X the build and installation procecss is as follows.
+For OS-X the build and installation process is as follows.
 
     ./build.sh
 

--- a/docs/content/local-file.md
+++ b/docs/content/local-file.md
@@ -24,7 +24,7 @@ The Paket project uses [Argu](http://fsprojects.github.io/Argu/) as one of its o
     nuget Argu
     ...
 
-When running [`paket restore`](file:///C:/github/Paket/docs/output/paket-restore.html), the Argu package is always restored from the NuGet source tha was specified in Paket's own `paket.lock` file:
+When running [`paket restore`](file:///C:/github/Paket/docs/output/paket-restore.html), the Argu package is always restored from the NuGet source that was specified in Paket's own `paket.lock` file:
 
     [lang=paket]
     NUGET

--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -93,14 +93,14 @@ A needs exactly C 1.0 and B wants version 1.1 of C.
 This is a version conflict and Paket will complain during resolution phase.
 
 If we specify C = 1.1 in the dependencies file then Paket still considers this as a version conflict with the version requirement in A.
-By specifying C == 1.1 we overwrite all other requirements and paket will not complain about the conflict anymore.</blockquote>
+By specifying C == 1.1 we overwrite all other requirements and Paket will not complain about the conflict anymore.</blockquote>
 
 If your transitive dependencies result in a version conflict you might want to instruct Paket to use a specific version. The `==` operator allows you to manually resolve the conflict:
 
     [lang=paket]
     nuget Example == 1.2.3 // take exactly this version
 
-<blockquote>Important: If you want to restrict the version to a specific version then use the <a href="nuget-dependencies.html#Pinned-version-constraint">= operator</a>. The == operator should only be used if you need to overwrite a dependency resultion due to a conflict.</blockquote>
+<blockquote>Important: If you want to restrict the version to a specific version then use the <a href="nuget-dependencies.html#Pinned-version-constraint">= operator</a>. The == operator should only be used if you need to overwrite a dependency resolution due to a conflict.</blockquote>
 
 #### Further version constraints
 
@@ -162,9 +162,9 @@ If want to allow newer backward-compatible versions but also need a specific fix
 
 The example above translates to `1.2.3 <= x < 2.0`.
 
-### PreReleases
+### Prereleases
 
-If you want to dependend on prereleases then Paket can assist you. In contrast to NuGet, Paket allows you to depend on different prerelease channels:
+If you want to depend on prereleases then Paket can assist you. In contrast to NuGet, Paket allows you to depend on different prerelease channels:
 
     [lang=paket]
     nuget Example >= 1.2.3 alpha      // at least 1.2.3 including alpha versions
@@ -240,7 +240,7 @@ Redirects are created only if they are required. However, you can instruct Paket
 
     nuget FSharp.Core redirects: force
 
-In constract, you have the option to force Paket to not create a redirect:
+In contrast, you have the option to force Paket to not create a redirect:
 
     [lang=paket]
     source https://nuget.org/api/v2
@@ -303,7 +303,7 @@ The following code is doing the same by using the `!` operator in your version c
 
     nuget Example !~> 1.2 // use "min" version resolution strategy
 
-The stragey setting and the corresponding `!` and `@` modifiers are applicable to all [version constraints](#Version-constraints):
+The strategy setting and the corresponding `!` and `@` modifiers are applicable to all [version constraints](#Version-constraints):
 
     [lang=paket]
     source https://nuget.org/api/v2

--- a/docs/content/paket-push.md
+++ b/docs/content/paket-push.md
@@ -7,13 +7,13 @@ Pushes the given `.nupkg` file.
 
 ### Options:
 
-  `url <string>`: Url of the NuGet feed.
+  `url <string>`: URL of the NuGet feed.
 
   `file <string>`: Path to the package.
 
   `apikey <string>`: Optionally specify your API key on the command line. Otherwise uses the value of the `nugetkey` environment variable.
 
-  `endpoint <string>`: Optionally specify a custom api endpoint to push to. Defaults to `/api/v2/package`.
+  `endpoint <string>`: Optionally specify a custom API endpoint to push to. Defaults to `/api/v2/package`.
 
 If you add the `-v` flag, then Paket will run in verbose mode and show detailed information.
 

--- a/docs/content/references-files.md
+++ b/docs/content/references-files.md
@@ -29,7 +29,7 @@ For each MSBuild project alongside a `paket.references`, [`paket install`](paket
 
 The references injected into the MSBuild project reflect the complete set of rules specified within the package for each `lib` and `Content` item; each reference is `Condition`al on an MSBuild expression predicated on the project's active framework etc. This allows you to change the target version of the MSBuild project (either within Visual Studio or e.g. as part of a multi-pass build) without reinstalling dependencies or incurring an impenetrable set of diffs.
 
-Any [roslyn based analyzer](analyzers.html) present in the packages will also be installed in the project.
+Any [Roslyn based analyzer](analyzers.html) present in the packages will also be installed in the project.
 
 ## copy_local settings
 
@@ -75,7 +75,7 @@ Redirects are created only if they are required. However, you can instruct Paket
     [lang=paket]
     FSharp.Core redirects: force
 
-In constract, you have the option to force Paket to not create a redirect:
+In contrast, you have the option to force Paket to not create a redirect:
 
     [lang=paket]
     FSharp.Core redirects: off
@@ -84,7 +84,7 @@ Redirects settings in [references files](references-files.html#Redirects-setting
 
 ## Excluding libraries
 
-<blockquote>This feature is only available in Paket 3.0 alpha versions.</blockquote>
+<blockquote>This feature is only available in Paket 3.0.</blockquote>
 
 This option allows you to exclude libraries from being referenced in project files:
 
@@ -98,7 +98,7 @@ This option allows you to exclude libraries from being referenced in project fil
 
 ## Library aliases
 
-<blockquote>This feature is only available in Paket 3.0 alpha versions.</blockquote>
+<blockquote>This feature is only available in Paket 3.0.</blockquote>
 
 This option allows you to specify library aliases:
 
@@ -113,7 +113,7 @@ This option allows you to specify library aliases:
 
 If Paket finds `paket.references` in a folder, the dependencies it specifies will be added to all MSBuild projects in that folder.
 
-If you have multiple MSBuild projects in a folder that require a non-homogenous set of references, you have two options:
+If you have multiple MSBuild projects in a folder that require a non-homogeneous set of references, you have two options:
 
 - Have a shared `paket.references` file that acts as a default for all except ones that require special treatment. For each special-case project, add a `<MSBuild project>.paket.references` file
 - Add a project-specific `<MSBuild project>.paket.references` file for each and every project that requires any references

--- a/docs/content/resolver.fsx
+++ b/docs/content/resolver.fsx
@@ -69,7 +69,7 @@ let selectNextRequirement (xs: Set<PackageRequirement>) = Some(Seq.head xs,xs)
 /// Calls the NuGet API and retrieves all versions for a package
 let getAllVersionsFromNuget (x:PackageName) :SemVerInfo list = []
 
-/// Checks if the given version is in the specified verion range
+/// Checks if the given version is in the specified version range
 let isInRange (vr:VersionRequirement) (v:SemVerInfo) : bool = true
 
 // Calls the NuGet API and returns package details for the given package version

--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -175,8 +175,8 @@ The `LOCKEDVERSION` placeholder allows to reference the currently used dependenc
 
 In a project file, the following dependencies will be added:
 
-* any paket dependency with the range specified in the [`paket.dependencies` file](dependencies-file.html).
-* any paket dependency with the range specified in the [`paket.lock` file](lock-file.html) (if `lock-dependencies` parameter is used in [`paket pack`](paket-pack.html)).
+* any Paket dependency with the range specified in the [`paket.dependencies` file](dependencies-file.html).
+* any Paket dependency with the range specified in the [`paket.lock` file](lock-file.html) (if `lock-dependencies` parameter is used in [`paket pack`](paket-pack.html)).
 * any project reference with a matching paket.template file with a minimum version requirement of the version currently being packaged.
 
 If you need to exclude dependencies from the automatic discovery then you can use the `excludeddependencies` block:
@@ -191,9 +191,9 @@ Another way to exclude dependencies is to exclude a whole dependency group with 
 	  build
 	  test
 
-#### Pdb files
+#### PDB files
 
-With the include-pdbs switch you can tell Paket to pack pdbs into the package.
+With the include-pdbs switch you can tell Paket to pack PDBs into the package.
 
     include-pdbs true
 

--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -123,7 +123,7 @@ Excluding certain files looks like this:
         ../outside/file.* ==> folder/in/nupkg/other
         !../outside/file.zip
 
-The pattern needs to match file-names, excluding directories like `!second` won't have an effect, please use `!second/*.*` instead.
+The pattern needs to match file-names, excluding directories like `!second` won't have an effect. Please use `!second/*.*` instead.
 
 In a project template, the files included will be:
 


### PR DESCRIPTION
+ Remove references to alpha/prerelease versions of Paket 3 since Paket 3 has been released
+ Mention Git as a new dependency type in the "Sources" section of the dependencies file documentation
+ Find and fix numerous spelling and casing mistakes using spell checker in Vim
+ Fix a comma splice by breaking it into two sentences