### PR TITLE
Add Install-Paket.ps1 to prevent embedding .exe in git.

### DIFF
--- a/Install-Paket.ps1
+++ b/Install-Paket.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)][System.IO.FileInfo]$Path,
+    [Switch]$AddToPath
+)
+
+$old_location = Get-Location
+$paket_directory = Join-Path $Path ".paket"
+If (-not (Test-Path $paket_directory)) {
+    New-Item -Path $paket_directory -Type Directory
+}
+
+$bootstrapper_name = 'paket.bootstrapper.exe'
+$latest_request = "https://api.github.com/repos/fsprojects/Paket/releases/latest"
+$executable =  Join-Path $paket_directory $bootstrapper_name
+
+$latest = (Invoke-WebRequest -Uri $latest_request).Content | ConvertFrom-Json
+$asset_request = "https://api.github.com/repos/fsprojects/Paket/releases/$($latest.id)/assets"
+
+$bootstrapper = (Invoke-WebRequest -Uri $asset_request).Content | ConvertFrom-Json
+$bootstrapper = $bootstrapper | Where name -eq $bootstrapper_name | Select browser_download_url, name -First 1
+
+Invoke-WebRequest -Uri $bootstrapper.browser_download_url -OutFile $executable
+
+Set-Location $paket_directory
+If (Test-Path $bootstrapper_name) {
+    .\paket.bootstrapper.exe
+
+    If ($AddToPath) {
+        [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$paket_directory", [System.EnvironmentVariableTarget]::Machine) 
+    }
+} Else {
+    "Download of $bootstrapper_name failed" | Write-Error
+}
+
+Set-Location $old_location

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -57,6 +57,14 @@ After that completes execute the install, to install Paket as a command line uti
 
 Please use the [Installation per repository](installation.html#Installation-per-repository) option.
 
+You may also use the PowerShell installation script.
+
+    ./Install-Paket.ps1 -Path .
+
+And for system-wide installation use the `-AddToPath` switch.
+
+    ./Install-Paket.ps1 -Path . -AddToPath
+
 ### Post Installation
 
 Once the basic installation is complete on your operating system of choice it is often very useful to add some tools to your IDE/Text Editor of choice. Here's some of the options that are available.


### PR DESCRIPTION
This checks the github api for the latest release and appropriately
downloads the paket bootstrapper. An optional parameter `-AddToPath` can
be used to add the paket directory to `$env:Path` for CI boxes.

The intent is to allow those who have *.exe in their .gitignore to more
easily use paket on Windows.