### PR TITLE
Fix pinning of packages not properly handled by the resolver

### DIFF
--- a/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
@@ -27,6 +27,12 @@ let ``#1166 Should resolve Nancy without timeout``() =
     |> shouldBeGreaterThan (SemVer.Parse "1.1")
 
 [<Test>]
+let ``#2294 Cannot pin NETStandard.Library = 1.6.0``() =
+    let lockFile = update "i002294-pin-netstandard-1-6"
+    lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "NETStandard.Library"].Version
+    |> shouldEqual (SemVer.Parse "1.6")
+
+[<Test>]
 [<Ignore("fails with SO, skipping until works")>]
 let ``#1174 Should find Ninject error``() =
     updateShouldFindPackageConflict "Ninject" "i001174-resolve-fast-conflict"

--- a/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
@@ -33,6 +33,12 @@ let ``#2294 Cannot pin NETStandard.Library = 1.6.0``() =
     |> shouldEqual (SemVer.Parse "1.6")
 
 [<Test>]
+let ``#2294 pin NETStandard.Library = 1.6.0 Strategy Workaround``() =
+    let lockFile = update "i002294-withstrategy"
+    lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "NETStandard.Library"].Version
+    |> shouldEqual (SemVer.Parse "1.6")
+
+[<Test>]
 [<Ignore("fails with SO, skipping until works")>]
 let ``#1174 Should find Ninject error``() =
     updateShouldFindPackageConflict "Ninject" "i001174-resolve-fast-conflict"

--- a/integrationtests/scenarios/i002294-pin-netstandard-1-6/before/paket.dependencies
+++ b/integrationtests/scenarios/i002294-pin-netstandard-1-6/before/paket.dependencies
@@ -1,0 +1,26 @@
+source https://www.nuget.org/api/v2/
+
+strategy: min
+lowest_matching: true
+
+nuget xunit >= 2.3 prerelease
+nuget FakeItEasy
+nuget FluentAssertions
+nuget Microsoft.NET.Test.Sdk
+nuget xunit.extensibility.execution >= 2.3 prerelease
+nuget xunit.runner.visualstudio >= 2.3 prerelease
+nuget Microsoft.AspNetCore.Mvc.Core
+nuget Amazon.Lambda.Core
+nuget Amazon.Lambda.Serialization.Json
+nuget Amazon.Lambda.APIGatewayEvents
+nuget Microsoft.AspNetCore.Server.Kestrel
+nuget Microsoft.Extensions.Configuration.EnvironmentVariables
+nuget Microsoft.Extensions.Configuration.FileExtensions
+nuget Microsoft.Extensions.Configuration.Json
+nuget Microsoft.Extensions.Logging
+nuget Microsoft.Extensions.Options.ConfigurationExtensions
+nuget AWSSDK.S3
+nuget AWSSDK.Extensions.NETCore.Setup
+nuget Amazon.Lambda.Logging.AspNetCore
+nuget Amazon.Lambda.AspNetCoreServer
+nuget NETStandard.Library 1.6.0

--- a/integrationtests/scenarios/i002294-withstrategy/before/paket.dependencies
+++ b/integrationtests/scenarios/i002294-withstrategy/before/paket.dependencies
@@ -1,5 +1,8 @@
 source https://www.nuget.org/api/v2/
 
+strategy: min
+lowest_matching: true
+
 nuget xunit >= 2.3 prerelease
 nuget FakeItEasy
 nuget FluentAssertions

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -12,6 +12,46 @@ open Paket.PackageSources
 
 type DependencySet = Set<PackageName * VersionRequirement * FrameworkRestrictions>
 
+/// Represents package details
+[<StructuredFormatDisplay "{Display}">]
+type PackageDetails = {
+    Name               : PackageName
+    Source             : PackageSource
+    DownloadLink       : string
+    LicenseUrl         : string
+    Unlisted           : bool
+    DirectDependencies : DependencySet
+}
+
+/// Represents data about resolved packages
+[<StructuredFormatDisplay "{Display}">]
+type ResolvedPackage = {
+    Name                : PackageName
+    Version             : SemVerInfo
+    Dependencies        : DependencySet
+    Unlisted            : bool
+    IsRuntimeDependency : bool
+    Settings            : InstallSettings
+    Source              : PackageSource
+} with
+    override this.ToString () = sprintf "%O %O" this.Name this.Version
+
+    member self.HasFrameworkRestrictions =
+        not (getRestrictionList self.Settings.FrameworkRestrictions = [])
+
+    member private self.Display
+        with get() =
+            let deps =
+                self.Dependencies
+                |> Seq.map (fun (name,ver,restrict) ->
+                    sprintf "  <%A - %A - %A>\n" name ver restrict)
+                |> String.Concat
+            sprintf
+                "%A\nDependencies -\n%s\nSource - %A\nInstall Settings\n%A"
+                    self.Name deps self.Source self.Settings
+
+type PackageResolution = Map<PackageName, ResolvedPackage>
+
 module DependencySetFilter =
     let isIncluded (restriction:FrameworkRestriction) (dependency:PackageName * VersionRequirement * FrameworkRestrictions) =
         let _,_,restrictions = dependency
