### PR TITLE
Ignore unknown frameworks

### DIFF
--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -5,6 +5,7 @@ open System
 
 [<RequireQualifiedAccess>]
 /// The Framework version.
+// Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
 type FrameworkVersion = 
     | V1
     | V1_1
@@ -62,6 +63,7 @@ type FrameworkVersion =
 
 [<RequireQualifiedAccess>]
 /// The .NET Standard version.
+// Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
 type DotNetStandardVersion = 
     | V1_0
     | V1_1
@@ -92,6 +94,7 @@ type DotNetStandardVersion =
 
 [<RequireQualifiedAccess>]
 /// The UAP version.
+// Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
 type UAPVersion = 
     | V10
     override this.ToString() =
@@ -105,6 +108,7 @@ type UAPVersion =
 
 [<RequireQualifiedAccess>]
 /// The .NET Standard version.
+// Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
 type DotNetCoreVersion = 
     | V1_0
     | V1_1
@@ -139,6 +143,7 @@ module KnownAliases =
 
 
 /// Framework Identifier type.
+// Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
 type FrameworkIdentifier = 
     | DotNetFramework of FrameworkVersion
     | UAP of UAPVersion
@@ -305,6 +310,7 @@ module FrameworkDetection =
                      sb.Replace(pattern,replacement) |> ignore
                 sb.ToString()
 
+            // Each time the parsing is changed, NuGetPackageCache.CurrentCacheVersion should be bumped.
             let result = 
                 match path with
                 | x when x.StartsWith "runtimes/" -> Some(Runtimes(x.Substring(9)))

--- a/src/Paket.Core/Nuget.fs
+++ b/src/Paket.Core/Nuget.fs
@@ -51,7 +51,7 @@ type NuGetPackageCache =
       Version: string
       CacheVersion: string }
 
-    static member CurrentCacheVersion = "2.8"
+    static member CurrentCacheVersion = "2.9"
 
 let inline normalizeUrl(url:string) = url.Replace("https://","http://").Replace("www.","")
 

--- a/src/Paket.Core/Nuget.fs
+++ b/src/Paket.Core/Nuget.fs
@@ -51,7 +51,7 @@ type NuGetPackageCache =
       Version: string
       CacheVersion: string }
 
-    static member CurrentCacheVersion = "2.9"
+    static member CurrentCacheVersion = "3.36"
 
 let inline normalizeUrl(url:string) = url.Replace("https://","http://").Replace("www.","")
 

