### PR TITLE
Package names are compared using non-linguistic Ordinal comparison

### DIFF
--- a/src/Paket.Core/Domain.fs
+++ b/src/Paket.Core/Domain.fs
@@ -1,5 +1,6 @@
 ﻿module Paket.Domain
 
+open System
 open System.IO
 open System.Text.RegularExpressions
 
@@ -27,7 +28,7 @@ type PackageName =
     interface System.IComparable with
        member this.CompareTo that = 
           match that with 
-          | :? PackageName as that -> this.GetCompareString().CompareTo(that.GetCompareString())
+          | :? PackageName as that -> StringComparer.Ordinal.Compare(this.GetCompareString(), that.GetCompareString())
           | _ -> invalidArg "that" "cannot compare value of different types"
 
 /// Function to convert a string into a NuGet package name
@@ -82,7 +83,7 @@ type GroupName =
     interface System.IComparable with
        member this.CompareTo that = 
           match that with 
-          | :? GroupName as that -> this.GetCompareString().CompareTo(that.GetCompareString())
+          | :? GroupName as that -> StringComparer.Ordinal.Compare(this.GetCompareString(), that.GetCompareString())
           | _ -> invalidArg "that" "cannot compare value of different types"
 
 /// Function to convert a string into a group name


### PR DESCRIPTION
Test `ParserSpecs.should parse lock file with depdencies` fails under OS with Czech regional settings because of linguistic comparison of `Chessie` package name. In Czech, [`ch` is a diagraph that is inserted between _H_ and _I_ letters in collation order](https://en.wikipedia.org/wiki/Ch_(digraph)#Czech).  I fixed the issue by using non-linguistic ordinal comparison.