### PR TITLE
[fix #2227] import .props/.targets better

### DIFF
--- a/integrationtests/scenarios/i001487-stable-props/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
+++ b/integrationtests/scenarios/i001487-stable-props/before/MyClassLibrary/MyClassLibrary/MyClassLibrary.csprojtemplate
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MultiTarget\build\MultiTarget.props" Condition="Exists('..\..\packages\MultiTarget\build\MultiTarget.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ProductVersion>8.0.30703</ProductVersion>
@@ -69,15 +70,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.6')">
-      <PropertyGroup>
-        <__paket__MultiTarget_props>MultiTarget</__paket__MultiTarget_props>
-        <__paket__MultiTarget_targets>MultiTarget</__paket__MultiTarget_targets>
-      </PropertyGroup>
-    </When>
-  </Choose>
-  <Import Project="..\..\packages\MultiTarget\build\$(__paket__MultiTarget_props).props" Condition="Exists('..\..\packages\MultiTarget\build\$(__paket__MultiTarget_props).props')" Label="Paket" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -120,5 +112,5 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="..\..\packages\MultiTarget\build\$(__paket__MultiTarget_targets).targets" Condition="Exists('..\..\packages\MultiTarget\build\$(__paket__MultiTarget_targets).targets')" Label="Paket" />
+  <Import Project="..\..\packages\MultiTarget\build\MultiTarget.targets" Condition="Exists('..\..\packages\MultiTarget\build\MultiTarget.targets')" Label="Paket" />
 </Project>

--- a/integrationtests/scenarios/i001585-websharper-props/before/xUnitTests/xUnitTests.expected.csprojtemplate
+++ b/integrationtests/scenarios/i001585-websharper-props/before/xUnitTests/xUnitTests.expected.csprojtemplate
@@ -56,13 +56,6 @@
     </Otherwise>
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
-      <PropertyGroup>
-        <__paket__WebSharper_targets>WebSharper</__paket__WebSharper_targets>
-      </PropertyGroup>
-    </When>
-  </Choose>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -126,5 +119,5 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="..\packages\WebSharper\build\$(__paket__WebSharper_targets).targets" Condition="Exists('..\packages\WebSharper\build\$(__paket__WebSharper_targets).targets')" Label="Paket" />
+  <Import Project="..\packages\WebSharper\build\WebSharper.targets" Condition="Exists('..\packages\WebSharper\build\WebSharper.targets')" Label="Paket" />
 </Project>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -37,8 +37,8 @@
     <StartWorkingDirectory>D:\temp\coreclrtest</StartWorkingDirectory>
     <StartArguments>install</StartArguments>
     <StartWorkingDirectory>C:\dev\src\Paket\integrationtests\scenarios\loading-scripts\dependencies-file-flag\temp</StartWorkingDirectory>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>C:\PROJ\FAKE\</StartWorkingDirectory>
+    <StartArguments>convert-from-nuget</StartArguments>
+    <StartWorkingDirectory>c:\users\lr\documents\visual studio 2017\Projects\PaketTest</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/CodeCracker.fs
@@ -34,8 +34,8 @@ let ``should generate Xml for codecracker.CSharp``() =
     
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>() ,Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>() ,Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedCsharp)
@@ -55,8 +55,8 @@ let ``should generate Xml for codecracker.CSharp in VisualBasic project``() =
     
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedEmpty)
@@ -86,8 +86,8 @@ let ``should generate Xml for codecracker.VisualBasic``() =
     
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedVb)

--- a/tests/Paket.Tests/InstallModel/Xml/EmptyLibs.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/EmptyLibs.fs
@@ -16,6 +16,7 @@ let expected = """
 
 [<Test>]
 let ``should generate Xml for framework references and empty libs``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "TempPkg", SemVer.Parse "0.1", [],
             [  ],

--- a/tests/Paket.Tests/InstallModel/Xml/EmptyLibs.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/EmptyLibs.fs
@@ -23,7 +23,7 @@ let ``should generate Xml for framework references and empty libs``() =
               [],
               Nuspec.Load("Nuspec/EmptyLibs.nuspec"))
     
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/FSharp.Data.SqlClient.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/FSharp.Data.SqlClient.fs
@@ -40,7 +40,7 @@ let ``should generate Xml for FSharp.Data.SqlClient 1.4.4``() =
               [],
               Nuspec.Load("Nuspec/FSharp.Data.SqlClient.nuspec"))
     
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    let currentXML = chooseNode.Head.OuterXml |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    let currentXML = ctx.ChooseNodes.Head.OuterXml |> normalizeXml
     currentXML
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
@@ -27,12 +27,13 @@ let ``should generate Xml for Fantomas 1.5``() =
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
-    let propertyNodes,targetsNodes,chooseNode,additionalNode, _ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)
     
-    propertyNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalPropsNodes |> Seq.length |> shouldEqual 0
 
 
 let emptyDoc = """<?xml version="1.0" encoding="utf-8"?>

