### PR TITLE
[WIP] Verbose bootstrapper

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -27,7 +27,9 @@ Cached paket.exe versions are removed when the NuGet cache folder is [cleared](p
 
   `--self`: Self updating the paket.bootstrapper.exe. When this option is used the download of paket.exe will be skipped. (Can be combined with `--prefer-nuget`)
 
-  `-s`: If this flag is set the bootstrapper will not perform any output.
+  `-s`: Make the boostrapper more silent. Use it once to display display only errors or twice to supress all output.
+
+  `-v`: Make the boostrapper more verbose. Display more information about the boostrapper process, including operation timings.
 
   `-f`: Forces the bootstrapper to ignore any cached paket.exe versions and go directly to github.com or nuget.org based on other flags.
 
@@ -83,7 +85,7 @@ nuget FAKE
 nuget FSharp.Core ~> 4
 ```
 
-or 
+or
 
 ```paket
 version 3.24.1 --prefer-nuget
@@ -112,5 +114,10 @@ Using this feature paket can be used simply by committing a ~50KB `paket.exe` to
 The fact that a boostrapper exists is completely hidden and become an implementation detail that contributors to your
 repository won't have to know — or care — about.
 
-While command line bootstrapper options can't be used (Except if `--run` is passed) the other sources
-(AppSettings, Environment Variables & paket.dependencies) can still be used to configure the bootstrapper.
+While command line bootstrapper options can't be used the other sources (AppSettings, Environment Variables
+& paket.dependencies) can still be used to configure the bootstrapper.
+
+A few default settings are applied:
+* The boostrapper is silent and only errors are displayed. `-v` can be used once to restore normal output or twice
+  to show more details.
+* If no version is specified a default `--max-file-age` of 12 Hours is used.

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -70,8 +70,8 @@ namespace Paket.Bootstrapper
             {
                 // Transparent magic mode mean that we're renamed 'paket.exe' and --run wasn't passed
                 
-                // Enforce silence
-                options.Verbosity = Verbosity.ErrorsOnly;
+                // Virtually add a '-s'
+                options.Verbosity -= 1;
                 
                 // Assume --run and that all arguments are for the real paket binary
                 options.Run = true;

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -21,6 +21,7 @@ namespace Paket.Bootstrapper
             public const string NugetSourceArgPrefix = "--nuget-source=";
             public const string SelfUpdate = "--self";
             public const string Silent = "-s";
+            public const string Verbose = "-v";
             public const string IgnoreCache = "-f";
             public const string MaxFileAge = "--max-file-age=";
             public const string Run = "--run";
@@ -70,7 +71,7 @@ namespace Paket.Bootstrapper
                 // Transparent magic mode mean that we're renamed 'paket.exe' and --run wasn't passed
                 
                 // Enforce silence
-                options.Silent = SilentMode.ErrorsOnly;
+                options.Verbosity = Verbosity.ErrorsOnly;
                 
                 // Assume --run and that all arguments are for the real paket binary
                 options.Run = true;
@@ -157,10 +158,15 @@ namespace Paket.Bootstrapper
                 options.ForceNuget = true;
                 commandArgs.Remove(CommandArgs.ForceNuget);
             }
