### PR TITLE
Msbuild reserved properties

### DIFF
--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -230,8 +230,12 @@ module ProjectFile =
             
         ] |> Map.ofList
 
+    /// Append two maps with the properties of the second replacing properties of the first
+    let private appendMap first second =
+        Map.fold (fun state key value -> Map.add key value state) first second
+
     let getPropertyWithDefaults propertyName defaultProperties (projectFile:ProjectFile) =
-        let defaultProperties = Map.fold (fun s k v -> Map.add k v s) defaultProperties (getReservedProperties projectFile)
+        let defaultProperties = appendMap defaultProperties (getReservedProperties projectFile)
 
         let processPlaceholders (data : Map<string, string>) text =
             

--- a/src/Paket.Core/ProjectFile.fs
+++ b/src/Paket.Core/ProjectFile.fs
@@ -208,7 +208,30 @@ module ProjectFile =
 
     open System.Text
 
+    let getReservedProperties (projectFile:ProjectFile) =
+        let projectFileInfo = FileInfo projectFile.FileName
+        let directoryNoRoot = Regex.Replace(projectFileInfo.FullName, "^.:\\\\?", "")
+        [
+            // Project file properties
+            "MSBuildProjectDirectory", projectFileInfo.DirectoryName
+            "MSBuildProjectDirectoryNoRoot", directoryNoRoot
+            "MSBuildProjectExtension", projectFileInfo.Extension
+            "MSBuildProjectFile", projectFileInfo.Name
+            "MSBuildProjectFullPath", projectFileInfo.FullName
+            "MSBuildProjectName", Path.GetFileNameWithoutExtension(projectFileInfo.FullName)
+            
+            // This file properties (Potentially an Imported file)
+            "MSBuildThisFileDirectory", projectFileInfo.DirectoryName + (string Path.DirectorySeparatorChar)
+            "MSBuildThisFileDirectoryNoRoot", directoryNoRoot + (string Path.DirectorySeparatorChar)
+            "MSBuildThisFileExtension", projectFileInfo.Extension
+            "MSBuildThisFile", projectFileInfo.Name
+            "MSBuildThisFileFullPath", projectFileInfo.FullName
+            "MSBuildThisFileName", Path.GetFileNameWithoutExtension(projectFileInfo.FullName)
+            
+        ] |> Map.ofList
+
     let getPropertyWithDefaults propertyName defaultProperties (projectFile:ProjectFile) =
+        let defaultProperties = Map.fold (fun s k v -> Map.add k v s) defaultProperties (getReservedProperties projectFile)
 
         let processPlaceholders (data : Map<string, string>) text =
             


### PR DESCRIPTION
This add a few reserved msbuild properties that are now supported with `$(XXX)` syntax (Used in pack command to find the output directory)

I placed `appendMap` locally because i'm lazy but i'm open to suggestions on where it should be :)