### PR TITLE
Added option to have paket restore fail on check failure

### DIFF
--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -549,7 +549,7 @@ let ``#1815 duplicate fsharp core reference when using netstandard1.6``() =
     let lockFilePath = Paket.DependenciesFile.FindLockfile paketDependencies.DependenciesFile
 
     // Restore
-    paketDependencies.Restore(false, group, [], false, true)
+    paketDependencies.Restore(false, group, [], false, true, false)
     |> ignore
     let lockFile = paketDependencies.GetLockFile()
     let lockGroup = lockFile.GetGroup groupName

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -241,32 +241,32 @@ type Dependencies(dependenciesFileName: string) =
                                                       NoInstall = installAfter |> not }))
 
     /// Restores all dependencies.
-    member this.Restore(ignoreChecks): unit = this.Restore(false,None,[],false,ignoreChecks)
+    member this.Restore(ignoreChecks): unit = this.Restore(false,None,[],false,ignoreChecks,false)
 
     /// Restores all dependencies.
-    member this.Restore(): unit = this.Restore(false,None,[],false,false)
+    member this.Restore(): unit = this.Restore(false,None,[],false,false,false)
 
     /// Restores the given paket.references files.
-    member this.Restore(group: string option, files: string list, ignoreChecks): unit = this.Restore(false, group, files, false, ignoreChecks)
+    member this.Restore(group: string option, files: string list, ignoreChecks): unit = this.Restore(false, group, files, false, ignoreChecks,false)
 
     /// Restores the given paket.references files.
-    member this.Restore(group: string option, files: string list): unit = this.Restore(false, group, files, false, false)
+    member this.Restore(group: string option, files: string list): unit = this.Restore(false, group, files, false, false,false)
 
     /// Restores the given paket.references files.
-    member this.Restore(force: bool, group: string option, files: string list, touchAffectedRefs: bool, ignoreChecks) : unit =
+    member this.Restore(force: bool, group: string option, files: string list, touchAffectedRefs: bool, ignoreChecks, failOnFailedChecks) : unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () ->
                 if touchAffectedRefs then
                     let packagesToTouch = RestoreProcess.FindPackagesNotExtractedYet(dependenciesFileName)
                     this.Process (FindReferences.TouchReferencesOfPackages packagesToTouch)
-                RestoreProcess.Restore(dependenciesFileName,force,Option.map GroupName group,files,ignoreChecks))
+                RestoreProcess.Restore(dependenciesFileName,force,Option.map GroupName group,files,ignoreChecks, failOnFailedChecks))
 
     /// Restores packages for all available paket.references files
     /// (or all packages if onlyReferenced is false)
-    member this.Restore(force: bool, group: string option, onlyReferenced: bool, touchAffectedRefs: bool, ignoreChecks): unit =
+    member this.Restore(force: bool, group: string option, onlyReferenced: bool, touchAffectedRefs: bool, ignoreChecks, failOnFailedChecks): unit =
         if not onlyReferenced then 
-            this.Restore(force,group,[],touchAffectedRefs,ignoreChecks) 
+            this.Restore(force,group,[],touchAffectedRefs,ignoreChecks,failOnFailedChecks) 
         else
             let referencesFiles =
                 this.RootPath
@@ -275,7 +275,7 @@ type Dependencies(dependenciesFileName: string) =
             if Array.isEmpty referencesFiles then
                 traceWarnfn "No paket.references files found for which packages could be installed."
             else 
-                this.Restore(force, group, Array.toList referencesFiles, touchAffectedRefs, ignoreChecks)
+                this.Restore(force, group, Array.toList referencesFiles, touchAffectedRefs, ignoreChecks,  failOnFailedChecks)
 
     /// Lists outdated packages.
     member this.ShowOutdated(strict: bool,includePrereleases: bool): unit =

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -253,14 +253,14 @@ type Dependencies(dependenciesFileName: string) =
     member this.Restore(group: string option, files: string list): unit = this.Restore(false, group, files, false, false,false)
 
     /// Restores the given paket.references files.
