### PR TITLE
Fix 2222 - improve output of the outdated warning and fix underlying bug

### DIFF
--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -3,25 +3,46 @@
 open Paket.Requirements
 open Paket.PackageResolver
 
+type DependencyChangeType =
+    /// The restrictions changed
+    | RestrictionsChanged
+    /// The settigns of the package changed
+    | SettingsChanged
+    /// The Version in the LockFile doesn't match the spec in the dependencies file.
+    | VersionNotValid
+    /// Package from dependencies file was not found in lockfile
+    | PackageNotFoundInLockFile
+    /// Group from dependencies file was not found in lockfile
+    | GroupNotFoundInLockFile
+    /// Package from lock file was not found in dependencies file
+    | PackageNotFoundInDependenciesFile
+
 let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFile:LockFile,strict) =
     let allTransitives groupName = lockFile.GetTransitiveDependencies groupName
-    let hasChanged groupName transitives (newRequirement:PackageRequirement) (originalPackage:ResolvedPackage) =
+    let getChanges groupName transitives (newRequirement:PackageRequirement) (originalPackage:ResolvedPackage) =
         let settingsChanged() =
             if newRequirement.Settings <> originalPackage.Settings then
                 if newRequirement.Settings = { originalPackage.Settings with FrameworkRestrictions = AutoDetectFramework } then
-                    false
+                    []
                 elif newRequirement.Settings.FrameworkRestrictions <> originalPackage.Settings.FrameworkRestrictions then
-                    transitives |> Seq.contains originalPackage.Name |> not
-                else true
-            else false
+                    let isTransitive = transitives |> Seq.contains originalPackage.Name
+                    if not isTransitive then
+                        [RestrictionsChanged]
+                    else []
+                else [SettingsChanged]
+            else []
 
         let requirementOk =
-            if strict then
-                newRequirement.VersionRequirement.IsInRange originalPackage.Version
-            else
-                newRequirement.IncludingPrereleases().VersionRequirement.IsInRange originalPackage.Version
+            let isInRange =
+                if strict then
+                    newRequirement.VersionRequirement.IsInRange originalPackage.Version
+                else
+                    newRequirement.IncludingPrereleases().VersionRequirement.IsInRange originalPackage.Version
+            if not isInRange then
+                [VersionNotValid]
+            else []
 
-        (not requirementOk) || settingsChanged()
+        requirementOk @ settingsChanged()
 
     let added groupName transitives =
         match dependenciesFile.Groups |> Map.tryFind groupName with
@@ -31,17 +52,19 @@ let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFil
             depsGroup.Packages
             |> Seq.map (fun d ->
                 d.Name, { d with Settings = depsGroup.Options.Settings + d.Settings })
-            |> Seq.filter (fun (name,dependenciesFilePackage) ->
+            |> Seq.map (fun (name,dependenciesFilePackage) ->
+                name, dependenciesFilePackage,
                 match lockFileGroup with
-                | None -> true
+                | None -> [GroupNotFoundInLockFile]
                 | Some group ->
                     match group.Resolution.TryFind name with
                     | Some lockFilePackage ->
-                        hasChanged groupName transitives 
+                        getChanges groupName transitives 
                             { dependenciesFilePackage with Settings = depsGroup.Options.Settings + dependenciesFilePackage.Settings }
                             { lockFilePackage with Settings = group.Options.Settings + lockFilePackage.Settings }
-                    | _ -> true)
-            |> Seq.map (fun (p,_) -> groupName,p)
+                    | _ -> [PackageNotFoundInLockFile])
+            |> Seq.filter (fun (_,_, changes) -> changes.Length > 0)
+            |> Seq.map (fun (p,_, changes) -> groupName, p, changes)
             |> Set.ofSeq
     
     let modified groupName transitives = 
@@ -59,11 +82,12 @@ let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFil
             | Some pr ->
                 let t = t.Value
                 let t = { t with Settings = lockFile.GetGroup(groupName).Options.Settings + t.Settings }
