### PR TITLE
Make Name and Guid in ProjectRefrence optional

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -39,8 +39,8 @@ type FileItem =
 type ProjectReference = 
     { Path : string
       RelativePath : string
-      Name : string
-      GUID : Guid }
+      Name : string option
+      GUID : Guid option }
 
 /// Compile items inside of project files.
 type CompileItem =
@@ -1045,13 +1045,13 @@ module ProjectFile =
     let getInterProjectDependencies project =
         let forceGetInnerText node name =
             match node |> getNode name with 
-            | Some n -> n.InnerText
+            | Some n -> Some n.InnerText
             | None ->
                 match node |> getAttribute "Include" with
                 | Some fileName ->
                     let fi = FileInfo(normalizePath fileName)
-                    fi.Name.Replace(fi.Extension,"")
-                | None -> failwithf "unable to parse %O" node
+                    Some <| fi.Name.Replace(fi.Extension,"")
+                | None -> None
 
         [for node in project.Document |> getDescendants "ProjectReference" -> 
             let path =
@@ -1069,7 +1069,7 @@ module ProjectFile =
 
               RelativePath = path.Replace("/","\\")
               Name = forceGetInnerText node "Name"
-              GUID = forceGetInnerText node "Project" |> Guid.Parse }]
+              GUID = forceGetInnerText node "Project" |> Option.map Guid.Parse }]
 
     let replaceNuGetPackagesFile project =
         let noneAndContentNodes = 

--- a/tests/Paket.Tests/ProjectFile/InterProjectDependencySpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/InterProjectDependencySpecs.fs
@@ -13,13 +13,13 @@ let ``should detect no dependencies in empty proj file``() =
 [<Test>]
 let ``should detect Paket dependency in Project1 proj file``() =
     ProjectFile.TryLoad("./ProjectFile/TestData/Project1.fsprojtest").Value.GetInterProjectDependencies()
-    |> List.map (fun p -> p.Name)
+    |> List.map (fun p -> p.Name.Value)
     |> shouldEqual ["Paket"]
 
 [<Test>]
 let ``should detect Paket and Paket.Core dependency in Project2 proj file``() =
     ProjectFile.TryLoad("./ProjectFile/TestData/Project2.fsprojtest").Value.GetInterProjectDependencies()
-    |> List.map (fun p -> p.Name)
+    |> List.map (fun p -> p.Name.Value)
     |> shouldEqual ["Paket"; "Paket.Core"]
 
 [<Test>]
@@ -45,7 +45,7 @@ let ``should detect Guids for dependencies in Project2 proj file``() =
     let p = ProjectFile.TryLoad("./ProjectFile/TestData/Project2.fsprojtest").Value
     p.GetProjectGuid() |> shouldEqual (Guid.Parse "e789c72a-5cfd-436b-8ef1-61aa2852a89f")
     p.GetInterProjectDependencies()
-    |> List.map (fun p -> p.GUID.ToString())
+    |> List.map (fun p -> p.GUID.Value.ToString())
     |> shouldEqual ["09b32f18-0c20-4489-8c83-5106d5c04c93"; "7bab0ae2-089f-4761-b138-a717aa2f86c5"]
 
 


### PR DESCRIPTION
According to [MSDN documentation](https://msdn.microsoft.com/en-us/library/bb629388.aspx) `Guid` and `Name` properties in `ProjectReference` entries in `.fsproj` files are optional. Paket failed if any of those 2 were not set. 