### PR TITLE
Fix cmd argument quoting in Paket.Restore.targets

### DIFF
--- a/src/Paket/embedded/Paket.Restore.targets
+++ b/src/Paket/embedded/Paket.Restore.targets
@@ -15,7 +15,7 @@
   <UsingTask TaskName="Paket.Build.Tasks.PaketRestoreTask" AssemblyFile="PaketRestoreTask.dll" />
 
   <Target Name="PaketRestore" BeforeTargets="_GenerateRestoreGraphWalkPerFramework" >
-    <Exec Command="$(PaketCommand) restore --project $(MSBuildProjectFullPath)" />
+    <Exec Command="$(PaketCommand) restore --project &quot;$(MSBuildProjectFullPath)&quot;" />
 
      <!-- Write out package references for NETCore -->
     <PaketRestoreTask


### PR DESCRIPTION
The line that runs `paket restore` in Paket.Restore.targets needs to wrap the path to the .csproj file in quotes if its path has spaces.