### PR TITLE
Use DU-based parameters for auto restore flags

### DIFF
--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -82,15 +82,15 @@ with
     interface IArgParserTemplate with
         member __.Usage = ""
 
+type AutoRestoreFlags = On | Off
+
 type AutoRestoreArgs =
-    | [<First>][<CustomCommandLine("on")>] On
-    | [<First>][<CustomCommandLine("off")>] Off
+    | [<MainCommand; Mandatory>] Flags of AutoRestoreFlags
 with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
-            | On -> "Turns auto restore on."
-            | Off -> "Turns auto restore off."
+            | Flags _ -> "enables or disables auto restore for the repo."
 
 type InstallArgs =
     | [<AltCommandLine("-f")>] Force

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -90,10 +90,9 @@ let validateAutoRestore (results : ParseResults<_>) =
     results.GetAllResults().Length = 1
 
 let autoRestore (results : ParseResults<_>) =
-    match results.GetAllResults() with
-    | [On] -> Dependencies.Locate().TurnOnAutoRestore()
-    | [Off] -> Dependencies.Locate().TurnOffAutoRestore()
-    | _ -> failwith "expected only one argument"
+    match results.GetResult <@ Flags @> with
+    | On -> Dependencies.Locate().TurnOnAutoRestore()
+    | Off -> Dependencies.Locate().TurnOffAutoRestore()
 
 let convert (results : ParseResults<_>) =
     let force = results.Contains <@ ConvertFromNugetArgs.Force @>


### PR DESCRIPTION
I incidentally noticed that the auto-restore command uses an odd way of specifying on/off params. This PR showcases Argu's ability to specify flags using DUs/enums. Here's what the syntax looks like now:
```
$ ./bin/paket.exe auto-restore --help
Paket version 3.16.0.0
Help was requested:
USAGE: paket auto-restore [--help] <on|off>

FLAGS:

    <on|off>              enables or disables auto restore for the repo.

OPTIONS:

    --verbose, -v         Enable verbose console output for the paket process.
    --log-file <path>     Specify a log file for the paket process.
    --silent, -s          Suppress console output for the paket process.
    --help                display this list of options.
```