### PR TITLE
fix #1741 by trying to repair the file paths and writing a warning.

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -377,10 +377,10 @@ let rec private cleanup (dir : DirectoryInfo) =
     for file in dir.GetFiles() do
 
         let newName = Uri.UnescapeDataString(file.Name)
-        if newName.Contains "..\\" then
+        if newName.Contains "..\\" || newName.Contains "../" then
           failwithf "Relative paths are not supported. Please tell the package author to fix the package to not use relative paths. The invalid file was '%s'" file.FullName
-        if newName.Contains "\\" then
-          traceWarnfn "File '%s' contains backslashes, probably because it wasn't properly packaged (for example with windows paths in nuspec on a unix like system). Please tell the package author to fix it." file.FullName
+        if newName.Contains "\\" || newName.Contains "/" then
+          traceWarnfn "File '%s' contains back- or forward-slashes, probably because it wasn't properly packaged (for example with windows paths in nuspec on a unix like system). Please tell the package author to fix it." file.FullName
         let newFullName = Path.Combine(file.DirectoryName, newName)
         if file.Name <> newName && not (File.Exists newFullName) then
             let dir = Path.GetDirectoryName newFullName

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -377,10 +377,15 @@ let rec private cleanup (dir : DirectoryInfo) =
     for file in dir.GetFiles() do
 
         let newName = Uri.UnescapeDataString(file.Name)
+        if newName.Contains "..\\" then
+          failwithf "Relative paths are not supported. Please tell the package author to fix the package to not use relative paths. The invalid file was '%s'" file.FullName
+        if newName.Contains "\\" then
+          traceWarnfn "File '%s' contains backslashes, probably because it wasn't properly packaged (for example with windows paths in nuspec on a unix like system). Please tell the package author to fix it." file.FullName
         let newFullName = Path.Combine(file.DirectoryName, newName)
         if file.Name <> newName && not (File.Exists newFullName) then
-            if not file.Directory.Exists then
-                file.Directory.Create()
+            let dir = Path.GetDirectoryName newFullName
+            if not <| Directory.Exists dir then
+                Directory.CreateDirectory dir |> ignore
 
             File.Move(file.FullName, newFullName)
 


### PR DESCRIPTION
I agree with trying to fix the package, but while starting to implement option 3, I think there is a problem. People can call their file `%2e%2e%5c%2e%2e%5ctest` (= ..\..\test) and make paket write anywhere. It shouldn't be more security relevant than using a type provider but I don't the idea of people depending on something like that therefore I tried to prevent it.