### PR TITLE
paket config should be able to run everywhere

### DIFF
--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -106,11 +106,11 @@ let config (results : ParseResults<_>) =
       let source = args.Item 0
       let username, password = results.GetResult (<@ ConfigArgs.Username @>, ""), results.GetResult (<@ ConfigArgs.Password @>, "") 
             
-      Dependencies.Locate().AddCredentials(source, username, password)
+      Dependencies(".").AddCredentials(source, username, password)
     | _, true ->
       let args = results.GetResults <@ ConfigArgs.AddToken @>
       let source, token = args.Item 0
-      Dependencies.Locate().AddToken(source, token)
+      Dependencies(".").AddToken(source, token)
     | _ -> ()
 
 let validateAutoRestore (results : ParseResults<_>) =


### PR DESCRIPTION
Currently, `paket config` runs into an error when not executed from within a project. However, a project is not necessary for this, since the command only accesses a user configuration file. This PR simply creates a dummy `Dependencies` instance to fix this.

This is especially usefull in combination with #1722 to allow an automatic setup of a developer machine (enterprise environment)