### PR TITLE
More boostrapper config

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -79,7 +79,7 @@ Would do the same thing as :
 paket.bootstrapper.exe -s --max-file-age=720 --run add nuget FAKE
 ```
 
-Even while renamed as `paket.exe` the bootstraper parameters can still be specified if `--run` is present:
+Even while renamed as `paket.exe` the bootstrapper parameters can still be specified if `--run` is present:
 
 ```batch
 paket.exe --force-nuget --run add nuget FAKE

--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -45,6 +45,7 @@ Example file :
   <appSettings>
     <add key="PreferNuget" value="True"/>
     <add key="ForceNuget" value="True"/>
+    <add key="Prerelease" value="True"/>
     <add key="PaketVersion" value="1.5"/>
   </appSettings>
 </configuration>
@@ -55,6 +56,8 @@ Example file :
   `ForceNuget`: Same as `--force-nuget` option. Downloads paket.exe from nuget.org instead of github.com, but does *not* use github.com as a fallback.
 
   `PaketVersion`: Same as `version` option. Downloads the given version of paket.exe from github.com.
+
+  `Prerelease`: Same as `prerelease` option. Ignored if a version number is specified in `PaketVersion` or via another way.
 
 ## Environment Variables
 

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -30,6 +30,7 @@ namespace Paket.Bootstrapper
             public const string PreferNugetAppSettingsKey = "PreferNuget";
             public const string ForceNugetAppSettingsKey = "ForceNuget";
             public const string PaketVersionAppSettingsKey = "PaketVersion";
