### PR TITLE
Fix detection of framework version with spaces

### DIFF
--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -98,7 +98,8 @@ module KnownAliases =
          ".netportable", "portable"
          "netportable", "portable"
          "0.0", ""
-         ".", "" ]
+         ".", ""
+         " ", "" ]
         |> List.map (fun (p,r) -> p.ToLower(),r.ToLower())
 
 

--- a/tests/Paket.Tests/ProjectFile/ConditionSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/ConditionSpecs.fs
@@ -67,6 +67,10 @@ let ``should detect net``() =
     FrameworkDetection.DetectFromPath(@"..\packages\RhinoMocks\lib\net\Rhino.Mocks.dll")|> element |> shouldEqual (DotNetFramework(FrameworkVersion.V2))
 
 [<Test>]
+let ``should detect with spaces``() =
+    FrameworkDetection.DetectFromPath(@"..\packages\FSharpx.Core\lib\.NetFramework 3.5\FSharp.Core.dll")|> element |> shouldEqual (DotNetFramework(FrameworkVersion.V3_5))
+
+[<Test>]
 let ``should detect 35, 40 and 45``() =
     FrameworkDetection.DetectFromPath(@"..\packages\FSharpx.Core\lib\35\FSharp.Core.dll")|> element |> shouldEqual (DotNetFramework(FrameworkVersion.V3_5))
     FrameworkDetection.DetectFromPath(@"..\packages\FSharpx.Core\lib\40\FSharp.Core.dll")|> element |> shouldEqual (DotNetFramework(FrameworkVersion.V4_Client))


### PR DESCRIPTION
Fixes #1790

Fixes compatibility with packages such as MarkdownDeep.NET which have the
internal folder structure of

    ./lib/.NetFramework 3.5/MarkdownDeep.dll

Resolve this issue by adding an alias to remove spaces in the framework string.