-            if (commandArgs.Contains(CommandArgs.Silent))
+            while (commandArgs.Contains(CommandArgs.Silent))
             {
-                options.Silent = SilentMode.Silent;
+                options.Verbosity -= 1;
                 commandArgs.Remove(CommandArgs.Silent);
+            }
+            while (commandArgs.Contains(CommandArgs.Verbose))
+            {
+                options.Verbosity += 1;
+                commandArgs.Remove(CommandArgs.Verbose);
             }
             if (commandArgs.Contains(CommandArgs.Help))
             {

--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -22,8 +22,9 @@ Options:
                                older than <IN MINUTES> all checks will be skipped.
 --self                         downloads and updates paket.bootstrapper
 -f                             don't use local cache; always downloads
--s                             silent mode; no output
---run                          run the downloaded paket.exe with all following arguments";
+-s                             silent mode; errors only. Use twice for no output
+-v                             verbose; show more information on console.
+--run <other args>             run the downloaded paket.exe with all following arguments";
         const string PaketBootstrapperUserAgent = "Paket.Bootstrapper";
 
         internal static string GetLocalFileVersion(string target)

--- a/src/Paket.Bootstrapper/BootstrapperOptions.cs
+++ b/src/Paket.Bootstrapper/BootstrapperOptions.cs
@@ -7,6 +7,7 @@ namespace Paket.Bootstrapper
     {
         public BootstrapperOptions()
         {
+            Verbosity = Verbosity.Normal;
             DownloadArguments = new DownloadArguments();
             RunArgs = Enumerable.Empty<string>();
             UnprocessedCommandArgs = Enumerable.Empty<string>();
@@ -14,7 +15,7 @@ namespace Paket.Bootstrapper
 
         public DownloadArguments DownloadArguments { get; set; }
 
-        public SilentMode Silent { get; set; }
+        public Verbosity Verbosity { get; set; }
         public bool ForceNuget { get; set; }
         public bool PreferNuget { get; set; }
         public bool ShowHelp { get; set; }

--- a/src/Paket.Bootstrapper/ConsoleImpl.cs
+++ b/src/Paket.Bootstrapper/ConsoleImpl.cs
@@ -5,44 +5,31 @@ namespace Paket.Bootstrapper
 {
     public static class ConsoleImpl
     {
-        public static SilentMode Silent { get; set; }
+        public static Verbosity Verbosity { get; set; }
 
         internal static void WriteError(string message, params object[] parameters)
         {
-            WriteError(string.Format(message, parameters));
-        }
-
-        internal static void WriteError(string message)
-        {
-            WriteConsole(message, ConsoleColor.Red, true);
+            WriteConsole(string.Format(message, parameters), ConsoleColor.Red, Verbosity.ErrorsOnly);
         }
 
         internal static void WriteInfo(string message, params object[] parameters)
         {
-            WriteInfo(string.Format(message, parameters));
+            WriteConsole(string.Format(message, parameters), ConsoleColor.Yellow);
         }
 
-        internal static void WriteInfo(string message)
-        {
-            WriteConsole(message, ConsoleColor.Yellow);
-        }
         internal static void WriteDebug(string message, params object[] parameters)
         {
-            WriteDebug(string.Format(message, parameters));
+            WriteConsole(string.Format(message, parameters), Console.ForegroundColor);
         }
 
-        internal static void WriteDebug(string message)
+        internal static void WriteTrace(string message, params object[] parameters)
         {
-            WriteConsole(message, Console.ForegroundColor);
+            WriteConsole(string.Format(message, parameters), ConsoleColor.DarkGray, Verbosity.Trace);
         }
 
-        private static void WriteConsole(string message, ConsoleColor consoleColor, bool error = false)
+        private static void WriteConsole(string message, ConsoleColor consoleColor, Verbosity minVerbosity = Verbosity.Normal)
         {
-            if (Silent == SilentMode.Silent)
-            {
-                return;
-            }
-            if (Silent == SilentMode.ErrorsOnly && !error)
+            if (Verbosity < minVerbosity)
             {
                 return;
             }

--- a/src/Paket.Bootstrapper/ConsoleImpl.cs
+++ b/src/Paket.Bootstrapper/ConsoleImpl.cs
@@ -7,24 +7,46 @@ namespace Paket.Bootstrapper
     {
         public static Verbosity Verbosity { get; set; }
 
+        public static bool IsTraceEnabled => Verbosity >= Verbosity.Trace;
+
         internal static void WriteError(string message, params object[] parameters)
         {
             WriteConsole(string.Format(message, parameters), ConsoleColor.Red, Verbosity.ErrorsOnly);
         }
 
-        internal static void WriteInfo(string message, params object[] parameters)
+        internal static void WriteError(string message)
+        {
+            WriteConsole(message, ConsoleColor.Red, Verbosity.ErrorsOnly);
+        }
+
+        internal static void WriteWarning(string message, params object[] parameters)
         {
             WriteConsole(string.Format(message, parameters), ConsoleColor.Yellow);
         }
 
-        internal static void WriteDebug(string message, params object[] parameters)
+        internal static void WriteWarning(string message)
+        {
+            WriteConsole(message, ConsoleColor.Yellow);
+        }
+
+        internal static void WriteInfo(string message, params object[] parameters)
         {
             WriteConsole(string.Format(message, parameters), Console.ForegroundColor);
+        }
+
+        internal static void WriteInfo(string message)
+        {
+            WriteConsole(message, Console.ForegroundColor);
         }
 
         internal static void WriteTrace(string message, params object[] parameters)
         {
             WriteConsole(string.Format(message, parameters), ConsoleColor.DarkGray, Verbosity.Trace);
+        }
+
+        internal static void WriteTrace(string message)
+        {
+            WriteConsole(message, ConsoleColor.DarkGray, Verbosity.Trace);
         }
 
         private static void WriteConsole(string message, ConsoleColor consoleColor, Verbosity minVerbosity = Verbosity.Normal)

--- a/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
@@ -6,10 +6,9 @@ using Paket.Bootstrapper.HelperProxies;
 
 namespace Paket.Bootstrapper.DownloadStrategies
 {
-    internal class CacheDownloadStrategy : IHaveEffectiveStrategy
+    internal class CacheDownloadStrategy : DownloadStrategy, IHaveEffectiveStrategy
     {
-        public string Name => $"{EffectiveStrategy.Name} - cached";
-        public IDownloadStrategy FallbackStrategy { get; set; }
+        public override string Name => $"{EffectiveStrategy.Name} - cached";
 
         private readonly string _paketCacheDir =
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NuGet", "Cache", "Paket");
@@ -29,7 +28,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
         }
 
 
-        public string GetLatestVersion(bool ignorePrerelease)
+        protected override string GetLatestVersionCore(bool ignorePrerelease)
         {
             try
             {
@@ -41,7 +40,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
                 {
                     var latestVersion = GetLatestVersionInCache(ignorePrerelease);
 
-                    ConsoleImpl.WriteDebug("Unable to look up the latest version online, the cache contains version {0}.", latestVersion);
+                    ConsoleImpl.WriteInfo("Unable to look up the latest version online, the cache contains version {0}.", latestVersion);
 
                     return latestVersion;
                 }
@@ -49,27 +48,29 @@ namespace Paket.Bootstrapper.DownloadStrategies
             }
         }
 
-        public void DownloadVersion(string latestVersion, string target)
+        protected override void DownloadVersionCore(string latestVersion, string target)
         {
             var cached = Path.Combine(_paketCacheDir, latestVersion, "paket.exe");
 
             if (!FileSystemProxy.FileExists(cached))
             {
-                ConsoleImpl.WriteDebug("Version {0} not found in cache.", latestVersion);
+                ConsoleImpl.WriteInfo("Version {0} not found in cache.", latestVersion);
 
                 EffectiveStrategy.DownloadVersion(latestVersion, target);
+
+                ConsoleImpl.WriteTrace("Caching version {0} for later", latestVersion);
                 FileSystemProxy.CreateDirectory(Path.GetDirectoryName(cached));
                 FileSystemProxy.CopyFile(target, cached);
             }
             else
             {
-                ConsoleImpl.WriteDebug("Copying version {0} from cache.", latestVersion);
-
+                ConsoleImpl.WriteInfo("Copying version {0} from cache.", latestVersion);
+                ConsoleImpl.WriteTrace("{0} -> {1}", cached, target);
                 FileSystemProxy.CopyFile(cached, target, true);
             }
         }
 
-        public void SelfUpdate(string latestVersion)
+        protected override void SelfUpdateCore(string latestVersion)
         {
             EffectiveStrategy.SelfUpdate(latestVersion);
         }

--- a/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+
+namespace Paket.Bootstrapper.DownloadStrategies
+{
+    public abstract class DownloadStrategy : IDownloadStrategy
+    {
+        public abstract string Name { get; }
+        public IDownloadStrategy FallbackStrategy { get; set; }
+        public string GetLatestVersion(bool ignorePrerelease)
+        {
+            return Wrap(() => GetLatestVersionCore(ignorePrerelease), "GetLatestVersion");
+        }
+
+        public void DownloadVersion(string latestVersion, string target)
+        {
+            Wrap(() => DownloadVersionCore(latestVersion, target), "DownloadVersion");
+        }
+
+        public void SelfUpdate(string latestVersion)
+        {
+            Wrap(() => SelfUpdateCore(latestVersion), "SelfUpdate");
+        }
+
+        protected abstract string GetLatestVersionCore(bool ignorePrerelease);
+        protected abstract void DownloadVersionCore(string latestVersion, string target);
+        protected abstract void SelfUpdateCore(string latestVersion);
+
+        private void Wrap(Action action, string actionName)
+        {
+            if (!ConsoleImpl.IsTraceEnabled)
+            {
+                action();
+                return;
+            }
+
+            Wrap(() => {
+                action();
+                return "void";
+            }, actionName);
+        }
+
+        private TResult Wrap<TResult>(Func<TResult> func, string actionName)
+        {
+            if (!ConsoleImpl.IsTraceEnabled)
+            {
+                return func();
+            }
+
+            ConsoleImpl.WriteTrace("[{0}] {1}...", Name, actionName);
+            var watch = Stopwatch.StartNew();
+            try
+            {
+                var result = func();
+                watch.Stop();
+                ConsoleImpl.WriteTrace("[{0}] {1} took {2:0.##} second(s) and returned {3}.", Name, actionName, watch.Elapsed.TotalSeconds, result);
+                return result;
+            }
+            catch (Exception exception)
+            {
+                watch.Stop();
+                ConsoleImpl.WriteTrace("[{0}] {1} took {2:0.##} second(s) and failed with {3}.", Name, actionName, watch.Elapsed.TotalSeconds, exception.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
@@ -6,7 +6,7 @@ using Paket.Bootstrapper.HelperProxies;
 
 namespace Paket.Bootstrapper.DownloadStrategies
 {
-    public class GitHubDownloadStrategy : IDownloadStrategy
+    public class GitHubDownloadStrategy : DownloadStrategy
     {
         public static class Constants
         {
@@ -17,8 +17,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
         private IWebRequestProxy WebRequestProxy { get; set; }
         private IFileSystemProxy FileSystemProxy { get; set; }
-        public string Name { get { return "Github"; } }
-        public IDownloadStrategy FallbackStrategy { get; set; }
+        public override string Name { get { return "Github"; } }
 
         public GitHubDownloadStrategy(IWebRequestProxy webRequestProxy, IFileSystemProxy fileSystemProxy)
         {
@@ -26,7 +25,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             FileSystemProxy = fileSystemProxy;
         }
 
-        public string GetLatestVersion(bool ignorePrerelease)
+        protected override string GetLatestVersionCore(bool ignorePrerelease)
         {
             var latestStable = GetLatestStable();
             if (ignorePrerelease)
@@ -70,10 +69,10 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return versions;
         }
 
-        public void DownloadVersion(string latestVersion, string target)
+        protected override void DownloadVersionCore(string latestVersion, string target)
         {
             var url = String.Format(Constants.PaketExeDownloadUrlTemplate, latestVersion);
-            ConsoleImpl.WriteDebug("Starting download from {0}", url);
+            ConsoleImpl.WriteInfo("Starting download from {0}", url);
 
             var tmpFile = BootstrapperHelper.GetTempFile("paket");
             WebRequestProxy.DownloadFile(url, tmpFile);
@@ -82,19 +81,19 @@ namespace Paket.Bootstrapper.DownloadStrategies
             FileSystemProxy.DeleteFile(tmpFile);
         }
 
-        public void SelfUpdate(string latestVersion)
+        protected override void SelfUpdateCore(string latestVersion)
         {
             var executingAssembly = Assembly.GetExecutingAssembly();
             string exePath = executingAssembly.Location;
             var localVersion = FileSystemProxy.GetLocalFileVersion(exePath);
             if (localVersion.StartsWith(latestVersion))
             {
-                ConsoleImpl.WriteDebug("Bootstrapper is up to date. Nothing to do.");
+                ConsoleImpl.WriteInfo("Bootstrapper is up to date. Nothing to do.");
                 return;
             }
 
             var url = String.Format("https://github.com/fsprojects/Paket/releases/download/{0}/paket.bootstrapper.exe", latestVersion);
-            ConsoleImpl.WriteDebug("Starting download of bootstrapper from {0}", url);
+            ConsoleImpl.WriteInfo("Starting download of bootstrapper from {0}", url);
 
             string renamedPath = BootstrapperHelper.GetTempFile("oldBootstrapper");
             string tmpDownloadPath = BootstrapperHelper.GetTempFile("newBootstrapper");
@@ -104,11 +103,11 @@ namespace Paket.Bootstrapper.DownloadStrategies
             {
                 FileSystemProxy.MoveFile(exePath, renamedPath);
                 FileSystemProxy.MoveFile(tmpDownloadPath, exePath);
-                ConsoleImpl.WriteDebug("Self update of bootstrapper was successful.");
+                ConsoleImpl.WriteInfo("Self update of bootstrapper was successful.");
             }
             catch (Exception)
             {
-                ConsoleImpl.WriteDebug("Self update failed. Resetting bootstrapper.");
+                ConsoleImpl.WriteInfo("Self update failed. Resetting bootstrapper.");
                 FileSystemProxy.MoveFile(renamedPath, exePath);
                 throw;
             }

--- a/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
@@ -8,10 +8,4 @@ namespace Paket.Bootstrapper.DownloadStrategies
         void DownloadVersion(string latestVersion, string target);
         void SelfUpdate(string latestVersion);
     }
-
-    public interface IHaveEffectiveStrategy : IDownloadStrategy
-    {
-        IDownloadStrategy EffectiveStrategy { get; }
-    }
-    
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/IHaveEffectiveStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/IHaveEffectiveStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Paket.Bootstrapper.DownloadStrategies
+{
+    public interface IHaveEffectiveStrategy
+    {
+        IDownloadStrategy EffectiveStrategy { get; }
+    }
+}

--- a/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
@@ -9,7 +9,7 @@ using Paket.Bootstrapper.HelperProxies;
 
 namespace Paket.Bootstrapper.DownloadStrategies
 {
-    internal class NugetDownloadStrategy : IDownloadStrategy
+    internal class NugetDownloadStrategy : DownloadStrategy
     {
         internal class NugetApiHelper
         {
@@ -63,14 +63,12 @@ namespace Paket.Bootstrapper.DownloadStrategies
             NugetSource = nugetSource;
         }
 
-        public string Name
+        public override string Name
         {
             get { return "Nuget"; }
         }
 
-        public IDownloadStrategy FallbackStrategy { get; set; }
-
-        public string GetLatestVersion(bool ignorePrerelease)
+        protected override string GetLatestVersionCore(bool ignorePrerelease)
         {
             IEnumerable<string> allVersions = null;
             if (FileSystemProxy.DirectoryExists(NugetSource))
@@ -102,7 +100,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return latestVersion != null ? latestVersion.Original : String.Empty;
         }
 
-        public void DownloadVersion(string latestVersion, string target)
+        protected override void DownloadVersionCore(string latestVersion, string target)
         {
             var apiHelper = new NugetApiHelper(PaketNugetPackageName, NugetSource);
 
@@ -126,13 +124,13 @@ namespace Paket.Bootstrapper.DownloadStrategies
                 if (String.IsNullOrWhiteSpace(latestVersion)) latestVersion = GetLatestVersion(false);
                 var sourcePath = Path.Combine(NugetSource, String.Format(paketNupkgFileTemplate, latestVersion));
 
-                ConsoleImpl.WriteDebug("Starting download from {0}", sourcePath);
+                ConsoleImpl.WriteInfo("Starting download from {0}", sourcePath);
 
                 FileSystemProxy.CopyFile(sourcePath, paketPackageFile);
             }
             else
             {
-                ConsoleImpl.WriteDebug("Starting download from {0}", paketDownloadUrl);
+                ConsoleImpl.WriteInfo("Starting download from {0}", paketDownloadUrl);
 
                 try
                 {
@@ -166,13 +164,13 @@ namespace Paket.Bootstrapper.DownloadStrategies
             FileSystemProxy.DeleteDirectory(randomFullPath, true);
         }
 
-        public void SelfUpdate(string latestVersion)
+        protected override void SelfUpdateCore(string latestVersion)
         {
             string target = Assembly.GetExecutingAssembly().Location;
             var localVersion = FileSystemProxy.GetLocalFileVersion(target);
             if (localVersion.StartsWith(latestVersion))
             {
-                ConsoleImpl.WriteDebug("Bootstrapper is up to date. Nothing to do.");
+                ConsoleImpl.WriteInfo("Bootstrapper is up to date. Nothing to do.");
                 return;
             }
             var apiHelper = new NugetApiHelper(PaketBootstrapperNugetPackageName, NugetSource);
@@ -198,13 +196,13 @@ namespace Paket.Bootstrapper.DownloadStrategies
                 if (String.IsNullOrWhiteSpace(latestVersion)) latestVersion = GetLatestVersion(false);
                 var sourcePath = Path.Combine(NugetSource, String.Format(paketNupkgFileTemplate, latestVersion));
 
-                ConsoleImpl.WriteDebug("Starting download from {0}", sourcePath);
+                ConsoleImpl.WriteInfo("Starting download from {0}", sourcePath);
 
                 FileSystemProxy.CopyFile(sourcePath, paketPackageFile);
             }
             else
             {
-                ConsoleImpl.WriteDebug("Starting download from {0}", paketDownloadUrl);
+                ConsoleImpl.WriteInfo("Starting download from {0}", paketDownloadUrl);
 
                 WebRequestProxy.DownloadFile(paketDownloadUrl, paketPackageFile);
             }
@@ -217,11 +215,11 @@ namespace Paket.Bootstrapper.DownloadStrategies
             {
                 FileSystemProxy.MoveFile(target, renamedPath);
                 FileSystemProxy.MoveFile(paketSourceFile, target);
-                ConsoleImpl.WriteDebug("Self update of bootstrapper was successful.");
+                ConsoleImpl.WriteInfo("Self update of bootstrapper was successful.");
             }
             catch (Exception)
             {
-                ConsoleImpl.WriteDebug("Self update failed. Resetting bootstrapper.");
+                ConsoleImpl.WriteInfo("Self update failed. Resetting bootstrapper.");
                 FileSystemProxy.MoveFile(renamedPath, target);
                 throw;
             }

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -53,6 +53,8 @@
     <Compile Include="ArgumentParser.cs" />
     <Compile Include="BootstrapperHelper.cs" />
     <Compile Include="BootstrapperOptions.cs" />
+    <Compile Include="DownloadStrategies\IDownloadStrategy.cs" />
+    <Compile Include="DownloadStrategies\IHaveEffectiveStrategy.cs" />
     <Compile Include="PaketDependencies.cs" />
     <Compile Include="PaketRunner.cs" />
     <Compile Include="Verbosity.cs" />
@@ -64,7 +66,7 @@
     <Compile Include="EnvProxy.cs" />
     <Compile Include="HelperProxies\FileSystemProxy.cs" />
     <Compile Include="DownloadStrategies\GitHubDownloadStrategy.cs" />
-    <Compile Include="DownloadStrategies\IDownloadStrategy.cs" />
+    <Compile Include="DownloadStrategies\DownloadStrategy.cs" />
     <Compile Include="HelperProxies\IFileSystemProxy.cs" />
     <Compile Include="DownloadStrategies\NugetDownloadStrategy.cs" />
     <Compile Include="ConsoleImpl.cs" />

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -55,7 +55,7 @@
     <Compile Include="BootstrapperOptions.cs" />
     <Compile Include="PaketDependencies.cs" />
     <Compile Include="PaketRunner.cs" />
-    <Compile Include="SilentMode.cs" />
+    <Compile Include="Verbosity.cs" />
     <Compile Include="WindowsProcessArguments.cs" />
     <Compile Include="DownloadStrategies\CacheDownloadStrategy.cs" />
     <Compile Include="HelperProxies\IWebRequestProxy.cs" />

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -30,7 +30,7 @@ namespace Paket.Bootstrapper
                 return;
             }
 
-            ConsoleImpl.Silent = options.Silent;
+            ConsoleImpl.Verbosity = options.Verbosity;
             if (options.UnprocessedCommandArgs.Any())
                 ConsoleImpl.WriteInfo("Ignoring the following unknown argument(s): {0}", String.Join(", ", options.UnprocessedCommandArgs));
 

--- a/src/Paket.Bootstrapper/SilentMode.cs
+++ b/src/Paket.Bootstrapper/SilentMode.cs
@@ -1,9 +1,0 @@
-namespace Paket.Bootstrapper
-{
-    public enum SilentMode
-    {
-        NotSilent,
-        ErrorsOnly,
-        Silent
-    }
-}

--- a/src/Paket.Bootstrapper/Verbosity.cs
+++ b/src/Paket.Bootstrapper/Verbosity.cs
@@ -1,0 +1,10 @@
+namespace Paket.Bootstrapper
+{
+    public enum Verbosity
+    {
+        Silent = 0,
+        ErrorsOnly = 1,
+        Normal = 2,
+        Trace = 3
+    }
+}

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -139,7 +139,7 @@ namespace Paket.Bootstrapper.Tests
             Assert.That(result, Is.Not.Null);
             Assert.That(result.ForceNuget, Is.False);
             Assert.That(result.PreferNuget, Is.False);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.NotSilent));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.Normal));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.DownloadArguments, Is.Not.Null);
             Assert.That(result.DownloadArguments.DoSelfUpdate, Is.False);
@@ -154,7 +154,7 @@ namespace Paket.Bootstrapper.Tests
             Assert.That(result.Run, Is.False);
             Assert.That(result.RunArgs, Is.Empty);
 
-            var knownProps = new[] { "DownloadArguments.MaxFileAgeInMinutes", "DownloadArguments.Folder", "DownloadArguments.Target", "DownloadArguments.NugetSource", "DownloadArguments.DoSelfUpdate", "DownloadArguments.LatestVersion", "DownloadArguments.IgnorePrerelease", "DownloadArguments.IgnoreCache", "Silent", "ForceNuget", "PreferNuget", "UnprocessedCommandArgs", "ShowHelp", "Run", "RunArgs" };
+            var knownProps = new[] { "DownloadArguments.MaxFileAgeInMinutes", "DownloadArguments.Folder", "DownloadArguments.Target", "DownloadArguments.NugetSource", "DownloadArguments.DoSelfUpdate", "DownloadArguments.LatestVersion", "DownloadArguments.IgnorePrerelease", "DownloadArguments.IgnoreCache", "Verbosity", "ForceNuget", "PreferNuget", "UnprocessedCommandArgs", "ShowHelp", "Run", "RunArgs" };
             var allProperties = GetAllProperties(result);
             Assert.That(allProperties, Is.Not.Null.And.Count.EqualTo(knownProps.Length));
             Assert.That(allProperties, Is.EquivalentTo(knownProps));
@@ -186,7 +186,31 @@ namespace Paket.Bootstrapper.Tests
             var result = Parse(new[] { ArgumentParser.CommandArgs.Silent }, null, null);
 
             //assert
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.Silent));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
+        }
+
+        [Test]
+        public void Silent_x2()
+        {
+            //arrange
+
+            //act
+            var result = Parse(new[] { ArgumentParser.CommandArgs.Silent, ArgumentParser.CommandArgs.Silent }, null, null);
+
+            //assert
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.Silent));
+        }
+
+        [Test]
+        public void Verbose()
+        {
+            //arrange
+
+            //act
+            var result = Parse(new[] { ArgumentParser.CommandArgs.Verbose }, null, null);
+
+            //assert
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.Trace));
         }
 
         [Test]
@@ -452,7 +476,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.ErrorsOnly));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.Run, Is.True);
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
@@ -472,7 +496,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.ErrorsOnly));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.Run, Is.True);
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
@@ -493,7 +517,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.ErrorsOnly));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.Run, Is.True);
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
@@ -520,7 +544,7 @@ namespace Paket.Bootstrapper.Tests
             
             //assert
             Assert.That(result.Run, Is.True);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.Silent));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.DownloadArguments.Target, Does.StartWith(MagicModeFileSystemSystem.GetTempPath()).And.EndsWith(".exe"));
