### PR TITLE
Lower case group folder name

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -384,7 +384,7 @@ type Dependencies(dependenciesFileName: string) =
             | None -> failwithf "Package %O is not installed in group %O." packageName groupName
             | Some resolvedPackage ->
                 let packageName = resolvedPackage.Name
-                let groupFolder = if groupName = Constants.MainDependencyGroup then "" else "/" + groupName.ToString()
+                let groupFolder = if groupName = Constants.MainDependencyGroup then "" else "/" + groupName.ToString().ToLower()
                 let folder = DirectoryInfo(sprintf "%s/packages%s/%O" this.RootPath groupFolder packageName)
                 let nuspec = FileInfo(sprintf "%s/packages%s/%O/%O.nuspec" this.RootPath groupFolder packageName packageName)
                 let nuspec = Nuspec.Load nuspec.FullName


### PR DESCRIPTION
generate-include-scripts fails on Linux systems when the group name is upper case since the folder is created lower case

This causes the dir.Exists check here:
https://github.com/fsprojects/Paket/blob/master/src/Paket.Core/NuGetV2.fs#L609
to fail