### PR TITLE
Why - take #2

### DIFF
--- a/src/Paket.Core/Why.fs
+++ b/src/Paket.Core/Why.fs
@@ -84,11 +84,14 @@ module DependencyChain =
 
 // In context of FAKE project dependencies
 type Reason =
-// e.g. Argu - specified in paket.dependencies, is not a dependency of any other package
+// e.g. Argu - specified in paket.dependencies
+// is not a dependency of any other package
 | TopLevel
-// e.g. Microsoft.AspNet.Razor - specified in paket.dependencies, but also a dependency of other package(s)
+// e.g. Microsoft.AspNet.Razor - specified in paket.dependencies
+// but also a dependency of other package(s)
 | Direct of DependencyChain list
-// e.g. Microsoft.AspNet.Mvc - not specified in paket.dependencies, a dependency of other package(s)
+// e.g. Microsoft.AspNet.Mvc - not specified in paket.dependencies
+// a dependency of other package(s)
 | Transient of DependencyChain list
 
 type InferError =
@@ -191,7 +194,7 @@ let ohWhy (packageName,
                     DependencyChain.format options.Details shortest |> tracen
                     tracen ""
                     tracefn 
-                        "... and %d path%s more starting at %O. To display all paths use --details flag" 
+                        "... and %d chain%s more starting at %O. To display all chains use --details flag" 
                         rest.Length 
                         (if rest.Length > 1 then "s" else "") 
                         top

--- a/src/Paket.Core/Why.fs
+++ b/src/Paket.Core/Why.fs
@@ -7,43 +7,66 @@ open Paket.Logging
 
 open Chessie.ErrorHandling
 
-type AdjGraph<'a> = list<'a * list<'a>>
+type AdjLblGraph<'a, 'b> = list<'a * list<('a * 'b)>>
 
-module AdjGraph =
-    let adj n (g: AdjGraph<_>) =
+type LblPath<'a, 'b> = 'a * LblPathNode<'a, 'b>
+
+and LblPathNode<'a, 'b> =
+| LblPathNode of LblPath<'a, 'b>
+| LblPathLeaf of 'a * 'b
+
+module AdjLblGraph =
+    let adj n (g: AdjLblGraph<_, _>) =
         g
         |> List.find (fst >> (=) n)
         |> snd
 
-    let rec paths start stop (g : AdjGraph<'a>) =
-        if start = stop then [[start]]
-        else
-            [ for n in adj start g do
-                for path in paths n stop g do
-                    yield start :: path ]
+    let rec paths start stop g : list<LblPath<_, _>> =
+        [ for (n, lbl) in adj start g do
+            if n = stop then yield (start, LblPathLeaf (stop, lbl))
+            for path in paths n stop g do 
+                yield (start, LblPathNode path)]
 
-let depGraph (res : PackageResolver.PackageResolution) : AdjGraph<Domain.PackageName> =
+let depGraph (res : PackageResolver.PackageResolution) : AdjLblGraph<Domain.PackageName, VersionRequirement> =
     res
     |> Seq.toList
     |> List.map (fun pair -> pair.Key, (pair.Value.Dependencies 
-                                       |> Set.map (fun (p,_,_) -> p) 
+                                       |> Set.map (fun (p,v,_) -> p,v) 
                                        |> Set.toList))
 
 type WhyOptions = 
-    { AllPaths : bool }
+    { AllPaths : bool
+      VersionConstraints : bool }
 
-type DependencyChain = List<PackageName>
+type DependencyChain = LblPath<PackageName, VersionRequirement>
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module DependencyChain =
-    let format (chain : DependencyChain) =
-        chain
-        |> Seq.mapi (fun i name -> sprintf "%s-> %O" (String.replicate i "  ") name)
-        |> String.concat Environment.NewLine
+    let first ((name, _) : DependencyChain) = name
 
-    let formatMany chains =
+    let rec length = function
+    | (_, LblPathNode n) -> length n + 1
+    | (_, LblPathLeaf _) -> 2
+
+    let format showVersions (c : DependencyChain) =
+        let formatVerReq (vr : VersionRequirement) =
+            match vr.ToString() with
+            | "" -> ""
+            | nonempty -> sprintf " (%s)" nonempty
+        let formatName name i = sprintf "%s-> %O" (String.replicate i "  ") name
+        let rec format' i (name,chain) =
+            let rest = 
+                match chain, showVersions with
+                | LblPathNode chain,_ -> format' (i+1) chain
+                | LblPathLeaf (name,req), true -> sprintf "%s%s" (formatName name (i+1)) (formatVerReq req)
+                | LblPathLeaf (name,req), false -> formatName name (i+1)
+            sprintf "%s%s%s" (formatName name i) Environment.NewLine rest
+        
+        format' 0 c
+
+    let formatMany showVersions chains =
         chains
-        |> Seq.map format
+        |> Seq.map (format showVersions)
         |> String.concat (String.replicate 2 Environment.NewLine)
 
 // In context of FAKE project dependencies
@@ -75,7 +98,7 @@ module Reason =
                groupName : GroupName,
                directDeps : Set<PackageName>, 
                lockFile : LockFile) :
-               Result<Reason, InferError> =
+               Result<_,_> =
 
         let inferError () =
             let otherGroups =
@@ -102,14 +125,18 @@ module Reason =
             let chains = 
                 topLevelDeps
                 |> Set.toList
-                |> List.collect (fun p -> AdjGraph.paths p packageName graph)
+                |> List.collect (fun p -> AdjLblGraph.paths p packageName graph)
+            let version =
+                group.Resolution
+                |> Map.find packageName
+                |> fun x -> x.Version
             match Set.contains packageName directDeps, Set.contains packageName topLevelDeps with
             | true, true ->
-                Result.Succeed TopLevel
+                Result.Ok ((TopLevel, version), [])
             | true, false ->
-                Result.Succeed (Direct chains)
+                Result.Ok ((Direct chains, version), [])
             | false, false ->
-                Result.Succeed (Transient chains)
+                Result.Ok ((Transient chains, version), [])
             | false, true ->
                 failwith "impossible"
 
@@ -131,10 +158,10 @@ let ohWhy (packageName,
             (otherGroups |> List.map (fun pair -> pair.ToString()))
 
         usage |> traceWarn
-    | Result.Ok (reason, []) ->
+    | Result.Ok ((reason, version), []) ->
         reason
         |> Reason.format
-        |> sprintf "NuGet %O is a %s" packageName
+        |> sprintf "NuGet %O%s is a %s" packageName (if options.VersionConstraints then " " + version.ToString() else "")
         |> tracen
 
         match reason with
@@ -143,12 +170,12 @@ let ohWhy (packageName,
         | Transient chains ->
             tracefn "It's a part of following dependency chains:"
             tracen ""
-            for (top, chains) in chains |> List.groupBy (Seq.item 0) do
-                match chains |> List.sortBy Seq.length, options.AllPaths with
+            for (top, chains) in chains |> List.groupBy (DependencyChain.first) do
+                match chains |> List.sortBy DependencyChain.length, options.AllPaths with
                 | shortest :: [], false ->
-                    DependencyChain.format shortest |> tracen
+                    DependencyChain.format options.VersionConstraints shortest |> tracen
                 | shortest :: rest, false ->
-                    DependencyChain.format shortest |> tracen
+                    DependencyChain.format options.VersionConstraints shortest |> tracen
                     tracen ""
                     tracefn 
                         "... and %d path%s more starting at %O. To display all paths use --allpaths flag" 
@@ -156,7 +183,7 @@ let ohWhy (packageName,
                         (if rest.Length > 1 then "s" else "") 
                         top
                 | all, true ->
-                    DependencyChain.formatMany all |> tracen
+                    DependencyChain.formatMany options.VersionConstraints all |> tracen
                 | _ ->
                     failwith "impossible"
                 tracen ""

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -318,16 +318,14 @@ with
 type WhyArgs =
     | [<CustomCommandLine("nuget")>][<Mandatory>] NuGet of package_id:string
     | [<CustomCommandLine("group")>] Group of name:string
-    | AllPaths
-    | VersionConstraints
+    | Details
 with
   interface IArgParserTemplate with
       member this.Usage = 
         match this with
         | NuGet _ -> "Name of the NuGet package."
         | Group _ -> "Allows to specify the dependency group."
-        | AllPaths -> "Display all paths found from a top level dependency."
-        | VersionConstraints -> "Display information about version constraints."
+        | Details -> "Display detailed info with all possible paths, versions and framework constraints."
 
 type Command =
     // global options

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -319,13 +319,15 @@ type WhyArgs =
     | [<CustomCommandLine("nuget")>][<Mandatory>] NuGet of package_id:string
     | [<CustomCommandLine("group")>] Group of name:string
     | AllPaths
+    | VersionConstraints
 with
   interface IArgParserTemplate with
       member this.Usage = 
         match this with
         | NuGet _ -> "Name of the NuGet package."
         | Group _ -> "Allows to specify the dependency group."
-        | AllPaths -> "Display all paths found from a top level dependency"
+        | AllPaths -> "Display all paths found from a top level dependency."
+        | VersionConstraints -> "Display information about version constraints."
 
 type Command =
     // global options

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -374,8 +374,7 @@ let why (results: ParseResults<WhyArgs>) =
             |> Seq.map (fun pair -> pair.Key)
             |> Set.ofSeq
     let options = 
-        { Why.WhyOptions.AllPaths = results.Contains <@ WhyArgs.AllPaths @>
-          Why.WhyOptions.VersionConstraints = results.Contains <@ WhyArgs.VersionConstraints @> }
+        { Why.WhyOptions.Details = results.Contains <@ WhyArgs.Details @> }
 
     Why.ohWhy(packageName, directDeps, lockFile, groupName, results.Parser.PrintUsage(), options)
 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -374,7 +374,8 @@ let why (results: ParseResults<WhyArgs>) =
             |> Seq.map (fun pair -> pair.Key)
             |> Set.ofSeq
     let options = 
-        { Why.WhyOptions.AllPaths = results.Contains <@ WhyArgs.AllPaths @> }
+        { Why.WhyOptions.AllPaths = results.Contains <@ WhyArgs.AllPaths @>
+          Why.WhyOptions.VersionConstraints = results.Contains <@ WhyArgs.VersionConstraints @> }
 
     Why.ohWhy(packageName, directDeps, lockFile, groupName, results.Parser.PrintUsage(), options)
 


### PR DESCRIPTION
adds "details" param to display detailed info including all paths, version and framework requirements

![image](https://cloud.githubusercontent.com/assets/5909015/19832813/0c946734-9e2e-11e6-9e85-0d9d0c13dd9e.png)
