### PR TITLE
[WIP] Fix rotating app.config entries when generating redirects

### DIFF
--- a/src/Paket.Core/BindingRedirects.fs
+++ b/src/Paket.Core/BindingRedirects.fs
@@ -156,8 +156,9 @@ let private applyBindingRedirects isFirstGroup cleanBindingRedirects (allKnownLi
     nsManager.AddNamespace("bindings", bindingNs)
     config.XPathSelectElements("//bindings:assemblyBinding", nsManager)
     |> Seq.collect (fun e -> e.Elements(XName.Get("dependentAssembly", bindingNs)))
-    |> Seq.filter (fun e -> isFirstGroup && (cleanBindingRedirects || isMarked e) && libIsContained e)
-    |> Seq.iter (fun e -> e.Remove())
+    |> List.ofSeq // strict evaluation, as otherwise e.Remove() also changes the order!
+    |> List.filter (fun e -> isFirstGroup && (cleanBindingRedirects || isMarked e) && libIsContained e)
+    |> List.iter (fun e -> e.Remove())
 
     let config = Seq.fold setRedirect config bindingRedirects
     indentAssemblyBindings config


### PR DESCRIPTION
An older commit termed "cleanup" seems to have inadvertently broken app.config binding redirects; they work, but on every paket install the order of the redirects is rotated, that is, the first one is moved to the last one (or the other way round).

This makes diffs more verbose than necessary, so I patched that out.

Tests still missing, but is it otherwise OK?