### PR TITLE
Correctly escape no_proxy domains

### DIFF
--- a/src/Paket.Bootstrapper/EnvProxy.cs
+++ b/src/Paket.Bootstrapper/EnvProxy.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace Paket.Bootstrapper
 {
@@ -21,7 +23,8 @@ namespace Paket.Bootstrapper
             var noproxy = GetEnvVarValue("NO_PROXY");
             if (string.IsNullOrEmpty(noproxy))
                 return new string[0];
-            return noproxy.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            return noproxy.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                          .Select(s => "^" + Regex.Escape(s).Replace(@"\*", ".*") + "$").ToArray();;
         }
 
         private bool TryGetCredentials(Uri uri, out NetworkCredential credentials)


### PR DESCRIPTION
Bootstrapping fails on my setup, because I use wildcard in `NO_PROXY`:

```
→ echo $NO_PROXY 
*.fritz.box

→ ./obj/Debug/paket.bootstrapper.exe
Checking Paket version (downloading latest stable)...
The type initializer for 'Paket.Bootstrapper.EnvProxy' threw an exception. (Github - cached)
```

This is actually the same issue as https://github.com/fsprojects/Paket/pull/1939 which also need to be fixed in the bootstrapping code.


