### PR TITLE
Fix build error in Paket.Tests

### DIFF
--- a/tests/Paket.Tests/NuspecWriterSpecs.fs
+++ b/tests/Paket.Tests/NuspecWriterSpecs.fs
@@ -18,8 +18,8 @@ let ``should serialize core info``() =
     <description>A description</description>
   </metadata>
 </package>"""
-    
-    let core = 
+
+    let core : CompleteCoreInfo =
         { Id = "Paket.Tests"
           Version = SemVer.Parse "1.0.0.0" |> Some
           Authors = [ "Two"; "Authors" ]
@@ -46,8 +46,8 @@ let ``should serialize dependencies``() =
     </dependencies>
   </metadata>
 </package>"""
-    
-    let core = 
+
+    let core : CompleteCoreInfo =
         { Id = "Paket.Tests"
           Version = SemVer.Parse "1.0.0.0" |> Some
           Authors = [ "Two"; "Authors" ]
@@ -82,8 +82,8 @@ let ``should serialize frameworkAssemblues``() =
     </frameworkAssemblies>
   </metadata>
 </package>"""
-    
-    let core = 
+
+    let core : CompleteCoreInfo =
         { Id = "Paket.Tests"
           Version = SemVer.Parse "1.0.0.0" |> Some
           Authors = [ "Two"; "Authors" ]
@@ -112,8 +112,8 @@ let ``should not serialize files``() =
     <description>A description</description>
   </metadata>
 </package>"""
-    
-    let core = 
+
+    let core : CompleteCoreInfo =
         { Id = "Paket.Core"
           Version = SemVer.Parse "4.2" |> Some
           Authors = [ "Michael"; "Steffen" ]
@@ -159,8 +159,8 @@ second line</releaseNotes>
     </references>
   </metadata>
 </package>"""
-    
-    let core = 
+
+    let core : CompleteCoreInfo =
         { Id = "Paket.Core"
           Version = SemVer.Parse "4.2" |> Some
           Authors = [ "Michael"; "Steffen" ]


### PR DESCRIPTION
I added explicit type information to the `NuspecWriterSpecs.fs` file, and this fixes the build for me at least.

I think the issue is that the Travis build uses a F# 4.0 compiler (https://travis-ci.org/fsprojects/Paket/builds/171333514#L1582), and I have a F# 4.1 compiler on my Mac, as it is bundled with Mono, installed via Homebrew. Seems there are some changes in the type inference stuff.

@piedar could you please try to build this branch and tell us if it succeeds for you now?