### PR TITLE
Allow 'max file age' to be set even in magic mode

### DIFF
--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -80,8 +80,10 @@ namespace Paket.Bootstrapper
                 // Don't check more than twice a day
                 //  - Except if we want pre-releases as we're living on the bleeding edge
                 //  - Or if we specify a fixed version because it will never check anyway
-                if (options.DownloadArguments.IgnorePrerelease &&
-                    string.IsNullOrEmpty(options.DownloadArguments.LatestVersion))
+                //  - Or if the user specified any other value via 'paket.dependencies'
+                if (options.DownloadArguments.IgnorePrerelease
+                    && string.IsNullOrEmpty(options.DownloadArguments.LatestVersion)
+                    && options.DownloadArguments.MaxFileAgeInMinutes == null)
                 {
                     options.DownloadArguments.MaxFileAgeInMinutes = 60*12;
                 }

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -594,5 +594,18 @@ namespace Paket.Bootstrapper.Tests
             Assert.That(result.DownloadArguments.Target, Does.StartWith(MagicModeFileSystemSystem.GetTempPath()).And.EndsWith(".exe"));
             Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.EqualTo(42));
         }
+
+        [Test]
+        public void Magic_MaxFileAgeInMinutes()
+        {
+            //arrange
+
+            //act
+            var result = ParseMagic(new List<string>(), null, null, new[] { ArgumentParser.CommandArgs.MaxFileAge + "4242" });
+
+            //assert
+            Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.EqualTo(4242));
+            Assert.That(result.UnprocessedCommandArgs, Is.Empty);
+        }
     }
 }


### PR DESCRIPTION
A simple change to allow max file age to be specified in paket.dependencies when magic mode is active