### PR TITLE
ConfigFileParseError wording fix

### DIFF
--- a/src/Paket.Core/Domain.fs
+++ b/src/Paket.Core/Domain.fs
@@ -167,7 +167,7 @@ type DomainMessage =
         | FileSaveError path ->
             sprintf "Unable to save file %s." path
 
-        | ConfigFileParseError -> "Unable to parse Paket configuration from packages.config."
+        | ConfigFileParseError -> "Unable to parse Paket configuration from paket.config."
 
         | PackagingConfigParseError(file,error) ->
             sprintf "Unable to parse template file %s: %s." file error


### PR DESCRIPTION
Fix wording of exception message to avoid confusion.