### PR TITLE
proposal for dotnet paket

### DIFF
--- a/buildtools/build.proj
+++ b/buildtools/build.proj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.0.2" />
+  </ItemGroup>
+</Project>

--- a/sourcelink.ps1
+++ b/sourcelink.ps1
@@ -1,0 +1,7 @@
+Push-Location buildtools
+if (-not (Test-Path 'obj/project.assets.json')) 
+{
+    dotnet restore
+}
+dotnet sourcelink @args
+Pop-Location


### PR DESCRIPTION
This is not to be merged. I'm proposing that a `donet-paket` be created to make distributing paket extremely easy. Distributing build tools like paket and FAKE via DotNetCliToolReference's is a great way to do things for MSBuild 15. I shipped SourceLink v2 last week as one. Pretend in the code example that it was `paket.ps1` instead. Perhaps the directory needs to be passed in too. Those details can be worked out.