### PR TITLE
Better Nuget V3 API and async caching

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -762,7 +762,8 @@ let GetVersions force root (sources, packageName:PackageName) =
                                       if not (String.containsIgnoreCase "teamcity" source.Url || String.containsIgnoreCase"feedservice.svc" source.Url  ) then
                                         yield getVersionsCached "Json" tryGetPackageVersionsViaJson (nugetSource, auth, source.Url, packageName) ]
 
-                                match NuGetV3.getAllVersionsAPI(source.Authentication,source.Url) with
+                                let apiV3 = NuGetV3.getAllVersionsAPI(source.Authentication,source.Url) |> Async.AwaitTask
+                                match apiV3 |> Async.RunSynchronously with
                                 | None -> v2Feeds
                                 | Some v3Url -> (getVersionsCached "V3" tryNuGetV3 (nugetSource, auth, v3Url, packageName)) :: v2Feeds
                        | NuGetV3 source ->

--- a/src/Paket.Core/NuGetV3.fs
+++ b/src/Paket.Core/NuGetV3.fs
@@ -71,7 +71,7 @@ let getSearchAPI(auth,nugetUrl) =
                     match v3res with
                     | Choice1Of2 s -> Some s
                     | Choice2Of2 ex -> 
-                        if verbose then traceWarnfn "getAllVersionsAPI: %s" (ex.ToString())
+                        if verbose then traceWarnfn "getSearchAPI: %s" (ex.ToString())
                         None
         } |> Async.StartAsTask)
 

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -465,7 +465,8 @@ type Dependencies(dependenciesFileName: string) =
         |> Seq.choose (fun source -> 
             match source with 
             | NuGetV2 s ->
-                match NuGetV3.getSearchAPI(s.Authentication,s.Url) with
+                let res = NuGetV3.getSearchAPI(s.Authentication,s.Url) |> Async.AwaitTask |> Async.RunSynchronously
+                match res with
                 | Some _ -> Some(NuGetV3.FindPackages(s.Authentication, s.Url, searchTerm, maxResults))
                 | None ->  Some(NuGetV2.FindPackages(s.Authentication, s.Url, searchTerm, maxResults))
             | NuGetV3 s -> Some(NuGetV3.FindPackages(s.Authentication, s.Url, searchTerm, maxResults))


### PR DESCRIPTION
Better Nuget V3 API and async caching.
Public API and Nuget V2 API calls to `Async.RunSynchronously` should be still refactored away to be real async, but those would cause function signature changes and for that reason bigger refactoring.
