### PR TITLE
Fix to handle weird malformed portable-only libraries.

### DIFF
--- a/src/Paket.Core/PlatformMatching.fs
+++ b/src/Paket.Core/PlatformMatching.fs
@@ -7,7 +7,7 @@ let MaxPenalty = 1000000
 
 let inline split (path : string) = 
     path.Split('+')
-    |> Array.map (fun s -> s.Replace("portable-", ""))
+    |> Array.map (fun s -> System.Text.RegularExpressions.Regex.Replace(s, "portable\\d*-",""))
     
 let extractPlatforms = memoize (fun path  -> split path |> Array.choose FrameworkDetection.Extract |> Array.toList)
 


### PR DESCRIPTION
Fix for issue #1645 

The nuget parser handles strings in the form of:
{Identifier}{Version}-{Profile}

(see `NuGet.VersionUtility.ParseFrameworkName`)

So the string: `portable-net45+win8+wp8` gets parsed to:
`.NETPortable,Version=v0.0,Profile=net45+win8+wp8`

The string: `portable45-net45+win8+wp8` gets parsed to:
`.NETPortable,Version=v4.5,Profile=net45+win8+wp8`

Both end up being "valid", but for portable frameworks, the version doesn't matter (the profile does).

The fix is to use a regex to strip out "portable-" and "portable{version}-" when doing platform matching.

(note: `NuGet pack` seems to be using the `portable45` for whatever reason now)