-                if hasChanged groupName transitives pr t then 
-                    yield groupName, name // Modified
-            | _ -> yield groupName, name // Removed
+                yield groupName, name, getChanges groupName transitives pr t// then 
+                //    yield groupName, name // Modified
+            | _ -> yield groupName, name, [PackageNotFoundInDependenciesFile] // Removed
         ]
-        |> List.map (fun (g,p) -> lockFile.GetAllNormalizedDependenciesOf(g,p,lockFile.FileName))
+        |> List.filter (fun (_,_, changes) -> changes.Length > 0)
+        |> List.map (fun (g,p, changes) -> lockFile.GetAllNormalizedDependenciesOf(g,p,lockFile.FileName) |> Seq.map (fun (a,b) -> a,b,changes))
         |> Seq.concat
         |> Set.ofSeq
 
@@ -195,7 +219,7 @@ let GetChanges(dependenciesFile,lockFile,strict) =
     let nuGetChanges = findNuGetChangesInDependenciesFile(dependenciesFile,lockFile,strict)
     let nuGetChangesPerGroup =
         nuGetChanges
-        |> Seq.groupBy fst
+        |> Seq.groupBy (fun (f,_,__) -> f)
         |> Map.ofSeq
 
     let remoteFileChanges = findRemoteFileChangesInDependenciesFile(dependenciesFile,lockFile)

--- a/src/Paket.Core/DependencyChangeDetection.fs
+++ b/src/Paket.Core/DependencyChangeDetection.fs
@@ -82,8 +82,7 @@ let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFil
             | Some pr ->
                 let t = t.Value
                 let t = { t with Settings = lockFile.GetGroup(groupName).Options.Settings + t.Settings }
-                yield groupName, name, getChanges groupName transitives pr t// then 
-                //    yield groupName, name // Modified
+                yield groupName, name, getChanges groupName transitives pr t // Modified
             | _ -> yield groupName, name, [PackageNotFoundInDependenciesFile] // Removed
         ]
         |> List.filter (fun (_,_, changes) -> changes.Length > 0)

--- a/src/Paket.Core/Files/LockFile.fs
+++ b/src/Paket.Core/Files/LockFile.fs
@@ -274,7 +274,7 @@ module LockFileParser =
                 | x -> failwithf "Unknown copy_content_to_output_dir settings: %A" x
                                             
             InstallOption(CopyContentToOutputDir(setting))
-        | _, String.StartsWith "FRAMEWORK:" trimmed -> InstallOption(FrameworkRestrictions(FrameworkRestrictionList (trimmed.Trim() |> Requirements.parseRestrictions)))
+        | _, String.StartsWith "FRAMEWORK:" trimmed -> InstallOption(FrameworkRestrictions(FrameworkRestrictionList (trimmed.Trim() |> Requirements.parseRestrictions true)))
         | _, String.StartsWith "CONDITION:" trimmed -> InstallOption(ReferenceCondition(trimmed.Trim().ToUpper()))
         | _, String.StartsWith "CONTENT:" trimmed -> 
             let setting =

--- a/src/Paket.Core/Files/ReferencesFile.fs
+++ b/src/Paket.Core/Files/ReferencesFile.fs
@@ -124,7 +124,9 @@ type ReferencesFile =
 
     static member FromFile(fileName : string) =
         let lines = File.ReadAllLines(fileName)
-        { ReferencesFile.FromLines lines with FileName = fileName }
+        try
+            { ReferencesFile.FromLines lines with FileName = fileName }
+        with e -> raise <| new Exception(sprintf "Could not parse reference file '%s': %s" fileName e.Message, e)
 
     member this.AddNuGetReference(groupName, packageName : PackageName, copyLocal: bool,  importTargets: bool, frameworkRestrictions, includeVersionInPath, omitContent : bool, createBindingRedirects, referenceCondition) =
         let package: PackageInstallSettings =

--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -181,7 +181,7 @@ type FrameworkIdentifier =
         | UAP v -> "uap" + v.ShortString()
         | XamarinMac -> "xamarinmac"
         | Windows v -> "win" + v
