### PR TITLE
Generate binding redirect that covers entire range of possible assembly versions

### DIFF
--- a/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/app.config
+++ b/integrationtests/scenarios/i001248-redirects-off/before/MyClassLibrary/MyClassLibrary/app.config
@@ -6,7 +6,7 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.4.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.0.0" />
   </dependentAssembly>
 </assemblyBinding></runtime>
 </configuration>

--- a/integrationtests/scenarios/i001544-redirects/before/BindingRedirectPaketBug/App.config.expected
+++ b/integrationtests/scenarios/i001544-redirects/before/BindingRedirectPaketBug/App.config.expected
@@ -10,32 +10,32 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2.2.0.0" />
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Common.Logging.NLog20" publicKeyToken="af08829b84f0328e" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2.2.0.0" />
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="2.2.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2.2.0.0" />
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.3.1.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.3.1.0" />
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="3.2.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="3.2.0.0" />
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="8.0.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="8.0.0.0" />
   </dependentAssembly>
 </assemblyBinding></runtime>
 </configuration>

--- a/integrationtests/scenarios/i001574-redirect-gac/before/BindingRedirectPaketBug/App.config.expected
+++ b/integrationtests/scenarios/i001574-redirect-gac/before/BindingRedirectPaketBug/App.config.expected
@@ -14,7 +14,7 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="4.3.1.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.3.1.0" />
   </dependentAssembly>
 </assemblyBinding></runtime>
 </configuration>

--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -49,7 +49,9 @@ let internal setRedirect (doc:XDocument) bindingRedirect =
                 assemblyBinding.Add(dependentAssembly)
                 dependentAssembly
                 
-    let newRedirect = createElementWithNs "bindingRedirect" [ "oldVersion", "0.0.0.0-999.999.999.999"
+    // According to MSDN (https://msdn.microsoft.com/en-us/library/eftw1fys(v=vs.110).aspx),
+    // "The format of an assembly version number is major.minor.build.revision. Valid values for each part of this version number are 0 to 65535"
+    let newRedirect = createElementWithNs "bindingRedirect" [ "oldVersion", "0.0.0.0-65535.65535.65535.65535"
                                                               "newVersion", bindingRedirect.Version ]
 
     match tryGetElementWithNs "Paket" dependentAssembly with

--- a/tests/Paket.Tests/BindingRedirect.fs
+++ b/tests/Paket.Tests/BindingRedirect.fs
@@ -50,7 +50,7 @@ let private containsDescendents count ns elementName (doc:XDocument) =
     Assert.AreEqual(count, doc.Descendants(XName.Get(elementName, ns)) |> Seq.length)
 let private containsSingleDescendent = containsDescendents 1 ""
 let private containsSingleDescendentWithNs = containsDescendents 1 bindingNs
-let private createBindingRedirectXml culture assembly version publicKey = sprintf "<dependentAssembly xmlns=\"urn:schemas-microsoft-com:asm.v1\">\r\n  <Paket>True</Paket>\r\n  <assemblyIdentity name=\"%s\" publicKeyToken=\"%s\" culture=\"%s\" />\r\n  <bindingRedirect oldVersion=\"0.0.0.0-999.999.999.999\" newVersion=\"%s\" />\r\n</dependentAssembly>" assembly publicKey culture version
+let private createBindingRedirectXml culture assembly version publicKey = sprintf "<dependentAssembly xmlns=\"urn:schemas-microsoft-com:asm.v1\">\r\n  <Paket>True</Paket>\r\n  <assemblyIdentity name=\"%s\" publicKeyToken=\"%s\" culture=\"%s\" />\r\n  <bindingRedirect oldVersion=\"0.0.0.0-65535.65535.65535.65535\" newVersion=\"%s\" />\r\n</dependentAssembly>" assembly publicKey culture version
 let private xNameForNs name = XName.Get(name, bindingNs)
 
 let sampleDocWithNoIndentation() = sprintf """<?xml version="1.0" encoding="utf-8"?>
@@ -155,7 +155,7 @@ let ``redirects got properly indented for readability in empty sample docs``() =
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Assembly" publicKeyToken="PUBLIC_KEY" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.0.0" />
   </dependentAssembly>
 </assemblyBinding></runtime></configuration>"""
 
@@ -193,7 +193,7 @@ let ``redirects got properly indented for readability in sample doc with runtime
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Assembly" publicKeyToken="PUBLIC_KEY" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.0.0" />
   </dependentAssembly>
 </assemblyBinding></runtime>
 </configuration>"""
@@ -231,7 +231,7 @@ let ``redirects got properly indented for readability in real world sample docs`
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Assembly" publicKeyToken="PUBLIC_KEY" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-999.999.999.999" newVersion="1.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.0.0" />
   </dependentAssembly>
 </assemblyBinding></runtime></configuration>"""
 


### PR DESCRIPTION
Fixes #1930