### PR TITLE
Duplicate Paket.SemVer.Parse into PublicAPI.fs

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -575,3 +575,8 @@ type Dependencies(dependenciesFileName: string) =
                          with
                            | _ -> None)
         |> Array.toList
+
+module PublicAPI =
+    /// Takes a version string formatted for Semantic Versioning and parses it
+    /// into the internal representation used by Paket.
+    let ParseSemVer (version:string) = SemVer.Parse version


### PR DESCRIPTION
As per the discussion on 79b57ac8177566c5f06ba595636f64c91583a7b8, only `PublicAPI.fs` is treated as a public API; added a function in this file that calls `Paket.SemVer.Parse` and has the same compiled signature that `Paket.SemVer.Parse` had prior to 79b57ac8177566c5f06ba595636f64c91583a7b8.