-        | WindowsPhoneSilverlight v -> "wp" + v.Replace("v","").Replace(".","")
+        | WindowsPhoneSilverlight v -> "wp" + v
         | WindowsPhoneApp v -> "wpa" + v
         | Silverlight v -> "sl" + v.Replace("v","").Replace(".","")
 
@@ -350,8 +350,8 @@ module FrameworkDetection =
                 | "sl5" | "sl50" -> Some (Silverlight "v5.0")
                 | "win8" | "windows8" | "win80" | "netcore45" | "win" | "winv45" -> Some (Windows "v4.5")
                 | "win81" | "windows81"  | "netcore46" | "netcore451" | "winv451" -> Some (Windows "v4.5.1")
-                | "wp7" | "wp70" | "sl4-wp7"| "sl4-wp70" -> Some (WindowsPhoneSilverlight "v7.0")
-                | "wp71" | "sl4-wp71" | "sl4-wp"  -> Some (WindowsPhoneSilverlight "v7.1")
+                | "wp7" | "wp70" | "wpv7" | "wpv70" | "sl4-wp7"| "sl4-wp70" -> Some (WindowsPhoneSilverlight "v7.0")
+                | "wp71" | "wpv71" | "sl4-wp71" | "sl4-wp"  -> Some (WindowsPhoneSilverlight "v7.1")
                 | "wpa00" | "wpa" | "wpa81" | "wpav81" | "wpapp81" | "wpapp" -> Some (WindowsPhoneApp "v8.1")
                 | "wp8" | "wp80"  | "wpv80" -> Some (WindowsPhoneSilverlight "v8.0")
                 | "wp81"  | "wpv81" -> Some (WindowsPhoneSilverlight "v8.1")

--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -181,7 +181,7 @@ type FrameworkIdentifier =
         | UAP v -> "uap" + v.ShortString()
         | XamarinMac -> "xamarinmac"
         | Windows v -> "win" + v
-        | WindowsPhoneSilverlight v -> "wp" + v
+        | WindowsPhoneSilverlight v -> "wp" + v.Replace("v","").Replace(".","")
         | WindowsPhoneApp v -> "wpa" + v
         | Silverlight v -> "sl" + v.Replace("v","").Replace(".","")
 

--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -365,8 +365,8 @@ module FrameworkDetection =
                 | "netstandard14" -> Some(DotNetStandard DotNetStandardVersion.V1_4)
                 | "netstandard15" -> Some(DotNetStandard DotNetStandardVersion.V1_5)
                 | "netstandard16" -> Some(DotNetStandard DotNetStandardVersion.V1_6)
-                | "netcore10" | "netcoreapp10" -> Some (DotNetCore DotNetCoreVersion.V1_0)
-                | "netcore11" | "netcoreapp11" -> Some (DotNetCore DotNetCoreVersion.V1_1)
+                | "netcore10" -> Some (DotNetCore DotNetCoreVersion.V1_0)
+                | "netcore11" -> Some (DotNetCore DotNetCoreVersion.V1_1)
                 | v when v.StartsWith "netstandard" -> Some(DotNetStandard DotNetStandardVersion.V1_6)
                 | _ -> None
             result)

--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -129,6 +129,7 @@ module KnownAliases =
          ".netframework", "net"
          ".netcore", "netcore"
          "winrt", "netcore"
+         "netcoreapp", "netcore"
          "silverlight", "sl"
          "windowsphone", "wp"
          "windows", "win"
@@ -364,8 +365,8 @@ module FrameworkDetection =
                 | "netstandard14" -> Some(DotNetStandard DotNetStandardVersion.V1_4)
                 | "netstandard15" -> Some(DotNetStandard DotNetStandardVersion.V1_5)
                 | "netstandard16" -> Some(DotNetStandard DotNetStandardVersion.V1_6)
