### PR TITLE
Transforming wildcard syntax to regex, which is used by WebProxy for …

### DIFF
--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -332,7 +332,9 @@ let envProxies () =
         // under mono, env vars are case sensitive
         if isNull v then Environment.GetEnvironmentVariable(name.ToLowerInvariant()) else v
     let bypassList =
-        let noproxy = getEnvValue "NO_PROXY"
+        let noproxyString = getEnvValue "NO_PROXY"
+        let noproxy = if not (String.IsNullOrEmpty (noproxyString)) then System.Text.RegularExpressions.Regex.Escape(noproxyString).Replace(@"*", ".*")  else noproxyString
+        
         if String.IsNullOrEmpty noproxy then [||] else
         noproxy.Split([| ',' |], StringSplitOptions.RemoveEmptyEntries)
     let getCredentials (uri:Uri) =

--- a/tests/Paket.Tests/UtilsSpecs.fs
+++ b/tests/Paket.Tests/UtilsSpecs.fs
@@ -222,8 +222,23 @@ let ``get http env proxy with bypass list``() =
     p.Address |> shouldEqual (new Uri("http://proxy.local:8080"))
     p.BypassProxyOnLocal |> shouldEqual true
     p.BypassList.Length |> shouldEqual 2
-    p.BypassList.[0] |> shouldEqual ".local"
+    p.BypassList.[0] |> shouldEqual "\\.local"
     p.BypassList.[1] |> shouldEqual "localhost"
+    p.Credentials |> shouldEqual null
+
+[<Test>]
+let ``get http env proxy with bypass list containing wildcards``() =
+    use v = new DisposableEnvVar("http_proxy", "http://proxy.local:8080")
+    use w = new DisposableEnvVar("no_proxy", ".local,localhost,*.asdf.com")
+    let pOpt = envProxies().TryFind "http"
+    Option.isSome pOpt |> shouldEqual true
+    let p = Option.get pOpt
+    p.Address |> shouldEqual (new Uri("http://proxy.local:8080"))
+    p.BypassProxyOnLocal |> shouldEqual true
+    p.BypassList.Length |> shouldEqual 3
+    p.BypassList.[0] |> shouldEqual "\\.local"
+    p.BypassList.[1] |> shouldEqual "localhost"
+    p.BypassList.[2] |> shouldEqual "\\.*\\.asdf\\.com"
     p.Credentials |> shouldEqual null
 
 [<Test>]


### PR DESCRIPTION
…NoProxy bypassing

I detected, that when using a NoProxy-environment variable is used, and this variable contains an element with wildcard (*.asdf.com), there was an error converting to paket from nuget.
The reason for that is, that the webproxy class can not handle wildcard-syntax and is using regular expression parsing here. So the wildcard and the dots have to be escaped.