-    member this.Restore(force: bool, group: string option, files: string list, touchAffectedRefs: bool, ignoreChecks, failOnFailedChecks) : unit =
+    member this.Restore(force: bool, group: string option, files: string list, touchAffectedRefs: bool, ignoreChecks, failOnChecks) : unit =
         Utils.RunInLockedAccessMode(
             this.RootPath,
             fun () ->
                 if touchAffectedRefs then
                     let packagesToTouch = RestoreProcess.FindPackagesNotExtractedYet(dependenciesFileName)
                     this.Process (FindReferences.TouchReferencesOfPackages packagesToTouch)
-                RestoreProcess.Restore(dependenciesFileName,force,Option.map GroupName group,files,ignoreChecks, failOnFailedChecks))
+                RestoreProcess.Restore(dependenciesFileName,force,Option.map GroupName group,files,ignoreChecks, failOnChecks))
 
     /// Restores packages for all available paket.references files
     /// (or all packages if onlyReferenced is false)

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -119,14 +119,12 @@ let internal computePackageHull groupName (lockFile : LockFile) (referencesFileN
         |> Seq.map (fun p -> (snd p.Key)))
     |> Seq.concat
 
-let Restore(dependenciesFileName,force,group,referencesFileNames,ignoreChecks) = 
+let Restore(dependenciesFileName,force,group,referencesFileNames,ignoreChecks,failOnFailedChecks) = 
     let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
     let localFileName = DependenciesFile.FindLocalfile dependenciesFileName
     let root = lockFileName.Directory.FullName
-
     if not lockFileName.Exists then 
         failwithf "%s doesn't exist." lockFileName.FullName
-
     let dependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
     let lockFile,localFile,hasLocalFile =
         let lockFile = LockFile.LoadFrom(lockFileName.FullName)
@@ -139,13 +137,12 @@ let Restore(dependenciesFileName,force,group,referencesFileNames,ignoreChecks) =
             LocalFile.overrideLockFile localFile lockFile,localFile,true
 
     if not hasLocalFile && not ignoreChecks then
-        try
-            let hasAnyChanges,_,_,_ = DependencyChangeDetection.GetChanges(dependenciesFile,lockFile,false)
+        let hasAnyChanges,_,_,_ = DependencyChangeDetection.GetChanges(dependenciesFile,lockFile,false)
 
-            if hasAnyChanges then 
-                traceWarnfn "paket.dependencies and paket.lock are out of sync in %s.%sPlease run 'paket install' or 'paket update' to recompute the paket.lock file." lockFileName.Directory.FullName Environment.NewLine
-        with
-        | _ -> ()
+        let checkResponse = if failOnFailedChecks then failwithf else traceWarnfn
+        if hasAnyChanges then 
+            checkResponse "paket.dependencies and paket.lock are out of sync in %s.%sPlease run 'paket install' or 'paket update' to recompute the paket.lock file." lockFileName.Directory.FullName Environment.NewLine
+
 
     let groups =
         match group with

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -119,7 +119,7 @@ let internal computePackageHull groupName (lockFile : LockFile) (referencesFileN
         |> Seq.map (fun p -> (snd p.Key)))
     |> Seq.concat
 
-let Restore(dependenciesFileName,force,group,referencesFileNames,ignoreChecks,failOnFailedChecks) = 
+let Restore(dependenciesFileName,force,group,referencesFileNames,ignoreChecks,failOnChecks) = 
     let lockFileName = DependenciesFile.FindLockfile dependenciesFileName
     let localFileName = DependenciesFile.FindLocalfile dependenciesFileName
     let root = lockFileName.Directory.FullName
