### PR TITLE
collect multiple install errors before failing

### DIFF
--- a/src/Paket.Core/Files/ProjectFile.fs
+++ b/src/Paket.Core/Files/ProjectFile.fs
@@ -1521,18 +1521,16 @@ type ProjectFile with
 
     member this.FindTemplatesFile() = this.FindCorrespondingFile Constants.TemplateFile
 
-    member this.GetToolsVersion() : float =         
-        try
-            this.ProjectNode.Attributes.["ToolsVersion"].Value |> float
-        with
-        | _ -> 
-            try
-                if this.ProjectNode.Attributes.["Sdk"].Value <> "" then
-                    15.0
-                else
-                    4.0
-            with
-            | _ -> 4.0
+    member this.GetToolsVersion () : float =         
+        match  Double.TryParse  this.ProjectNode.Attributes.["ToolsVersion"].Value with
+        | true , 15.0 -> 
+                let sdkAttr = this.ProjectNode.Attributes.["Sdk"]
+                if  isNull sdkAttr || String.IsNullOrWhiteSpace sdkAttr.Value
+                then 14.0   // adjustment so paket still installs to old style msbuild projects
+                else 15.0   // that are using MSBuild15 but not the new format
+        | true,  version -> version
+        | _         ->  4.0
+
 
     static member FindOrCreateReferencesFile projectFile =
         match ProjectFile.FindReferencesFile(projectFile) with

--- a/src/Paket.Core/InstallProcess.fs
+++ b/src/Paket.Core/InstallProcess.fs
@@ -338,162 +338,181 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
     for project, referenceFile in projectsAndReferences do
         let toolsVersion = project.GetToolsVersion()
         verbosefn "Installing to %s with ToolsVersion %O" project.FileName toolsVersion
-        let directDependencies =
+        let directDependencies, errorMessages =
             referenceFile.Groups
             |> Seq.map (fun kv ->
                 lockFile.GetRemoteReferencedPackages(referenceFile,kv.Value) @ kv.Value.NugetPackages
                 |> Seq.map (fun ps ->
                     let group = 
                         match lockFile.Groups |> Map.tryFind kv.Key with
-                        | Some g -> g
-                        | None -> failwithf "%s uses the group %O, but this group was not found in paket.lock." referenceFile.FileName kv.Key
+                        | Some g -> Choice1Of2 g
+                        | None -> Choice2Of2 <| sprintf " - %s uses the group %O, but this group was not found in paket.lock." referenceFile.FileName kv.Key
 
                     let package = 
                         match model |> Map.tryFind (kv.Key, ps.Name) with
-                        | Some (p,_) -> p
-                        | None -> failwithf "%s uses NuGet package %O, but it was not found in the paket.lock file in group %O.%s" referenceFile.FileName ps.Name kv.Key (lockFile.CheckIfPackageExistsInAnyGroup ps.Name)
+                        | Some (p,_) -> Choice1Of2 p
+                        | None -> Choice2Of2 <| sprintf " - %s uses NuGet package %O, but it was not found in the paket.lock file in group %O.%s" referenceFile.FileName ps.Name kv.Key (lockFile.CheckIfPackageExistsInAnyGroup ps.Name)
 
-                    let resolvedSettings = 
-                        [package.Settings; group.Options.Settings] 
-                        |> List.fold (+) ps.Settings
-                    (kv.Key,ps.Name), (package.Version,resolvedSettings)))
+                    match group, package with
+                    | Choice1Of2 group, Choice1Of2 package -> 
+                        let resolvedSettings = 
+                            [package.Settings; group.Options.Settings] 
+                            |> List.fold (+) ps.Settings 
+                        ((kv.Key,ps.Name), (package.Version,resolvedSettings))    
+                        |> Choice1Of2
+                    | Choice2Of2 error1, Choice2Of2 error2 -> Choice2Of2 (error1 + "\n" + error2) 
+                    | Choice2Of2 error, _ | _, Choice2Of2 error -> Choice2Of2 error
+                    ))                    
             |> Seq.concat