@@ -55,46 +95,16 @@ module DependencySetFilter =
             |> Set.filter (fun dependency ->
                 restrictions |> List.exists (fun r -> isIncluded r dependency))
 
+    let isPackageCompatible (dependencies:DependencySet) (package:ResolvedPackage) : bool =
+        dependencies
+        // exists any not matching stuff
+        |> Seq.exists (fun (name, requirement, restriction) ->
+            if name = package.Name then
+                requirement.IsInRange package.Version |> not
+            else false
+            )
+        |> not // then we are not compatible
 
-/// Represents package details
-[<StructuredFormatDisplay "{Display}">]
-type PackageDetails = {
-    Name               : PackageName
-    Source             : PackageSource
-    DownloadLink       : string
-    LicenseUrl         : string
-    Unlisted           : bool
-    DirectDependencies : DependencySet
-}
-
-/// Represents data about resolved packages
-[<StructuredFormatDisplay "{Display}">]
-type ResolvedPackage = {
-    Name                : PackageName
-    Version             : SemVerInfo
-    Dependencies        : DependencySet
-    Unlisted            : bool
-    IsRuntimeDependency : bool
-    Settings            : InstallSettings
-    Source              : PackageSource
-} with
-    override this.ToString () = sprintf "%O %O" this.Name this.Version
-
-    member self.HasFrameworkRestrictions =
-        not (getRestrictionList self.Settings.FrameworkRestrictions = [])
-    
-    member private self.Display 
-        with get() =
-            let deps = 
-                self.Dependencies 
-                |> Seq.map (fun (name,ver,restrict) -> 
-                    sprintf "  <%A - %A - %A>\n" name ver restrict)
-                |> String.Concat
-            sprintf
-                "%A\nDependencies -\n%s\nSource - %A\nInstall Settings\n%A"                
-                    self.Name deps self.Source self.Settings
-
-type PackageResolution = Map<PackageName, ResolvedPackage>
 
 let cleanupNames (model : PackageResolution) : PackageResolution =
     model
@@ -624,7 +634,6 @@ type private Stage =
     | Outer of currentConflict : (ConflictState * ResolverStep * PackageRequirement) * priorConflictSteps : (ConflictState * ResolverStep * PackageRequirement *  seq<SemVerInfo * PackageSource list> * StepFlags) list
     | Inner of currentConflict : (ConflictState * ResolverStep * PackageRequirement) * priorConflictSteps : (ConflictState * ResolverStep * PackageRequirement *  seq<SemVerInfo * PackageSource list> * StepFlags) list
 
-
 /// Resolves all direct and transitive dependencies
 let Resolve (getVersionsF, getPackageDetailsF, groupName:GroupName, globalStrategyForDirectDependencies, globalStrategyForTransitives, globalFrameworkRestrictions, (rootDependencies:PackageRequirement Set), updateMode : UpdateMode) =
     tracefn "Resolving packages for group %O:" groupName
