### PR TITLE
Make config writer use XmlWriter for disk write

### DIFF
--- a/src/Paket.Core/ConfigFile.fs
+++ b/src/Paket.Core/ConfigFile.fs
@@ -17,13 +17,6 @@ let private rootElement = "configuration"
 let private getConfigNode (nodeName : string) =
     let rootNode = 
         let doc = XmlDocument ()
-        
-        let xmldecl = doc.CreateXmlDeclaration("1.0",null,null)
-        xmldecl.Encoding <- "UTF-8"
-        xmldecl.Standalone <- "yes"
-
-        doc.InsertBefore(xmldecl, doc.DocumentElement) |> ignore
-
         if File.Exists Constants.PaketConfigFile then 
             try 
                 use f = File.OpenRead(Constants.PaketConfigFile)
@@ -49,7 +42,7 @@ let private getConfigNode (nodeName : string) =
 let private saveConfigNode (node : XmlNode) =
     trial {
         do! createDir Constants.PaketConfigFolder
-        do! saveFile Constants.PaketConfigFile (normalizeXml node.OwnerDocument)
+        do! saveNormalizedXml Constants.PaketConfigFile node.OwnerDocument
     }
 
 

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -316,6 +316,19 @@ let inline normalizeXml (doc:XmlDocument) =
     xmlTextWriter.Flush()
     stringWriter.GetStringBuilder() |> string
 
+let saveNormalizedXml (fileName:string) (doc:XmlDocument) =
+    // combination of saveFile and normalizeXml which ensures that the
+    // file encoding matches the one listed in the XML itself.
+    tracefn "Saving xml %s" fileName
+    let settings = XmlWriterSettings (Indent=true)
+
+    try
+        use fstream = File.Create(fileName)
+        use xmlTextWriter = XmlWriter.Create(fstream, settings)
+        doc.WriteTo(xmlTextWriter) |> ok
+    with _ ->
+        FileSaveError fileName |> fail
+
 let normalizeFeedUrl (source:string) =
     match source.TrimEnd([|'/'|]) with
     | "https://api.nuget.org/v3/index.json" -> Constants.DefaultNuGetV3Stream 


### PR DESCRIPTION
... instead of doing XmlWriter -> string -> disk.
- This guarantees that the file encoding and the XML declaration are
  properly in sync.
- Adds a `saveNormalizedXml` function to Utils to facilitate this.
- Adds a test to UtilsSpecs for the new function.
- Updates ConfigFile.saveConfigNode to use the new function.
- Should fix #2003 more permanently.
- Removes the previous fix in commit d1d06b7