@@ -139,7 +139,7 @@ let Restore(dependenciesFileName,force,group,referencesFileNames,ignoreChecks,fa
     if not hasLocalFile && not ignoreChecks then
         let hasAnyChanges,_,_,_ = DependencyChangeDetection.GetChanges(dependenciesFile,lockFile,false)
 
-        let checkResponse = if failOnFailedChecks then failwithf else traceWarnfn
+        let checkResponse = if failOnChecks then failwithf else traceWarnfn
         if hasAnyChanges then 
             checkResponse "paket.dependencies and paket.lock are out of sync in %s.%sPlease run 'paket install' or 'paket update' to recompute the paket.lock file." lockFileName.Directory.FullName Environment.NewLine
 

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -156,7 +156,7 @@ type RestoreArgs =
     | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
     | [<CustomCommandLine("--touch-affected-refs")>] Touch_Affected_Refs
     | [<CustomCommandLine("--ignore-checks")>] Ignore_Checks
-    | [<CustomCommandLine("--fail-on-failed-checks")>] Fail_On_Failed_Checks
+    | [<CustomCommandLine("--fail-on-checks")>] Fail_On_Checks
     | [<CustomCommandLine("group")>] Group of name:string
     | [<Unique>] References_Files of file_name:string list
 with
@@ -168,7 +168,7 @@ with
             | Install_Only_Referenced -> "Allows to restore packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
             | Touch_Affected_Refs -> "Touches project files referencing packages which are being restored, to help incremental build tools detecting the change."
             | Ignore_Checks -> "Skips the test if paket.dependencies and paket.lock are in sync."
-            | Fail_On_Failed_Checks -> "Causes the restore to fail if any of the checks fail."
+            | Fail_On_Checks -> "Causes the restore to fail if any of the checks fail."
             | References_Files(_) -> "Allows to restore all packages from the given paket.references files. This implies --only-referenced."
 
 type SimplifyArgs =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -156,6 +156,7 @@ type RestoreArgs =
     | [<CustomCommandLine("--only-referenced")>] Install_Only_Referenced
     | [<CustomCommandLine("--touch-affected-refs")>] Touch_Affected_Refs
     | [<CustomCommandLine("--ignore-checks")>] Ignore_Checks
+    | [<CustomCommandLine("--fail-on-failed-checks")>] Fail_On_Failed_Checks
     | [<CustomCommandLine("group")>] Group of name:string
     | [<Unique>] References_Files of file_name:string list
 with
@@ -167,6 +168,7 @@ with
             | Install_Only_Referenced -> "Allows to restore packages that are referenced in paket.references files, instead of all packages in paket.dependencies."
             | Touch_Affected_Refs -> "Touches project files referencing packages which are being restored, to help incremental build tools detecting the change."
             | Ignore_Checks -> "Skips the test if paket.dependencies and paket.lock are in sync."
+            | Fail_On_Failed_Checks -> "Causes the restore to fail if any of the checks fail."
             | References_Files(_) -> "Allows to restore all packages from the given paket.references files. This implies --only-referenced."
 
 type SimplifyArgs =

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -154,8 +154,9 @@ let restore (results : ParseResults<_>) =
     let installOnlyReferenced = results.Contains <@ RestoreArgs.Install_Only_Referenced @>
     let touchAffectedRefs = results.Contains <@ RestoreArgs.Touch_Affected_Refs @>
     let ignoreChecks = results.Contains <@ RestoreArgs.Ignore_Checks @>
-    if List.isEmpty files then Dependencies.Locate().Restore(force, group, installOnlyReferenced, touchAffectedRefs, ignoreChecks)
-    else Dependencies.Locate().Restore(force, group, files, touchAffectedRefs, ignoreChecks)
+    let failOnFailedChecks = results.Contains <@ RestoreArgs.Fail_On_Failed_Checks @>
+    if List.isEmpty files then Dependencies.Locate().Restore(force, group, installOnlyReferenced, touchAffectedRefs, ignoreChecks, failOnFailedChecks)
+    else Dependencies.Locate().Restore(force, group, files, touchAffectedRefs, ignoreChecks, failOnFailedChecks)
 
 let simplify (results : ParseResults<_>) =
     let interactive = results.Contains <@ SimplifyArgs.Interactive @>

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -154,9 +154,9 @@ let restore (results : ParseResults<_>) =
     let installOnlyReferenced = results.Contains <@ RestoreArgs.Install_Only_Referenced @>
     let touchAffectedRefs = results.Contains <@ RestoreArgs.Touch_Affected_Refs @>
     let ignoreChecks = results.Contains <@ RestoreArgs.Ignore_Checks @>
-    let failOnFailedChecks = results.Contains <@ RestoreArgs.Fail_On_Failed_Checks @>
-    if List.isEmpty files then Dependencies.Locate().Restore(force, group, installOnlyReferenced, touchAffectedRefs, ignoreChecks, failOnFailedChecks)
-    else Dependencies.Locate().Restore(force, group, files, touchAffectedRefs, ignoreChecks, failOnFailedChecks)
+    let failOnChecks = results.Contains <@ RestoreArgs.Fail_On_Checks @>
+    if List.isEmpty files then Dependencies.Locate().Restore(force, group, installOnlyReferenced, touchAffectedRefs, ignoreChecks, failOnChecks)
+    else Dependencies.Locate().Restore(force, group, files, touchAffectedRefs, ignoreChecks, failOnChecks)
 
 let simplify (results : ParseResults<_>) =
     let interactive = results.Contains <@ SimplifyArgs.Interactive @>


### PR DESCRIPTION
I removed the exception swallowing. If there's a specific exception it was meant to suppress that should be added back in. Also are there tests around this functionality? I couldn't find any related ones.

PS: Total F# noob here