### PR TITLE
One of the file writes was missing a Directory.Create()

### DIFF
--- a/src/Paket.Core/ScriptGeneration.fs
+++ b/src/Paket.Core/ScriptGeneration.fs
@@ -360,7 +360,8 @@ module ScriptGeneration =
 
       let getGroupFile group = 
         let folder = getScriptFolder includeScriptsRootFolder framework group
-        FileInfo(Path.Combine(folder.FullName, sprintf "include.%s.group.%s" (group.GetCompareString()) extension).ToLowerInvariant())
+        let fileName = (sprintf "include.%s.group.%s" (group.GetCompareString()) extension).ToLowerInvariant()
+        FileInfo(Path.Combine(folder.FullName, fileName))
         
       generateGroupScript dependenciesFile getGroupFile scriptWriter filterFrameworkLibs filterNuget framework
 

--- a/src/Paket.Core/ScriptGeneration.fs
+++ b/src/Paket.Core/ScriptGeneration.fs
@@ -183,6 +183,8 @@ module ScriptGeneration =
       pieces
       |> String.concat ("\n")
     
+
+    scriptFile.Directory.Create()
     File.WriteAllText(scriptFile.FullName, text)
     
   let writeCSharpScript scriptFile input =
@@ -316,7 +318,6 @@ module ScriptGeneration =
           match scriptGenerator scriptInfo with
           | DoNotGenerate -> knownIncludeScripts
           | Generate pieces -> 
-            scriptFile.Directory.Create()
             writeScript scriptFile pieces
             knownIncludeScripts |> Map.add package.Name scriptFile
 


### PR DESCRIPTION
1. generate-include-scripts used ToLowerInvariant() on the full path name which caused issues in Linux that wouldn't appear in Windows. Though apparently wasn't an issue on Macs? not sure why that would be, I don't have a mac.

2. At first I thought the issue was the lack of Directory.Create() before File.WriteAllText for some files, but turned out this wasn't the issue due to file creation order meaning the directory was actually already there.

Regardless I changed it so in the function to write fsharp scripts it does a Directory.Create immediately before writing, which makes the functions to create fsharp and csharp scripts more consistent, and I think it's less confusing

3. The Linux CI build is broken because of an issue with the .NET Core build, I have the same  problem locally