-                | "netcoreapp10" -> Some (DotNetCore DotNetCoreVersion.V1_0)
-                | "netcoreapp11" -> Some (DotNetCore DotNetCoreVersion.V1_1)
+                | "netcore10" | "netcoreapp10" -> Some (DotNetCore DotNetCoreVersion.V1_0)
+                | "netcore11" | "netcoreapp11" -> Some (DotNetCore DotNetCoreVersion.V1_1)
                 | v when v.StartsWith "netstandard" -> Some(DotNetStandard DotNetStandardVersion.V1_6)
                 | _ -> None
             result)

--- a/src/Paket.Core/NuGetV3.fs
+++ b/src/Paket.Core/NuGetV3.fs
@@ -245,7 +245,7 @@ let getPackageDetails (source:NugetV3Source) (packageName:PackageName) (version:
                     let targetFramework =
                         match targetFramework with
                         | null -> []
-                        | x -> Requirements.parseRestrictions x
+                        | x -> Requirements.parseRestrictions false x
                     (PackageName dep.Id), (VersionRequirement.Parse dep.Range), targetFramework)
                 |> Seq.toList
         let unlisted =

--- a/src/Paket.Core/NugetConvert.fs
+++ b/src/Paket.Core/NugetConvert.fs
@@ -259,7 +259,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
             let latestVersion, _ = versions |> List.maxBy fst
             let restrictions =
                 match versions with
-                | [ version, targetFramework ] -> targetFramework |> Option.toList |> List.collect Requirements.parseRestrictions 
+                | [ version, targetFramework ] -> targetFramework |> Option.toList |> List.collect (Requirements.parseRestrictions false)
                 | _ -> []
             name, latestVersion, restrictions)
 

--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -651,7 +651,7 @@ let Resolve (getVersionsF, getPackageDetailsF, groupName:GroupName, globalStrate
 
     let rec step (stage:Stage) (stackpack:StackPack) compatibleVersions (flags:StepFlags) =
 
-        let fuseConflicts currentConflict priorConflictSteps =
+        let inline fuseConflicts currentConflict priorConflictSteps =
             match currentConflict, priorConflictSteps with
             | currentConflict, (lastConflict,lastStep,lastRequirement,lastCompatibleVersions,lastFlags)::priorConflictSteps -> 
                 let continueConflict = 

--- a/src/Paket.Core/Parsers/DependenciesFileParser.fs
+++ b/src/Paket.Core/Parsers/DependenciesFileParser.fs
@@ -301,7 +301,7 @@ module DependenciesFileParser =
             if text = "auto-detect" then 
                 Some (ParserOptions(ParserOption.AutodetectFrameworkRestrictions))
             else 
-                let restrictions = Requirements.parseRestrictions text
+                let restrictions = Requirements.parseRestrictions true text
                 if String.IsNullOrWhiteSpace text |> not && List.isEmpty restrictions then 
                     failwithf "Could not parse framework restriction \"%s\"" text
 

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -4,6 +4,7 @@ open System
 open Paket
 open Paket.Domain
 open Paket.PackageSources
+open Paket.Logging
 
 [<RequireQualifiedAccess>]
 type FrameworkRestriction = 
@@ -60,13 +61,17 @@ let parseRestrictions(text:string) =
         | None -> 
                 if PlatformMatching.extractPlatforms framework |> List.isEmpty |> not then
                     yield FrameworkRestriction.Portable framework
+                else
+                    traceErrorfn "Could not parse framework '%s'. Try to update or install again or report a paket bug." framework
         | Some x -> 
             if operatorSplit.[0] = ">=" then
                 if operatorSplit.Length < 4 then
                     yield FrameworkRestriction.AtLeast x
                 else
-                    match FrameworkDetection.Extract(operatorSplit.[3]) with
-                    | None -> ()
+                    let item = operatorSplit.[3]
+                    match FrameworkDetection.Extract(item) with
+                    | None ->
+                        traceErrorfn "Could not parse second framework of between operator '%s'. Try to update or install again or report a paket bug." item
                     | Some y -> yield FrameworkRestriction.Between(x,y)
             else
                 yield FrameworkRestriction.Exactly x]

