### PR TITLE
[WIP] Make pushing changes from Git dependency repositories easier

### DIFF
--- a/src/Paket.Core/GitHandling.fs
+++ b/src/Paket.Core/GitHandling.fs
@@ -171,16 +171,15 @@ let checkoutToPaketFolder repoFolder cloneUrl cacheCloneUrl commit =
     try
         // checkout to local folder
         if Directory.Exists repoFolder then
-            CommandHelper.runSimpleGitCommand repoFolder ("remote set-url origin " + quote cacheCloneUrl) |> ignore
-            verbosefn "Fetching %s to %s" cacheCloneUrl repoFolder 
-            CommandHelper.runSimpleGitCommand repoFolder "fetch origin -f" |> ignore
+            verbosefn "Fetching %s to %s" cacheCloneUrl repoFolder
+            CommandHelper.runSimpleGitCommand repoFolder (sprintf "fetch --tags --prune %s +refs/heads/*:refs/remotes/origin/*" <| quote cacheCloneUrl) |> ignore
         else
             let destination = DirectoryInfo(repoFolder).Parent.FullName
             if not <| Directory.Exists destination then
                 Directory.CreateDirectory destination |> ignore
             verbosefn "Cloning %s to %s" cacheCloneUrl repoFolder
-            CommandHelper.runSimpleGitCommand destination ("clone " + quote cacheCloneUrl) |> ignore
-            CommandHelper.runSimpleGitCommand repoFolder ("remote add upstream " + quote cloneUrl) |> ignore
+            CommandHelper.runSimpleGitCommand destination (sprintf "clone %s %s" (quote cacheCloneUrl) (quote repoFolder)) |> ignore
+            CommandHelper.runSimpleGitCommand repoFolder (sprintf "remote set-url origin %s" <| quote cloneUrl) |> ignore
 
         tracefn "Setting %s to %s" repoFolder commit
         tagCommitForCheckout repoFolder commit

--- a/src/Paket.Core/GitHandling.fs
+++ b/src/Paket.Core/GitHandling.fs
@@ -147,12 +147,12 @@ let fetchCache repoCacheFolder cloneUrl =
             if not <| Directory.Exists Constants.GitRepoCacheFolder then
                 Directory.CreateDirectory Constants.GitRepoCacheFolder |> ignore
             tracefn "Cloning %s to %s" cloneUrl repoCacheFolder
-            CommandHelper.runSimpleGitCommand Constants.GitRepoCacheFolder ("clone " + quote cloneUrl) |> ignore
+            CommandHelper.runSimpleGitCommand Constants.GitRepoCacheFolder ("clone --mirror " + quote cloneUrl + " " + quote repoCacheFolder) |> ignore
         else
             CommandHelper.runSimpleGitCommand repoCacheFolder ("remote set-url origin " + quote cloneUrl) |> ignore
-            verbosefn "Fetching %s to %s" cloneUrl repoCacheFolder 
-        
-        CommandHelper.runSimpleGitCommand repoCacheFolder "fetch -f --tags" |> ignore
+            verbosefn "Fetching %s to %s" cloneUrl repoCacheFolder
+
+        CommandHelper.runSimpleGitCommand repoCacheFolder "remote update --prune" |> ignore
     with
     | exn -> failwithf "Fetching the git cache at %s failed.%sMessage: %s" repoCacheFolder Environment.NewLine exn.Message
 

--- a/src/Paket.Core/RemoteDownload.fs
+++ b/src/Paket.Core/RemoteDownload.fs
@@ -150,7 +150,7 @@ let downloadDependenciesFile(force,rootPath,groupName,parserF,remoteFile:ModuleR
 
 
 let rec DirectoryCopy(sourceDirName, destDirName, copySubDirs) =
-    let dir = new DirectoryInfo(sourceDirName)
+    let dir = DirectoryInfo(sourceDirName)
     let dirs = dir.GetDirectories()
 
     if not <| Directory.Exists(destDirName) then
@@ -180,9 +180,7 @@ let downloadRemoteFiles(remoteFile:ResolvedSourceFile,destination) = async {
         let repoFolder = Path.Combine(destination,remoteFile.Project)
         let cacheCloneUrl = "file:///" + repoCacheFolder
 
-        let branchName = sprintf "b%d" <| (repoFolder |> hash |> abs)
-
-        Paket.Git.Handling.updateCache repoCacheFolder branchName cloneUrl remoteFile.Commit
+        Paket.Git.Handling.fetchCache repoCacheFolder cloneUrl
         Paket.Git.Handling.checkoutToPaketFolder repoFolder cloneUrl cacheCloneUrl remoteFile.Commit
 
         match remoteFile.Command with


### PR DESCRIPTION
This PR mostly addresses issues raised in #2119 and changes the way Git dependencies are initialized to make pushing changes from the cloned repository easier. The following workflow will be now possible/easier with Paket:
1. Add a git dependency to `paket.dependencies`, then run `paket update/install` to clone and checkout the repo.
1. Checkout `master` or create a feature branch in the cloned (_downstream_) repo, i.e. the repo under `paket-files` directory.
1. Make changes in the cloned repo, run tests and commit the changes.
1. Push the changes from the cloned repo to the `origin` (_upstream_) repo, i.e. the repo specified in `paket.dependencies`.
1. Run `paket update` to update `paket.lock` with SHA1 of the changes pushed to the upstream repo.

I understand this PR may be controversial as it develops Paket in a way that may be currently served by Git submodules. However, Paket has some advantages over submodules:
- Paket supports semver tags when resolving Git dependencies
- Paket caches the upstream repository locally which helps build servers and saves space/time when working with multiple projects depending on same Git dependency

The changes helped our company to move away from (very painful) Nuget source packages. Feel free to suggest changes or reject the PR entirely :-). However, if you choose to accept the proposed changes, **a migration strategy has to be devised before merging the PR. Otherwise users would be required to clear Paket local temp directory and respective `paket-files` directories as this is a breaking change.**
  
### The following changes were made to the implementation of Git dependencies:

- Cache repository (i.e. the repo under `%USERPROFILE%\.paket\git\db`) is cloned as a bare mirror

  Bare clone saves disk space as it does not need a working directory. Mirror clone tracks the upstream remote more closely as it always recreates refs.

- Downstream repository is configured with the `origin` remote pointing to the upstream repository (instead of the cache repository)

  Having the upstream repo configured as the `origin` makes pushing changes to the upstream more natural. We also want to prevent user from pushing the changes to the cache directly - the cache should be managed by Paket.

- Tracking branch for each downstream repo (`b<REPO_PATH_HASH>`) is no longer created in the cache repo

  The branch IMO serves no practical purpose now, see next point.

- `paket/lock` tag is created and checked out in the downstream repository when `update`ing/`restore`ing the dependency

  This allows user to see what the original checked out commit was when making changes. By checking out the tag - instead of resetting the downstream repo `--hard` to the tracking branch - the repo starts in the detached HEAD state which:
    * allows easy experimentation - user can discard her commits simply by checking out the `paket/lock` tag again
    * forces user to checkout a branch when doing meaningful changes.

- Downstream repository is checked for uncommitted changes before `update`ing/`restore`ing the dependency

  This prevents hard-to-track bugs as well as non-repeatable builds that might occur by merging user's uncommitted changes into the new working directory.

- Downstream repository is checked for commits made in the detached HEAD state before `update`ing/`restore`ing the dependency

  This makes working in the downstream repository safer as it saves user from having to inspect reflog after "losing" her commits. It also forces the user to move the changes to a permanent branch when making meaningful changes.

No tests were impacted by the changes. However, there are currently few integration tests covering Git dependencies.