### PR TITLE
re-enable ``#1174 Should find Ninject error`` for Net, because it SOs with mono

### DIFF
--- a/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
@@ -27,7 +27,7 @@ let ``#1166 Should resolve Nancy without timeout``() =
     |> shouldBeGreaterThan (SemVer.Parse "1.1")
 
 [<Test>]
-[<Ignore("fails with SO, skipping until works")>]
+[<Platform("Net")>]
 let ``#1174 Should find Ninject error``() =
     updateShouldFindPackageConflict "Ninject" "i001174-resolve-fast-conflict"
 


### PR DESCRIPTION
… 