--- a/tests/Paket.Tests/NuGetOData/BenchmarkDotNet-UnknownFramework.xml
+++ b/tests/Paket.Tests/NuGetOData/BenchmarkDotNet-UnknownFramework.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xml:base="https://www.nuget.org/api/v2">
+   <id>http://schemas.datacontract.org/2004/07/</id>
+   <title />
+   <updated>2017-01-29T21:10:54Z</updated>
+   <link rel="self" href="https://www.nuget.org/api/v2/Packages" />
+   <entry>
+      <id>https://www.nuget.org/api/v2/Packages(Id='BenchmarkDotNet',Version='0.10.1')</id>
+      <category term="NuGetGallery.OData.V2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+      <link rel="edit" href="https://www.nuget.org/api/v2/Packages(Id='BenchmarkDotNet',Version='0.10.1')" />
+      <link rel="self" href="https://www.nuget.org/api/v2/Packages(Id='BenchmarkDotNet',Version='0.10.1')" />
+      <title type="text">BenchmarkDotNet</title>
+      <updated>2016-12-04T06:12:30Z</updated>
+      <author>
+         <name>.NET Foundation and contributors</name>
+      </author>
+      <content type="application/zip" src="https://www.nuget.org/api/v2/package/BenchmarkDotNet/0.10.1" />
+      <m:properties>
+         <d:Id>BenchmarkDotNet</d:Id>
+         <d:Version>0.10.1</d:Version>
+         <d:NormalizedVersion>0.10.1</d:NormalizedVersion>
+         <d:Authors>.NET Foundation and contributors</d:Authors>
+         <d:Copyright>.NET Foundation and contributors</d:Copyright>
+         <d:Created m:type="Edm.DateTime">2016-12-04T06:12:30.877</d:Created>
+         <d:Dependencies>BenchmarkDotNet.Core:[0.10.1, ):unknown-framework-42|BenchmarkDotNet.Toolchains.Roslyn:[0.10.1, ):net45</d:Dependencies>
+         <d:Description>Powerful .NET library for benchmarking</d:Description>
+         <d:DownloadCount m:type="Edm.Int32">54909</d:DownloadCount>
+         <d:GalleryDetailsUrl>https://www.nuget.org/packages/BenchmarkDotNet/0.10.1</d:GalleryDetailsUrl>
+         <d:IconUrl>https://raw.githubusercontent.com/dotnet/BenchmarkDotNet/master/docs/guide/logo.png</d:IconUrl>
+         <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+         <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+         <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+         <d:Language>en-US</d:Language>
+         <d:LastUpdated m:type="Edm.DateTime">2016-12-04T06:12:30.877</d:LastUpdated>
+         <d:Published m:type="Edm.DateTime">2016-12-04T06:12:30.877</d:Published>
+         <d:PackageHash>492Rz7UdKnM3i/H3P2EW8ZrE0R53D/8sIvfAZbvFk8tqf9vHe/mg/MazXijZm0UKInkBgslotwQL8pRg0ZSnIQ==</d:PackageHash>
+         <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+         <d:PackageSize m:type="Edm.Int64">15435</d:PackageSize>
+         <d:ProjectUrl>https://github.com/dotnet/BenchmarkDotNet</d:ProjectUrl>
+         <d:ReportAbuseUrl>https://www.nuget.org/packages/BenchmarkDotNet/0.10.1/ReportAbuse</d:ReportAbuseUrl>
+         <d:ReleaseNotes m:null="true" />
+         <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+         <d:Summary m:null="true" />
+         <d:Tags>benchmark benchmarking performance</d:Tags>
+         <d:Title>BenchmarkDotNet</d:Title>
+         <d:VersionDownloadCount m:type="Edm.Int32">5778</d:VersionDownloadCount>
+         <d:MinClientVersion m:null="true" />
+         <d:LastEdited m:null="true" />
+         <d:LicenseUrl>https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md</d:LicenseUrl>
+         <d:LicenseNames m:null="true" />
+         <d:LicenseReportUrl m:null="true" />
+      </m:properties>
+   </entry>
+</feed>

--- a/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
+++ b/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
@@ -152,3 +152,21 @@ let ``can detect explicit dependencies for WindowsAzure.Storage``() =
     dependencies.[44] |> shouldEqual 
         (PackageName "Newtonsoft.Json", DependenciesFileParser.parseVersionRequirement(">= 6.0.8"), 
             FrameworkRestrictionList [FrameworkRestriction.Exactly(WindowsPhoneSilverlight("v8.0")); FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_Client))])
+
+[<Test>]
+let ``can ignore unknown frameworks``() = 
+    parse "NuGetOData/BenchmarkDotNet-UnknownFramework.xml"
+    |> shouldEqual 
+        { PackageName = "BenchmarkDotNet"
+          DownloadUrl = "https://www.nuget.org/api/v2/package/BenchmarkDotNet/0.10.1"
+          Dependencies =
+            [
+                PackageName "BenchmarkDotNet.Toolchains.Roslyn",
+                DependenciesFileParser.parseVersionRequirement(">= 0.10.1"),
+                FrameworkRestrictionList [FrameworkRestriction.AtLeast (DotNetFramework FrameworkVersion.V4_5)]
+            ]
+          Unlisted = false
+          LicenseUrl = "https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md"
+          CacheVersion = NuGet.NuGetPackageCache.CurrentCacheVersion
+          Version = "0.10.1"
+          SourceUrl = fakeUrl }

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -199,6 +199,9 @@
     <Content Include="NuGetOData\EasyNetQ.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="NuGetOData\BenchmarkDotNet-UnknownFramework.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Compile Include="NuGetOData\ODataSpecs.fs" />
     <Content Include="NuGetConfig\ClearTextPasswordConfig.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
* Ignore unknown frameworks in conditional references 
Previously when a conditional reference was parsed (BenchmarkDotNet depending on BenchmarDotNet.Core only on netcoreapp1.1 for example) and the framework was unknown it was assumed to be .Net 1.0+
Such conditional references are now ignored and a message is displayed on the verbose log about it instead.
* Bump CurrentCacheVersion
It isn't necessary for this PR but wasn't done in #2129 and it is necessary to ensure that new frameworks are correctly parsed and used.
This commit also add comments to remember to do it each time frameworks are added or their parsing is changed.
(I discussed in #2109 that I wanted to add such version number but it turns out that it already exists 👍 )

Fixes #2109