### PR TITLE
Bootstrapper: fixed partial download

### DIFF
--- a/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
@@ -8,8 +8,6 @@ namespace Paket.Bootstrapper.DownloadStrategies
 {
     public class GitHubDownloadStrategy : IDownloadStrategy
     {
-        private const int HttpBufferSize = 4096;
-
         public static class Constants
         {
             public const string PaketReleasesLatestUrl = "https://github.com/fsprojects/Paket/releases/latest";
@@ -78,10 +76,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             ConsoleImpl.WriteDebug("Starting download from {0}", url);
 
             var tmpFile = BootstrapperHelper.GetTempFile("paket");
-            using (var fileStream = FileProxy.Create(tmpFile))
-            {
-                WebRequestProxy.DownloadFile(url, fileStream, HttpBufferSize);
-            }
+            WebRequestProxy.DownloadFile(url, tmpFile);
 
             FileProxy.Copy(tmpFile, target, true);
             FileProxy.Delete(tmpFile);
@@ -103,11 +98,8 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
             string renamedPath = BootstrapperHelper.GetTempFile("oldBootstrapper");
             string tmpDownloadPath = BootstrapperHelper.GetTempFile("newBootstrapper");
+            WebRequestProxy.DownloadFile(url, tmpDownloadPath);
 
-            using (var toStream = FileProxy.Create(tmpDownloadPath))
-            {
-                WebRequestProxy.DownloadFile(url, toStream, HttpBufferSize);
-            }
             try
             {
                 FileProxy.FileMove(exePath, renamedPath);

--- a/src/Paket.Bootstrapper/HelperProxies/IWebRequestProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/IWebRequestProxy.cs
@@ -6,6 +6,5 @@ namespace Paket.Bootstrapper.HelperProxies
     {
         string DownloadString(string address);
         void DownloadFile(string url, string targetLocation);
-        void DownloadFile(string url, Stream stream, int bufferSize);
     }
 }

--- a/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
@@ -33,18 +33,5 @@ namespace Paket.Bootstrapper.HelperProxies
             BootstrapperHelper.PrepareWebClient(Client, url);
             Client.DownloadFile(url, targetLocation);
         }
-
-        public void DownloadFile(string url, Stream stream, int bufferSize)
-        {
-            var request = BootstrapperHelper.PrepareWebRequest(url);
-
-            using (var httpResponse = (HttpWebResponse)request.GetResponse())
-            {
-                using (var responseStream = httpResponse.GetResponseStream())
-                {
-                    responseStream.CopyTo(stream, bufferSize);
-                }
-            }
-        }
     }
 }

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
@@ -56,51 +56,35 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         public void DownloadVersion()
         {
             //arrange
-            var byteArray = Encoding.ASCII.GetBytes("paketExeContent");
-            var stream = new MemoryStream(byteArray);
             var tempFileName = BootstrapperHelper.GetTempFile("paket");
-
-            mockWebProxy.Setup(x => x.DownloadFile(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<int>()))
-                .Callback<string, Stream, int>((url, streamIn, bufferIn) => stream.CopyTo(streamIn)).Verifiable();
-            var buffer = new byte[byteArray.Length];
-            mockFileProxy.Setup(x => x.Create(tempFileName)).Returns(new MemoryStream(buffer));
+            mockWebProxy.Setup(x => x.DownloadFile(It.IsAny<string>(), It.IsAny<string>())).Verifiable();
 
             //act
             sut.DownloadVersion("2.57.1", "paketExeLocation");
 
             //assert
-            mockWebProxy.Verify();
+            mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileName));
             mockFileProxy.Verify(x => x.Copy(tempFileName, "paketExeLocation", true));
             mockFileProxy.Verify(x => x.Delete(tempFileName));
-            var text = Encoding.ASCII.GetString(buffer);
-            Assert.That(text, Is.EqualTo("paketExeContent"));
         }
 
         [Test]
         public void SelfUpdate()
         {
             //arrange
-            var byteArray = Encoding.ASCII.GetBytes("paketExeContent");
-            var stream = new MemoryStream(byteArray);
             var tempFileNameNew = BootstrapperHelper.GetTempFile("newBootstrapper");
             var tempFileNameOld = BootstrapperHelper.GetTempFile("oldBootstrapper");
 
-            mockWebProxy.Setup(x => x.DownloadFile(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<int>()))
-               .Callback<string, Stream, int>((url, streamIn, bufferIn) => stream.CopyTo(streamIn)).Verifiable();
-            var buffer = new byte[byteArray.Length];
-            mockFileProxy.Setup(x => x.Create(tempFileNameNew)).Returns(new MemoryStream(buffer));
+            mockWebProxy.Setup(x => x.DownloadFile(It.IsAny<string>(), It.IsAny<string>())).Verifiable();
             mockFileProxy.Setup(x => x.GetLocalFileVersion(It.IsAny<string>())).Returns("2.52.1");
             
             //act
             sut.SelfUpdate("2.57.1");
 
             //assert
-            mockWebProxy.Verify();
+            mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileNameNew));
             mockFileProxy.Verify(x => x.FileMove(Assembly.GetAssembly(typeof(GitHubDownloadStrategy)).Location, tempFileNameOld));
             mockFileProxy.Verify(x => x.FileMove(tempFileNameNew, Assembly.GetAssembly(typeof(GitHubDownloadStrategy)).Location));
-
-            var text = Encoding.ASCII.GetString(buffer);
-            Assert.That(text, Is.EqualTo("paketExeContent"));
         }
     }
 }


### PR DESCRIPTION
For some reason, when downloading using the three-parameter `DownloadFile` method (which was only used by the `GitHubDownloadStrategy`), it only downloaded a partial file. The simpler two-parameter overload (used by `NugetDownloadStrategyTests`) always downloaded a full file. It seems the `stream.CopyTo()` used in the three-parameter overload doesn't work well. I removed the problematic overload (which wasn't needed anyway, the simpler one is better). Now Paket always downloads files correctly for me.