### PR TITLE
Unity3d version support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Xamarin Studio / monodevelop user-specific
 *.userprefs
 
+# Visual Studio and VS Code
+/.vs/
+/.vscode/
+
 # Build results
 
 [Dd]ebug/

--- a/src/Paket.Core/Files/ProjectFile.fs
+++ b/src/Paket.Core/Files/ProjectFile.fs
@@ -989,6 +989,14 @@ module ProjectFile =
         match getTargetFrameworkProfile project with
         | Some profile when profile = "Client" ->
             SinglePlatform (DotNetFramework FrameworkVersion.V4_Client)
+        | Some profile when profile = "Unity Web v3.5" ->
+            SinglePlatform (DotNetUnity DotNetUnityVersion.V3_5_Web)
+        | Some profile when profile = "Unity Micro v3.5" ->
+            SinglePlatform (DotNetUnity DotNetUnityVersion.V3_5_Micro)
+        | Some profile when profile = "Unity Subset v3.5" ->
+            SinglePlatform (DotNetUnity DotNetUnityVersion.V3_5_Subset)
+        | Some profile when profile = "Unity Full v3.5" ->
+            SinglePlatform (DotNetUnity DotNetUnityVersion.V3_5_Full)
         | Some profile when String.IsNullOrWhiteSpace profile |> not ->
             KnownTargetProfiles.FindPortableProfile profile
         | _ ->

--- a/src/Paket.Core/FrameworkHandling.fs
+++ b/src/Paket.Core/FrameworkHandling.fs
@@ -146,6 +146,28 @@ type DotNetCoreVersion =
         | DotNetCoreVersion.V1_1 -> "11"
         | DotNetCoreVersion.V2_0 -> "20"
 
+[<RequireQualifiedAccess>]
+/// The Framework version.
+// Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
+type DotNetUnityVersion = 
+    | V3_5_Web
+    | V3_5_Micro
+    | V3_5_Subset
+    | V3_5_Full
+    override this.ToString() =
+        match this with
+        | V3_5_Web    -> "net35-Unity Web v3.5"
+        | V3_5_Micro  -> "net35-Unity Micro v3.5"
+        | V3_5_Subset -> "net35-Unity Subset v3.5"
+        | V3_5_Full   -> "net35-Unity Full v3.5"
+
+    member this.ShortString() =
+        match this with
+        | DotNetUnityVersion.V3_5_Web -> "35-Unity Web v3.5"
+        | DotNetUnityVersion.V3_5_Micro -> "35-Unity Micro v3.5"
+        | DotNetUnityVersion.V3_5_Subset -> "35-Unity Subset v3.5"
+        | DotNetUnityVersion.V3_5_Full -> "35-Unity Full v3.5"
+
 module KnownAliases =
     let Data =
         [".net", "net"
@@ -176,6 +198,7 @@ type FrameworkIdentifier =
     | DNXCore of FrameworkVersion
     | DotNetStandard of DotNetStandardVersion
     | DotNetCore of DotNetCoreVersion
+    | DotNetUnity of DotNetUnityVersion
     | MonoAndroid
     | MonoTouch
     | MonoMac
@@ -196,6 +219,7 @@ type FrameworkIdentifier =
         | DNXCore v -> "dnxcore" + v.ShortString()
         | DotNetStandard v -> "netstandard" + v.ShortString()
         | DotNetCore v -> "netcore" + v.ShortString()
+        | DotNetUnity v -> "net" + v.ShortString()
         | MonoAndroid -> "monoandroid"
         | MonoTouch -> "monotouch"
         | MonoMac -> "monomac"
@@ -251,6 +275,10 @@ type FrameworkIdentifier =
         | DotNetCore DotNetCoreVersion.V1_0 -> [ DotNetStandard DotNetStandardVersion.V1_6 ]
         | DotNetCore DotNetCoreVersion.V1_1 -> [ DotNetCore DotNetCoreVersion.V1_0 ]
         | DotNetCore DotNetCoreVersion.V2_0 -> [ DotNetCore DotNetCoreVersion.V1_1;  DotNetStandard DotNetStandardVersion.V2_0 ]
+        | DotNetUnity DotNetUnityVersion.V3_5_Full -> [ ]
+        | DotNetUnity DotNetUnityVersion.V3_5_Subset -> [ ]
+        | DotNetUnity DotNetUnityVersion.V3_5_Micro -> [ ]
+        | DotNetUnity DotNetUnityVersion.V3_5_Web -> [ ]
         | Silverlight "v3.0" -> [ ]
         | Silverlight "v4.0" -> [ Silverlight "v3.0" ]
         | Silverlight "v5.0" -> [ Silverlight "v4.0" ]
@@ -274,6 +302,7 @@ type FrameworkIdentifier =
         | DotNetFramework _, DotNetFramework _ -> true
         | DotNetStandard _, DotNetStandard _ -> true
         | DotNetCore _, DotNetCore _ -> true
+        | DotNetUnity _, DotNetUnity _ -> true
         | Silverlight _, Silverlight _ -> true
         | DNX _, DNX _ -> true
         | DNXCore _, DNXCore _ -> true
@@ -341,6 +370,10 @@ module FrameworkDetection =
             let result = 
                 match path with
                 | x when x.StartsWith "runtimes/" -> Some(Runtimes(x.Substring(9)))
+                | "net35-Unity Web v3.5" ->  Some (DotNetUnity DotNetUnityVersion.V3_5_Web)
+                | "net35-Unity Micro v3.5" -> Some (DotNetUnity DotNetUnityVersion.V3_5_Micro)
+                | "net35-Unity Subset v3.5" -> Some (DotNetUnity DotNetUnityVersion.V3_5_Subset)
+                | "net35-Unity Full v3.5" -> Some (DotNetUnity DotNetUnityVersion.V3_5_Full)
                 | "net10" | "net1" | "10" -> Some (DotNetFramework FrameworkVersion.V1)
                 | "net11" | "11" -> Some (DotNetFramework FrameworkVersion.V1_1)
                 | "net20" | "net2" | "net" | "net20-full" | "net20-client" | "20" -> Some (DotNetFramework FrameworkVersion.V2)
@@ -543,6 +576,13 @@ module KnownTargetProfiles =
         DotNetCoreVersion.V1_1
         DotNetCoreVersion.V2_0
     ]
