### PR TITLE
Ensure case when getting packages from nuget feed

### DIFF
--- a/src/Paket.Core/NuGetV2.fs
+++ b/src/Paket.Core/NuGetV2.fs
@@ -241,7 +241,7 @@ let parseODataDetails(url,nugetURL,packageName:PackageName,version:SemVerInfo,ra
 let getDetailsFromNuGetViaODataFast auth nugetURL (packageName:PackageName) (version:SemVerInfo) =
     async {
         try
-            let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%O') and (NormalizedVersion eq '%s')" nugetURL packageName (version.Normalize())
+            let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%s') and (NormalizedVersion eq '%s')" nugetURL (packageName.GetCompareString()) (version.Normalize())
             let! raw = getFromUrl(auth,url,acceptXml)
             if verbose then
                 tracefn "Response from %s:" url
@@ -249,7 +249,7 @@ let getDetailsFromNuGetViaODataFast auth nugetURL (packageName:PackageName) (ver
                 tracefn "%s" raw
             return parseODataDetails(url,nugetURL,packageName,version,raw)
         with _ ->
-            let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%O') and (Version eq '%O')" nugetURL packageName version
+            let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%s') and (Version eq '%O')" nugetURL (packageName.GetCompareString()) version
             let! raw = getFromUrl(auth,url,acceptXml)
             if verbose then
                 tracefn "Response from %s:" url


### PR DESCRIPTION
Fix an issue when comparing a nuget name against a lowered nuget id in odata query that may have different case