### PR TITLE
prettify paket.config

### DIFF
--- a/src/Paket.Core/ConfigFile.fs
+++ b/src/Paket.Core/ConfigFile.fs
@@ -42,7 +42,7 @@ let private getConfigNode (nodeName : string) =
 let private saveConfigNode (node : XmlNode) =
     trial {
         do! createDir Constants.PaketConfigFolder
-        do! saveFile Constants.PaketConfigFile (node.OwnerDocument.OuterXml)
+        do! saveFile Constants.PaketConfigFile (normalizeXml node.OwnerDocument)
     }
 
 


### PR DESCRIPTION
fixes #1952

Before:

```xml
<configuration><credentials><token source="https://www.nuget.org" value="..." /></credentials></configuration>
```

After:

```xml
<?xml version="1.0" encoding="utf-16"?>
<configuration>
  <credentials>
    <token source="https://www.nuget.org" value="..." />
  </credentials>
</configuration>
```

Do you mind the addition of `<?xml version="1.0" encoding="utf-16"?>`?