### PR TITLE
[WIP] bootstrapper: Support NugetSource app-setting key

### DIFF
--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -30,6 +30,7 @@ namespace Paket.Bootstrapper
         {
             public const string PreferNuget = "PreferNuget";
             public const string ForceNuget = "ForceNuget";
+            public const string NugetSource = "NugetSource";
             public const string PaketVersion = "PaketVersion";
             public const string Prerelease = "Prerelease";
         }
@@ -125,6 +126,11 @@ namespace Paket.Bootstrapper
             if (appSettings.IsTrue(AppSettingKeys.Prerelease))
             {
                 options.DownloadArguments.IgnorePrerelease = false;
+            }
+            var nugetSource = appSettings.GetKey(AppSettingKeys.NugetSource);
+            if (nugetSource != null)
+            {
+                options.DownloadArguments.NugetSource = nugetSource;
             }
         }
 


### PR DESCRIPTION
Options like PreferNuget, ForceNuget and NugetSource often go together (for instance to force a specific internal NuGet server for CI). Added one that I wanted.

Tests are still missing, but is this otherwise OK?