### PR TITLE
Added convert-from-nuget environment vars note

### DIFF
--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -35,6 +35,9 @@ If you don't want to check your username and password into source control, you c
 
 The [`paket.lock` file](lock-file.html) will also reflect these settings.
 
+* _ __Note__:_ In the case that a `paket.dependencies` file exists while running the `convert-from-nuget` command, the `PRIVATE_FEED_USER` and `PRIVATE_FEED_PASS`
+will *not* be expanded. Please see [this document](convert-from-nuget-tutorial.html) for instructions on migrating credentials.
+
 ### Path sources
 
 Paket also supports file paths such as local directories or references to UNC shares:


### PR DESCRIPTION
When converting a project from NuGet to Paket, it is possible to get into a state that a paket.dependencies file is generated, but the process is not finished. If you put plaintext credentials in this spot, it will continue as suspected with the --hard argument. If you put an environment variable it is not expanded.

As this situation might be confusing to anyone who gets into this situation and sees this document, a note linking to the proper credential migration procedure is a reasonable concession.

This references [issue 1822.](https://github.com/fsprojects/Paket/issues/1822)