### PR TITLE
Added handling for cache not being accessible

### DIFF
--- a/src/Paket.Core/Cache.fs
+++ b/src/Paket.Core/Cache.fs
@@ -45,3 +45,11 @@ type Cache =
 
         settings
              
+    member this.IsAccessible =
+        try
+            let targetFolder = DirectoryInfo(this.Location)
+            if not targetFolder.Exists then
+                targetFolder.Create()
+            true
+        with
+        | _ -> false


### PR DESCRIPTION
Fixes #1758

I moved the directory creation to when the cache is loaded from the dependencies file. It tries to create the directory if it doesn't exist, and doesn't include the cache in the feed list or cache list if it fails.