@@ -537,7 +561,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.ErrorsOnly));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.Run, Is.True);
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
@@ -556,7 +580,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.ErrorsOnly));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.Run, Is.True);
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
@@ -588,7 +612,7 @@ namespace Paket.Bootstrapper.Tests
             
             //assert
             Assert.That(result.Run, Is.True);
-            Assert.That(result.Silent, Is.EqualTo(SilentMode.Silent));
+            Assert.That(result.Verbosity, Is.EqualTo(Verbosity.ErrorsOnly));
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
             Assert.That(result.DownloadArguments.Target, Does.StartWith(MagicModeFileSystemSystem.GetTempPath()).And.EndsWith(".exe"));

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
@@ -35,7 +35,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         public void CreateStrategy_EffectiveStrategyHasFallback()
         {
             //arrange
-            mockEffectiveStrategy.SetupGet(x => x.FallbackStrategy).Returns(new Mock<IDownloadStrategy>().Object);
+            mockEffectiveStrategy.SetupGet(x => x.FallbackStrategy).Returns(new Mock<DownloadStrategy>().Object);
 
             //act
             //assert
@@ -71,7 +71,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Throws<WebException>().Verifiable();
-            var mockFallback = new Mock<IDownloadStrategy>();
+            var mockFallback = new Mock<DownloadStrategy>();
             mockEffectiveStrategy.SetupGet(x => x.FallbackStrategy).Returns(mockFallback.Object);
             mockFileProxy.Setup(x => x.GetDirectories(It.IsAny<string>())).Returns(new[] { "1.0" });
 

--- a/tests/Paket.Bootstrapper.Tests/StartPaketBootstrappingTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/StartPaketBootstrappingTests.cs
@@ -14,7 +14,7 @@ namespace Paket.Bootstrapper.Tests
         private Mock<IDownloadStrategy> mockDownloadStrategy;
         private Mock<IFileSystemProxy> mockFileProxy;
 
-        private static Action DoNothing = () => { };
+        private static readonly Action DoNothing = () => { };
 
         [SetUp]
         public void Setup()
@@ -204,6 +204,8 @@ namespace Paket.Bootstrapper.Tests
             int successCount = 0;
             Action onSuccess = () => successCount++;
             dlArgs.LatestVersion = "1.5";
+            mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+            mockFileProxy.Setup(x => x.GetLocalFileVersion(It.IsAny<string>())).Returns("1.5");
 
             //act
             Program.StartPaketBootstrapping(mockDownloadStrategy.Object, dlArgs, mockFileProxy.Object, onSuccess);


### PR DESCRIPTION
This PR change the way `-s` work in the bootstrapper. There is now a verbosity level that can be decreased via `-s` and increased via `-v`.

The levels are :

* Silent -> Never display anything.
* ErrorsOnly -> Only errors are shown on the console (Default in magic mode)
* Normal -> Informative logs (Default in non-magic mode)
* Trace -> More logs, especially timing for most operation is displayed.

**This PR change the default behavior, before a single `-s` resulted in the boostrapper being silent but 2 are now needed for the same result**