+            public const string PrereleaseAppSettingsKey = "Prerelease";
         }
         public static class EnvArgs
         {
@@ -124,7 +125,7 @@ namespace Paket.Bootstrapper
             string nugetSource = null;
 
             var latestVersion = appSettings.GetKey(AppSettingKeys.PaketVersionAppSettingsKey) ?? envVariables.GetKey(EnvArgs.PaketVersionEnv) ?? String.Empty;
-            var ignorePrerelease = true;
+            var prerelease = appSettings.GetKey(AppSettingKeys.PrereleaseAppSettingsKey).ToLowerSafe() == "true" && string.IsNullOrEmpty(latestVersion);
             bool doSelfUpdate = false;
             var ignoreCache = false;
             var commandArgs = args.ToList();
@@ -166,19 +167,20 @@ namespace Paket.Bootstrapper
             {
                 if (commandArgs[0] == CommandArgs.Prerelease)
                 {
-                    ignorePrerelease = false;
+                    prerelease = true;
                     latestVersion = String.Empty;
                     commandArgs.Remove(CommandArgs.Prerelease);
                 }
                 else
                 {
+                    prerelease = false;
                     latestVersion = commandArgs[0];
                     commandArgs.Remove(commandArgs[0]);
                 }
             }
 
             downloadArguments.LatestVersion = latestVersion;
-            downloadArguments.IgnorePrerelease = ignorePrerelease;
+            downloadArguments.IgnorePrerelease = !prerelease;
             downloadArguments.IgnoreCache = ignoreCache;
             downloadArguments.NugetSource = nugetSource;
             downloadArguments.DoSelfUpdate = doSelfUpdate;

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -27,10 +27,10 @@ namespace Paket.Bootstrapper
         }
         public static class AppSettingKeys
         {
-            public const string PreferNugetAppSettingsKey = "PreferNuget";
-            public const string ForceNugetAppSettingsKey = "ForceNuget";
-            public const string PaketVersionAppSettingsKey = "PaketVersion";
-            public const string PrereleaseAppSettingsKey = "Prerelease";
+            public const string PreferNuget = "PreferNuget";
+            public const string ForceNuget = "ForceNuget";
+            public const string PaketVersion = "PaketVersion";
+            public const string Prerelease = "Prerelease";
         }
         public static class EnvArgs
         {
@@ -92,11 +92,11 @@ namespace Paket.Bootstrapper
 
         private static void ApplyAppSettings(NameValueCollection appSettings, BootstrapperOptions options)
         {
-            if (appSettings.GetKey(AppSettingKeys.PreferNugetAppSettingsKey).ToLowerSafe() == "true")
+            if (appSettings.IsTrue(AppSettingKeys.PreferNuget))
             {
                 options.PreferNuget = true;
             }
-            if (appSettings.GetKey(AppSettingKeys.ForceNugetAppSettingsKey).ToLowerSafe() == "true")
+            if (appSettings.IsTrue(AppSettingKeys.ForceNuget))
             {
                 options.ForceNuget = true;
             }
@@ -124,9 +124,9 @@ namespace Paket.Bootstrapper
             var target = magicMode ? GetMagicModeTarget() : Path.Combine(folder, "paket.exe");
             string nugetSource = downloadArguments.NugetSource;
 
-            var latestVersion = appSettings.GetKey(AppSettingKeys.PaketVersionAppSettingsKey) ?? envVariables.GetKey(EnvArgs.PaketVersionEnv) ?? downloadArguments.LatestVersion;
-            var prerelease = (appSettings.GetKey(AppSettingKeys.PrereleaseAppSettingsKey).ToLowerSafe() == "true" &&
-                              string.IsNullOrEmpty(latestVersion)) || !downloadArguments.IgnorePrerelease;
+            var latestVersion = appSettings.GetKey(AppSettingKeys.PaketVersion) ?? envVariables.GetKey(EnvArgs.PaketVersionEnv) ?? downloadArguments.LatestVersion;
+            var prerelease = (appSettings.IsTrue(AppSettingKeys.Prerelease) && string.IsNullOrEmpty(latestVersion))
+                || !downloadArguments.IgnorePrerelease;
             bool doSelfUpdate = downloadArguments.DoSelfUpdate;
             var ignoreCache = downloadArguments.IgnoreCache;
             var commandArgs = args.ToList();
@@ -191,6 +191,11 @@ namespace Paket.Bootstrapper
             return commandArgs;
         }
 
+        private static bool IsTrue(this NameValueCollection appSettings, string key)
+        {
+            return appSettings.GetKey(key).ToLowerSafe() == "true";
+        }
+
         private static string GetKey(this NameValueCollection appSettings, string key)
         {
             if (appSettings != null && appSettings.AllKeys.Any(x => x == key))
@@ -207,9 +212,7 @@ namespace Paket.Bootstrapper
 
         private static string ToLowerSafe(this string value)
         {
-            if (value != null)
-                return value.ToLower();
-            return null;
+            return value?.ToLower();
         }
     }
 }

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -122,14 +122,15 @@ namespace Paket.Bootstrapper
         {
             var folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var target = magicMode ? GetMagicModeTarget() : Path.Combine(folder, "paket.exe");
-            string nugetSource = null;
+            string nugetSource = downloadArguments.NugetSource;
 
-            var latestVersion = appSettings.GetKey(AppSettingKeys.PaketVersionAppSettingsKey) ?? envVariables.GetKey(EnvArgs.PaketVersionEnv) ?? String.Empty;
-            var prerelease = appSettings.GetKey(AppSettingKeys.PrereleaseAppSettingsKey).ToLowerSafe() == "true" && string.IsNullOrEmpty(latestVersion);
-            bool doSelfUpdate = false;
-            var ignoreCache = false;
+            var latestVersion = appSettings.GetKey(AppSettingKeys.PaketVersionAppSettingsKey) ?? envVariables.GetKey(EnvArgs.PaketVersionEnv) ?? downloadArguments.LatestVersion;
+            var prerelease = (appSettings.GetKey(AppSettingKeys.PrereleaseAppSettingsKey).ToLowerSafe() == "true" &&
+                              string.IsNullOrEmpty(latestVersion)) || !downloadArguments.IgnorePrerelease;
+            bool doSelfUpdate = downloadArguments.DoSelfUpdate;
+            var ignoreCache = downloadArguments.IgnoreCache;
             var commandArgs = args.ToList();
-            int? maxFileAgeInMinutes = null;
+            int? maxFileAgeInMinutes = downloadArguments.MaxFileAgeInMinutes;
 
             if (commandArgs.Contains(CommandArgs.SelfUpdate))
             {

--- a/src/Paket.Bootstrapper/PaketRunner.cs
+++ b/src/Paket.Bootstrapper/PaketRunner.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Paket.Bootstrapper
 {
-    class PaketRunner
+    static class PaketRunner
     {
         static readonly Version VersionWithFromBootstrapper = new Version("3.23.3");
 

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -15,8 +15,6 @@ namespace Paket.Bootstrapper
 {
     static class Program
     {
-        private static readonly PaketRunner ConsoleRunner = new PaketRunner();
-
         static bool GetIsMagicMode()
         {
             var fileName = Path.GetFileName(Assembly.GetExecutingAssembly().Location);

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -99,7 +99,7 @@ namespace Paket.Bootstrapper.Tests
         {
             //arrange
             var appSettings = new NameValueCollection();
-            appSettings.Add(ArgumentParser.AppSettingKeys.ForceNugetAppSettingsKey, "TrUe");
+            appSettings.Add(ArgumentParser.AppSettingKeys.ForceNuget, "TrUe");
 
             //act
             var result = ArgumentParser.ParseArgumentsAndConfigurations(new string[] { }, appSettings, null, false);
@@ -137,7 +137,7 @@ namespace Paket.Bootstrapper.Tests
         {
             //arrange
             var appSettings = new NameValueCollection();
-            appSettings.Add(ArgumentParser.AppSettingKeys.PreferNugetAppSettingsKey, "TrUe");
+            appSettings.Add(ArgumentParser.AppSettingKeys.PreferNuget, "TrUe");
 
             //act
             var result = ArgumentParser.ParseArgumentsAndConfigurations(new string[] {}, appSettings, null, false);
@@ -188,7 +188,7 @@ namespace Paket.Bootstrapper.Tests
         {
             //arrange
             var appSettings = new NameValueCollection();
-            appSettings.Add(ArgumentParser.AppSettingKeys.PrereleaseAppSettingsKey, "TrUe");
+            appSettings.Add(ArgumentParser.AppSettingKeys.Prerelease, "TrUe");
 
             //act
             var result = ArgumentParser.ParseArgumentsAndConfigurations(new string[] { }, appSettings, null, false);

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -184,6 +184,20 @@ namespace Paket.Bootstrapper.Tests
         }
 
         [Test]
+        public void Prerelease_FromAppSettings()
+        {
+            //arrange
+            var appSettings = new NameValueCollection();
+            appSettings.Add(ArgumentParser.AppSettingKeys.PrereleaseAppSettingsKey, "TrUe");
+
+            //act
+            var result = ArgumentParser.ParseArgumentsAndConfigurations(new string[] { }, appSettings, null, false);
+
+            //assert
+            Assert.That(result.DownloadArguments.IgnorePrerelease, Is.False);
+        }
+
+        [Test]
         public void SelfUpdate()
         {
             //arrange


### PR DESCRIPTION
Add a "Prerelease" setting in `.config` file so that even magic mode bootstrapper can use pre-releases as discussed in #1961.

To use it :

```xml
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
  <appSettings>
    <add key="Prerelease" value="True"/>
  </appSettings>
</configuration>
```

Also do a small cleanup in ArgumentParser of the bootstrapper.