### PR TITLE
fix #1731, config now removes trailings slashes

### DIFF
--- a/src/Paket.Core/ConfigFile.fs
+++ b/src/Paket.Core/ConfigFile.fs
@@ -202,4 +202,4 @@ let askAndAddAuth (source : string) (username : string) =
             username
 
     let password = readPassword "Password: "
-    AddCredentials (source, username, password)
+    AddCredentials (source.TrimEnd [|'/'|], username, password)


### PR DESCRIPTION
Simple solution for #1731. 

not (yet) implemented a check for defective paket.config