### PR TITLE
Check if references file exists on disk before installing into project file

### DIFF
--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -210,7 +210,7 @@ let ``generates script on install`` () =
 
 [<Test; Category("scriptgen dependencies")>]
 let ``issue 2156 netstandard`` () =
-    let scenario = "issue-2156"
+    let scenario = "issue-2156-netstandard"
     paket "install" scenario |> ignore
     directPaket "generate-load-scripts" scenario |> ignore
     // note: no assert for now, I don't know what we are exactly expecting

--- a/src/Paket.Core/RestoreProcess.fs
+++ b/src/Paket.Core/RestoreProcess.fs
@@ -134,9 +134,17 @@ let findAllReferencesFiles root =
                 Path.Combine(fi.Directory.FullName,Constants.ReferencesFile)
 
             ok <| (p, ReferencesFile.New fileName)
+    
+    let refFileExistsOnDisk (result:Result<(ProjectFile * ReferencesFile), DomainMessage>) =
+        result
+        |>
+        either
+            (fun ((_, referenceFile), _) -> File.Exists(referenceFile.FileName))
+            (fun (_) -> true)
 
-    ProjectFile.FindAllProjects root 
+    ProjectFile.FindAllProjects root
     |> Array.map findRefFile
+    |> Array.filter( fun result -> refFileExistsOnDisk result )
     |> collect
 
 let copiedElements = ref false


### PR DESCRIPTION
Check if `paket.references` file exists on disk before allowing paket to blindly install/modify (`csproj`) project files with `<Import>`. If `paket.references` is missing from a project directory, paket should not touch any project files.

Also, according to @forki:
> If you remove the `paket.references` file from the dotnetcore project folder
then it should ignore the csproj.

This is currently not true as there is no check [here to exclude project files](https://github.com/fsprojects/Paket/blob/master/src/Paket.Core/RestoreProcess.fs#L124-L139) (`csproj`s) from the `FindAllProjects` enumeration. Additionally, this particular issue has caused some drama in issue https://github.com/fsprojects/Paket/issues/2029.

This PR resolves the issue and makes sure that `paket.references` exists on disk before paket does anything to MSBuild project files.

Also resolves #2220 by providing a way to opt-out of the `<Import>` mechanism.

Thanks,
Brian

:chocolate_bar: :cookie: :lollipop: **[Ronald Jenkees - Stay Crunchy](https://www.youtube.com/watch?v=GeIAXlwVlZc)**