### PR TITLE
Fix package name displayed when package is found in different group

### DIFF
--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -518,7 +518,7 @@ type LockFile(fileName:string,groups: Map<GroupName,LockFileGroup>) =
 
     member this.CheckIfPackageExistsInAnyGroup (packageName:PackageName) =
         match groups |> Seq.tryFind (fun g -> g.Value.Resolution.ContainsKey packageName) with
-        | Some group -> sprintf "%sHowever, %O was found in group %O." Environment.NewLine PackageName group.Value.Name
+        | Some group -> sprintf "%sHowever, %O was found in group %O." Environment.NewLine packageName group.Value.Name
         | None -> ""
         
 


### PR DESCRIPTION
When a package is not found in the same group in `paket.lock` and a project's `paket.references` during `paket install`, the package name is displayed as `<StartupCode$Paket-Core>.$LockFile+CheckIfPackageExistsInAnyGroup@521-5` in the error message. This PR fixes that.