### PR TITLE
Fix default address of NuGet v3 stream

### DIFF
--- a/src/Paket.Core/Constants.fs
+++ b/src/Paket.Core/Constants.fs
@@ -7,7 +7,7 @@ open Paket.Domain
 
 let [<Literal>] GitHubUrl                 = "https://github.com"
 let [<Literal>] DefaultNuGetStream        = "https://www.nuget.org/api/v2"
-let [<Literal>] DefaultNuGetV3Stream      = "http://api.nuget.org/v3/index.json"
+let [<Literal>] DefaultNuGetV3Stream      = "https://api.nuget.org/v3/index.json"
 let [<Literal>] GitHubReleasesUrl         = "https://api.github.com/repos/fsprojects/Paket/releases"
 let [<Literal>] GithubReleaseDownloadUrl  = "https://github.com/fsprojects/Paket/releases/download"
 let [<Literal>] LockFileName              = "paket.lock"


### PR DESCRIPTION
Just a quickfix, untested. See #2053 for details.