-            |> Map.ofSeq
+            |> Seq.partitionAndChoose 
+                    (function Choice1Of2 _ -> true | Choice2Of2 _ -> false)
+                    (function Choice1Of2 resolvedPackage -> Some resolvedPackage | _ -> None)
+                    (function Choice2Of2 errorMessage -> Some errorMessage | _ -> None)
+            |> fun (resolvedPackages, dependencyErrors) ->
+                    Map.ofSeq resolvedPackages, dependencyErrors 
 
-        let usedPackages =
-            let d = ref directDependencies
+
+        let usedPackages, errorMessages =
+            let mutable d = directDependencies
 
             /// we want to treat the settings from the references file through the computation so that it can be used as the base that 
             /// the other settings modify. In this way we ensure that references files can override the dependencies file, which in turn overrides the lockfile.
-            let usedPackageDependencies = 
+            let usedPackageDependencies, groupErrors = 
                 directDependencies 
                 |> Seq.collect (fun u -> lookup.[u.Key] |> Seq.map (fun i -> fst u.Key, u.Value, i))
-                |> Seq.choose (fun (groupName,(_,parentSettings), dep) -> 
-                    let group = 
-                        match lockFile.Groups |> Map.tryFind groupName with
-                        | Some g -> g
-                        | None -> failwithf "%s uses the group %O, but this group was not found in paket.lock." referenceFile.FileName groupName
-
-                    match group.Resolution |> Map.tryFind dep with
-                    | None -> None
-                    | Some p -> 
-                        let resolvedSettings = 
-                            [p.Settings; group.Options.Settings] 
-                            |> List.fold (+) parentSettings
-                        Some ((groupName,p.Name), (p.Version,resolvedSettings)) )
-
+                |> Seq.partitionAndChoose 
+                        (fun (groupName,(_,parentSettings), dep) -> 
+                            lockFile.Groups |> Map.containsKey groupName)
+                        (fun (groupName,(_,parentSettings), dep) -> 
+                            let group = lockFile.Groups.[groupName]
+                            match group.Resolution |> Map.tryFind dep with
+                            | None -> None
+                            | Some p -> 
+                                let resolvedSettings = 
+                                    [p.Settings; group.Options.Settings] 
+                                    |> List.fold (+) parentSettings
+                                Some ((groupName,p.Name), (p.Version,resolvedSettings)) )
+                        (fun (groupName,(_,parentSettings), dep) -> 
+                            Some <| sprintf "%s uses the group %O, but this group was not found in paket.lock." referenceFile.FileName groupName
+                        )
             for key,settings in usedPackageDependencies do
-                if (!d).ContainsKey key |> not then
-                    d := Map.add key settings !d
+                if d.ContainsKey key |> not then
+                    d <- Map.add key settings d
+            d, Seq.append errorMessages groupErrors
 
-            !d
-
-        let usedPackages =
-            let dict = System.Collections.Generic.Dictionary<_,_>()
+        let usedPackages, errorMessages =
+            let dict = System.Collections.Generic.Dictionary<PackageName,SemVerInfo>()
+            let errors = ResizeArray ()
             usedPackages
             |> Map.filter (fun (_groupName,packageName) (v,_) -> 
                 match dict.TryGetValue packageName with
                 | true,v' -> 
                     if v' = v then false else
-                    failwithf "Package %O is referenced in different versions in %s" packageName project.FileName
+                    errors.Add <| sprintf "Package %O is referenced in different versions in %s" packageName project.FileName
+                    false
                 | _ ->
                     dict.Add(packageName,v)
                     true)
+            |> fun usedPackages -> usedPackages, Seq.append errorMessages errors
 
-        if toolsVersion >= 15.0 then 
-            installForDotnetSDK root project  
+        // if any errors have been found during the installation process thus far, fail and print all errors collected
+        if not (Seq.isEmpty errorMessages) then 
+            failwithf  "Installation Failed :\n%s" (String.concat "\n" errorMessages)
         else
-            project.UpdateReferences(root, model, directDependencies, usedPackages)
+            if toolsVersion >= 15.0 then 
+                installForDotnetSDK root project  
+            else
+                project.UpdateReferences(root, model, directDependencies, usedPackages)
     