--- a/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fantomas.fs
@@ -18,6 +18,7 @@ let expected = """
 
 [<Test>]
 let ``should generate Xml for Fantomas 1.5``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "Fantomas", SemVer.Parse "1.5.0", [],
             [ @"..\Fantomas\lib\FantomasLib.dll" 
@@ -55,6 +56,7 @@ let fullDoc = """<?xml version="1.0" encoding="utf-8"?>
 
 [<Test>]
 let ``should generate full Xml for Fantomas 1.5``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "Fantomas", SemVer.Parse "1.5.0", [],
             [ @"..\Fantomas\lib\FantomasLib.dll" 
@@ -76,6 +78,7 @@ let ``should generate full Xml for Fantomas 1.5``() =
 
 [<Test>]
 let ``should not generate full Xml for Fantomas 1.5 if not referenced``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "Fantomas", SemVer.Parse "1.5.0", [],
             [ @"..\Fantomas\lib\FantomasLib.dll" 
@@ -112,6 +115,7 @@ let fullDocWithRefernceCondition = """<?xml version="1.0" encoding="utf-8"?>
 
 [<Test>]
 let ``should generate full Xml with reference condition for Fantomas 1.5``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "Fantomas", SemVer.Parse "1.5.0", [],
             [ @"..\Fantomas\lib\FantomasLib.dll" 
@@ -153,6 +157,7 @@ let fullDocWithRefernceConditionAndFrameworkRestriction = """<?xml version="1.0"
 let ``should generate full Xml with reference condition and framework restrictions without msbuild warning``() =
     // msbuild triggers a warning MSB4130 when we leave out the quotes around $(LEGACY) and add the condition at the end
     // It seems like the warning is triggered when there is an "Or" without parentheses somewhere
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "Fantomas", SemVer.Parse "1.5.0",
             [ FrameworkRestriction.Exactly (FrameworkIdentifier.XamariniOS)

--- a/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
@@ -27,7 +27,7 @@ let ``should generate Xml for Fantomas 1.5``() =
               [],
               Nuspec.Explicit ["FantomasLib.dll"])
     
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some false,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some false,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/FantomasLib.fs
@@ -18,6 +18,7 @@ let expected = """
 
 [<Test>]
 let ``should generate Xml for Fantomas 1.5``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "Fantomas", SemVer.Parse "1.5.0", [],
             [ @"..\Fantomas\Lib\FantomasLib.dll" 

--- a/tests/Paket.Tests/InstallModel/Xml/Fuchu.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Fuchu.fs
@@ -28,7 +28,7 @@ let ``should generate Xml for Fuchu 0.4``() =
               [],
               Nuspec.All)
     
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
@@ -25,18 +25,20 @@ let ``should generate Xml for GitInfoPlanter2.0.0``() =
             [],
               Nuspec.All)
 
-    let propsNodes,targetsNodes,chooseNode,propertyChooseNode,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyReferences)
 
-    propertyChooseNode.OuterXml
+    ctx.FrameworkSpecificPropertyChooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyPropertyDefinitionNodes)
 
-    propsNodes |> Seq.length |> shouldEqual 0
-    targetsNodes |> Seq.length |> shouldEqual 1
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificTargetsNodes |> Seq.length |> shouldEqual 1
+    ctx.GlobalTargetsNodes |> Seq.length |> shouldEqual 0
 
-    (targetsNodes |> Seq.head).OuterXml
+    (ctx.FrameworkSpecificTargetsNodes |> Seq.head).OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedPropertyNodes)

--- a/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/GitInfoPlanter.fs
@@ -18,6 +18,7 @@ let expectedPropertyNodes = """<?xml version="1.0" encoding="utf-16"?>
 
 [<Test>]
 let ``should generate Xml for GitInfoPlanter2.0.0``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "GitInfoPlanter", SemVer.Parse "0.21", [],
             [ ],

--- a/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/LibGit2Sharp.fs
@@ -44,18 +44,20 @@ let ``should generate Xml for LibGit2Sharp 2.0.0``() =
     
     model.GetLibReferences(SinglePlatform (DotNetFramework FrameworkVersion.V4_Client)) |> shouldContain @"..\LibGit2Sharp\lib\net40\LibGit2Sharp.dll"
 
-    let propertyNodes,targetsNodes,chooseNode,propertyChooseNode,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedReferenceNodes)
 
-    propertyChooseNode.OuterXml
+    ctx.FrameworkSpecificPropertyChooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedPropertyDefinitionNodes)
 
