### PR TITLE
proper encoding "+" in package download url

### DIFF
--- a/src/Paket.Core/SemVer.fs
+++ b/src/Paket.Core/SemVer.fs
@@ -193,7 +193,7 @@ module SemVer =
                     match firstDash, plusIndex with
                     | -1, _ -> ""
                     | d, p when p = -1 -> version.Substring(d+1)
-                    | d, p -> version.Substring(d+1, (version.Length - 1 - p) )
+                    | d, p -> version.Substring(d+1, (p - 1 - d) )
             
                 /// there can only be one piece of build metadata, and it is signified by a + and then any number of dot-separated alpha-numeric groups.
                 /// this just greedily takes the whole remaining string :(


### PR DESCRIPTION
Should fix #2261 properly. Encode "+" only in base url not query string. And encode when the download link is just fetched.
See https://dotnetfiddle.net/7RwLPU for what the encodeURL does.
Also there is another bug in `SemVer.Parse` that parse the prerelease incorrectly when metadata is used. e.g. `2.0.54674-master+d277eaf` would have `master+` as prerelease, but it should be `master`.