-            Path.Combine(FileInfo(project.FileName).Directory.FullName, Constants.PackagesConfigFile)
-            |> updatePackagesConfigFile usedPackages 
+                Path.Combine(FileInfo(project.FileName).Directory.FullName, Constants.PackagesConfigFile)
+                |> updatePackagesConfigFile usedPackages 
 
-        let gitRemoteItems =
-            referenceFile.Groups
-            |> Seq.map (fun kv ->
-                kv.Value.RemoteFiles
-                |> List.map (fun file ->
-                    let link = if file.Link = "." then Path.GetFileName file.Name else Path.Combine(file.Link, Path.GetFileName file.Name)
-                    let remoteFilePath = 
-                        if verbose then
-                            tracefn "FileName: %s " file.Name 
+            let gitRemoteItems =
+                referenceFile.Groups
+                |> Seq.map (fun kv ->
+                    kv.Value.RemoteFiles
+                    |> List.map (fun file ->
+                        let link = if file.Link = "." then Path.GetFileName file.Name else Path.Combine(file.Link, Path.GetFileName file.Name)
+                        let remoteFilePath = 
+                            if verbose then
+                                tracefn "FileName: %s " file.Name 
 
-                        let lockFileReference =
-                            match lockFile.Groups |> Map.tryFind kv.Key with
-                            | None -> None
-                            | Some group ->
-                                group.RemoteFiles
-                                |> Seq.tryFind (fun f -> Path.GetFileName(f.Name) = file.Name)
+                            let lockFileReference =
+                                match lockFile.Groups |> Map.tryFind kv.Key with
+                                | None -> None
+                                | Some group ->
+                                    group.RemoteFiles
+                                    |> Seq.tryFind (fun f -> Path.GetFileName(f.Name) = file.Name)
 
-                        match lockFileReference with
-                        | Some file -> file.FilePath(root,kv.Key)
-                        | None -> failwithf "%s references file %s in group %O, but it was not found in the paket.lock file." referenceFile.FileName file.Name kv.Key
+                            match lockFileReference with
+                            | Some file -> file.FilePath(root,kv.Key)
+                            | None -> failwithf "%s references file %s in group %O, but it was not found in the paket.lock file." referenceFile.FileName file.Name kv.Key
 
-                    let linked = defaultArg file.Settings.Link true
+                        let linked = defaultArg file.Settings.Link true
 
-                    let buildAction = project.DetermineBuildActionForRemoteItems file.Name
-                    if buildAction <> BuildAction.Reference && linked then
-                        { BuildAction = buildAction
-                          Include = createRelativePath project.FileName remoteFilePath
-                          WithPaketSubNode = true
-                          CopyToOutputDirectory = None
-                          Link = Some link }
-                    else
-                        { BuildAction = buildAction
-                          WithPaketSubNode = true
-                          CopyToOutputDirectory = None
-                          Include =
-                            if buildAction = BuildAction.Reference then
-                                 createRelativePath project.FileName remoteFilePath
-                            else
-                                let toDir = Path.GetDirectoryName(project.FileName)
-                                let targetFile = FileInfo(Path.Combine(toDir,link))
-                                if targetFile.Directory.Exists |> not then
-                                    targetFile.Directory.Create()
+                        let buildAction = project.DetermineBuildActionForRemoteItems file.Name
+                        if buildAction <> BuildAction.Reference && linked then
+                            { BuildAction = buildAction
+                              Include = createRelativePath project.FileName remoteFilePath
+                              WithPaketSubNode = true
+                              CopyToOutputDirectory = None
+                              Link = Some link }
+                        else
+                            { BuildAction = buildAction
+                              WithPaketSubNode = true
+                              CopyToOutputDirectory = None
+                              Include =
+                                if buildAction = BuildAction.Reference then
+                                     createRelativePath project.FileName remoteFilePath
+                                else
+                                    let toDir = Path.GetDirectoryName(project.FileName)
+                                    let targetFile = FileInfo(Path.Combine(toDir,link))
+                                    if targetFile.Directory.Exists |> not then
+                                        targetFile.Directory.Create()
 
-                                File.Copy(remoteFilePath,targetFile.FullName)
-                                createRelativePath project.FileName targetFile.FullName
-                          Link = None }))
-            |> List.concat
+                                    File.Copy(remoteFilePath,targetFile.FullName)
+                                    createRelativePath project.FileName targetFile.FullName
+                              Link = None }))
+                |> List.concat
 