--- a/src/Paket.Core/Requirements.fs
+++ b/src/Paket.Core/Requirements.fs
@@ -50,8 +50,7 @@ let parseRestrictions failImmediatly (text:string) =
             if verbose then
                 (fun s ->
                     traceError s
-                    traceVerbose Environment.StackTrace
-                )
+                    traceVerbose Environment.StackTrace)
             else traceError
     let text =
         // workaround missing spaces

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -193,11 +193,13 @@ let Restore(dependenciesFileName,projectFile,force,group,referencesFileNames,ign
             LocalFile.overrideLockFile localFile lockFile,localFile,true
 
     if not hasLocalFile && not ignoreChecks then
-        let hasAnyChanges,_,_,_ = DependencyChangeDetection.GetChanges(dependenciesFile,lockFile,false)
+        let hasAnyChanges,nugetChanges,remoteFilechanges,hasChanges = DependencyChangeDetection.GetChanges(dependenciesFile,lockFile,false)
 
         let checkResponse = if failOnChecks then failwithf else traceWarnfn
         if hasAnyChanges then 
             checkResponse "paket.dependencies and paket.lock are out of sync in %s.%sPlease run 'paket install' or 'paket update' to recompute the paket.lock file." lockFileName.Directory.FullName Environment.NewLine
+            for (group, package, changes) in nugetChanges do
+                traceWarnfn "Changes %A were detected in %s/%s" changes (group.ToString()) (package.ToString())
 
     let groups =
         match group with

--- a/src/Paket.Core/UpdateProcess.fs
+++ b/src/Paket.Core/UpdateProcess.fs
@@ -109,7 +109,7 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF (lockFil
                     dependenciesFile.Groups
                     |> Map.filter hasChanges
 
-                nuGetChanges,groups
+                nuGetChanges |> Set.map (fun (f,s,_) -> f,s), groups
 
         let preferredVersions = 
             DependencyChangeDetection.GetPreferredNuGetVersions(dependenciesFile,lockFile)

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -37,7 +37,7 @@
     <StartWorkingDirectory>D:\temp\coreclrtest</StartWorkingDirectory>
     <StartArguments>install</StartArguments>
     <StartWorkingDirectory>C:\dev\src\Paket\integrationtests\scenarios\loading-scripts\dependencies-file-flag\temp</StartWorkingDirectory>
-    <StartArguments>restore -v</StartArguments>
+    <StartArguments>install</StartArguments>
     <StartWorkingDirectory>C:\PROJ\FAKE\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -68,8 +68,8 @@
     <StartWorkingDirectory>D:\temp\unlisted</StartWorkingDirectory>
     <StartArguments>install</StartArguments>
     <StartWorkingDirectory>D:\temp\PaketWithProblem1</StartWorkingDirectory>
-    <StartArguments>restore</StartArguments>
-    <StartWorkingDirectory>D:\temp\watchr2</StartWorkingDirectory>
+    <StartArguments>update</StartArguments>
+    <StartWorkingDirectory>C:\PROJ\FAKE\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -37,8 +37,8 @@
     <StartWorkingDirectory>D:\temp\coreclrtest</StartWorkingDirectory>
     <StartArguments>install</StartArguments>
     <StartWorkingDirectory>C:\dev\src\Paket\integrationtests\scenarios\loading-scripts\dependencies-file-flag\temp</StartWorkingDirectory>
-    <StartArguments>install --createnewbindingfiles</StartArguments>
-    <StartWorkingDirectory>D:\temp\pakkit2</StartWorkingDirectory>
+    <StartArguments>restore -v</StartArguments>
+    <StartWorkingDirectory>C:\PROJ\FAKE\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/DependencyChangesSpecs.fs
@@ -61,7 +61,7 @@ nuget Castle.Windsor-log4net"""
     let cfg = DependenciesFile.FromCode(after)
     let lockFile = LockFile.Parse("",toLines lockFileData)
    
-    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true)
+    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true) |> Set.map (fun (g,p,_) -> g, p)
     let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions(cfg,lockFile)
     newDependencies
     |> Map.filter (fun k v -> not <| changedDependencies.Contains(k))
@@ -98,7 +98,7 @@ nuget NUnit"""
 
     let cfg = DependenciesFile.FromCode(after)
     let lockFile = LockFile.Parse("",toLines lockFileData)
-    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true)
+    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true) |> Set.map (fun (g,p,_) -> g, p)
    
     let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions (cfg,lockFile)
     let expected =
