### PR TITLE
Improve subcommand document generation

### DIFF
--- a/docs/content/paket-push.md
+++ b/docs/content/paket-push.md
@@ -2,24 +2,22 @@
 
 Pushes the given `.nupkg` file.
 
-    [lang=msh]
+    [lang=console]
     paket push [--help] url <url> file <path> [apikey <key>] [endpoint <path>]
 
 OPTIONS:
 
     url <url>             Url of the NuGet feed.
     file <path>           Path to the package.
-    apikey <key>          Optionally specify your API key on the command line.
-                          Otherwise uses the value of the `nugetkey`
-                          environment variable.
-    endpoint <path>       Optionally specify a custom api endpoint to push to.
-                          Defaults to `/api/v2/package`.
+    apikey <key>          Optionally specify your API key on the command line. Otherwise uses the
+                          value of the `nugetkey` environment variable.
+    endpoint <path>       Optionally specify a custom api endpoint to push to. Defaults to
+                          `/api/v2/package`.
     --verbose, -v         Enable verbose console output for the paket process.
     --log-file <path>     Specify a log file for the paket process.
     --silent, -s          Suppress console output for the paket process.
     --version             Display the version.
-    --from-bootstrapper   Call comming from the '--run' feature of the
-                          bootstrapper.
+    --from-bootstrapper   Call comming from the '--run' feature of the bootstrapper.
     --help                display this list of options.
 If you add the `-v` flag, then Paket will run in verbose mode and show detailed information.
 

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -5,6 +5,8 @@ open System.IO
 
 
 #if COMMANDS
+let MaxCodeWidth = 100
+
 Paket.Commands.getAllCommands()
 |> List.iter (fun command ->
     let metadata = command.ParentInfo |> Option.get
@@ -20,9 +22,8 @@ With `--log-file [FileName]` you can trace the logged information into a file.
         if File.Exists optFile
         then verboseOption + File.ReadAllText optFile
         else verboseOption
-    // Work around bug tpetricek/FSharp.Formatting#321 (FSharp.Literate does not escape HTML entities in code blocks with unknown language)
-    let cleanText (text : string) = text.Replace("[lang=batchfile]", "[lang=msh]").Replace("```batchfile", "```msh")
-    File.WriteAllText(sprintf "../content/paket-%s.md" metadata.Name, Paket.Commands.markdown command additionalText |> cleanText))
+
+    File.WriteAllText(sprintf "../content/paket-%s.md" metadata.Name, Paket.Commands.markdown command MaxCodeWidth additionalText))
 #endif
 
 

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -385,7 +385,7 @@ with
 
 let commandParser = ArgumentParser.Create<Command>(programName = "paket", errorHandler = new ProcessExiter())
 
-let markdown (subParser : ArgumentParser) (additionalText : string) =
+let markdown (subParser : ArgumentParser) (width : int) (additionalText : string) =
     let (afterCommandText, afterOptionsText) =
         let ensureLineBreak (text : string) = if String.IsNullOrEmpty(text) then text else text + Environment.NewLine + Environment.NewLine
         let cleanUp (text : string) = text.Replace("# [after-command]", "")
@@ -400,14 +400,20 @@ let markdown (subParser : ArgumentParser) (additionalText : string) =
 
     let parentMetadata = subParser.ParentInfo |> Option.get
 
+    let indentBy spaces (text:string) =
+        let whitespace = String(' ', spaces)
+        text.Split([|Environment.NewLine|], StringSplitOptions.None)
+        |> Seq.map (fun line -> whitespace + line)
+        |> String.concat Environment.NewLine
+
     let replace (pattern : string) (replacement : string) input =
         System.Text.RegularExpressions.Regex.Replace(input, pattern, replacement)
 
-    let syntax = subParser.PrintCommandLineSyntax()
-    let options =
-        subParser.PrintUsage(hideSyntax=true)
-        |> replace @"\s\t--help.*" ""
-        |> replace @"\t([-\w \[\]|\/\?<>\.]+):" (System.Environment.NewLine + @"  `$1`:")
+    let syntax = 
+        subParser.PrintCommandLineSyntax(usageStringCharacterWidth = width)
+        |> indentBy 4
+
+    let options = subParser.PrintUsage(hideSyntax=true, usageStringCharacterWidth = width)
 
     System.Text.StringBuilder()
         .Append("# paket ")
@@ -415,8 +421,7 @@ let markdown (subParser : ArgumentParser) (additionalText : string) =
         .AppendLine()
         .AppendLine(parentMetadata.Description)
         .AppendLine()
-        .AppendLine("    [lang=batchfile]")
-        .Append("    ")
+        .AppendLine("    [lang=console]")
         .AppendLine(syntax)
         .AppendLine()
         .Append(afterCommandText)


### PR DESCRIPTION
Did a bit of tweaking in document generation code to improve subcommand documentation. What currently looks like
<img width="792" alt="1" src="https://cloud.githubusercontent.com/assets/2813363/21567915/f10d1268-cea7-11e6-9173-e6e63e7e48a2.PNG">
has been changed to this
<img width="815" alt="2" src="https://cloud.githubusercontent.com/assets/2813363/21567917/f7bf614c-cea7-11e6-9ce8-4bdd46a22775.PNG">
