### PR TITLE
NuGetV2-OData: retrieve versions in descending order

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -56,7 +56,7 @@ let rec private followODataLink auth url =
 let tryGetAllVersionsFromNugetODataWithFilter (auth, nugetURL, package:PackageName) =
     async {
         try
-            let url = sprintf "%s/Packages?$filter=tolower(Id) eq '%s'" nugetURL (package.GetCompareString())
+            let url = sprintf "%s/Packages?$orderby=Published desc&$filter=tolower(Id) eq '%s'" nugetURL (package.GetCompareString())
             verbosefn "getAllVersionsFromNugetODataWithFilter from url '%s'" url
             let! result = followODataLink auth url
             return Some result
@@ -66,7 +66,7 @@ let tryGetAllVersionsFromNugetODataWithFilter (auth, nugetURL, package:PackageNa
 let tryGetPackageVersionsViaOData (auth, nugetURL, package:PackageName) =
     async {
         try
-            let url = sprintf "%s/FindPackagesById()?id='%O'" nugetURL package
+            let url = sprintf "%s/FindPackagesById()?$orderby=Published desc&id='%O'" nugetURL package
             verbosefn "getAllVersionsFromNugetOData from url '%s'" url
             let! result = followODataLink auth url
             return Some result


### PR DESCRIPTION
Some of the NuGet servers have broken feed paging. This PR changes the order such that newer packages are returned first (Publish date, descending). In case of broken paging, getting only newer versions seems less of an issue than getting only older versions. This is in particular relevant when using the update command without explicitly specifying a version (which downgrades to older versions otherwise). With this change, the request is also closer to how the `NuGet Package Explorer` queries all versions of a package.