### PR TITLE
Don't remove group with only remote files

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -1,13 +1,14 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Mark that this target file has been loaded.  -->
-    <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>    
+    <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
+    <PaketRestoreCommand>"$(MSBuildThisFileDirectory)\paket.exe" restore --project "$(MSBuildProjectFullPath)"</PaketRestoreCommand>
   </PropertyGroup>
-  
+
   <UsingTask TaskName="Paket.Build.Tasks.PaketRestoreTask" AssemblyFile="PaketRestoreTask.dll" />
 
   <Target Name="PaketRestore" BeforeTargets="_GenerateRestoreGraphWalkPerFramework" >
-    <Exec Command="$(MSBuildThisFileDirectory)\paket.exe restore --project $(MSBuildProjectFullPath)" />
+    <Exec Command="$(PaketRestoreCommand)" />
 
      <!-- Write out package references for NETCore -->
     <PaketRestoreTask
@@ -15,7 +16,7 @@
       PackageReferences="@(PackageReference)"
       TargetFrameworks="$(TargetFramework)">
       <Output TaskParameter="NewPackageReferences" ItemName="PackageReference" />
-      <Output TaskParameter="AlternativeConfigFile" ItemName="RestoreConfigFile" />        
+      <Output TaskParameter="AlternativeConfigFile" ItemName="RestoreConfigFile" />
     </PaketRestoreTask>
    </Target>
 </Project>

--- a/src/Paket.Core/DependenciesFile.fs
+++ b/src/Paket.Core/DependenciesFile.fs
@@ -385,7 +385,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
             let filteredGroups, filteredLines =
               groups
               |> Seq.map(fun item -> item.Value)
-              |> Seq.filter(fun group -> group.Packages.IsEmpty && group.Name <> Constants.MainDependencyGroup)
+              |> Seq.filter(fun group -> group.Packages.IsEmpty && group.RemoteFiles.IsEmpty && group.Name <> Constants.MainDependencyGroup)
               |> Seq.fold(fun (groups, (lines:string[])) emptyGroup ->
                   groups 
                   |> Map.remove emptyGroup.Name,

--- a/tests/Paket.Tests/DependenciesFile/RemovePackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/RemovePackageSpecs.fs
@@ -124,3 +124,27 @@ nuget Castle.Windsor ~> 3.2"""
 
     cfg.ToString()
     |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should not remove group if only contains remote files``() = 
+    let config = """source http://www.nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2
+nuget Castle.Windsor ~> 3.2
+
+group Test
+http http://www.fssnip.net/1n decrypt.fs
+nuget Castle.Windsor ~> 3.2"""
+
+    let cfg = DependenciesFile.FromCode(config).Remove(GroupName "Test", PackageName "Castle.Windsor")
+    
+    let expected = """source http://www.nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2
+nuget Castle.Windsor ~> 3.2
+
+group Test
+http http://www.fssnip.net/1n decrypt.fs"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)


### PR DESCRIPTION
Created the test first and confirmed it failed. I've not yet had time to see if there are any similar bugs in other areas of the dependencies code - only taken a look at the removal case so far.

Edit: I've also added an extra fix for building on a path with spaces, though this still fails after due to a similar bug in the dotnet core targets file which I've reported here: https://github.com/dotnet/netcorecli-fsc/issues/59