### PR TITLE
Generate default description when packing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
-#### 3.9.3 - 25.07.2016
-* REVERT: Don't allow empty string as description in template file - https://github.com/fsprojects/Paket/pull/1831
+#### 3.9.2 - 25.07.2016
+* BUGFIX: Don't allow empty string as description in template file - https://github.com/fsprojects/Paket/pull/1831
 
 #### 3.9.1 - 22.07.2016
 * Respect comments in dependencies file

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -56,12 +56,16 @@ let private merge buildConfig buildPlatform versionFromAssembly specificVersions
                     | Some id -> traceWarnfn "No description was provided for package %A. Generating from ID and project output type." id
                     | _ -> ()
                     tryGenerateDescription packageId outputType
+                let execIfNone f opt =
+                    match opt with
+                    | None -> f ()
+                    | x -> x
 
                 let merged = 
                     { Id = md.Id
                       Version = md.Version ++ versionFromAssembly
                       Authors = md.Authors ++ getAuthors attribs
-                      Description = md.Description ++ getDescription attribs ++ tryGenerateDescription md.Id projectFile.OutputType
+                      Description = md.Description ++ getDescription attribs |> execIfNone (fun _ -> tryGenerateDescription md.Id projectFile.OutputType)
                       Symbols = md.Symbols }
 
                 match merged with

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -11,6 +11,16 @@ open Paket.PackageMetaData
 open Chessie.ErrorHandling
 open InstallProcess
 
+let private tryGenerateDescription packageId outputType =
+    match packageId with
+    | Some id when notNullOrEmpty id ->
+        let outputType =
+            match outputType with
+            | ProjectOutputType.Library -> "library"
+            | ProjectOutputType.Exe -> "program"
+        Some (sprintf "%s %s." id outputType)
+    | _ -> None
+
 let private merge buildConfig buildPlatform versionFromAssembly specificVersions (projectFile:ProjectFile) templateFile = 
     let withVersion =
         match versionFromAssembly with
@@ -44,7 +54,7 @@ let private merge buildConfig buildPlatform versionFromAssembly specificVersions
                     { Id = md.Id
                       Version = md.Version ++ versionFromAssembly
                       Authors = md.Authors ++ getAuthors attribs
-                      Description = md.Description ++ getDescription attribs
+                      Description = md.Description ++ getDescription attribs ++ tryGenerateDescription md.Id projectFile.OutputType
                       Symbols = md.Symbols }
 
                 match merged with

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -59,7 +59,7 @@ let private merge buildConfig buildPlatform versionFromAssembly specificVersions
                     failwithf 
                         "Incomplete mandatory metadata in template file %s (even including assembly attributes)%sTemplate: %A%sMissing: %s" 
                         templateFile.FileName 
-                        Environment.NewLine md 
+                        Environment.NewLine merged
                         Environment.NewLine missing
 
                 | Valid completeCore -> { templateFile with Contents = CompleteInfo(completeCore, mergedOpt) }

--- a/src/Paket.Core/PackageProcess.fs
+++ b/src/Paket.Core/PackageProcess.fs
@@ -50,6 +50,13 @@ let private merge buildConfig buildPlatform versionFromAssembly specificVersions
                     | Some _ as specificVersion -> specificVersion
                     | None -> getVersion versionFromAssembly attribs
 
+                // See discussion at https://github.com/fsprojects/Paket/pull/1831
+                let tryGenerateDescription packageId outputType =
+                    match packageId with
+                    | Some id -> traceWarnfn "No description was provided for package %A. Generating from ID and project output type." id
+                    | _ -> ()
+                    tryGenerateDescription packageId outputType
+
                 let merged = 
                     { Id = md.Id
                       Version = md.Version ++ versionFromAssembly


### PR DESCRIPTION
@forki you didn't revert the actual change yesterday, only the commit related to the error message. I brought the change back again.

I'm not entirely sure about the generated description, though.

/cc @richard-green