-    propertyNodes |> Seq.length |> shouldEqual 1
-    targetsNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 1
+    ctx.FrameworkSpecificTargetsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalTargetsNodes |> Seq.length |> shouldEqual 0
 
-    (propertyNodes |> Seq.head).OuterXml
+    (ctx.FrameworkSpecificPropsNodes |> Seq.head).OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedPropertyNodes)

--- a/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
@@ -4,9 +4,11 @@ open Paket
 open NUnit.Framework
 open FsUnit
 open Paket.Domain
+open Paket.TestHelpers
 
 [<Test>]
 let ``should not install targets node for Microsoft.Bcl.Build``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "Microsoft.Bcl.Build", SemVer.Parse "1.0.21", [],
             [ ],

--- a/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Microsoft.Bcl.Build.fs
@@ -16,6 +16,9 @@ let ``should not install targets node for Microsoft.Bcl.Build``() =
     
     model.GetTargetsFiles(SinglePlatform (DotNetFramework FrameworkVersion.V4)) |> shouldContain @"..\Microsoft.Bcl.Build\build\Microsoft.Bcl.Build.targets"
 
-    let propertyNodes,_,_,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,false,None)
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,false,KnownTargetProfiles.AllProfiles,None)
 
-    propertyNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificTargetsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalTargetsNodes |> Seq.length |> shouldEqual 0

--- a/tests/Paket.Tests/InstallModel/Xml/Microsoft.CodeAnalysis.Analyzers.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Microsoft.CodeAnalysis.Analyzers.fs
@@ -36,8 +36,8 @@ let ``should generate Xml for Microsoft.CodeAnalysis.Analyzers in CSharp project
     ensureDir()
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedCs)
@@ -57,8 +57,8 @@ let ``should generate Xml for RefactoringEssentials in VisualBasic project``() =
     ensureDir()
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedVb)
@@ -77,8 +77,8 @@ let ``should generate Xml for Microsoft.CodeAnalysis.Analyzers 1.0.0-rc2``() =
     ensureDir()
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(oldModel, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(oldModel, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedEmpty)

--- a/tests/Paket.Tests/InstallModel/Xml/Plossum.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/Plossum.fs
@@ -30,7 +30,7 @@ let ``should generate Xml for Plossum``() =
               [],
               Nuspec.All)
     
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RefactoringEssentials.fs
@@ -27,8 +27,8 @@ let ``should generate Xml for RefactoringEssentials in CSharp project``() =
     
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)
@@ -47,8 +47,8 @@ let ``should generate Xml for RefactoringEssentials in VisualBasic project``() =
     
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyVbGuid.vbprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,_,_,analyzerNodes = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    analyzerNodes
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.AnalyzersNode
     |> (fun n -> n.OuterXml)
     |> normalizeXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/RemovesOldNodes.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RemovesOldNodes.fs
@@ -9,6 +9,7 @@ open Paket.Requirements
 
 [<Test>]
 let ``should generate Xml for Fuchu 0.4``() = 
+    ensureDir()
     let p = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyWithOldStuff.fsprojtest").Value
     let empty = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value
     p.RemovePaketNodes()

--- a/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/RxXaml.fs
@@ -112,7 +112,7 @@ let ``should generate Xml for Rx-XAML 2.2.4 with correct framework assembly refe
                   { AssemblyName = "System.Windows"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(Silverlight "v5.0")] }
                   { AssemblyName = "System.Windows"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(WindowsPhoneSilverlight "v7.1")] }]})
 
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    let currentXml = chooseNode.Head.OuterXml  |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    let currentXml = ctx.ChooseNodes.Head.OuterXml  |> normalizeXml
     currentXml
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SQLite.fs
@@ -164,17 +164,19 @@ let ``should generate Xml for SQLite``() =
                 Nuspec.All)
 
 
-    let propsNodes,targetsNodes,chooseNode,propertyDefinitionNodes,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    let currentXML = chooseNode.Head.OuterXml |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    let currentXML = ctx.ChooseNodes.Head.OuterXml |> normalizeXml
     currentXML |> shouldEqual (normalizeXml expectedReferenceNodes)
 
-    let currentPropertyXML = propertyDefinitionNodes.OuterXml |> normalizeXml
+    let currentPropertyXML = ctx.FrameworkSpecificPropertyChooseNode.OuterXml |> normalizeXml
     currentPropertyXML
     |> shouldEqual (normalizeXml expectedPropertyDefinitionNodes)
 
