### PR TITLE
Added missing tolower()

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -230,7 +230,7 @@ let parseODataDetails(url,nugetURL,packageName:PackageName,version:SemVerInfo,ra
 let getDetailsFromNuGetViaODataFast auth nugetURL (packageName:PackageName) (version:SemVerInfo) =
     async {
         try
-            let url = sprintf "%s/Packages?$filter=(Id eq '%O') and (NormalizedVersion eq '%s')" nugetURL packageName (version.Normalize())
+            let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%O') and (NormalizedVersion eq '%s')" nugetURL packageName (version.Normalize())
             let! raw = getFromUrl(auth,url,acceptXml)
             if verbose then
                 tracefn "Response from %s:" url
@@ -238,7 +238,7 @@ let getDetailsFromNuGetViaODataFast auth nugetURL (packageName:PackageName) (ver
                 tracefn "%s" raw
             return parseODataDetails(url,nugetURL,packageName,version,raw)
         with _ ->
-            let url = sprintf "%s/Packages?$filter=(Id eq '%O') and (Version eq '%O')" nugetURL packageName version
+            let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%O') and (Version eq '%O')" nugetURL packageName version
             let! raw = getFromUrl(auth,url,acceptXml)
             if verbose then
                 tracefn "Response from %s:" url


### PR DESCRIPTION
PR #1775  adds tolower function for packages id in OData filter, but two places are missed. This makes update command by regex filter with version specified to fail, like:
`paket update nuget <regex> --filter version <version>`
After adding tolower in this filters such command succeeds.