@@ -146,7 +146,7 @@ nuget Castle.Windsor-log4net >= 3.3.0"""
 
     let cfg = DependenciesFile.FromCode(after)
     let lockFile = LockFile.Parse("",toLines lockFileData)
-    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true)
+    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true) |> Set.map (fun (g,p,_) -> g, p)
    
     let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions (cfg,lockFile)
     let expected =
@@ -193,7 +193,7 @@ nuget Castle.Windsor-log4net >= 3.4.0"""
 
     let cfg = DependenciesFile.FromCode(after)
     let lockFile = LockFile.Parse("",toLines lockFileData)
-    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true)
+    let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true) |> Set.map (fun (g,p,_) -> g, p)
    
     let newDependencies = DependencyChangeDetection.GetPreferredNuGetVersions (cfg,lockFile)
     newDependencies
@@ -297,7 +297,7 @@ nuget Caliburn.Micro !~> 2.0.2"""
     let lockFile = LockFile.Parse("",toLines lockFileData)
     let changedDependencies = DependencyChangeDetection.findNuGetChangesInDependenciesFile(cfg,lockFile,true)
     changedDependencies.Count |> shouldEqual 1
-    (changedDependencies |> Seq.head) |> shouldEqual (Constants.MainDependencyGroup, PackageName "Caliburn.Micro")
+    (changedDependencies |> Seq.head) |> shouldEqual (Constants.MainDependencyGroup, PackageName "Caliburn.Micro",[Paket.DependencyChangeDetection.DependencyChangeType.PackageNotFoundInLockFile])
 
 [<Test>]
 let ``should detect if nothing changes in github dependency``() = 


### PR DESCRIPTION
fixes both issues in #2222.

Before
```
paket.dependencies and paket.lock are out of sync in C:\PROJ\FAKE.
Please run 'paket install' or 'paket update' to recompute the paket.lock file.
```

After
```
paket.dependencies and paket.lock are out of sync in C:\PROJ\FAKE.
Please run 'paket install' or 'paket update' to recompute the paket.lock file.
Changes [RestrictionsChanged] were detected in netcore/FSharp.Compiler.Service
Changes [RestrictionsChanged] were detected in netcore/FSharp.Core
Changes [RestrictionsChanged] were detected in netcore/Libuv
Changes [RestrictionsChanged] were detected in netcore/Microsoft.CodeAnalysis.Common
Changes [RestrictionsChanged] were detected in netcore/Microsoft.CodeAnalysis.CSharp
Changes [RestrictionsChanged] were detected in netcore/Microsoft.CodeAnalysis.VisualBasic
Changes [RestrictionsChanged] were detected in netcore/Microsoft.CSharp
Changes [RestrictionsChanged] were detected in netcore/Microsoft.DiaSymReader
Changes [RestrictionsChanged] were detected in netcore/Microsoft.DiaSymReader.PortablePdb
Changes [RestrictionsChanged] were detected in netcore/Microsoft.NETCore.App
Changes [RestrictionsChanged] were detected in netcore/Microsoft.NETCore.DotNetHost
Changes [RestrictionsChanged] were detected in netcore/Microsoft.NETCore.DotNetHostPolicy
Changes [RestrictionsChanged] were detected in netcore/Microsoft.NETCore.DotNetHostResolver
Changes [RestrictionsChanged] were detected in netcore/Microsoft.NETCore.Jit
Changes [RestrictionsChan...
```