### PR TITLE
Don't allow empty string as authors and description metadata

### DIFF
--- a/integrationtests/scenarios/i001234-missing-assemblyname/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001234-missing-assemblyname/before/PaketBug/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001375-pack-specific/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001375-pack-specific/before/PaketBug/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001376-pack-template-plus/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001376-pack-template-plus/before/PaketBug/paket.templatetemplate
@@ -2,5 +2,6 @@ type project
 id PaketBug
 description
     Silly empty demo project
+authors Paket team
 files
   paket.references => content/net45+net451

--- a/integrationtests/scenarios/i001376-pack-template/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001376-pack-template/before/PaketBug/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/PaketBug/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/PaketBug2/paket.templatetemplate
+++ b/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/PaketBug2/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug2
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001429-pack-deps-specific/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001429-pack-deps-specific/before/PaketBug/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001429-pack-deps-specific/before/PaketBug2/paket.templatetemplate
+++ b/integrationtests/scenarios/i001429-pack-deps-specific/before/PaketBug2/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug2
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001429-pack-deps/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001429-pack-deps/before/PaketBug/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001429-pack-deps/before/PaketBug2/paket.templatetemplate
+++ b/integrationtests/scenarios/i001429-pack-deps/before/PaketBug2/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug2
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001586-pack-referenced/before/PaketBug/paket.templatetemplate
+++ b/integrationtests/scenarios/i001586-pack-referenced/before/PaketBug/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001586-pack-referenced/before/PaketBug2/paket.templatetemplate
+++ b/integrationtests/scenarios/i001586-pack-referenced/before/PaketBug2/paket.templatetemplate
@@ -2,3 +2,4 @@ type project
 id PaketBug2
 description
     Silly empty demo project
+authors Paket team

--- a/integrationtests/scenarios/i001594-pack/before/paket.templatetemplate
+++ b/integrationtests/scenarios/i001594-pack/before/paket.templatetemplate
@@ -1,2 +1,4 @@
 type project
+description Test project.
+authors Paket team
 licenseUrl http://opensource.org/licenses/MIT

--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -49,8 +49,8 @@ let getVersion versionFromAssembly attributes =
 
 let getAuthors attributes = 
     attributes
-    |> Seq.tryPick (function Company a -> Some a | _ -> None)
-    |> Option.map (fun a -> 
+    |> Seq.tryPick (function Company a when notNullOrEmpty a -> Some a | _ -> None)
+    |> Option.map (fun a ->
             a.Split(',')
             |> Array.map (fun s -> s.Trim())
             |> List.ofArray)

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -53,7 +53,7 @@ let private merge buildConfig buildPlatform versionFromAssembly specificVersions
                         [ if merged.Id = None then yield "Id"
                           if merged.Version = None then yield "Version"
                           if merged.Authors = None || merged.Authors = Some [] then yield "Authors"
-                          if merged.Description = None then yield "Description" ]
+                          if merged.Description = None || merged.Description = Some "" then yield "Description" ]
                         |> fun xs -> String.Join(", ",xs)
 
                     failwithf 


### PR DESCRIPTION
Paket produces invalid metadata for packages, which only have `type project` in their `paket.template` file.

Those packages look ok, but cause problems further down the road, i. e. when trying to upload them or when using test adapters installed via Paket. Probably when trying to install them with NuGet, too, because the non-descriptive error message in VS comes from NuGet.Core.

/cc @biehlermi