### PR TITLE
Link to documentation on how to resolve a conflict

### DIFF
--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -163,7 +163,7 @@ type Resolution =
         | Resolution.Conflict(_) -> 
             "There was a version conflict during package resolution." + Environment.NewLine +
                 this.GetErrorText(true)  + Environment.NewLine +
-                "  Please try to relax some conditions."
+                "  Please try to relax some conditions or resolve the conflict manually (see http://fsprojects.github.io/Paket/nuget-dependencies.html#Use-exactly-this-version-constraint)."
             |> failwithf "%s"
 
     member this.IsDone =


### PR DESCRIPTION
When I got this error (due to a broken package), it took me way too long to find the correct documentation.

I'm a big fan of error messages telling you what to do.

(I didn't mention the == operator directly in the error message on purpose, because fixing the version can cause a lot of fun ( MethodNotFoundException <3 ), and there should be at least a chance to warn the user.

What would you think about adding a big bold warning to http://fsprojects.github.io/Paket/nuget-dependencies.html#Use-exactly-this-version-constraint how it can cause all kinds of trouble? (Here be dragons ...)