+
+    let DotNetUnityVersions = [
+        DotNetUnityVersion.V3_5_Full
+        DotNetUnityVersion.V3_5_Subset
+        DotNetUnityVersion.V3_5_Micro
+        DotNetUnityVersion.V3_5_Web
+    ]
        
     let DotNetCoreProfiles =
        DotNetCoreVersions
@@ -551,6 +591,10 @@ module KnownTargetProfiles =
     let WindowsProfiles =
        [SinglePlatform(Windows "v4.5")
         SinglePlatform(Windows "v4.5.1")]
+
+    let DotNetUnityProfiles = 
+       DotNetUnityVersions
+       |> List.map (DotNetUnity >> SinglePlatform)
 
     let SilverlightProfiles =
        [SinglePlatform(Silverlight "v3.0")
@@ -629,6 +673,7 @@ module KnownTargetProfiles =
 
     let AllDotNetProfiles =
        DotNetFrameworkProfiles @ 
+       DotNetUnityProfiles @ 
        WindowsProfiles @ 
        UAPProfiles @
        SilverlightProfiles @

--- a/src/Paket.Core/Nuget.fs
+++ b/src/Paket.Core/Nuget.fs
@@ -51,7 +51,7 @@ type NuGetPackageCache =
       Version: string
       CacheVersion: string }
 
-    static member CurrentCacheVersion = "3.36"
+    static member CurrentCacheVersion = "3.37"
 
 let inline normalizeUrl(url:string) = url.Replace("https://","http://").Replace("www.","")
 

--- a/src/Paket.Core/PlatformMatching.fs
+++ b/src/Paket.Core/PlatformMatching.fs
@@ -173,6 +173,14 @@ let getTargetCondition (target:TargetProfile) =
         | DNXCore(version) ->"$(TargetFrameworkIdentifier) == 'DNXCore'", sprintf "$(TargetFrameworkVersion) == '%O'" version
         | DotNetStandard(version) ->"$(TargetFrameworkIdentifier) == '.NETStandard'", sprintf "$(TargetFrameworkVersion) == '%O'" version
         | DotNetCore(version) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", sprintf "$(TargetFrameworkVersion) == '%O'" version
