### PR TITLE
Support GitHub dependencies with spaces

### DIFF
--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -165,10 +165,16 @@ module LockFileSerializer =
                     yield sprintf "  remote: " + url
 
                 for file in files |> Seq.sortBy (fun f -> f.Owner.ToLower(),f.Project.ToLower(),f.Name.ToLower())  do
-                    
-                    let path = file.Name.TrimStart '/'
-                    match String.IsNullOrEmpty(file.Commit) with 
-                    | false -> 
+
+                    let path =
+                        file.Name.TrimStart '/'
+                        |> fun s ->
+                            if System.Text.RegularExpressions.Regex.IsMatch (s, "\s") then
+                                String.Concat ("\"", s, "\"")
+                            else
+                                s
+                    match String.IsNullOrEmpty(file.Commit) with
+                    | false ->
                         match file.AuthKey with
                         | Some authKey -> 
                             yield sprintf "    %s (%s) %s" path file.Commit authKey

--- a/src/Paket.Core/LockFile.fs
+++ b/src/Paket.Core/LockFile.fs
@@ -429,7 +429,7 @@ module LockFileParser =
                                         | _ -> None
                                     match pathInfo with
                                     | Some (path, pathEndIdx) ->
-                                        let commitAndAuthKey = details.Substring(pathEndIdx + 1).Split(' ')
+                                        let commitAndAuthKey = details.Substring(pathEndIdx + 2).Split(' ')
                                         Array.append [| path |] commitAndAuthKey
                                     | None -> Array.empty
                                 else

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -157,6 +157,7 @@ let expectedWithGitHub = """GITHUB
   remote: owner/project1
     folder/file.fs (master)
     folder/file1.fs (commit1)
+    "folder/file 2.fs" (commit)
   remote: owner/project2
     folder/file.fs (commit2)
     folder/file3.fs (commit3) githubAuth"""
@@ -165,6 +166,7 @@ let expectedWithGitHub = """GITHUB
 let ``should generate lock file for source files``() = 
     let config = """github "owner:project1:master" "folder/file.fs"
 github "owner/project1:commit1" "folder/file1.fs"
+github "owner/project1" "folder/file 2.fs"
 github "owner:project2:commit2" "folder/file.fs"
 github "owner:project2:commit3" "folder/file3.fs" githubAuth """ 
 

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -157,7 +157,7 @@ let expectedWithGitHub = """GITHUB
   remote: owner/project1
     folder/file.fs (master)
     folder/file1.fs (commit1)
-    "folder/file 2.fs" (commit)
+    "folder/file 2.fs" (commit1)
   remote: owner/project2
     folder/file.fs (commit2)
     folder/file3.fs (commit3) githubAuth"""
@@ -166,7 +166,7 @@ let expectedWithGitHub = """GITHUB
 let ``should generate lock file for source files``() = 
     let config = """github "owner:project1:master" "folder/file.fs"
 github "owner/project1:commit1" "folder/file1.fs"
-github "owner/project1" "folder/file 2.fs"
+github "owner/project1:commit1" "folder/file 2.fs"
 github "owner:project2:commit2" "folder/file.fs"
 github "owner:project2:commit3" "folder/file3.fs" githubAuth """ 
 

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -155,9 +155,9 @@ let ``should generate lock file with disabled content for packages``() =
 
 let expectedWithGitHub = """GITHUB
   remote: owner/project1
+    "folder/file 2.fs" (commit1)
     folder/file.fs (master)
     folder/file1.fs (commit1)
-    "folder/file 2.fs" (commit1)
   remote: owner/project2
     folder/file.fs (commit2)
     folder/file3.fs (commit3) githubAuth"""

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -880,3 +880,25 @@ let ``should parse local git lock file with build and no specs``() =
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
     lockFile.Head.SourceFiles.Head.Project |> shouldEqual "nupkgtest"
     lockFile.Head.SourceFiles.Head.Command |> shouldEqual (Some "build.cmd Test")
+
+let lockFileWithFilesContainingSpaces = """
+GITHUB
+  remote: owner/repo
+  specs:
+    "file 1.fs" (7623fc13439f0e60bd05c1ed3b5f6dcb937fe468)"""
+
+[<Test>]
+let ``should parse lock file with spaces in file names``() =
+    let lockFile = LockFileParser.Parse (toLines lockFileWithFilesContainingSpaces)
+    let sourceFiles = List.rev lockFile.Head.SourceFiles
+    sourceFiles|> shouldEqual
+        [ { Owner = "owner"
+            Project = "repo"
+            Name = "file 1.fs"
+            Origin = ModuleResolver.Origin.GitHubLink
+            Dependencies = Set.empty
+            Commit = "7623fc13439f0e60bd05c1ed3b5f6dcb937fe468"
+            Command = None
+            OperatingSystemRestriction = None
+            PackagePath = None
+            AuthKey = None } ]

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -885,7 +885,8 @@ let lockFileWithFilesContainingSpaces = """
 GITHUB
   remote: owner/repo
   specs:
-    "file 1.fs" (7623fc13439f0e60bd05c1ed3b5f6dcb937fe468)"""
+    "file 1.fs" (7623fc13439f0e60bd05c1ed3b5f6dcb937fe468)
+    "file 2.fs" (7623fc13439f0e60bd05c1ed3b5f6dcb937fe468) secret"""
 
 [<Test>]
 let ``should parse lock file with spaces in file names``() =
@@ -901,4 +902,14 @@ let ``should parse lock file with spaces in file names``() =
             Command = None
             OperatingSystemRestriction = None
             PackagePath = None
-            AuthKey = None } ]
+            AuthKey = None }
+          { Owner = "owner"
+            Project = "repo"
+            Name = "file 2.fs"
+            Origin = ModuleResolver.Origin.GitHubLink
+            Dependencies = Set.empty
+            Commit = "7623fc13439f0e60bd05c1ed3b5f6dcb937fe468"
+            Command = None
+            OperatingSystemRestriction = None
+            PackagePath = None
+            AuthKey = Some "secret" } ]


### PR DESCRIPTION
This should enable support for GitHub dependencies which contain spaces in their file name.