### PR TITLE
Fix of Git dependency change detection

### DIFF
--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -150,7 +150,7 @@ let findRemoteFileChangesInDependenciesFile(dependenciesFile:DependenciesFile,lo
             lockFileGroup.RemoteFiles
             |> List.map RemoteFileChange.CreateResolvedVersion
             |> List.map (fun r ->
-                match dependenciesFileRemoteFiles |> Seq.tryFind (fun d -> d.Name = r.Name) with
+                match dependenciesFileRemoteFiles |> Seq.tryFind (fun d -> d.Name = r.Name && d.Origin = r.Origin) with
                 | Some d -> { r with Commit = d.Commit }
                 | _ -> { r with Commit = None })
             |> Set.ofList

--- a/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
@@ -332,6 +332,67 @@ github zurb/bower-foundation js/foundation.min.js"""
     changedDependencies.Count |> shouldEqual 0
 
 [<Test>]
+let ``should detect no changes if nothing changes in git dependency``() = 
+    let before = """source https://www.nuget.org/api/v2
+
+nuget FAKE
+
+git https://github.com/zurb/bower-foundation.git 5.5.3
+git https://github.com/zurb/tribute.git 2.1.0"""
+
+    let lockFileData = """NUGET
+  remote: https://www.nuget.org/api/v2
+  specs:
+    FAKE (4.4.4)
+GIT
+  remote: https://github.com/zurb/bower-foundation.git
+     (b879716aa268e1f88fe43de98db2db4487af00ca)
+  remote: https://github.com/zurb/tribute.git
+     (94d4f17e1d338c2afdc6bb7cedea98b04d253932)
+"""
+
+    let after = """source https://www.nuget.org/api/v2
+
+nuget FAKE
+
+git https://github.com/zurb/bower-foundation.git 5.5.3
+git https://github.com/zurb/tribute.git 2.1.0"""
+
+    let cfg = DependenciesFile.FromCode(after)
+    let lockFile = LockFile.Parse("",toLines lockFileData)
+    let changedDependencies = DependencyChangeDetection.findRemoteFileChangesInDependenciesFile(cfg,lockFile)
+    changedDependencies.Count |> shouldEqual 0
+
+[<Test>]
+let ``should detect new git dependency``() = 
+    let before = """source https://www.nuget.org/api/v2
+
+nuget FAKE
+
+git https://github.com/zurb/bower-foundation.git 5.5.3"""
+
+    let lockFileData = """NUGET
+  remote: https://www.nuget.org/api/v2
+  specs:
+    FAKE (4.4.4)
+GIT
+  remote: https://github.com/zurb/bower-foundation.git
+     (b879716aa268e1f88fe43de98db2db4487af00ca)
+"""
+
+    let after = """source https://www.nuget.org/api/v2
+
+nuget FAKE
+
+git https://github.com/zurb/bower-foundation.git 5.5.3
+git https://github.com/zurb/tribute.git 2.1.0"""
+
+    let cfg = DependenciesFile.FromCode(after)
+    let lockFile = LockFile.Parse("",toLines lockFileData)
+    let changedDependencies = DependencyChangeDetection.findRemoteFileChangesInDependenciesFile(cfg,lockFile)
+    changedDependencies.Count |> shouldEqual 1
+
+[<Test>]
 let ``should detect new github dependency``() = 
     let before = """source https://www.nuget.org/api/v2
 


### PR DESCRIPTION
Change detection of Git dependencies does not work correctly for two or more dependencies as their `RemoteFileChange`s have `Name` set to "". This causes mismatch of dependencies during change detection. This PR fixes the bug by including remote's `Origin` in comparison.