### PR TITLE
NuGetV2-OData: retrieve versions in descending order for artifactory

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -67,7 +67,7 @@ let tryGetAllVersionsFromNugetODataFindById (auth, nugetURL, package:PackageName
     async {
         try
             let url = sprintf "%s/FindPackagesById()?id='%O'" nugetURL package
-            verbosefn "getPackageVersionsViaOData from url '%s'" url
+            verbosefn "getAllVersionsFromNugetODataFindById from url '%s'" url
             let! result = followODataLink auth url
             return Some result
         with _ -> return None
@@ -77,7 +77,7 @@ let tryGetAllVersionsFromNugetODataFindByIdNewestFirst (auth, nugetURL, package:
     async {
         try
             let url = sprintf "%s/FindPackagesById()?id='%O'&$orderby=Published desc" nugetURL package
-            verbosefn "getPackageVersionsViaODataNewestFirst from url '%s'" url
+            verbosefn "getAllVersionsFromNugetODataFindByIdNewestFirst from url '%s'" url
             let! result = followODataLink auth url
             return Some result
         with _ -> return None

--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -63,11 +63,21 @@ let tryGetAllVersionsFromNugetODataWithFilter (auth, nugetURL, package:PackageNa
         with _ -> return None
     }
 
-let tryGetPackageVersionsViaOData (auth, nugetURL, package:PackageName) =
+let tryGetAllVersionsFromNugetODataFindById (auth, nugetURL, package:PackageName) =
     async {
         try
             let url = sprintf "%s/FindPackagesById()?id='%O'" nugetURL package
-            verbosefn "getAllVersionsFromNugetOData from url '%s'" url
+            verbosefn "getPackageVersionsViaOData from url '%s'" url
+            let! result = followODataLink auth url
+            return Some result
+        with _ -> return None
+    }
+
+let tryGetAllVersionsFromNugetODataFindByIdNewestFirst (auth, nugetURL, package:PackageName) =
+    async {
+        try
+            let url = sprintf "%s/FindPackagesById()?id='%O'&$orderby=Published desc" nugetURL package
+            verbosefn "getPackageVersionsViaODataNewestFirst from url '%s'" url
             let! result = followODataLink auth url
             return Some result
         with _ -> return None
@@ -785,9 +795,11 @@ let GetVersions force root (sources, packageName:PackageName) =
                             let auth = source.Authentication |> Option.map toBasicAuth
                             if not force && (String.containsIgnoreCase "nuget.org" source.Url || String.containsIgnoreCase "myget.org" source.Url || String.containsIgnoreCase "visualstudio.com" source.Url) then
                                 [getVersionsCached "Json" tryGetPackageVersionsViaJson (nugetSource, auth, source.Url, packageName) ]
+                            elif String.containsIgnoreCase "artifactory" source.Url then
+                                [getVersionsCached "ODataNewestFirst" tryGetAllVersionsFromNugetODataFindByIdNewestFirst (nugetSource, auth, source.Url, packageName) ]
                             else
                                 let v2Feeds =
-                                    [ yield getVersionsCached "OData" tryGetPackageVersionsViaOData (nugetSource, auth, source.Url, packageName)
+                                    [ yield getVersionsCached "OData" tryGetAllVersionsFromNugetODataFindById (nugetSource, auth, source.Url, packageName)
                                       yield getVersionsCached "ODataWithFilter" tryGetAllVersionsFromNugetODataWithFilter (nugetSource, auth, source.Url, packageName)
                                       if not (String.containsIgnoreCase "teamcity" source.Url || String.containsIgnoreCase"feedservice.svc" source.Url  ) then
                                         yield getVersionsCached "Json" tryGetPackageVersionsViaJson (nugetSource, auth, source.Url, packageName) ]


### PR DESCRIPTION
Related to #2008 which was reverted in #2018 because it affected non-artifactory servers negatively (in an unknown way).

This change adds an alternative variant of tryGetAllVersions to fetch the versions in descending order (by publish date) instead of modifying the original one.

GetVersions chooses to use the alternative variant in case the source URI contains the string "artifactory". This is a very unreliable way of discovering a server to be an artifactory one, but is in line with the existing rules and should prevent affecting non-artifactory servers.

Ideally the decision should be more controllable than URI matching, e.g. by introducing the concept of source options (explicitly in the dependencies and lock files).