### PR TITLE
Convert from nuget with analyzers.

### DIFF
--- a/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
@@ -75,3 +75,15 @@ let ``#1591 should convert denormalized versions``() =
 
     let depsFile = File.ReadAllText(Path.Combine(scenarioTempPath "i001591-convert-denormalized","paket.dependencies"))
     depsFile.Contains "6.1.0" |> shouldEqual true
+
+[<Test>]
+let ``#1922 should remove references to moved analyzers``() =
+    let scenario = "i001922-convert-nuget-with-analyzers"
+    paket "convert-from-nuget" scenario |> ignore
+    let projectFile = ProjectFile.loadFromFile(Path.Combine(scenarioTempPath scenario, "ConvertFromNugetWithAnalyzers", "ConvertFromNugetWithAnalyzers.csproj"))
+    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll\" />") |> shouldEqual false
+    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll\" />") |> shouldEqual false
+    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll\" />") |> shouldEqual false
+    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\Newtonsoft.Json.dll\" />") |> shouldEqual true
+    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll\" />") |> shouldEqual true
+    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\StyleCop.Analyzers.dll\" />") |> shouldEqual true

--- a/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
@@ -81,9 +81,11 @@ let ``#1922 should remove references to moved analyzers``() =
     let scenario = "i001922-convert-nuget-with-analyzers"
     paket "convert-from-nuget" scenario |> ignore
     let projectFile = ProjectFile.loadFromFile(Path.Combine(scenarioTempPath scenario, "ConvertFromNugetWithAnalyzers", "ConvertFromNugetWithAnalyzers.csproj"))
-    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll\" />") |> shouldEqual false
-    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll\" />") |> shouldEqual false
-    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll\" />") |> shouldEqual false
-    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\Newtonsoft.Json.dll\" />") |> shouldEqual true
-    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll\" />") |> shouldEqual true
-    projectFile.Document.OuterXml.Contains("<Analyzer Include=\"..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\StyleCop.Analyzers.dll\" />") |> shouldEqual true
+    let projectXml = projectFile.Document.OuterXml
+    StringAssert.DoesNotContain(@"<Analyzer Include=""..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll""", projectXml)
+    StringAssert.DoesNotContain(@"<Analyzer Include=""..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll""", projectXml)
+    StringAssert.DoesNotContain(@"<Analyzer Include=""..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll""", projectXml)
+
+    StringAssert.Contains(@"<Analyzer Include=""..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\Newtonsoft.Json.dll"">", projectXml)
+    StringAssert.Contains(@"<Analyzer Include=""..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll"">", projectXml)
+    StringAssert.Contains(@"<Analyzer Include=""..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\StyleCop.Analyzers.dll"">", projectXml)

--- a/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers.sln
+++ b/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConvertFromNugetWithAnalyzers", "ConvertFromNugetWithAnalyzers\ConvertFromNugetWithAnalyzers.csproj", "{F57CF427-0036-47D2-A718-23029124DB92}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F57CF427-0036-47D2-A718-23029124DB92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F57CF427-0036-47D2-A718-23029124DB92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F57CF427-0036-47D2-A718-23029124DB92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F57CF427-0036-47D2-A718-23029124DB92}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/Class1.cs
+++ b/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace ConvertFromNugetWithAnalyzers
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/ConvertFromNugetWithAnalyzers.csproj
+++ b/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/ConvertFromNugetWithAnalyzers.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F57CF427-0036-47D2-A718-23029124DB92}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConvertFromNugetWithAnalyzers</RootNamespace>
+    <AssemblyName>ConvertFromNugetWithAnalyzers</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/Properties/AssemblyInfo.cs
+++ b/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+[assembly: AssemblyTitle("ConvertFromNugetWithAnalyzers")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConvertFromNugetWithAnalyzers")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("f57cf427-0036-47d2-a718-23029124db92")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/packages.config
+++ b/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/before/ConvertFromNugetWithAnalyzers/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/AssemblyReader.fs
+++ b/paket-files/fsprojects/FSharp.TypeProviders.StarterPack/src/AssemblyReader.fs
@@ -1,4 +1,4 @@
-﻿// Copyright 2011-2015, Tomas Petricek (http://tomasp.net), Gustavo Guerra (http://functionalflow.co.uk), and other contributors
+// Copyright 2011-2015, Tomas Petricek (http://tomasp.net), Gustavo Guerra (http://functionalflow.co.uk), and other contributors
 // Licensed under the Apache License, Version 2.0, see LICENSE.md in this project
 //
 // A lightweight .NET assembly reader that fits in a single F# file.  Based on the well-tested Abstract IL 

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -320,10 +320,12 @@ let convertDependenciesConfigToReferencesFile projectFileName dependencies =
                  referencesFile
 
 let convertProjects nugetEnv =
-    [for project,packagesConfig in nugetEnv.NuGetProjectFiles do 
+    [for project,packagesConfig in nugetEnv.NuGetProjectFiles do
+        let packagesAndIds = packagesConfig.Packages |> List.map (fun p -> p.Id, p.Version)
         project.ReplaceNuGetPackagesFile()
         project.RemoveNuGetTargetsEntries()
-        project.RemoveImportAndTargetEntries(packagesConfig.Packages |> List.map (fun p -> p.Id, p.Version))
+        project.RemoveNugetAnalysers(packagesAndIds)
+        project.RemoveImportAndTargetEntries(packagesAndIds)
         project.RemoveNuGetPackageImportStamp()
         yield project, convertPackagesConfigToReferencesFile project.FileName packagesConfig]
 

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -30,8 +30,8 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>update</StartArguments>
-    <StartWorkingDirectory>D:\code\suaveondocker</StartWorkingDirectory>
+    <StartArguments>convert-from-nuget</StartArguments>
+    <StartWorkingDirectory>C:\Git\Third Party\Paket\integrationtests\scenarios\i001922-convert-nuget-with-analyzers\before\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Removes old nodes for analyzers in packages from project files.

@baronfel did all the work in this PR. 