### PR TITLE
Report which nuspec file is invalid when the nuspec cannot be loaded

### DIFF
--- a/src/Paket.Core/Nuspec.fs
+++ b/src/Paket.Core/Nuspec.fs
@@ -192,5 +192,9 @@ type Nuspec =
                 Nuspec.Load(fileName, f)
             with
             | exn ->
-                let text = File.ReadAllText(fi.FullName)  // work around mono bug https://github.com/fsprojects/Paket/issues/1189
-                Nuspec.Load(fileName, text)
+                try
+                    let text = File.ReadAllText(fi.FullName)  // work around mono bug https://github.com/fsprojects/Paket/issues/1189
+                    Nuspec.Load(fileName, text)
+                with
+                | ex ->
+                    raise (IOException("Cannot load " + fileName + " because: " + ex.Message))


### PR DESCRIPTION
I had a nuspec file in the `packages` folder that was empty (zero bytes) , paket failed with an XML error, but did not report *which* file had an error.  This change will report which nuspec file had the problem, and what the problem was.