### PR TITLE
Version in lock file

### DIFF
--- a/src/Paket.Core/Constants.fs
+++ b/src/Paket.Core/Constants.fs
@@ -28,6 +28,7 @@ let [<Literal>] PackagesConfigFile        = "packages.config"
 let [<Literal>] NuGetConfigFile           = "NuGet.Config"
 let [<Literal>] FullProjectSourceFileName = "FULLPROJECT"
 let [<Literal>] ProjectDefaultNameSpace   = "http://schemas.microsoft.com/developer/msbuild/2003"
+let [<Literal>] DefaultLocalDependencyVersion = "0.0.0-local"
 
 let MainDependencyGroup = GroupName "Main"
 let AppDataFolder       = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)

--- a/src/Paket.Core/Constants.fs
+++ b/src/Paket.Core/Constants.fs
@@ -28,7 +28,6 @@ let [<Literal>] PackagesConfigFile        = "packages.config"
 let [<Literal>] NuGetConfigFile           = "NuGet.Config"
 let [<Literal>] FullProjectSourceFileName = "FULLPROJECT"
 let [<Literal>] ProjectDefaultNameSpace   = "http://schemas.microsoft.com/developer/msbuild/2003"
-let [<Literal>] DefaultLocalDependencyVersion = "0.0.0-local"
 
 let MainDependencyGroup = GroupName "Main"
 let AppDataFolder       = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)

--- a/src/Paket.Core/LocalFile.fs
+++ b/src/Paket.Core/LocalFile.fs
@@ -70,7 +70,7 @@ module LocalFile =
         resolution
         |> Map.map (fun name original -> 
             if name = packageName then
-                { original with PackageResolver.ResolvedPackage.Source = source; PackageResolver.ResolvedPackage.Version = (if version <> null then SemVer.Parse(version) else original.Version)}
+                { original with PackageResolver.ResolvedPackage.Source = source; PackageResolver.ResolvedPackage.Version = (if version <> String.Empty then SemVer.Parse(version) else original.Version)}
             else
                 original)
 

--- a/tests/Paket.Tests/LocalFile/LocalFileSpecs.fs
+++ b/tests/Paket.Tests/LocalFile/LocalFileSpecs.fs
@@ -20,14 +20,34 @@ let ``should parse single dev source override``() =
             LocalSourceOverride 
                 (OverriddenPackage(
                     PackageName "NUnit",
-                    GroupName "main"), 
-                 LocalNuGet ("./local_source", None)) 
+                    GroupName "main"),
+                 LocalNuGet ("./local_source", None), "") 
         ]
         |> Trial.ok
 
     let actual = LocalFile.parse (toLines contents |> Array.toList)
 
     actual |> shouldEqual expected
+
+[<Test>]
+let ``should parse single dev source override with custom version``() = 
+    let contents = """
+        nuget NUnit -> source ./local_source version 0.1.2
+        """
+    let expected = 
+        LocalFile [
+            LocalSourceOverride 
+                (OverriddenPackage(
+                    PackageName "NUnit",
+                    GroupName "main"),
+                 LocalNuGet ("./local_source", None), "0.1.2") 
+        ]
+        |> Trial.ok
+
+    let actual = LocalFile.parse (toLines contents |> Array.toList)
+
+    actual |> shouldEqual expected
+
 
 [<Test>]
 let ``should parse single dev source override in group``() = 
@@ -40,14 +60,13 @@ let ``should parse single dev source override in group``() =
                 (OverriddenPackage(
                     PackageName "NUnit",
                     GroupName "Build"), 
-                 LocalNuGet ("./local_source", None)) 
+                 LocalNuGet ("./local_source", None), "") 
         ]
         |> Trial.ok
 
     let actual = LocalFile.parse (toLines contents |> Array.toList)
 
     actual |> shouldEqual expected
-
 
 
 [<Test>]


### PR DESCRIPTION
Enabled a way to specify a version in the local source override.

If a version for a dependeny is provided in the local-file, this version is used from the specified source location. If no version is provided, the original version is used. 

UseCase:
We have a buildprocess and releaseprocess which builds different versions as the local build. So for example the releasebuild creates a buildartifact with version 16.1.0. The local build creates an artifact with a version 0.0.0-local. By this extention, it is possible to reference the local-build-folder in the local-file **without changing the version in the lock-file**.