-    propsNodes |> Seq.length |> shouldEqual 0
-    targetsNodes |> Seq.length |> shouldEqual 1
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificTargetsNodes |> Seq.length |> shouldEqual 1
+    ctx.GlobalPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalTargetsNodes |> Seq.length |> shouldEqual 0
 
-    let currentTargetsXML = (targetsNodes |> Seq.head).OuterXml |> normalizeXml
+    let currentTargetsXML = (ctx.FrameworkSpecificTargetsNodes |> Seq.head).OuterXml |> normalizeXml
     currentTargetsXML
     |> shouldEqual (normalizeXml expectedPropertyNodes)

--- a/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
@@ -23,15 +23,18 @@ let ``should generate Xml for StyleCop.MSBuild``() =
 
     model.GetTargetsFiles(SinglePlatform (DotNetFramework FrameworkVersion.V2)) |> shouldContain @"..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets" 
     
-    let propsNodes,targetsNodes,chooseNode,propertyChooseNode,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
     
-    propertyChooseNode.OuterXml
+    ctx.FrameworkSpecificPropertyChooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyPropertyNameNodes)
         
-    propsNodes |> Seq.length |> shouldEqual 0
-    targetsNodes |> Seq.length |> shouldEqual 1
 
-    (targetsNodes |> Seq.head).OuterXml
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificTargetsNodes |> Seq.length |> shouldEqual 1
+    ctx.GlobalPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalTargetsNodes |> Seq.length |> shouldEqual 0
+
+    (ctx.FrameworkSpecificTargetsNodes |> Seq.head).OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedPropertyNodes)

--- a/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/StyleCop.MSBuild.fs
@@ -15,6 +15,7 @@ let expectedPropertyNodes = """<?xml version="1.0" encoding="utf-16"?>
 
 [<Test>]
 let ``should generate Xml for StyleCop.MSBuild``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "StyleCop.MSBuild", SemVer.Parse "4.7.49.1", [],[],
             [ @"..\StyleCop.MSBuild\build\StyleCop.MSBuild.Targets" ],

--- a/tests/Paket.Tests/InstallModel/Xml/System.Security.Cryptography.Algorithms.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/System.Security.Cryptography.Algorithms.fs
@@ -91,9 +91,9 @@ let ``should generate Xml for System.Security.Cryptography.Algorithms in CSharp 
     
     let project = ProjectFile.TryLoad("./ProjectFile/TestData/EmptyCsharpGuid.csprojtest")
     Assert.IsTrue(project.IsSome)
-    let _,_,chooseNode,_,_ = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,None,true,None)
+    let ctx = project.Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,None,true,KnownTargetProfiles.AllProfiles,None)
     let result =
-      chooseNode
+      ctx.ChooseNodes
       |> (fun n -> n.Head.OuterXml)
       |> normalizeXml
     result |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/System.Spatial.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/System.Spatial.fs
@@ -45,7 +45,7 @@ let ``should generate Xml for System.Spatial``() =
               @"..\System.Spatial\lib\sl4\zh-Hans\System.Spatial.resources.dll" 
             ],[],[],Nuspec.All)
     
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    let currentXML = chooseNode.Head.OuterXml |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    let currentXML = ctx.ChooseNodes.Head.OuterXml |> normalizeXml
     currentXML
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttp.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttp.fs
@@ -192,7 +192,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               [],
               Nuspec.All)
 
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    let currentXML = chooseNode.Head.OuterXml |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    let currentXML = ctx.ChooseNodes.Head.OuterXml |> normalizeXml
     currentXML
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
@@ -69,7 +69,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
               [],
               Nuspec.All)
 
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None) 
-    let currentXML = chooseNode.Head.OuterXml |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None) 
+    let currentXML = ctx.ChooseNodes.Head.OuterXml |> normalizeXml
     currentXML
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpForNet4.fs
@@ -37,6 +37,7 @@ let expected = """
 
 [<Test>]
 let ``should generate Xml for System.Net.Http 2.2.8``() = 
+    ensureDir()
     let model =     
         InstallModel.CreateFromLibs(PackageName "System.Net.Http", SemVer.Parse "2.2.8", [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4))],
             [ @"..\Microsoft.Net.Http\lib\monoandroid\System.Net.Http.Extensions.dll" 

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
@@ -71,7 +71,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                  [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }
                   { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
 
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/FrameworkAssemblies.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    let currentXML = chooseNode.Head.OuterXml |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/FrameworkAssemblies.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    let currentXML = ctx.ChooseNodes.Head.OuterXml |> normalizeXml
     currentXML
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithFrameworkReferences.fs
@@ -79,7 +79,7 @@ let ``should generate Xml for System.Net.Http 2.2.8``() =
                  [{ AssemblyName = "System.Net.Http"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.AtLeast(DotNetFramework(FrameworkVersion.V4_5))] }
                   { AssemblyName = "System.Net.Http.WebRequest"; FrameworkRestrictions = FrameworkRestrictionList [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5))] }]})
 
