### PR TITLE
Fix displayed package name for packages found in another group

### DIFF
--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -107,7 +107,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
 
     member this.CheckIfPackageExistsInAnyGroup (packageName:PackageName) =
         match groups |> Seq.tryFind (fun g -> g.Value.Packages |> List.exists (fun p -> p.Name = packageName)) with
-        | Some group -> sprintf "%sHowever, %O was found in group %O." Environment.NewLine PackageName group.Value.Name
+        | Some group -> sprintf "%sHowever, %O was found in group %O." Environment.NewLine packageName group.Value.Name
         | None -> ""
 
     member __.Groups = groups


### PR DESCRIPTION
This is the same problem and fix as #2031, just in a different place. I did a regex search over the solution for more occurrences but couldn't find any others for the `PackageName` DU.