### PR TITLE
Allow override of NuGetCacheFolder location through environment variable

### DIFF
--- a/docs/content/caches.md
+++ b/docs/content/caches.md
@@ -56,3 +56,13 @@ All configured caches are automatically used as additional package feeds. So if 
 The fact that it's now only found in the cache will be written to the [`paket.lock` file](lock-file.html).
 
 All packages in the cache are treated as "unlisted". This means Paket's resolver will only use these packages in a new resolution if the central feed has no unlisted packages.
+
+## NuGet machine cache
+
+In addition to the above, Paket will also cache packages to a local machine cache, which defaults to `%LocalAppData%\NuGet\Cache`.  
+
+This location can be overridden to support cases where parallelised package installs (or updates) are prone to file locks, such as when running multiple build agent processes on a single server.
+
+To override at the process level, define a process environment variable called `"NuGetCachePath"` with the custom location, such as
+
+    $env:NuGetCachePath = "C:\NuGetCaches\BuildAgentName"

--- a/src/Paket.Core/Constants.fs
+++ b/src/Paket.Core/Constants.fs
@@ -92,15 +92,23 @@ let MagicUnlistingDate = DateTimeOffset(1900, 1, 1, 0, 0, 0, TimeSpan.FromHours(
 
 /// The NuGet cache folder.
 let NuGetCacheFolder =
-    match Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) 
+    match Environment.GetEnvironmentVariable("NuGetCachePath")
           |> toOption with
-    | Some appData ->
-      let di = DirectoryInfo(Path.Combine(Path.Combine(appData, "NuGet"), "Cache"))
-      if not di.Exists then
-          di.Create()
-      di.FullName
+    | Some cachePath ->
+        let di = DirectoryInfo(cachePath)
+        if not di.Exists then
+            di.Create()
+        di.FullName
     | None ->
-      let fallback = Path.GetFullPath (".paket")
-      Logging.traceWarnfn "Could not find LocalApplicationData folder, try to set the 'LocalAppData' environment variable. Using '%s' instead" fallback
-      fallback
+        match Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) 
+              |> toOption with
+        | Some appData ->
+          let di = DirectoryInfo(Path.Combine(Path.Combine(appData, "NuGet"), "Cache"))
+          if not di.Exists then
+              di.Create()
+          di.FullName
+        | None ->
+          let fallback = Path.GetFullPath (".paket")
+          Logging.traceWarnfn "Could not find LocalApplicationData folder, try to set the 'LocalAppData' environment variable. Using '%s' instead" fallback
+          fallback
       


### PR DESCRIPTION
The NuGet CLI (2.x) provides an environment variable override for specifying the location of the NuGet cache.  This is key when running multiple processes that pull NuGet packages to avoid file locks in the cache (i.e. in a multi- build agent per server environment).  This change enables support for the override in Paket, via an environment variable (e.g. Windows PS):

`$env:NuGetCachePath = "C:\Custom\Cache\Location"`