+        | DotNetUnity(version) when version = DotNetUnityVersion.V3_5_Full ->
+            "$(TargetFrameworkIdentifier) == '.NETFramework'", sprintf "($(TargetFrameworkVersion) == '%O' And $(TargetFrameworkProfile) == 'Unity Full v3.5')" version
+        | DotNetUnity(version) when version = DotNetUnityVersion.V3_5_Subset ->
+            "$(TargetFrameworkIdentifier) == '.NETFramework'", sprintf "($(TargetFrameworkVersion) == '%O' And $(TargetFrameworkProfile) == 'Unity Subset v3.5')" version
+        | DotNetUnity(version) when version = DotNetUnityVersion.V3_5_Micro ->
+            "$(TargetFrameworkIdentifier) == '.NETFramework'", sprintf "($(TargetFrameworkVersion) == '%O' And $(TargetFrameworkProfile) == 'Unity Micro v3.5')" version
+        | DotNetUnity(version) when version = DotNetUnityVersion.V3_5_Web ->
+            "$(TargetFrameworkIdentifier) == '.NETFramework'", sprintf "($(TargetFrameworkVersion) == '%O' And $(TargetFrameworkProfile) == 'Unity Web v3.5')" version               
         | Windows(version) -> "$(TargetFrameworkIdentifier) == '.NETCore'", sprintf "$(TargetFrameworkVersion) == '%O'" version
         | Silverlight(version) -> "$(TargetFrameworkIdentifier) == 'Silverlight'", sprintf "$(TargetFrameworkVersion) == '%O'" version
         | WindowsPhoneApp(version) -> "$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'", sprintf "$(TargetFrameworkVersion) == '%O'" version

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -322,6 +322,9 @@
     <None Include="ProjectFile\TestData\LocalizedLib.csprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="ProjectFile\TestData\Unity.csprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Compile Include="ProjectFile\ConditionSpecs.fs" />
     <Compile Include="ProjectFile\TargetFrameworkSpecs.fs" />
     <Compile Include="ProjectFile\FileBuildActionSpecs.fs" />

--- a/tests/Paket.Tests/ProjectFile/TestData/Unity.csprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/Unity.csprojtest
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1F76D195-1C08-4A5B-82CF-601F5A53A63E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>VDimensions.UnityEngine</RootNamespace>
+    <AssemblyName>VDimensions.UnityEngine</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>Unity Subset v3.5</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\net35-Unity Subset v3.5</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\net35-Unity Subset v3.5</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="UnityEditor, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\lib\UnityAssemblies\UnityEditor.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.UI">
+      <HintPath>..\..\..\..\lib\UnityAssemblies\UnityEditor.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\lib\UnityAssemblies\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\lib\UnityAssemblies\UnityEngine.Networking.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\lib\UnityAssemblies\UnityEngine.UI.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Assets\.gitignore" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Paket.Tests/ProjectFile/TestData/Unity.csprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/Unity.csprojtest
@@ -7,8 +7,8 @@
     <ProjectGuid>{1F76D195-1C08-4A5B-82CF-601F5A53A63E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>VDimensions.UnityEngine</RootNamespace>
-    <AssemblyName>VDimensions.UnityEngine</AssemblyName>
+    <RootNamespace>Unity</RootNamespace>
+    <AssemblyName>Unity</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>Unity Subset v3.5</TargetFrameworkProfile>

--- a/tests/Paket.Tests/RestrictionApplicationSpecs.fs
+++ b/tests/Paket.Tests/RestrictionApplicationSpecs.fs
@@ -24,6 +24,15 @@ module TestTargetProfiles =
 
     let DotNetFrameworkProfiles = DotNetFrameworkVersions |> List.map dotnet
 
+    let DotNetUnityVersions = [
+        DotNetUnityVersion.V3_5_Full
+        DotNetUnityVersion.V3_5_Subset
+        DotNetUnityVersion.V3_5_Micro
+        DotNetUnityVersion.V3_5_Web
+    ]
+
+    let DotNetUnityProfiles = DotNetUnityVersions |> List.map (DotNetUnity >> SinglePlatform)
+
     let WindowsProfiles =
        [SinglePlatform(Windows "v4.5")
         SinglePlatform(Windows "v4.5.1")]
@@ -44,6 +53,7 @@ module TestTargetProfiles =
        WindowsProfiles @ 
        SilverlightProfiles @
        WindowsPhoneSilverlightProfiles @
+       DotNetUnityProfiles @
        [SinglePlatform(MonoAndroid)
         SinglePlatform(MonoTouch)
         SinglePlatform(XamariniOS)


### PR DESCRIPTION
This is a proposed fix for issue #2005 

Unity3D Projects have the following specifics:

 - They all use `TargetFrameworkVersion` = `v3.5`
 - They use up to 4 different `TargetFrameworkProfile` values:
   -  Unity Full v3.5
   -  Unity Subset v3.5
   -  Unity Micro v3.5
   -  Unity Web v3.5
 - The above profiles are recognised by Nuget if the following (corresponding) framework names are used:
   - net35-Unity Full v3.5
   - net35-Unity Subset v3.5
   - net35-Unity Micro v3.5
   - net35-Unity Web v3.5

**NB**. 
I must admit  I am a newbie in F# and it is possible to have messed up something with the version and framework detection. So far, all existing tests are passing and the executable I've built **does** work for me with Unity. 
Still, I'd appreciate a somewhat thorough code review.
