### PR TITLE
Fix lowest_matching constraint out of sync

### DIFF
--- a/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
@@ -121,6 +121,43 @@ NUGET
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
     |> shouldEqual (normalizeLineEndings expected)
 
+[<Test>]
+let ``should generate lowest_matching true lock file``() = 
+    let config = """
+    lowest_matching true
+    source "http://www.nuget.org/api/v2"
+
+    nuget "Microsoft.SqlServer.Types"
+    """
+
+    let expected = """LOWEST_MATCHING: TRUE
+NUGET
+  remote: http://www.nuget.org/api/v2
+    Microsoft.SqlServer.Types (1.0)"""
+
+    let cfg = DependenciesFile.FromCode(config)
+    ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
+    |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should generate lowest_matching false lock file``() = 
+    let config = """
+    lowest_matching false
+    source "http://www.nuget.org/api/v2"
+
+    nuget "Microsoft.SqlServer.Types"
+    """
+
+    let expected = """LOWEST_MATCHING: FALSE
+NUGET
+  remote: http://www.nuget.org/api/v2
+    Microsoft.SqlServer.Types (1.0)"""
+
+    let cfg = DependenciesFile.FromCode(config)
+    ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
+    |> shouldEqual (normalizeLineEndings expected)
 
 
 [<Test>]


### PR DESCRIPTION
[Lowest_matching constraint](https://fsprojects.github.io/Paket/dependencies-file.html#Lowest_matching-option) isn't working when you set it at group level.

**Cause : The lowest_matching constraint isn't wrote into paket.lock file when the paket install occurs**

You can reproduce the out of sync error with this simple paket.dependencies content

```
source https://www.nuget.org/api/v2

lowest_matching: true

```

In paket verion 2.66.9.0 the command succeed but does not populate the paket.lock file

```
--------------------------------In paket version 2.66.9.0--------------------------------
$ paket install
Paket version 2.66.9.0
Resolving packages for group Main:
Locked version resolution written to ...\paket.lock
0 seconds - ready.

$ paket restore
Paket version 2.66.9.0
0 seconds - ready.
```
In current paket version the command failed

```
--------------------------------In paket version 3.16.0.0--------------------------------

$ .paket/paket install
Paket version 3.16.0.0
Resolving packages for group Main:
...\paket.lock is already up-to-date
0 seconds - ready.


$ .paket/paket restore
Paket version 3.16.0.0
paket.dependencies and paket.lock are out of sync in ...
Please run 'paket install' or 'paket update' to recompute the paket.lock file.
0 seconds - ready.

```


