### PR TITLE
Update the FAQ

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -89,6 +89,7 @@ The following files can be committed, but are not essential:
 The following files should *not* be committed to your version control system, and should be added to any ignore files:
 
 * `.paket/paket.exe` - the main Paket executable, downloaded by [`.paket/paket.bootstrapper.exe`](getting-started.html). This should not be committed, as it is a binary file, which can unnecessarily bloat repositories, and because it is likely to be updated on a regular basis.
+* `paket-files` directory, as paket install will restore this. Same goes for the `packages` directory
 
 ## Why should I commit the lock file?
 


### PR DESCRIPTION
Indicate that the paket-files directory and packages directory should not be committed to source control.