-        processContentFiles root project usedPackages gitRemoteItems options
-        project.Save forceTouch
-        projectCache.[project.FileName] <- Some project
+            processContentFiles root project usedPackages gitRemoteItems options
+            project.Save forceTouch
+            projectCache.[project.FileName] <- Some project
 
-        let first = ref true
+            let first = ref true
 
-        let redirects =
-            match options.Redirects with
-            | true -> Some true
-            | false -> None
+            let redirects =
+                match options.Redirects with
+                | true -> Some true
+                | false -> None
 
-        let allKnownLibs =
-            model
-            |> Seq.map (fun kv -> (snd kv.Value).GetLibReferencesLazy.Force())
-            |> Set.unionMany
+            let allKnownLibs =
+                model
+                |> Seq.map (fun kv -> (snd kv.Value).GetLibReferencesLazy.Force())
+                |> Set.unionMany
 
-        for g in lockFile.Groups do
-            let group = g.Value
-            model
-            |> Seq.filter (fun kv -> (fst kv.Key) = g.Key)
-            |> Seq.map (fun kv ->
-                let packageRedirects =
-                    group.Resolution
-                    |> Map.tryFind (snd kv.Key)
-                    |> Option.bind (fun p -> p.Settings.CreateBindingRedirects)
+            for g in lockFile.Groups do
+                let group = g.Value
+                model
+                |> Seq.filter (fun kv -> (fst kv.Key) = g.Key)
+                |> Seq.map (fun kv ->
+                    let packageRedirects =
+                        group.Resolution
+                        |> Map.tryFind (snd kv.Key)
+                        |> Option.bind (fun p -> p.Settings.CreateBindingRedirects)
 
-                (snd kv.Value,packageRedirects))
-            |> applyBindingRedirects 
-                !first 
-                options.CreateNewBindingFiles
-                (g.Value.Options.Redirects ++ redirects) 
-                options.CleanBindingRedirects
-                (FileInfo project.FileName).Directory.FullName 
-                g.Key 
-                lockFile.GetAllDependenciesOf
-                allKnownLibs
-                projectCache
-            first := false
+                    (snd kv.Value,packageRedirects))
+                |> applyBindingRedirects 
+                    !first 
+                    options.CreateNewBindingFiles
+                    (g.Value.Options.Redirects ++ redirects) 
+                    options.CleanBindingRedirects
+                    (FileInfo project.FileName).Directory.FullName 
+                    g.Key 
+                    lockFile.GetAllDependenciesOf
+                    allKnownLibs
+                    projectCache
+                first := false
 
 /// Installs all packages from the lock file.
 let Install(options : InstallerOptions, forceTouch, dependenciesFile, lockFile : LockFile, updatedGroups) =    

--- a/src/Paket.Core/Utils.fs
+++ b/src/Paket.Core/Utils.fs
@@ -977,3 +977,24 @@ type StringBuilder with
         self.AppendLine text |> ignore
 
     member self.AppendLinef text = Printf.kprintf self.AppendLine text
+
+[<RequireQualifiedAccess>]
+module Seq =
+    /// Unzip a seq by mapping the elements that satisfy the predicate 
+    /// into the first seq and mapping the elements that fail to satisfy the predicate
+    /// into the second seq
+    let partitionAndChoose predicate choosefn1 choosefn2 sqs =   
+        (([],[]),sqs)
+        ||> Seq.fold (fun (xs,ys) elem ->
+            if predicate elem then 
+                match choosefn1 elem with 
+                | Some x ->  (x::xs,ys) 
+                | None -> xs,ys
+            else 
+                match choosefn2 elem with
+                | Some y -> xs,y::ys 
+                | None -> xs,ys
+        ) |> fun (xs,ys) ->
+            List.rev xs :> seq<_>, List.rev ys :> seq<_>
+
+


### PR DESCRIPTION
Needing to run install several times in a row to get one successive error is a tedious chore, instead let's collect them and return them all at once.

![](http://i.imgur.com/z50exKZ.png)