### PR TITLE
Don't allow empty string as description - take II

### DIFF
--- a/src/Paket.Core/PackageMetaData.fs
+++ b/src/Paket.Core/PackageMetaData.fs
@@ -61,7 +61,7 @@ let getTitle attributes =
 
 let getDescription attributes = 
     attributes 
-    |> Seq.tryPick (function Description d -> Some d | _ -> None) 
+    |> Seq.tryPick (function Description d when notNullOrEmpty d -> Some d | _ -> None)
 
 let readAssembly fileName =
     traceVerbose <| sprintf "Loading assembly metadata for %s" fileName

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -59,7 +59,7 @@ let private merge buildConfig buildPlatform versionFromAssembly specificVersions
                     failwithf 
                         "Incomplete mandatory metadata in template file %s (even including assembly attributes)%sTemplate: %A%sMissing: %s" 
                         templateFile.FileName 
-                        Environment.NewLine md 
+                        Environment.NewLine merged
                         Environment.NewLine missing
 
                 | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, mergedOpt) }


### PR DESCRIPTION
Seems like I forgot this in #1728.

However, I also changed the error message to show the merged metadata, not only the infos from `paket.template`. I think that was the intent anyways.