### PR TITLE
Fix issue #1794: Fix error with local sources and run convert-from-nuget

### DIFF
--- a/src/Paket.Core/PackageSources.fs
+++ b/src/Paket.Core/PackageSources.fs
@@ -220,7 +220,7 @@ type PackageSource =
         | NuGetV2 x -> n x.Url x.Authentication
         | NuGetV3 x -> n x.Url x.Authentication
         | LocalNuGet(path,_) -> 
-            if not <| File.Exists path then 
+            if not <| Directory.Exists path then 
                 traceWarnfn "Local NuGet feed doesn't exist: %s." path
 
 let DefaultNuGetSource = PackageSource.NuGetV2Source Constants.DefaultNuGetStream


### PR DESCRIPTION
Simple fix: File.Exists should be Directory.Exists.

I have tested this locally and this fixes the error.