### PR TITLE
Fix "directory doesn't exist" in NugetV2

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -324,6 +324,8 @@ let fixArchive fileName =
         fixDatesInArchive fileName
 
 let findLocalPackage directory (packageName:PackageName) (version:SemVerInfo) =
+    if not <| Directory.Exists directory then 
+        failwithf "The package %O %O can't be found in %s. (The directory doesn't exist.)%sPlease check the feed definition in your paket.dependencies file." packageName version directory Environment.NewLine
     let v1 = FileInfo(Path.Combine(directory, sprintf "%O.%O.nupkg" packageName version))
     if v1.Exists then v1 else
     let normalizedVersion = version.Normalize()


### PR DESCRIPTION
When doing a paket restore using a local nuget repository that is not reachable, the process crashes without telling which package or feed cause the issue. There's already a check if the package is not present in the repository but not if the repository itself is unreachable.

Had the issue with a repo in the paket.lock that can't be reached from another server.