-    let _,targetsNodes,chooseNode,_,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    let currentXML = chooseNode.Head.OuterXml |> normalizeXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    let currentXML = ctx.ChooseNodes.Head.OuterXml |> normalizeXml
     currentXML
     |> shouldEqual (normalizeXml expected)

--- a/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
@@ -60,6 +60,7 @@ let disabledChooseNode = """<?xml version="1.0" encoding="utf-16"?>
 
 [<Test>]
 let ``should not generate Xml for xunit.runner.visualstudio 2.0.0 if import is disabled``() = 
+    ensureDir()
     let model =
         InstallModel.CreateFromLibs(PackageName "xunit.runner.visualstudio", SemVer.Parse "2.50.0", [],[],
             [ @"..\xunit.runner.visualstudio\build\net20\xunit.runner.visualstudio.props" 

--- a/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/xunit.runner.fs
@@ -37,19 +37,21 @@ let ``should generate Xml for xunit.runner.visualstudio 2.0.0``() =
             [],
               Nuspec.All)
     
-    let propsNodes,targetsNodes,chooseNode,propertyChooseNode,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,true,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyReferenceNodes)
 
-    let currentXML = propertyChooseNode.OuterXml |> normalizeXml
+    let currentXML = ctx.FrameworkSpecificPropertyChooseNode.OuterXml |> normalizeXml
     currentXML
     |> shouldEqual (normalizeXml expectedPropertyDefinitionNodes)
-    
-    propsNodes |> Seq.length |> shouldEqual 1
-    targetsNodes |> Seq.length |> shouldEqual 0
 
-    (propsNodes |> Seq.head).OuterXml
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 1
+    ctx.FrameworkSpecificTargetsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalPropsNodes |> Seq.length |> shouldEqual 0
+    ctx.GlobalTargetsNodes |> Seq.length |> shouldEqual 0
+
+    (ctx.FrameworkSpecificPropsNodes |> Seq.head).OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml expectedPropertyNodes)
 
@@ -65,13 +67,13 @@ let ``should not generate Xml for xunit.runner.visualstudio 2.0.0 if import is d
               [],
               Nuspec.All)
     
-    let propertyNodes,targetsNodes,chooseNode,propertyChooseNode,_ = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,false,None)
-    chooseNode.Head.OuterXml
+    let ctx = ProjectFile.TryLoad("./ProjectFile/TestData/Empty.fsprojtest").Value.GenerateXml(model, System.Collections.Generic.HashSet<_>(),Map.empty,Some true,false,KnownTargetProfiles.AllProfiles,None)
+    ctx.ChooseNodes.Head.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml emptyReferenceNodes)
 
-    propertyChooseNode.OuterXml
+    ctx.FrameworkSpecificPropertyChooseNode.OuterXml
     |> normalizeXml
     |> shouldEqual (normalizeXml disabledChooseNode)
     
-    propertyNodes |> Seq.length |> shouldEqual 0
+    ctx.FrameworkSpecificPropsNodes |> Seq.length |> shouldEqual 0

--- a/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
@@ -3,6 +3,7 @@
 open Paket
 open NUnit.Framework
 open FsUnit
+open Paket.TestHelpers
 
 let TestData: obj[][] = 
     [|
@@ -31,6 +32,7 @@ let TestData: obj[][] =
 [<Test>]
 [<TestCaseSource("TestData")>]
 let ``should detect the correct framework on test projects`` projectFile expectedProfile expectedProfileString expectedTargetFramework =
+    ensureDir()
     let p = ProjectFile.TryLoad("./ProjectFile/TestData/" + projectFile).Value
     p.GetTargetProfile() |> shouldEqual expectedProfile
     p.GetTargetProfile().ToString() |> shouldEqual expectedProfileString


### PR DESCRIPTION
fixes https://github.com/fsprojects/Paket/issues/2227

* differentiate between global targets/props, and framework specific targets/props
* fw-specifc targets/props continue to be imported in the the middle with a condition (no change to before)
* global props are imported at the top of the file (same as nuget does)
* global targets are imported at the end of the file (same as nuget)

The reason is that many props depend on being imported at the top, so do that for the files where it is actually possible.