### PR TITLE
Change project file condition handling to be case-insensitive

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -356,7 +356,11 @@ module ProjectFile =
 
                 let result =
                     match comp with
-                    | "==" | "!=" -> doComp left right
+                    | "==" | "!=" ->
+                        let eq = left.Equals(right, StringComparison.InvariantCultureIgnoreCase)
+                        if comp = "=="
+                        then eq
+                        else not eq
                     | _ ->
                         match System.Int64.TryParse left, System.Int64.TryParse right with
                         | (true, l), (true, r) -> doComp l r

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -357,7 +357,7 @@ module ProjectFile =
                 let result =
                     match comp with
                     | "==" | "!=" ->
-                        let eq = left.Equals(right, StringComparison.InvariantCultureIgnoreCase)
+                        let eq = left.Equals(right, StringComparison.OrdinalIgnoreCase)
                         if comp = "=="
                         then eq
                         else not eq

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -41,7 +41,7 @@ let ``should detect target framework for Project2 proj file``() =
 [<Test>]
 let ``should detect output path for proj file``
         ([<Values("Project1", "Project2", "Project3", "ProjectWithConditions")>] project)
-        ([<Values("Debug", "Release")>] configuration) =
+        ([<Values("Debug", "Release", "dEbUg", "rElEaSe")>] configuration) =
     ensureDir ()
     ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s.fsprojtest" project).Value.GetOutputDirectory configuration ""
     |> shouldEqual (System.IO.Path.Combine(@"bin", configuration) |> normalizePath)

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -43,8 +43,9 @@ let ``should detect output path for proj file``
         ([<Values("Project1", "Project2", "Project3", "ProjectWithConditions")>] project)
         ([<Values("Debug", "Release", "dEbUg", "rElEaSe")>] configuration) =
     ensureDir ()
-    ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s.fsprojtest" project).Value.GetOutputDirectory configuration ""
-    |> shouldEqual (System.IO.Path.Combine(@"bin", configuration) |> normalizePath)
+    let outPath = ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s.fsprojtest" project).Value.GetOutputDirectory configuration ""
+    let expected = (System.IO.Path.Combine(@"bin", configuration) |> normalizePath)
+    outPath.ToLowerInvariant() |> shouldEqual (expected.ToLowerInvariant())
 
 [<Test>]
 let ``should detect framework profile for ProjectWithConditions file`` () =


### PR DESCRIPTION
Had to fiddle with the test a bit because one of the test projects uses the given build configuration as part of its output path, but this should fix #1889.