### PR TITLE
Allow printing of version number through command-line option

### DIFF
--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -311,12 +311,12 @@ with
         | Framework _ -> "Framework identifier to generate scripts for, such as net4 or netcore."
         | ScriptType _ -> "Language to generate scripts for, must be one of 'fsx' or 'csx'."
   
-[<RequireSubcommand>]
 type Command =
     // global options
     | [<AltCommandLine("-v"); Inherit>]                 Verbose
     | [<Inherit>]                                       Log_File of path:string
     | [<AltCommandLine("-s"); Inherit>]                 Silent
+    | [<Inherit>]                                       Version
     // subcommands
     | [<CustomCommandLine("add")>]                      Add of ParseResults<AddArgs>
     | [<CustomCommandLine("clear-cache")>]              ClearCache of ParseResults<ClearCacheArgs>
@@ -365,6 +365,7 @@ with
             | Log_File _ -> "Specify a log file for the paket process."
             | Silent -> "Suppress console output for the paket process."
             | Verbose -> "Enable verbose console output for the paket process." 
+            | Version -> "Display the version." 
 
 let commandParser = ArgumentParser.Create<Command>(programName = "paket", errorHandler = new ProcessExiter())
 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -375,37 +375,41 @@ let main() =
         elif results.Contains <@ Verbose @> then
             Logging.verbose <- true
 
-        use fileTrace =
-            match results.TryGetResult <@ Log_File @> with
-            | Some lf -> setLogFile lf
-            | None -> null
+        let version = results.Contains <@ Version @> 
+        if not version then            
 
-        match results.GetSubCommand() with
-        | Add r -> processCommand silent add r
-        | ClearCache r -> processCommand silent clearCache r
-        | Config r -> processWithValidation silent validateConfig config r
-        | ConvertFromNuget r -> processCommand silent convert r
-        | FindRefs r -> processCommand silent findRefs r
-        | Init r -> processCommand silent init r
-        | AutoRestore r -> processWithValidation silent validateAutoRestore autoRestore r
-        | Install r -> processCommand silent install r
-        | Outdated r -> processCommand silent outdated r
-        | Remove r -> processCommand silent remove r
-        | Restore r -> processCommand silent restore r
-        | Simplify r -> processCommand silent simplify r
-        | Update r -> processCommand silent update r
-        | FindPackages r -> processCommand silent (findPackages silent) r
-        | FindPackageVersions r -> processCommand silent findPackageVersions r
-        | ShowInstalledPackages r -> processCommand silent showInstalledPackages r
-        | ShowGroups r -> processCommand silent showGroups r
-        | Pack r -> processCommand silent pack r
-        | Push r -> processCommand silent push r
-        | GenerateIncludeScripts r -> processCommand silent generateIncludeScripts r
-        // global options; list here in order to maintain compiler warnings
-        // in case of new subcommands added
-        | Verbose
-        | Silent
-        | Log_File _ -> failwith "internal error: this code should never be reached."
+            use fileTrace =
+                match results.TryGetResult <@ Log_File @> with
+                | Some lf -> setLogFile lf
+                | None -> null
+
+            match results.GetSubCommand() with
+            | Add r -> processCommand silent add r
+            | ClearCache r -> processCommand silent clearCache r
+            | Config r -> processWithValidation silent validateConfig config r
+            | ConvertFromNuget r -> processCommand silent convert r
+            | FindRefs r -> processCommand silent findRefs r
+            | Init r -> processCommand silent init r
+            | AutoRestore r -> processWithValidation silent validateAutoRestore autoRestore r
+            | Install r -> processCommand silent install r
+            | Outdated r -> processCommand silent outdated r
+            | Remove r -> processCommand silent remove r
+            | Restore r -> processCommand silent restore r
+            | Simplify r -> processCommand silent simplify r
+            | Update r -> processCommand silent update r
+            | FindPackages r -> processCommand silent (findPackages silent) r
+            | FindPackageVersions r -> processCommand silent findPackageVersions r
+            | ShowInstalledPackages r -> processCommand silent showInstalledPackages r
+            | ShowGroups r -> processCommand silent showGroups r
+            | Pack r -> processCommand silent pack r
+            | Push r -> processCommand silent push r
+            | GenerateIncludeScripts r -> processCommand silent generateIncludeScripts r            
+            // global options; list here in order to maintain compiler warnings
+            // in case of new subcommands added
+            | Verbose
+            | Silent
+            | Version
+            | Log_File _ -> failwith "internal error: this code should never be reached."
 
     with
     | exn when not (exn :? System.NullReferenceException) ->


### PR DESCRIPTION
This PR implements the feature requested in #1875, where you can specify the `--version` argument to print the version to the console. However, while implementing this,  I found I had to remove the `RequireSubcommand` attribute, as `--version` is (rightfully) not considered a sub-command and having the `RequireSubcommand` attribute would cause it to fail. The result of this change is of course that sub-commands are now not necessary, which I think is a bit odd. What do you think about this? 

The main problem is that #1875 suggests that the `--version` flags is used for displaying the version, but perhaps it should just be a regular subcommand?