@@ -638,6 +647,15 @@ let Resolve (getVersionsF, getPackageDetailsF, groupName:GroupName, globalStrate
         rootDependencies
         |> Seq.map (fun x -> x.Name,x.Settings)
         |> dict
+
+    let lockedPackages =
+        rootDependencies
+        |> Seq.choose (fun d ->
+            match d.VersionRequirement with
+            | VersionRequirement.VersionRequirement(VersionRange.OverrideAll v, _) -> Some (d.Name)
+            | _ -> None)
+        |> Set.ofSeq
+
 
     if Set.isEmpty rootDependencies then Resolution.Ok Map.empty 
     else
@@ -797,19 +815,30 @@ let Resolve (getVersionsF, getPackageDetailsF, groupName:GroupName, globalStrate
                             tracefn "     %O %O was unlisted" exploredPackage.Name exploredPackage.Version
                         step (Inner ((currentConflict,currentStep,currentRequirement), priorConflictSteps)) stackpack compatibleVersions flags 
                     else
-                        let nextStep =
-                            {   Relax              = currentStep.Relax
-                                FilteredVersions   = Map.add currentRequirement.Name ([versionToExplore],currentConflict.GlobalOverride) currentStep.FilteredVersions
-                                CurrentResolution  = Map.add exploredPackage.Name exploredPackage currentStep.CurrentResolution
-                                ClosedRequirements = Set.add currentRequirement currentStep.ClosedRequirements
-                                OpenRequirements   = calcOpenRequirements(exploredPackage,globalFrameworkRestrictions,versionToExplore,currentRequirement,currentStep)
-                            }
-                        if nextStep.OpenRequirements = currentStep.OpenRequirements then
-                            failwithf "The resolver confused itself. The new open requirements are the same as the old ones.\n\
-                                       This will result in an endless loop.%sCurrent Requirement: %A%sRequirements: %A" 
-                                            Environment.NewLine currentRequirement Environment.NewLine nextStep.OpenRequirements                        
-                        step (Step((currentConflict,nextStep,currentRequirement), (currentConflict,currentStep,currentRequirement,compatibleVersions,flags)::priorConflictSteps)) stackpack currentConflict.VersionsToExplore flags
-
+                        // It might be that this version is already not possible because of your current set.
+                        // Example: We took A with version 1.0.0 (in our current resolution), but this version depends on A > 1.0.0
+                        let canTakePackage =
+                            currentStep.CurrentResolution
+                            |> Map.toSeq
+                            |> Seq.map snd
+                            // Ignore packages which have "OverrideAll", otherwise == will not work anymore.
+                            |> Seq.filter (fun resolved -> lockedPackages.Contains resolved.Name |> not)
+                            |> Seq.forall (DependencySetFilter.isPackageCompatible exploredPackage.Dependencies)
+                        if canTakePackage then
+                            let nextStep =
+                                {   Relax              = currentStep.Relax
+                                    FilteredVersions   = Map.add currentRequirement.Name ([versionToExplore],currentConflict.GlobalOverride) currentStep.FilteredVersions
+                                    CurrentResolution  = Map.add exploredPackage.Name exploredPackage currentStep.CurrentResolution
+                                    ClosedRequirements = Set.add currentRequirement currentStep.ClosedRequirements
+                                    OpenRequirements   = calcOpenRequirements(exploredPackage,globalFrameworkRestrictions,versionToExplore,currentRequirement,currentStep)
+                                }
+                            if nextStep.OpenRequirements = currentStep.OpenRequirements then
+                                failwithf "The resolver confused itself. The new open requirements are the same as the old ones.\n\
+                                           This will result in an endless loop.%sCurrent Requirement: %A%sRequirements: %A"
+                                                Environment.NewLine currentRequirement Environment.NewLine nextStep.OpenRequirements
+                            step (Step((currentConflict,nextStep,currentRequirement), (currentConflict,currentStep,currentRequirement,compatibleVersions,flags)::priorConflictSteps)) stackpack currentConflict.VersionsToExplore flags
+                        else
+                            step (Inner ((currentConflict,currentStep,currentRequirement), priorConflictSteps)) stackpack compatibleVersions flags
 
     let startingStep = {
         Relax              = false

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -815,7 +815,7 @@ let Resolve (getVersionsF, getPackageDetailsF, groupName:GroupName, globalStrate
                             tracefn "     %O %O was unlisted" exploredPackage.Name exploredPackage.Version
                         step (Inner ((currentConflict,currentStep,currentRequirement), priorConflictSteps)) stackpack compatibleVersions flags 
                     else
-                        // It might be that this version is already not possible because of your current set.
+                        // It might be that this version is already not possible because of our current set.
                         // Example: We took A with version 1.0.0 (in our current resolution), but this version depends on A > 1.0.0
                         let canTakePackage =
                             currentStep.CurrentResolution

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -356,7 +356,9 @@ let private explorePackageConfig getPackageDetailsF  (pkgConfig:PackageConfig) =
     | _ ->
         match dependency.VersionRequirement.Range with
         | Specific _ when dependency.Parent.IsRootRequirement() -> traceWarnfn " - %O is pinned to %O" dependency.Name version
-        | _ -> tracefn  " - %O %A" dependency.Name version
+        | _ ->
+            let compareString = dependency.Name.CompareString
+            tracefn  " - %O %A" dependency.Name version
 
     let newRestrictions =
         filterRestrictions dependency.Settings.FrameworkRestrictions pkgConfig.GlobalRestrictions
@@ -693,7 +695,7 @@ let Resolve (getVersionsF, getPackageDetailsF, groupName:GroupName, globalStrate
                         currentStep.CurrentResolution.Count 
                         (currentStep.CurrentResolution |> Seq.map (fun x -> sprintf "\n     - %O, %O" x.Key x.Value.Version) |> String.Concat)
                         currentStep.OpenRequirements.Count
-                        (currentStep.OpenRequirements  |> Seq.map (fun x -> sprintf "\n     - %O, %O" x.Parent x.VersionRequirement) |> String.Concat)
+                        (currentStep.OpenRequirements  |> Seq.map (fun x -> sprintf "\n     - %O, %O (from %O)" x.Name x.VersionRequirement x.Parent) |> String.Concat)
 
                 let currentRequirement = 
                     getCurrentRequirement packageFilter currentStep.OpenRequirements stackpack.ConflictHistory

--- a/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
@@ -314,7 +314,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
                               Settings =
                                 match oldDepsInfo with
                                 | Some d -> d.Settings
-                                | None -> group.Options.Settings })
+                                | None -> p.Settings })
                         |> fun des -> Seq.append des runtimeDeps
                         |> Seq.distinctBy (fun p -> p.Name) |> Set.ofSeq
                         // works, alternatively

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,11 +31,7 @@
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
     <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>D:\temp\coreclrtest</StartWorkingDirectory>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>C:\dev\src\Paket\integrationtests\scenarios\loading-scripts\dependencies-file-flag\temp</StartWorkingDirectory>
-    <StartArguments>update</StartArguments>
-    <StartWorkingDirectory>C:\PROJ\Paket\integrationtests\scenarios\i002294-pin-netstandard-1-6\temp</StartWorkingDirectory>
+    <StartWorkingDirectory>C:\PROJ\Paket\integrationtests\scenarios\i001145-excludes\temp</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -45,25 +41,6 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
-    <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001663-google-apis\temp</StartWorkingDirectory>
-    <StartArguments>update</StartArguments>
-    <StartArguments>update --hard</StartArguments>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>D:\code\tempp</StartWorkingDirectory>
-    <StartArguments>update --keep-major</StartArguments>
-    <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001701-keep-major\temp</StartWorkingDirectory>
-    <StartArguments>update</StartArguments>
-    <StartWorkingDirectory>D:\code\PaketKopie</StartWorkingDirectory>
-    <StartArguments>update -f</StartArguments>
-    <StartWorkingDirectory>D:\code\Paket\integrationtests\scenarios\i001117-aws\temp</StartWorkingDirectory>
-    <StartArguments>update</StartArguments>
-    <StartWorkingDirectory>D:\temp\repo3</StartWorkingDirectory>
-    <StartArguments>install -v</StartArguments>
-    <StartWorkingDirectory>D:\temp\IconPacksTestApp\src</StartWorkingDirectory>
-    <StartArguments>update</StartArguments>
-    <StartWorkingDirectory>D:\temp\unlisted</StartWorkingDirectory>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>D:\temp\PaketWithProblem1</StartWorkingDirectory>
     <StartArguments>install</StartArguments>
     <StartWorkingDirectory>D:\temp\paketRestoreBug</StartWorkingDirectory>
   </PropertyGroup>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -34,8 +34,8 @@
     <StartWorkingDirectory>D:\temp\coreclrtest</StartWorkingDirectory>
     <StartArguments>install</StartArguments>
     <StartWorkingDirectory>C:\dev\src\Paket\integrationtests\scenarios\loading-scripts\dependencies-file-flag\temp</StartWorkingDirectory>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>C:\PROJ\Paket\integrationtests\scenarios\i001145-excludes\temp</StartWorkingDirectory>
+    <StartArguments>update</StartArguments>
+    <StartWorkingDirectory>C:\PROJ\Paket\integrationtests\scenarios\i002294-pin-netstandard-1-6\temp</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -412,7 +412,6 @@ let why (results: ParseResults<WhyArgs>) =
 
 
 let main() =
-    //Environment.SetEnvironmentVariable("PAKET_DEBUG_RUNTIME_DEPS", "true")
     use consoleTrace = Logging.event.Publish |> Observable.subscribe Logging.traceToConsole
     let paketVersion = AssemblyVersionInformation.AssemblyInformationalVersion
 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -412,6 +412,7 @@ let why (results: ParseResults<WhyArgs>) =
 
 
 let main() =
+    //Environment.SetEnvironmentVariable("PAKET_DEBUG_RUNTIME_DEPS", "true")
     use consoleTrace = Logging.event.Publish |> Observable.subscribe Logging.traceToConsole
     let paketVersion = AssemblyVersionInformation.AssemblyInformationalVersion
 


### PR DESCRIPTION
I got started by the test of @0x53A, therefore this was done on top of his branch and contains https://github.com/fsprojects/Paket/pull/2305.

Fixes #2294 

Edit: Its actually OK to have this in the same PR because #2294 was the underlying issue the runtime solution didn't work out. So this actually first allows the workaround to "work" by applying the correct settings to the runtime resolution. At the same time it fixes #2294 itself (therefore a separate PR)