### PR TITLE
implement caching of the dependency graph 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ AppPackages/
 # Others
 sql/
 *.Cache
+!/integrationtests/scenarios/*/cache
+!/integrationtests/scenarios/*/cache/*
 ClientBin/
 [Ss]tyle[Cc]op.*
 ~$*

--- a/integrationtests/Paket.IntegrationTests/TestHelper.fs
+++ b/integrationtests/Paket.IntegrationTests/TestHelper.fs
@@ -14,7 +14,11 @@ let scenarios = System.Collections.Generic.List<_>()
 let paketToolPath = FullName(__SOURCE_DIRECTORY__ + "../../../bin/paket.exe")
 let integrationTestPath = FullName(__SOURCE_DIRECTORY__ + "../../../integrationtests/scenarios")
 let scenarioTempPath scenario = Path.Combine(integrationTestPath,scenario,"temp")
+let scenarioCachePath scenario = Path.Combine(integrationTestPath,scenario,"cache")
 let originalScenarioPath scenario = Path.Combine(integrationTestPath,scenario,"before")
+
+let useCache = false
+let preventLiveData = false
 
 let cleanup scenario =
     let scenarioPath = scenarioTempPath scenario
@@ -32,7 +36,9 @@ let prepare scenario =
     scenarios.Add scenario
     let originalScenarioPath = originalScenarioPath scenario
     let scenarioPath = scenarioTempPath scenario
+    let cachePath = scenarioCachePath scenario
     CleanDir scenarioPath
+    if not useCache then CleanDir cachePath
     CopyDir scenarioPath originalScenarioPath (fun _ -> true)
     Directory.GetFiles(scenarioPath, "*.fsprojtemplate", SearchOption.AllDirectories)
     |> Seq.iter (fun f -> File.Move(f, Path.ChangeExtension(f, "fsproj")))
@@ -45,10 +51,14 @@ let prepare scenario =
     Directory.GetFiles(scenarioPath, "*.jsontemplate", SearchOption.AllDirectories)
     |> Seq.iter (fun f -> File.Move(f, Path.ChangeExtension(f, "json")))
 
-let directPaketInPath command scenarioPath =
+let directPaketInPath command scenarioPath cachePath =
     #if INTERACTIVE
     let result =
         ExecProcessWithLambdas (fun info ->
+          if useCache then
+            info.EnvironmentVariables.["PAKET_GRAPH_CACHE"] <- Path.Combine(cachePath, "paket-graph.cache")
+            if preventLiveData then
+              info.EnvironmentVariables.["PAKET_GRAPH_CACHE_PREVENT_ONLINE"] <- "true"
           info.FileName <- paketToolPath
           info.WorkingDirectory <- scenarioPath
           info.Arguments <- command) 
@@ -60,6 +70,10 @@ let directPaketInPath command scenarioPath =
     #else
     let result =
         ExecProcessAndReturnMessages (fun info ->
+          if useCache then
+            info.EnvironmentVariables.["PAKET_GRAPH_CACHE"] <- Path.Combine(cachePath, "paket-graph.cache")
+            if preventLiveData then
+              info.EnvironmentVariables.["PAKET_GRAPH_CACHE_PREVENT_ONLINE"] <- "true"
           info.FileName <- paketToolPath
           info.WorkingDirectory <- scenarioPath
           info.Arguments <- command) (System.TimeSpan.FromMinutes 5.)
@@ -71,7 +85,7 @@ let directPaketInPath command scenarioPath =
     #endif
 
 let directPaket command scenario =
-    directPaketInPath command (scenarioTempPath scenario)
+    directPaketInPath command (scenarioTempPath scenario) (scenarioCachePath scenario)
 
 let paket command scenario =
     prepare scenario

--- a/integrationtests/Paket.IntegrationTests/TestHelper.fs
+++ b/integrationtests/Paket.IntegrationTests/TestHelper.fs
@@ -17,7 +17,8 @@ let scenarioTempPath scenario = Path.Combine(integrationTestPath,scenario,"temp"
 let scenarioCachePath scenario = Path.Combine(integrationTestPath,scenario,"cache")
 let originalScenarioPath scenario = Path.Combine(integrationTestPath,scenario,"before")
 
-let useCache = false
+let useCache = true
+let cleanCache = false
 let preventLiveData = false
 
 let cleanup scenario =
@@ -38,7 +39,8 @@ let prepare scenario =
     let scenarioPath = scenarioTempPath scenario
     let cachePath = scenarioCachePath scenario
     CleanDir scenarioPath
-    if not useCache then CleanDir cachePath
+    if useCache then
+        if cleanCache || not (Directory.Exists cachePath) then CleanDir cachePath
     CopyDir scenarioPath originalScenarioPath (fun _ -> true)
     Directory.GetFiles(scenarioPath, "*.fsprojtemplate", SearchOption.AllDirectories)
     |> Seq.iter (fun f -> File.Move(f, Path.ChangeExtension(f, "fsproj")))

--- a/integrationtests/scenarios/i000049-resolve-windsor-correctly/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000049-resolve-windsor-correctly/cache/paket-graph.cache
@@ -1,0 +1,613 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:49",
+        "PackageName": "Castle.LoggingFacility",
+        "Versions": [
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "Castle.LoggingFacility",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.LoggingFacility/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.2"
+                },
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:49",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.2.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:49",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:50",
+        "PackageName": "Castle.Windsor-log4net",
+        "Versions": [
+          {
+            "Version": "3.2",
+            "PackageDetails": {
+              "Name": "Castle.Windsor-log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor-log4net/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core-log4net",
+                  "VersionRequirement": ">= 3.2"
+                },
+                {
+                  "PackageName": "Castle.LoggingFacility",
+                  "VersionRequirement": ">= 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:49",
+        "PackageName": "Castle.Core-log4net",
+        "Versions": [
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.0.0.4002"
+          },
+          {
+            "Version": "3.0.0.4003"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "Castle.Core-log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core-log4net/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.2"
+                },
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": "1.2.10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:19.3241672+02:00",
+        "PackageName": "Nancy",
+        "Versions": [
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.5.0"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.7.1"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.8.1"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.14.1"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.15.1"
+          },
+          {
+            "Version": "0.15.2"
+          },
+          {
+            "Version": "0.15.3"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.16.1"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.17.1"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.22.1"
+          },
+          {
+            "Version": "0.22.2"
+          },
+          {
+            "Version": "0.23.0",
+            "PackageDetails": {
+              "Name": "Nancy",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy/0.23.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.23.1"
+          },
+          {
+            "Version": "0.23.2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3",
+            "PackageDetails": {
+              "Name": "Nancy",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy/1.4.3",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-barneyrubble"
+          },
+          {
+            "Version": "2.0.0-clienteastwood"
+          },
+          {
+            "Version": "2.0.0-clinteastwood"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:20.0426693+02:00",
+        "PackageName": "Nancy.Bootstrappers.Windsor",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.14.1"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.15.1"
+          },
+          {
+            "Version": "0.15.2"
+          },
+          {
+            "Version": "0.15.3"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.16.1"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.17.1"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.22.1"
+          },
+          {
+            "Version": "0.22.2"
+          },
+          {
+            "Version": "0.23.0",
+            "PackageDetails": {
+              "Name": "Nancy.Bootstrappers.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy.Bootstrappers.Windsor/0.23.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Bootstrappers.Windsor/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.2.1"
+                },
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 0.23"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.23.1"
+          },
+          {
+            "Version": "0.23.2",
+            "PackageDetails": {
+              "Name": "Nancy.Bootstrappers.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy.Bootstrappers.Windsor/0.23.2",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Bootstrappers.Windsor/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.2.1"
+                },
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 0.23.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-barneyrubble"
+          },
+          {
+            "Version": "2.0.0-clienteastwood"
+          },
+          {
+            "Version": "2.0.0-clinteastwood"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:50",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "1.2.10",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/1.2.10",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000051-resolve-pessimistic/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000051-resolve-pessimistic/cache/paket-graph.cache
@@ -1,0 +1,12591 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:45",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:59",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:32",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:58",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:48",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:54",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:46",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:36",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:51",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:42",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:48",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:17",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:11",
+        "PackageName": "Castle.Windsor-log4net",
+        "Versions": [
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.0.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor-log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor-log4net/3.2.0.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core-log4net",
+                  "VersionRequirement": ">= 3.2"
+                },
+                {
+                  "PackageName": "Castle.LoggingFacility",
+                  "VersionRequirement": ">= 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:39",
+        "PackageName": "System.Security.Claims",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Claims",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Claims/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:42",
+        "PackageName": "System.Security.Principal.Windows",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Principal.Windows",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Principal.Windows/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Claims",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:24",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:44",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:49",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:01",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:11",
+        "PackageName": "Castle.Core-log4net",
+        "Versions": [
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.0.0.4002"
+          },
+          {
+            "Version": "3.0.0.4003"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0",
+            "PackageDetails": {
+              "Name": "Castle.Core-log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core-log4net/4.0.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 4.0"
+                },
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 2.0.7"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:28",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:40",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:55",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:31",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:49",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:20",
+        "PackageName": "System.Diagnostics.Process",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Process",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Process/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Registry",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:41",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:29",
+        "PackageName": "System.Net.WebHeaderCollection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.WebHeaderCollection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.WebHeaderCollection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:53",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:59",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:52",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "Microsoft.Win32.Registry",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Registry",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Registry/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:45",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:18",
+        "PackageName": "System.Collections.Specialized",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Specialized",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.Specialized/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:24",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:45",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:58",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:52",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:01",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:11",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.3.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.4.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.3 < 4.0"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:01",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:54",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:01",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:57",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:19",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:28",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:51",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:31",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:56",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:47",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:32",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:55",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:49",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:52",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:00",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:26",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:48",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:40",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:32",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:11",
+        "PackageName": "Castle.LoggingFacility",
+        "Versions": [
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "Castle.LoggingFacility",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.LoggingFacility/3.3.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.3"
+                },
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "Castle.LoggingFacility",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.LoggingFacility/3.4.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.3 < 4.0"
+                },
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.4"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:40",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:22",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:54",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:30",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:36",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:50",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:51",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:51",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:52",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:52",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:19",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:42",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:20",
+        "PackageName": "System.Diagnostics.StackTrace",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.StackTrace",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Diagnostics.StackTrace/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Metadata",
+                  "VersionRequirement": ">= 1.4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:39",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:59",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:47",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:31",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:43",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:20",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:51",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:33",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:39",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:57",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:17",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:50",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:31",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:54",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:54",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:59",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:53",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:01",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:38",
+        "PackageName": "System.Runtime.Serialization.Formatters",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Formatters",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Formatters/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:23",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:38",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:25",
+        "PackageName": "System.IO.FileSystem.Watcher",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Watcher",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.IO.FileSystem.Watcher/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:59",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:00",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:25",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:28",
+        "PackageName": "System.Net.NameResolution",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.NameResolution",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Net.NameResolution/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:41",
+        "PackageName": "System.Security.Principal",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Principal",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Principal/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:53",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:55",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:56",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:54",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:50",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:57",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:14",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:52",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:58",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:58",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:49",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:40",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:45",
+        "PackageName": "System.Threading.Thread",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Thread",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Thread/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:37",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:48",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:55",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:46",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:57",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:56",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:47",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:56",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:21",
+        "PackageName": "System.Diagnostics.TraceSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.TraceSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.TraceSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:25",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:11",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Core/4.0.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlSerializer",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:22",
+        "PackageName": "System.Dynamic.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Dynamic.Runtime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Dynamic.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:16",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:56",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:18",
+        "PackageName": "System.ComponentModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:38",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:35",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:15",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:29",
+        "PackageName": "System.Net.Requests",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Requests",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Requests/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.WebHeaderCollection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:21",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:23",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:53",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:55",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:18",
+        "PackageName": "System.Collections.NonGeneric",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.NonGeneric",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.NonGeneric/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:48",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:27",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:49",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:18",
+        "PackageName": "System.ComponentModel.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:32",
+        "PackageName": "System.Reflection.Metadata",
+        "Versions": [
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.18-beta"
+          },
+          {
+            "Version": "1.0.19-rc"
+          },
+          {
+            "Version": "1.0.21"
+          },
+          {
+            "Version": "1.0.22-beta-23019"
+          },
+          {
+            "Version": "1.0.22-beta-23109"
+          },
+          {
+            "Version": "1.0.22"
+          },
+          {
+            "Version": "1.0.23-beta-23225"
+          },
+          {
+            "Version": "1.0.23-beta-23409"
+          },
+          {
+            "Version": "1.1.0-alpha-00009"
+          },
+          {
+            "Version": "1.1.0-alpha-00012"
+          },
+          {
+            "Version": "1.1.0-alpha-00014"
+          },
+          {
+            "Version": "1.1.0-alpha-00015"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-23826"
+          },
+          {
+            "Version": "1.2.0-rc3-23811"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1-beta-23918"
+          },
+          {
+            "Version": "1.3.0-rc2-24027"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.1-beta-24227-04"
+          },
+          {
+            "Version": "1.4.1-beta-24322-03"
+          },
+          {
+            "Version": "1.4.1-beta-24430-01"
+          },
+          {
+            "Version": "1.4.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2",
+            "PackageDetails": {
+              "Name": "System.Reflection.Metadata",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Metadata/1.4.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.1.37",
+                  "FrameworkRestrictions": "portable-net45+win8"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.3.1",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, winv4.5, wpav8.1, >= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:56",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:44",
+        "PackageName": "System.Threading.Overlapped",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Overlapped",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Threading.Overlapped/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:47",
+        "PackageName": "System.Xml.XmlSerializer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlSerializer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XmlSerializer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:57",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:29",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:14",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:50",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:17",
+        "PackageName": "System.Collections.Immutable",
+        "Versions": [
+          {
+            "Version": "1.1.32-beta"
+          },
+          {
+            "Version": "1.1.33-beta"
+          },
+          {
+            "Version": "1.1.34-rc"
+          },
+          {
+            "Version": "1.1.36"
+          },
+          {
+            "Version": "1.1.37-beta-23019"
+          },
+          {
+            "Version": "1.1.37-beta-23109"
+          },
+          {
+            "Version": "1.1.37"
+          },
+          {
+            "Version": "1.1.38-beta-23225"
+          },
+          {
+            "Version": "1.1.38-beta-23409"
+          },
+          {
+            "Version": "1.1.38-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-24027"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1",
+            "PackageDetails": {
+              "Name": "System.Collections.Immutable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Immutable/1.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:58",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:53",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:40",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:59",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:49:39.1582103+02:00",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.7",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.StackTrace",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Watcher",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.8",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.8",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.StackTrace",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Watcher",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:49",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:45",
+        "PackageName": "System.Threading.ThreadPool",
+        "Versions": [
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.0.10-beta-23225"
+          },
+          {
+            "Version": "4.0.10-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23516"
+          },
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.ThreadPool",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.ThreadPool/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:50",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:19",
+        "PackageName": "System.ComponentModel.TypeConverter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.TypeConverter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.TypeConverter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, net45, >= net462, netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:51",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:32:23",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000055-resolve-with-pessimistic-strategy/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000055-resolve-with-pessimistic-strategy/cache/paket-graph.cache
@@ -1,0 +1,449 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:06",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.2.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:06",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:24.1071693+02:00",
+        "PackageName": "Nancy",
+        "Versions": [
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.5.0"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.7.1"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.8.1"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.14.1"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.15.1"
+          },
+          {
+            "Version": "0.15.2"
+          },
+          {
+            "Version": "0.15.3"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.16.1"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.17.1"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.22.1"
+          },
+          {
+            "Version": "0.22.2"
+          },
+          {
+            "Version": "0.23.0",
+            "PackageDetails": {
+              "Name": "Nancy",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy/0.23.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.23.1"
+          },
+          {
+            "Version": "0.23.2",
+            "PackageDetails": {
+              "Name": "Nancy",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy/0.23.2",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-barneyrubble"
+          },
+          {
+            "Version": "2.0.0-clienteastwood"
+          },
+          {
+            "Version": "2.0.0-clinteastwood"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:24.1571667+02:00",
+        "PackageName": "Nancy.Bootstrappers.Windsor",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.14.1"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.15.1"
+          },
+          {
+            "Version": "0.15.2"
+          },
+          {
+            "Version": "0.15.3"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.16.1"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.17.1"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.22.1"
+          },
+          {
+            "Version": "0.22.2"
+          },
+          {
+            "Version": "0.23.0",
+            "PackageDetails": {
+              "Name": "Nancy.Bootstrappers.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy.Bootstrappers.Windsor/0.23.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Bootstrappers.Windsor/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.2.1"
+                },
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 0.23"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.23.1"
+          },
+          {
+            "Version": "0.23.2",
+            "PackageDetails": {
+              "Name": "Nancy.Bootstrappers.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy.Bootstrappers.Windsor/0.23.2",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Bootstrappers.Windsor/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.2.1"
+                },
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 0.23.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-barneyrubble"
+          },
+          {
+            "Version": "2.0.0-clienteastwood"
+          },
+          {
+            "Version": "2.0.0-clinteastwood"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000071-ignore-trailing-zero-during-resolve/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000071-ignore-trailing-zero-during-resolve/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:09.5460683+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "6.0.5.0",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/6.0.5",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000083-resolve-jquery/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000083-resolve-jquery/cache/paket-graph.cache
@@ -1,0 +1,14823 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:13.1347569+02:00",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.8672484+02:00",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:11.5342572+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:27.020827+02:00",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.0362497+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:00.3952533+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.0637576+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:26.0527111+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.7817482+02:00",
+        "PackageName": "Microsoft.Owin.Security",
+        "Versions": [
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Security",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin.Security/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:14.9302573+02:00",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:21.9822605+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:12.5382565+02:00",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:04.1237587+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:18.3372756+02:00",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:09.6267559+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:15.1352613+02:00",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:46.4812497+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.9887469+02:00",
+        "PackageName": "Microsoft.Owin.Security.OAuth",
+        "Versions": [
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Security.OAuth",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin.Security.OAuth/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Microsoft.Owin.Security",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.4"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.7372483+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.0962474+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:52.8037506+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:10.8587559+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:16.8347583+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:28.6013715+02:00",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:39.7032464+02:00",
+        "PackageName": "Microsoft.AspNet.WebApi.WebHost",
+        "Versions": [
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.WebHost",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.WebHost/5.1.2",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.WebApi.Core",
+                  "VersionRequirement": ">= 5.1.2 < 5.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.4297461+02:00",
+        "PackageName": "Microsoft.Owin",
+        "Versions": [
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:39.2667465+02:00",
+        "PackageName": "Microsoft.AspNet.WebApi",
+        "Versions": [
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi/5.1.2",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.WebApi.WebHost",
+                  "VersionRequirement": ">= 5.1.2 < 5.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.468751+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:57.3377537+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:08.1492575+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:22.3602583+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:58.9422534+02:00",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.3512495+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:16.4652576+02:00",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:40.8892463+02:00",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:53.5687651+02:00",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:34.6002229+02:00",
+        "PackageName": "AngularJS.Cookies",
+        "Versions": [
+          {
+            "Version": "1.2.0-rc2"
+          },
+          {
+            "Version": "1.2.0-rc3"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.2.7"
+          },
+          {
+            "Version": "1.2.8"
+          },
+          {
+            "Version": "1.2.9"
+          },
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "1.2.12"
+          },
+          {
+            "Version": "1.2.13"
+          },
+          {
+            "Version": "1.2.14"
+          },
+          {
+            "Version": "1.2.15"
+          },
+          {
+            "Version": "1.2.16"
+          },
+          {
+            "Version": "1.2.18"
+          },
+          {
+            "Version": "1.2.19"
+          },
+          {
+            "Version": "1.2.20"
+          },
+          {
+            "Version": "1.2.21"
+          },
+          {
+            "Version": "1.2.22"
+          },
+          {
+            "Version": "1.2.23"
+          },
+          {
+            "Version": "1.2.24"
+          },
+          {
+            "Version": "1.2.25"
+          },
+          {
+            "Version": "1.2.26"
+          },
+          {
+            "Version": "1.2.27"
+          },
+          {
+            "Version": "1.2.28"
+          },
+          {
+            "Version": "1.2.29"
+          },
+          {
+            "Version": "1.2.30"
+          },
+          {
+            "Version": "1.2.32",
+            "PackageDetails": {
+              "Name": "AngularJS.Cookies",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AngularJS.Cookies/1.2.32",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "AngularJS.Core",
+                  "VersionRequirement": ">= 1.2.32"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.0-beta14"
+          },
+          {
+            "Version": "1.3.0-beta18"
+          },
+          {
+            "Version": "1.3.0-beta2"
+          },
+          {
+            "Version": "1.3.0-beta3"
+          },
+          {
+            "Version": "1.3.0-beta6"
+          },
+          {
+            "Version": "1.3.0-rc0"
+          },
+          {
+            "Version": "1.3.0-rc1"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.3.4"
+          },
+          {
+            "Version": "1.3.8"
+          },
+          {
+            "Version": "1.3.14"
+          },
+          {
+            "Version": "1.3.15"
+          },
+          {
+            "Version": "1.3.16"
+          },
+          {
+            "Version": "1.3.17"
+          },
+          {
+            "Version": "1.3.18"
+          },
+          {
+            "Version": "1.3.19"
+          },
+          {
+            "Version": "1.3.20"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.4.4"
+          },
+          {
+            "Version": "1.4.5"
+          },
+          {
+            "Version": "1.4.6"
+          },
+          {
+            "Version": "1.4.7"
+          },
+          {
+            "Version": "1.4.8"
+          },
+          {
+            "Version": "1.4.9"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.5.3"
+          },
+          {
+            "Version": "1.5.5"
+          },
+          {
+            "Version": "1.5.6"
+          },
+          {
+            "Version": "1.5.7"
+          },
+          {
+            "Version": "1.5.8"
+          },
+          {
+            "Version": "1.5.9"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.6.3"
+          },
+          {
+            "Version": "1.6.4"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:08.7607546+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:20.4322626+02:00",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:27.4023371+02:00",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:19.0852586+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:11.8487564+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:47.5587652+02:00",
+        "PackageName": "System.Collections.Specialized",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Specialized",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.Specialized/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.8802765+02:00",
+        "PackageName": "Microsoft.Owin.Security.Cookies",
+        "Versions": [
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Security.Cookies",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin.Security.Cookies/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Microsoft.Owin.Security",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:53.3422522+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.5562483+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.7937496+02:00",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:35.2372238+02:00",
+        "PackageName": "bootstrap",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "bootstrap",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/bootstrap/3.1.1",
+              "LicenseUrl": "https://github.com/twbs/bootstrap/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "jquery",
+                  "VersionRequirement": ">= 1.9"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.4"
+          },
+          {
+            "Version": "3.3.5"
+          },
+          {
+            "Version": "3.3.6-jQuery3"
+          },
+          {
+            "Version": "3.3.6"
+          },
+          {
+            "Version": "3.3.6.1"
+          },
+          {
+            "Version": "3.3.7"
+          },
+          {
+            "Version": "4.0.0-alpha"
+          },
+          {
+            "Version": "4.0.0-alpha2"
+          },
+          {
+            "Version": "4.0.0-alpha3"
+          },
+          {
+            "Version": "4.0.0-alpha4"
+          },
+          {
+            "Version": "4.0.0-alpha5"
+          },
+          {
+            "Version": "4.0.0-alpha6"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:11.637756+02:00",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:25.8712127+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:19.8532579+02:00",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:29.3693693+02:00",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:35.9022559+02:00",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.2.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:39.4327482+02:00",
+        "PackageName": "Microsoft.AspNet.WebApi.Client",
+        "Versions": [
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "4.1.0-alpha-120809"
+          },
+          {
+            "Version": "5.0.0-alpha1"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2"
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.Client",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.Client/5.2.3",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Net.Http",
+                  "VersionRequirement": ">= 2.2.22",
+                  "FrameworkRestrictions": "portable-wp80+win+wp81+wpa81"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.4",
+                  "FrameworkRestrictions": "portable-wp80+win+wp81+wpa81, >= net45"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:28.7928762+02:00",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:22.1672602+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:29.193871+02:00",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:24.4617102+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:49.0797493+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:56.7482522+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:41.0077487+02:00",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:18.5227602+02:00",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:28.4033871+02:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:58.6977533+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:23.3130651+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:14.2947638+02:00",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:59.7192528+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:22.7397694+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:35.0317236+02:00",
+        "PackageName": "Antlr",
+        "Versions": [
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.3.42154"
+          },
+          {
+            "Version": "3.4.1.9004-pre"
+          },
+          {
+            "Version": "3.4.1.9004"
+          },
+          {
+            "Version": "3.5.0.2",
+            "PackageDetails": {
+              "Name": "Antlr",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Antlr/3.5.0.2",
+              "LicenseUrl": "http://www.antlr3.org/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:16.6517578+02:00",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:20.0512593+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:27.5953506+02:00",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.4927474+02:00",
+        "PackageName": "Respond",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2",
+            "PackageDetails": {
+              "Name": "Respond",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Respond/1.4.2",
+              "LicenseUrl": "https://github.com/scottjehl/Respond/blob/master/LICENSE-MIT",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:54.6402526+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:15.5277571+02:00",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:07.862264+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:00.0342527+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:21.2137627+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.1652481+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:07.5897567+02:00",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:50.454751+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:58.1002535+02:00",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:03.9487603+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:17.0232575+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:39.5987469+02:00",
+        "PackageName": "Microsoft.AspNet.WebApi.Core",
+        "Versions": [
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.Core/5.1.2",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.WebApi.Client",
+                  "VersionRequirement": ">= 5.1.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:18.7027593+02:00",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:19.4702719+02:00",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:17.9512603+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:19.6692621+02:00",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:48.68125+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:09.1912593+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:06.5362569+02:00",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:26.8248223+02:00",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:14.5007559+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:59.4147561+02:00",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:10.2982564+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:34.8227282+02:00",
+        "PackageName": "AngularJS.Core",
+        "Versions": [
+          {
+            "Version": "1.2.0-rc2"
+          },
+          {
+            "Version": "1.2.0-rc2-package-test-1"
+          },
+          {
+            "Version": "1.2.0-rc3"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.2.7"
+          },
+          {
+            "Version": "1.2.8"
+          },
+          {
+            "Version": "1.2.9"
+          },
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "1.2.12"
+          },
+          {
+            "Version": "1.2.13"
+          },
+          {
+            "Version": "1.2.14"
+          },
+          {
+            "Version": "1.2.15"
+          },
+          {
+            "Version": "1.2.16"
+          },
+          {
+            "Version": "1.2.18"
+          },
+          {
+            "Version": "1.2.19"
+          },
+          {
+            "Version": "1.2.20"
+          },
+          {
+            "Version": "1.2.21"
+          },
+          {
+            "Version": "1.2.22"
+          },
+          {
+            "Version": "1.2.23"
+          },
+          {
+            "Version": "1.2.24"
+          },
+          {
+            "Version": "1.2.25"
+          },
+          {
+            "Version": "1.2.26"
+          },
+          {
+            "Version": "1.2.27"
+          },
+          {
+            "Version": "1.2.28"
+          },
+          {
+            "Version": "1.2.29"
+          },
+          {
+            "Version": "1.2.30"
+          },
+          {
+            "Version": "1.2.32",
+            "PackageDetails": {
+              "Name": "AngularJS.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AngularJS.Core/1.2.32",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.0-beta14"
+          },
+          {
+            "Version": "1.3.0-beta18"
+          },
+          {
+            "Version": "1.3.0-beta2"
+          },
+          {
+            "Version": "1.3.0-beta3"
+          },
+          {
+            "Version": "1.3.0-beta6"
+          },
+          {
+            "Version": "1.3.0-rc0"
+          },
+          {
+            "Version": "1.3.0-rc1"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.3.4"
+          },
+          {
+            "Version": "1.3.8"
+          },
+          {
+            "Version": "1.3.14"
+          },
+          {
+            "Version": "1.3.15"
+          },
+          {
+            "Version": "1.3.16"
+          },
+          {
+            "Version": "1.3.17"
+          },
+          {
+            "Version": "1.3.18"
+          },
+          {
+            "Version": "1.3.19"
+          },
+          {
+            "Version": "1.3.20"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.4.4"
+          },
+          {
+            "Version": "1.4.5"
+          },
+          {
+            "Version": "1.4.6"
+          },
+          {
+            "Version": "1.4.7"
+          },
+          {
+            "Version": "1.4.8"
+          },
+          {
+            "Version": "1.4.9"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.5.3"
+          },
+          {
+            "Version": "1.5.5"
+          },
+          {
+            "Version": "1.5.6"
+          },
+          {
+            "Version": "1.5.7"
+          },
+          {
+            "Version": "1.5.8"
+          },
+          {
+            "Version": "1.5.9"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.6.3"
+          },
+          {
+            "Version": "1.6.4"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:49.251249+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:18.1522597+02:00",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:07.0117571+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:00.6697541+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:25.2382111+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.6727484+02:00",
+        "PackageName": "Microsoft.Owin.Host.SystemWeb",
+        "Versions": [
+          {
+            "Version": "0.12-alpha2"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0-rc2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Host.SystemWeb",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin.Host.SystemWeb/2.1.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 2.1",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:47.017249+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:14.0772565+02:00",
+        "PackageName": "WebGrease",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.6.0",
+            "PackageDetails": {
+              "Name": "WebGrease",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/WebGrease/1.6.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Antlr",
+                  "VersionRequirement": ">= 3.4.1.9004"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 5.0.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:17.2187578+02:00",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:59.1737523+02:00",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:21.7877592+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.9722493+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:38.9742467+02:00",
+        "PackageName": "Microsoft.AspNet.Mvc",
+        "Versions": [
+          {
+            "Version": "3.0.20105.1"
+          },
+          {
+            "Version": "3.0.50813.1"
+          },
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "4.0.40804.0"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2"
+          },
+          {
+            "Version": "5.1.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Mvc",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Mvc/5.1.3",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 3.1.2 < 3.2"
+                },
+                {
+                  "PackageName": "Microsoft.AspNet.WebPages",
+                  "VersionRequirement": ">= 3.1.2 < 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3"
+          },
+          {
+            "Version": "6.0.0-beta1"
+          },
+          {
+            "Version": "6.0.0-beta2"
+          },
+          {
+            "Version": "6.0.0-beta3"
+          },
+          {
+            "Version": "6.0.0-beta4"
+          },
+          {
+            "Version": "6.0.0-beta5"
+          },
+          {
+            "Version": "6.0.0-beta6"
+          },
+          {
+            "Version": "6.0.0-beta7"
+          },
+          {
+            "Version": "6.0.0-beta8"
+          },
+          {
+            "Version": "6.0.0-rc1-final"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:21.4077599+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:26.4462335+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:20.6357586+02:00",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:28.9988687+02:00",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:06.0572538+02:00",
+        "PackageName": "System.Runtime.Serialization.Formatters",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Formatters",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Formatters/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.7807487+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:05.9082541+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:52.1112517+02:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:27.206324+02:00",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:27.9773727+02:00",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:54.0817512+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:34.9137287+02:00",
+        "PackageName": "AngularJS.Sanitize",
+        "Versions": [
+          {
+            "Version": "1.2.0-rc2"
+          },
+          {
+            "Version": "1.2.0-rc3"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.2.7"
+          },
+          {
+            "Version": "1.2.8"
+          },
+          {
+            "Version": "1.2.9"
+          },
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "1.2.12"
+          },
+          {
+            "Version": "1.2.13"
+          },
+          {
+            "Version": "1.2.14"
+          },
+          {
+            "Version": "1.2.15"
+          },
+          {
+            "Version": "1.2.16"
+          },
+          {
+            "Version": "1.2.18"
+          },
+          {
+            "Version": "1.2.19"
+          },
+          {
+            "Version": "1.2.20"
+          },
+          {
+            "Version": "1.2.21"
+          },
+          {
+            "Version": "1.2.22"
+          },
+          {
+            "Version": "1.2.23"
+          },
+          {
+            "Version": "1.2.24"
+          },
+          {
+            "Version": "1.2.25"
+          },
+          {
+            "Version": "1.2.26"
+          },
+          {
+            "Version": "1.2.27"
+          },
+          {
+            "Version": "1.2.28"
+          },
+          {
+            "Version": "1.2.29"
+          },
+          {
+            "Version": "1.2.30"
+          },
+          {
+            "Version": "1.2.32",
+            "PackageDetails": {
+              "Name": "AngularJS.Sanitize",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AngularJS.Sanitize/1.2.32",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "AngularJS.Core",
+                  "VersionRequirement": ">= 1.2.32"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.0-beta14"
+          },
+          {
+            "Version": "1.3.0-beta18"
+          },
+          {
+            "Version": "1.3.0-beta2"
+          },
+          {
+            "Version": "1.3.0-beta3"
+          },
+          {
+            "Version": "1.3.0-beta6"
+          },
+          {
+            "Version": "1.3.0-rc0"
+          },
+          {
+            "Version": "1.3.0-rc1"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.3.4"
+          },
+          {
+            "Version": "1.3.8"
+          },
+          {
+            "Version": "1.3.14"
+          },
+          {
+            "Version": "1.3.15"
+          },
+          {
+            "Version": "1.3.16"
+          },
+          {
+            "Version": "1.3.17"
+          },
+          {
+            "Version": "1.3.18"
+          },
+          {
+            "Version": "1.3.19"
+          },
+          {
+            "Version": "1.3.20"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.4.4"
+          },
+          {
+            "Version": "1.4.5"
+          },
+          {
+            "Version": "1.4.6"
+          },
+          {
+            "Version": "1.4.7"
+          },
+          {
+            "Version": "1.4.8"
+          },
+          {
+            "Version": "1.4.9"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.5.3"
+          },
+          {
+            "Version": "1.5.5"
+          },
+          {
+            "Version": "1.5.6"
+          },
+          {
+            "Version": "1.5.7"
+          },
+          {
+            "Version": "1.5.8"
+          },
+          {
+            "Version": "1.5.9"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.6.3"
+          },
+          {
+            "Version": "1.6.4"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:34.5192276+02:00",
+        "PackageName": "Angular.UI.UI-Router",
+        "Versions": [
+          {
+            "Version": "0.2.7"
+          },
+          {
+            "Version": "0.2.8.0"
+          },
+          {
+            "Version": "0.2.10"
+          },
+          {
+            "Version": "0.2.11"
+          },
+          {
+            "Version": "0.2.12"
+          },
+          {
+            "Version": "0.2.13"
+          },
+          {
+            "Version": "0.2.14"
+          },
+          {
+            "Version": "0.2.15"
+          },
+          {
+            "Version": "0.2.17"
+          },
+          {
+            "Version": "0.2.18",
+            "PackageDetails": {
+              "Name": "Angular.UI.UI-Router",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Angular.UI.UI-Router/0.2.18",
+              "LicenseUrl": "https://github.com/angular-ui/ui-router/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.3.1"
+          },
+          {
+            "Version": "0.3.2"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:41.3957468+02:00",
+        "PackageName": "Microsoft.CSharp",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.CSharp",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.CSharp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:21.0167593+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:23.5003659+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:22.9172647+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:21.6047728+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:38.7112499+02:00",
+        "PackageName": "Microsoft.AspNet.Identity.EntityFramework",
+        "Versions": [
+          {
+            "Version": "1.0.0-alpha1"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "2.0.0-alpha1"
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0-alpha1"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Identity.EntityFramework",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Identity.EntityFramework/2.1.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.1"
+                },
+                {
+                  "PackageName": "Microsoft.AspNet.Identity.Core",
+                  "VersionRequirement": ">= 2.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.2.0-alpha1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta2"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-beta6"
+          },
+          {
+            "Version": "3.0.0-beta7"
+          },
+          {
+            "Version": "3.0.0-beta8"
+          },
+          {
+            "Version": "3.0.0-rc1-final"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:17.5827583+02:00",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.2612478+02:00",
+        "PackageName": "Owin",
+        "Versions": [
+          {
+            "Version": "0.5"
+          },
+          {
+            "Version": "0.7"
+          },
+          {
+            "Version": "0.11"
+          },
+          {
+            "Version": "0.12"
+          },
+          {
+            "Version": "0.14"
+          },
+          {
+            "Version": "1.0",
+            "PackageDetails": {
+              "Name": "Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Owin/1.0",
+              "LicenseUrl": "https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:24.8587124+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.2222474+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:19.2782857+02:00",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:25.4392117+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:25.6787107+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.6842491+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:36.7912462+02:00",
+        "PackageName": "EntityFramework",
+        "Versions": [
+          {
+            "Version": "4.1.10311.0"
+          },
+          {
+            "Version": "4.1.10331.0"
+          },
+          {
+            "Version": "4.1.10715.0"
+          },
+          {
+            "Version": "4.2.0.0"
+          },
+          {
+            "Version": "4.3.0-beta1"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "6.0.0-alpha1"
+          },
+          {
+            "Version": "6.0.0-alpha2"
+          },
+          {
+            "Version": "6.0.0-alpha3"
+          },
+          {
+            "Version": "6.0.0-beta1"
+          },
+          {
+            "Version": "6.0.0-rc1"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2-beta1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.1.0-alpha1"
+          },
+          {
+            "Version": "6.1.0-beta1"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "6.1.1-beta1"
+          },
+          {
+            "Version": "6.1.1"
+          },
+          {
+            "Version": "6.1.2-beta1"
+          },
+          {
+            "Version": "6.1.2-beta2"
+          },
+          {
+            "Version": "6.1.2"
+          },
+          {
+            "Version": "6.1.3-beta1"
+          },
+          {
+            "Version": "6.1.3-beta1-40122"
+          },
+          {
+            "Version": "6.1.3",
+            "PackageDetails": {
+              "Name": "EntityFramework",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/EntityFramework/6.1.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320539",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "7.0.0-beta1"
+          },
+          {
+            "Version": "7.0.0-beta2"
+          },
+          {
+            "Version": "7.0.0-beta3"
+          },
+          {
+            "Version": "7.0.0-beta4"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:16.0777572+02:00",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.4102489+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:07.391255+02:00",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:38.8132569+02:00",
+        "PackageName": "Microsoft.AspNet.Identity.Owin",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "2.0.0-alpha1"
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0-alpha1"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Identity.Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Identity.Owin/2.1.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Identity.Core",
+                  "VersionRequirement": ">= 2.1"
+                },
+                {
+                  "PackageName": "Microsoft.Owin.Security",
+                  "VersionRequirement": ">= 2.1"
+                },
+                {
+                  "PackageName": "Microsoft.Owin.Security.Cookies",
+                  "VersionRequirement": ">= 2.1"
+                },
+                {
+                  "PackageName": "Microsoft.Owin.Security.OAuth",
+                  "VersionRequirement": ">= 2.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.2.0-alpha1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:05.2657531+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:39.9297464+02:00",
+        "PackageName": "Microsoft.AspNet.WebPages",
+        "Versions": [
+          {
+            "Version": "1.0.20105.408"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.0.30506.0"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta2"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebPages",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.WebPages/3.1.2",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 3.1.2 < 3.2"
+                },
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.0-rc"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1-beta"
+          },
+          {
+            "Version": "3.2.2-rc"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3-beta1"
+          },
+          {
+            "Version": "3.2.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:39.2092503+02:00",
+        "PackageName": "Microsoft.AspNet.Web.Optimization",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0-beta3"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0-Beta1"
+          },
+          {
+            "Version": "1.1.0-alpha1"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Web.Optimization",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Web.Optimization/1.1.3",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0"
+                },
+                {
+                  "PackageName": "WebGrease",
+                  "VersionRequirement": ">= 1.5.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.181247+02:00",
+        "PackageName": "NProgress.js",
+        "Versions": [
+          {
+            "Version": "0.1.2.0",
+            "PackageDetails": {
+              "Name": "NProgress.js",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NProgress.js/0.1.2.0",
+              "LicenseUrl": "https://raw.github.com/rstacruz/nprogress/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.1.6.0"
+          },
+          {
+            "Version": "0.1.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.1322482+02:00",
+        "PackageName": "Microsoft.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.1.3-beta"
+          },
+          {
+            "Version": "2.1.6-rc"
+          },
+          {
+            "Version": "2.1.10"
+          },
+          {
+            "Version": "2.2.3-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.10-rc"
+          },
+          {
+            "Version": "2.2.13"
+          },
+          {
+            "Version": "2.2.15"
+          },
+          {
+            "Version": "2.2.18"
+          },
+          {
+            "Version": "2.2.19"
+          },
+          {
+            "Version": "2.2.20"
+          },
+          {
+            "Version": "2.2.22"
+          },
+          {
+            "Version": "2.2.23-beta"
+          },
+          {
+            "Version": "2.2.27-beta"
+          },
+          {
+            "Version": "2.2.28"
+          },
+          {
+            "Version": "2.2.29",
+            "PackageDetails": {
+              "Name": "Microsoft.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Net.Http/2.2.29",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:15.7042598+02:00",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:23.1062332+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:36.9582463+02:00",
+        "PackageName": "FontAwesome",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.2.1"
+          },
+          {
+            "Version": "3.0.2.2"
+          },
+          {
+            "Version": "3.0.2.3"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.3.1"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.2.0",
+            "PackageDetails": {
+              "Name": "FontAwesome",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FontAwesome/4.2.0",
+              "LicenseUrl": "http://fontawesome.io/license/",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.7.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.2922574+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:13.4037571+02:00",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:24.6512104+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:23.8867116+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.8412474+02:00",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:24.2772244+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:14.7332569+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:49.7562527+02:00",
+        "PackageName": "System.Diagnostics.TraceSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.TraceSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.TraceSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:53.8462511+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:35.5072246+02:00",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Core/4.0.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlSerializer",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:43.2452613+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:45.2262622+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:51.0457492+02:00",
+        "PackageName": "System.Dynamic.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Dynamic.Runtime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Dynamic.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:24.0787121+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:39.1107465+02:00",
+        "PackageName": "Microsoft.AspNet.Razor",
+        "Versions": [
+          {
+            "Version": "1.0.20105.408"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.0.20715.0"
+          },
+          {
+            "Version": "2.0.30506.0"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta2"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Razor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Razor/3.1.2",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.0-rc"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.2-rc"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3-beta1"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "4.0.0-beta1"
+          },
+          {
+            "Version": "4.0.0-beta2"
+          },
+          {
+            "Version": "4.0.0-beta3"
+          },
+          {
+            "Version": "4.0.0-beta4"
+          },
+          {
+            "Version": "4.0.0-beta5"
+          },
+          {
+            "Version": "4.0.0-beta6"
+          },
+          {
+            "Version": "4.0.0-beta7"
+          },
+          {
+            "Version": "4.0.0-beta8"
+          },
+          {
+            "Version": "4.0.0-rc1-final"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.622248+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:47.7897495+02:00",
+        "PackageName": "System.ComponentModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:05.5642534+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:03.1442527+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.906248+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:44.3707562+02:00",
+        "PackageName": "Placeholders.js",
+        "Versions": [
+          {
+            "Version": "3.0.2",
+            "PackageDetails": {
+              "Name": "Placeholders.js",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Placeholders.js/3.0.2",
+              "LicenseUrl": "http://jamesallardice.github.io/Placeholders.js/",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:49.4352497+02:00",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:51.8282499+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:43.5282476+02:00",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:20.2382602+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:22.5462646+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:47.2867496+02:00",
+        "PackageName": "System.Collections.NonGeneric",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.NonGeneric",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.NonGeneric/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:15.3262578+02:00",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:38.5947465+02:00",
+        "PackageName": "Microsoft.AspNet.Identity.Core",
+        "Versions": [
+          {
+            "Version": "1.0.0-alpha1"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "2.0.0-alpha1"
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0-alpha1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0-alpha1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Identity.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Identity.Core/2.2.1",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:38.3408366+02:00",
+        "PackageName": "Machine.Specifications",
+        "Versions": [
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.4.1.0"
+          },
+          {
+            "Version": "0.4.2.0"
+          },
+          {
+            "Version": "0.4.4.0"
+          },
+          {
+            "Version": "0.4.7.0"
+          },
+          {
+            "Version": "0.4.8.0"
+          },
+          {
+            "Version": "0.4.9.0"
+          },
+          {
+            "Version": "0.4.10.0"
+          },
+          {
+            "Version": "0.4.12.0"
+          },
+          {
+            "Version": "0.4.13.0"
+          },
+          {
+            "Version": "0.4.18.0"
+          },
+          {
+            "Version": "0.4.19.0"
+          },
+          {
+            "Version": "0.4.20.0"
+          },
+          {
+            "Version": "0.4.21.0"
+          },
+          {
+            "Version": "0.4.22.0"
+          },
+          {
+            "Version": "0.4.23.0"
+          },
+          {
+            "Version": "0.4.24.0"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.5.4.0"
+          },
+          {
+            "Version": "0.5.5.0"
+          },
+          {
+            "Version": "0.5.6.0"
+          },
+          {
+            "Version": "0.5.7-beta2"
+          },
+          {
+            "Version": "0.5.7-beta3"
+          },
+          {
+            "Version": "0.5.7-beta4"
+          },
+          {
+            "Version": "0.5.7-beta5"
+          },
+          {
+            "Version": "0.5.7"
+          },
+          {
+            "Version": "0.5.8-beta10"
+          },
+          {
+            "Version": "0.5.8-beta11"
+          },
+          {
+            "Version": "0.5.8-beta6"
+          },
+          {
+            "Version": "0.5.8-beta9"
+          },
+          {
+            "Version": "0.5.8"
+          },
+          {
+            "Version": "0.5.9-beta1"
+          },
+          {
+            "Version": "0.5.9-beta2"
+          },
+          {
+            "Version": "0.5.9-beta3"
+          },
+          {
+            "Version": "0.5.9-beta4"
+          },
+          {
+            "Version": "0.5.9"
+          },
+          {
+            "Version": "0.5.10-beta1"
+          },
+          {
+            "Version": "0.5.10-beta2"
+          },
+          {
+            "Version": "0.5.10-beta3"
+          },
+          {
+            "Version": "0.5.10-beta4"
+          },
+          {
+            "Version": "0.5.10"
+          },
+          {
+            "Version": "0.5.11-beta1"
+          },
+          {
+            "Version": "0.5.11-beta2"
+          },
+          {
+            "Version": "0.5.11-beta3"
+          },
+          {
+            "Version": "0.5.11-beta4"
+          },
+          {
+            "Version": "0.5.11-beta5"
+          },
+          {
+            "Version": "0.5.11-beta6"
+          },
+          {
+            "Version": "0.5.11-beta7"
+          },
+          {
+            "Version": "0.5.11-beta8"
+          },
+          {
+            "Version": "0.5.11"
+          },
+          {
+            "Version": "0.5.12-beta1"
+          },
+          {
+            "Version": "0.5.12-beta2"
+          },
+          {
+            "Version": "0.5.12-beta3"
+          },
+          {
+            "Version": "0.5.12"
+          },
+          {
+            "Version": "0.5.13-beta4"
+          },
+          {
+            "Version": "0.5.13-beta5"
+          },
+          {
+            "Version": "0.5.13-beta6"
+          },
+          {
+            "Version": "0.5.13-beta8"
+          },
+          {
+            "Version": "0.5.13-beta9"
+          },
+          {
+            "Version": "0.5.14-beta01"
+          },
+          {
+            "Version": "0.5.14-beta05"
+          },
+          {
+            "Version": "0.5.14-beta10"
+          },
+          {
+            "Version": "0.5.14"
+          },
+          {
+            "Version": "0.5.15-beta06"
+          },
+          {
+            "Version": "0.5.15-beta07"
+          },
+          {
+            "Version": "0.5.15"
+          },
+          {
+            "Version": "0.5.16-beta01"
+          },
+          {
+            "Version": "0.5.16-beta02"
+          },
+          {
+            "Version": "0.5.16"
+          },
+          {
+            "Version": "0.5.17-beta04"
+          },
+          {
+            "Version": "0.5.18-beta01"
+          },
+          {
+            "Version": "0.5.18-beta02"
+          },
+          {
+            "Version": "0.5.18-beta03"
+          },
+          {
+            "Version": "0.5.18-beta06"
+          },
+          {
+            "Version": "0.5.18-beta07"
+          },
+          {
+            "Version": "0.6.0-beta09"
+          },
+          {
+            "Version": "0.6.0-beta10"
+          },
+          {
+            "Version": "0.6.0-beta11"
+          },
+          {
+            "Version": "0.6.0-beta19"
+          },
+          {
+            "Version": "0.6.0-beta26"
+          },
+          {
+            "Version": "0.6.0-beta36"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.6.1-Beta0000-0005"
+          },
+          {
+            "Version": "0.6.1-Beta0000-0006"
+          },
+          {
+            "Version": "0.6.1"
+          },
+          {
+            "Version": "0.6.2-Beta0000-0020"
+          },
+          {
+            "Version": "0.6.2"
+          },
+          {
+            "Version": "0.7.0-Unstable0014"
+          },
+          {
+            "Version": "0.7.0-Unstable0022"
+          },
+          {
+            "Version": "0.7.0-Unstable0028"
+          },
+          {
+            "Version": "0.7.0-Unstable0033"
+          },
+          {
+            "Version": "0.7.0-Unstable0037"
+          },
+          {
+            "Version": "0.7.0-Unstable0038"
+          },
+          {
+            "Version": "0.7.0-Unstable0059"
+          },
+          {
+            "Version": "0.7.0-Unstable0072"
+          },
+          {
+            "Version": "0.7.0-Unstable0073"
+          },
+          {
+            "Version": "0.7.0-Unstable0077"
+          },
+          {
+            "Version": "0.7.0-Unstable0078"
+          },
+          {
+            "Version": "0.7.0-Unstable0080"
+          },
+          {
+            "Version": "0.7.0",
+            "PackageDetails": {
+              "Name": "Machine.Specifications",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Machine.Specifications/0.7.0",
+              "LicenseUrl": "http://github.com/machine/machine.specifications/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.8.0-Unstable0003"
+          },
+          {
+            "Version": "0.8.0-Unstable0005"
+          },
+          {
+            "Version": "0.8.0-Unstable0006"
+          },
+          {
+            "Version": "0.8.0-Unstable0010"
+          },
+          {
+            "Version": "0.8.0-Unstable0014"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.8.1-Beta0000-0001"
+          },
+          {
+            "Version": "0.8.1"
+          },
+          {
+            "Version": "0.8.2-Beta0000-0001"
+          },
+          {
+            "Version": "0.8.2"
+          },
+          {
+            "Version": "0.8.3-Beta0000"
+          },
+          {
+            "Version": "0.8.3-Beta0000-0006"
+          },
+          {
+            "Version": "0.8.3-Beta0000-0007"
+          },
+          {
+            "Version": "0.8.3-Beta0000-0010"
+          },
+          {
+            "Version": "0.8.3-Beta0000-0011"
+          },
+          {
+            "Version": "0.8.3-Beta0000-0013"
+          },
+          {
+            "Version": "0.8.3-Beta0000-0014"
+          },
+          {
+            "Version": "0.8.3"
+          },
+          {
+            "Version": "0.9.0-Feature-Runner"
+          },
+          {
+            "Version": "0.9.0-Unstable0023"
+          },
+          {
+            "Version": "0.9.0-Unstable0024"
+          },
+          {
+            "Version": "0.9.0-Unstable0025"
+          },
+          {
+            "Version": "0.9.0-Unstable0027"
+          },
+          {
+            "Version": "0.9.0-Unstable0067"
+          },
+          {
+            "Version": "0.9.0-Unstable0070"
+          },
+          {
+            "Version": "0.9.0-Unstable0071"
+          },
+          {
+            "Version": "0.9.0-Unstable0074"
+          },
+          {
+            "Version": "0.9.0-Unstable0076"
+          },
+          {
+            "Version": "0.9.0-Unstable0077"
+          },
+          {
+            "Version": "0.9.0-Unstable0079"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.9.1-Beta0000-0001"
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.2-Beta0000-0001"
+          },
+          {
+            "Version": "0.9.2"
+          },
+          {
+            "Version": "0.9.3-Beta0000"
+          },
+          {
+            "Version": "0.9.3-Beta0000-0001"
+          },
+          {
+            "Version": "0.9.3-Beta0000-0007"
+          },
+          {
+            "Version": "0.9.3"
+          },
+          {
+            "Version": "0.10.0-Feature-mspec"
+          },
+          {
+            "Version": "0.10.0-Unstable0004"
+          },
+          {
+            "Version": "0.10.0-Unstable0005"
+          },
+          {
+            "Version": "0.10.0-Unstable0014"
+          },
+          {
+            "Version": "0.10.0-beta1"
+          },
+          {
+            "Version": "0.10.0-unstable0011"
+          },
+          {
+            "Version": "0.10.0-unstable0032"
+          },
+          {
+            "Version": "0.10.0-unstable0033"
+          },
+          {
+            "Version": "0.10.0-unstable0035"
+          },
+          {
+            "Version": "0.10.0-unstable0037"
+          },
+          {
+            "Version": "0.10.0-unstable0039"
+          },
+          {
+            "Version": "0.11.0-beta1"
+          },
+          {
+            "Version": "0.11.0-beta2"
+          },
+          {
+            "Version": "0.11.0-beta3"
+          },
+          {
+            "Version": "0.11.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:28.2113696+02:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:37.3552462+02:00",
+        "PackageName": "jquery",
+        "Versions": [
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.4.4"
+          },
+          {
+            "Version": "1.5"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.6"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.6.3"
+          },
+          {
+            "Version": "1.6.4"
+          },
+          {
+            "Version": "1.7"
+          },
+          {
+            "Version": "1.7.1"
+          },
+          {
+            "Version": "1.7.1.1"
+          },
+          {
+            "Version": "1.7.2"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.2"
+          },
+          {
+            "Version": "1.8.3"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.10.0"
+          },
+          {
+            "Version": "1.10.0.1"
+          },
+          {
+            "Version": "1.10.1"
+          },
+          {
+            "Version": "1.10.2"
+          },
+          {
+            "Version": "1.11.0"
+          },
+          {
+            "Version": "1.11.1"
+          },
+          {
+            "Version": "1.11.2"
+          },
+          {
+            "Version": "1.11.3"
+          },
+          {
+            "Version": "1.12.0"
+          },
+          {
+            "Version": "1.12.1"
+          },
+          {
+            "Version": "1.12.2"
+          },
+          {
+            "Version": "1.12.3"
+          },
+          {
+            "Version": "1.12.4"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.1.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.1.3"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.0.1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/jQuery/3.1.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:16.2782593+02:00",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:55.7972513+02:00",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:47.9877486+02:00",
+        "PackageName": "System.ComponentModel.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:23.6845765+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:25.0542105+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:13.9212565+02:00",
+        "PackageName": "System.Xml.XmlSerializer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlSerializer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XmlSerializer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:43.3612479+02:00",
+        "PackageName": "Modernizr",
+        "Versions": [
+          {
+            "Version": "1.6"
+          },
+          {
+            "Version": "1.7"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.6.2",
+            "PackageDetails": {
+              "Name": "Modernizr",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Modernizr/2.6.2",
+              "LicenseUrl": "http://www.modernizr.com/license/",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.8.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:57.5412519+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:42.322246+02:00",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:38.4802479+02:00",
+        "PackageName": "Machine.Specifications.Should",
+        "Versions": [
+          {
+            "Version": "0.7.0-Unstable0008"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.7.1-Beta0000-0001"
+          },
+          {
+            "Version": "0.7.1-Beta0000-0002"
+          },
+          {
+            "Version": "0.7.1"
+          },
+          {
+            "Version": "0.7.2-Beta0000-0006"
+          },
+          {
+            "Version": "0.7.2",
+            "PackageDetails": {
+              "Name": "Machine.Specifications.Should",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Machine.Specifications.Should/0.7.2",
+              "LicenseUrl": "http://github.com/machine/machine.specifications.should/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Machine.Specifications",
+                  "VersionRequirement": ">= 0.7 < 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.8.0-Unstable0003"
+          },
+          {
+            "Version": "0.8.0-Unstable0007"
+          },
+          {
+            "Version": "0.8.0-Unstable0008"
+          },
+          {
+            "Version": "0.8.0-Unstable0009"
+          },
+          {
+            "Version": "0.8.0-Unstable0011"
+          },
+          {
+            "Version": "0.8.0-Unstable0012"
+          },
+          {
+            "Version": "0.8.0-Unstable0013"
+          },
+          {
+            "Version": "0.8.0-Unstable0018"
+          },
+          {
+            "Version": "0.8.0-Unstable0019"
+          },
+          {
+            "Version": "0.8.0-Unstable0022"
+          },
+          {
+            "Version": "0.8.0-Unstable0023"
+          },
+          {
+            "Version": "0.8.0-Unstable0025"
+          },
+          {
+            "Version": "0.8.0-Unstable0026"
+          },
+          {
+            "Version": "0.8.0-Unstable0027"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.9.0-Beta0000"
+          },
+          {
+            "Version": "0.9.0-Beta0000-0001"
+          },
+          {
+            "Version": "0.9.0-Unstable0015"
+          },
+          {
+            "Version": "0.9.0-Unstable0016"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0-Unstable0001"
+          },
+          {
+            "Version": "0.10.0-rc1"
+          },
+          {
+            "Version": "0.11.0-rc1"
+          },
+          {
+            "Version": "0.11.0-rc2"
+          },
+          {
+            "Version": "0.11.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:17.396258+02:00",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:26.2582128+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:20.8312585+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:43.4792474+02:00",
+        "PackageName": "Modernizr.full",
+        "Versions": [
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.3.1"
+          },
+          {
+            "Version": "2.6.2.0"
+          },
+          {
+            "Version": "2.6.2.1",
+            "PackageDetails": {
+              "Name": "Modernizr.full",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Modernizr.full/2.6.2.1",
+              "LicenseUrl": "http://www.modernizr.com/license/",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:26.6423236+02:00",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:07.9902886+02:00",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:15.8982596+02:00",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:43.0712477+02:00",
+        "PackageName": "Microsoft.Web.Infrastructure",
+        "Versions": [
+          {
+            "Version": "1.0.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Web.Infrastructure",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Web.Infrastructure/1.0.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=214339",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:17.7767611+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:18.9017571+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:48.4537508+02:00",
+        "PackageName": "System.ComponentModel.TypeConverter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.TypeConverter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.TypeConverter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, net45, >= net462, netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:33:51.571751+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:27.7973702+02:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000108-case-insensitive-nuget-packages/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000108-case-insensitive-nuget-packages/cache/paket-graph.cache
@@ -1,0 +1,45 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:18:59.5487068+02:00",
+        "PackageName": "jQuery",
+        "Versions": [
+          {
+            "Version": "1.9.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/jQuery/1.9.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:18:59.193208+02:00",
+        "PackageName": "bootstrap",
+        "Versions": [
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "bootstrap",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/bootstrap/3.2.0",
+              "LicenseUrl": "https://github.com/twbs/bootstrap/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "jquery",
+                  "VersionRequirement": ">= 1.9"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000140-resolve-framework-restrictions/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000140-resolve-framework-restrictions/cache/paket-graph.cache
@@ -1,0 +1,6631 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:52",
+        "PackageName": "TaskParallelLibrary",
+        "Versions": [
+          {
+            "Version": "1.0.2856.0",
+            "PackageDetails": {
+              "Name": "TaskParallelLibrary",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/TaskParallelLibrary/1.0.2856.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=186234",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:54.1453763+02:00",
+        "PackageName": "MathNet.Numerics.FSharp",
+        "Versions": [
+          {
+            "Version": "2.1.0.19"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          },
+          {
+            "Version": "3.0.0-beta02"
+          },
+          {
+            "Version": "3.0.0-beta03"
+          },
+          {
+            "Version": "3.0.0-beta04"
+          },
+          {
+            "Version": "3.0.0-beta05"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "MathNet.Numerics.FSharp",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/MathNet.Numerics.FSharp/3.2.1",
+              "LicenseUrl": "http://numerics.mathdotnet.com/docs/License.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "MathNet.Numerics",
+                  "VersionRequirement": "3.2.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3",
+            "PackageDetails": {
+              "Name": "MathNet.Numerics.FSharp",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/MathNet.Numerics.FSharp/3.2.3",
+              "LicenseUrl": "http://numerics.mathdotnet.com/docs/License.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "MathNet.Numerics",
+                  "VersionRequirement": "3.2.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0-beta1"
+          },
+          {
+            "Version": "3.3.0-beta2"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.12.0"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.14.0-beta01"
+          },
+          {
+            "Version": "3.14.0-beta02"
+          },
+          {
+            "Version": "3.14.0-beta03"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.0"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.19.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:54.8118754+02:00",
+        "PackageName": "NUnit.Runners",
+        "Versions": [
+          {
+            "Version": "2.6.0.12051",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.0.12051",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Runners/2.6.4",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:48",
+        "PackageName": "FSharp.Compiler.Service",
+        "Versions": [
+          {
+            "Version": "2.0.0.6",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/2.0.0.6",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:52.3798751+02:00",
+        "PackageName": "MathNet.Numerics",
+        "Versions": [
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "MathNet.Numerics",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/MathNet.Numerics/3.2.1",
+              "LicenseUrl": "http://numerics.mathdotnet.com/docs/License.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "TaskParallelLibrary",
+                  "VersionRequirement": ">= 1.0.2856",
+                  "FrameworkRestrictions": "net35"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.3",
+            "PackageDetails": {
+              "Name": "MathNet.Numerics",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/MathNet.Numerics/3.2.3",
+              "LicenseUrl": "http://numerics.mathdotnet.com/docs/License.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "TaskParallelLibrary",
+                  "VersionRequirement": ">= 1.0.2856",
+                  "FrameworkRestrictions": "net35"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:54.3168749+02:00",
+        "PackageName": "NuGet.CommandLine",
+        "Versions": [
+          {
+            "Version": "1.0.11220.26",
+            "PackageDetails": {
+              "Name": "NuGet.CommandLine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NuGet.CommandLine/1.0.11220.26",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.1.2120.134"
+          },
+          {
+            "Version": "1.1.2120.136"
+          },
+          {
+            "Version": "1.1.2121.140"
+          },
+          {
+            "Version": "1.1.2122.156"
+          },
+          {
+            "Version": "1.2.2128.11"
+          },
+          {
+            "Version": "1.2.20216.59"
+          },
+          {
+            "Version": "1.2.20310.1"
+          },
+          {
+            "Version": "1.2.20311.3"
+          },
+          {
+            "Version": "1.2.20325.10"
+          },
+          {
+            "Version": "1.2.20401.11"
+          },
+          {
+            "Version": "1.2.20409.25"
+          },
+          {
+            "Version": "1.2.20415.26"
+          },
+          {
+            "Version": "1.2.20416.28"
+          },
+          {
+            "Version": "1.2.20416.30"
+          },
+          {
+            "Version": "1.2.20417.31"
+          },
+          {
+            "Version": "1.3.20425.372"
+          },
+          {
+            "Version": "1.4.20615.182"
+          },
+          {
+            "Version": "1.5.20830.9001"
+          },
+          {
+            "Version": "1.5.20905.5"
+          },
+          {
+            "Version": "1.5.21005.9019"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.4"
+          },
+          {
+            "Version": "1.8.40000"
+          },
+          {
+            "Version": "1.8.40001"
+          },
+          {
+            "Version": "1.8.40002"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.40000"
+          },
+          {
+            "Version": "2.0.40001"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.3"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.8.1"
+          },
+          {
+            "Version": "2.8.2-beta"
+          },
+          {
+            "Version": "2.8.2"
+          },
+          {
+            "Version": "2.8.3"
+          },
+          {
+            "Version": "2.8.5"
+          },
+          {
+            "Version": "2.8.6"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.4.4-rtm-final"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NuGet.CommandLine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NuGet.CommandLine/3.5.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0-rc2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:37.9632198+02:00",
+        "PackageName": "FAKE",
+        "Versions": [
+          {
+            "Version": "1.46.1.0"
+          },
+          {
+            "Version": "1.46.2.0"
+          },
+          {
+            "Version": "1.48.0.0"
+          },
+          {
+            "Version": "1.50.0.0"
+          },
+          {
+            "Version": "1.50.1.0"
+          },
+          {
+            "Version": "1.50.2.0"
+          },
+          {
+            "Version": "1.50.3.0"
+          },
+          {
+            "Version": "1.50.4.0"
+          },
+          {
+            "Version": "1.52.0.0"
+          },
+          {
+            "Version": "1.52.1.0"
+          },
+          {
+            "Version": "1.52.5.0"
+          },
+          {
+            "Version": "1.52.6.0"
+          },
+          {
+            "Version": "1.54.0.0"
+          },
+          {
+            "Version": "1.54.1.0"
+          },
+          {
+            "Version": "1.54.2.0"
+          },
+          {
+            "Version": "1.54.3.0"
+          },
+          {
+            "Version": "1.56"
+          },
+          {
+            "Version": "1.56.2"
+          },
+          {
+            "Version": "1.56.3"
+          },
+          {
+            "Version": "1.56.4"
+          },
+          {
+            "Version": "1.56.5"
+          },
+          {
+            "Version": "1.56.6"
+          },
+          {
+            "Version": "1.56.7"
+          },
+          {
+            "Version": "1.56.9"
+          },
+          {
+            "Version": "1.56.10"
+          },
+          {
+            "Version": "1.56.12"
+          },
+          {
+            "Version": "1.58"
+          },
+          {
+            "Version": "1.58.2"
+          },
+          {
+            "Version": "1.58.3"
+          },
+          {
+            "Version": "1.58.5"
+          },
+          {
+            "Version": "1.58.6"
+          },
+          {
+            "Version": "1.58.7"
+          },
+          {
+            "Version": "1.58.8"
+          },
+          {
+            "Version": "1.58.9"
+          },
+          {
+            "Version": "1.58.10"
+          },
+          {
+            "Version": "1.58.11"
+          },
+          {
+            "Version": "1.58.14"
+          },
+          {
+            "Version": "1.60"
+          },
+          {
+            "Version": "1.62"
+          },
+          {
+            "Version": "1.62.1"
+          },
+          {
+            "Version": "1.62.2"
+          },
+          {
+            "Version": "1.62.4"
+          },
+          {
+            "Version": "1.62.5"
+          },
+          {
+            "Version": "1.64"
+          },
+          {
+            "Version": "1.64.1"
+          },
+          {
+            "Version": "1.64.2"
+          },
+          {
+            "Version": "1.64.3"
+          },
+          {
+            "Version": "1.64.4"
+          },
+          {
+            "Version": "1.64.5"
+          },
+          {
+            "Version": "1.64.6"
+          },
+          {
+            "Version": "1.64.7"
+          },
+          {
+            "Version": "1.64.8"
+          },
+          {
+            "Version": "1.64.9"
+          },
+          {
+            "Version": "1.64.10"
+          },
+          {
+            "Version": "1.64.11"
+          },
+          {
+            "Version": "1.64.14"
+          },
+          {
+            "Version": "1.64.15"
+          },
+          {
+            "Version": "1.64.16.0"
+          },
+          {
+            "Version": "1.64.17.0"
+          },
+          {
+            "Version": "1.64.18.0"
+          },
+          {
+            "Version": "1.64.19.0"
+          },
+          {
+            "Version": "1.66.0.0"
+          },
+          {
+            "Version": "1.66.1.0"
+          },
+          {
+            "Version": "1.66.2.0"
+          },
+          {
+            "Version": "1.68.1.0"
+          },
+          {
+            "Version": "1.68.5.0"
+          },
+          {
+            "Version": "1.68.6.0"
+          },
+          {
+            "Version": "1.70.0.0"
+          },
+          {
+            "Version": "1.70.1.0"
+          },
+          {
+            "Version": "1.70.2.0"
+          },
+          {
+            "Version": "1.70.3.0"
+          },
+          {
+            "Version": "1.70.6.0"
+          },
+          {
+            "Version": "1.70.8.0"
+          },
+          {
+            "Version": "1.70.9.0"
+          },
+          {
+            "Version": "1.70.10.0"
+          },
+          {
+            "Version": "1.70.11.0"
+          },
+          {
+            "Version": "1.70.13.0"
+          },
+          {
+            "Version": "1.70.16.0"
+          },
+          {
+            "Version": "1.70.17.0"
+          },
+          {
+            "Version": "1.70.18.0"
+          },
+          {
+            "Version": "1.70.20.0"
+          },
+          {
+            "Version": "1.70.21.0"
+          },
+          {
+            "Version": "1.70.22.0"
+          },
+          {
+            "Version": "1.70.24.0"
+          },
+          {
+            "Version": "1.70.25.0"
+          },
+          {
+            "Version": "1.70.29.0"
+          },
+          {
+            "Version": "1.70.32.0"
+          },
+          {
+            "Version": "1.72.33.0"
+          },
+          {
+            "Version": "1.74.0.0"
+          },
+          {
+            "Version": "1.74.1.0"
+          },
+          {
+            "Version": "1.74.2.0"
+          },
+          {
+            "Version": "1.74.4.0"
+          },
+          {
+            "Version": "1.74.6.0"
+          },
+          {
+            "Version": "1.74.8.0"
+          },
+          {
+            "Version": "1.74.9.0"
+          },
+          {
+            "Version": "1.74.10.0"
+          },
+          {
+            "Version": "1.74.13.0"
+          },
+          {
+            "Version": "1.74.14.0"
+          },
+          {
+            "Version": "1.74.15.0"
+          },
+          {
+            "Version": "1.74.16.0"
+          },
+          {
+            "Version": "1.74.17.0"
+          },
+          {
+            "Version": "1.74.18.0"
+          },
+          {
+            "Version": "1.74.19.0"
+          },
+          {
+            "Version": "1.74.20.0"
+          },
+          {
+            "Version": "1.74.21.0"
+          },
+          {
+            "Version": "1.74.22.0"
+          },
+          {
+            "Version": "1.74.24.0"
+          },
+          {
+            "Version": "1.74.25.0"
+          },
+          {
+            "Version": "1.74.26.0"
+          },
+          {
+            "Version": "1.74.27.0"
+          },
+          {
+            "Version": "1.74.28.0"
+          },
+          {
+            "Version": "1.74.29.0"
+          },
+          {
+            "Version": "1.74.30.0"
+          },
+          {
+            "Version": "1.74.31.0"
+          },
+          {
+            "Version": "1.74.32.0"
+          },
+          {
+            "Version": "1.74.33.0"
+          },
+          {
+            "Version": "1.74.34.0"
+          },
+          {
+            "Version": "1.74.35.0"
+          },
+          {
+            "Version": "1.74.39.0"
+          },
+          {
+            "Version": "1.74.40.0"
+          },
+          {
+            "Version": "1.74.41.0"
+          },
+          {
+            "Version": "1.74.42.0"
+          },
+          {
+            "Version": "1.74.43.0"
+          },
+          {
+            "Version": "1.74.44.0"
+          },
+          {
+            "Version": "1.74.48.0"
+          },
+          {
+            "Version": "1.74.49.0"
+          },
+          {
+            "Version": "1.74.50.0"
+          },
+          {
+            "Version": "1.74.51.0"
+          },
+          {
+            "Version": "1.74.55.0"
+          },
+          {
+            "Version": "1.74.56.0"
+          },
+          {
+            "Version": "1.74.57.0"
+          },
+          {
+            "Version": "1.74.60.0"
+          },
+          {
+            "Version": "1.74.61.0"
+          },
+          {
+            "Version": "1.74.62.0"
+          },
+          {
+            "Version": "1.74.63.0"
+          },
+          {
+            "Version": "1.74.65.0"
+          },
+          {
+            "Version": "1.74.74.0"
+          },
+          {
+            "Version": "1.74.75.0"
+          },
+          {
+            "Version": "1.74.77.0"
+          },
+          {
+            "Version": "1.74.78.0"
+          },
+          {
+            "Version": "1.74.79.0"
+          },
+          {
+            "Version": "1.74.81.0"
+          },
+          {
+            "Version": "1.74.82.0"
+          },
+          {
+            "Version": "1.74.84.0"
+          },
+          {
+            "Version": "1.74.85.0"
+          },
+          {
+            "Version": "1.74.86.0"
+          },
+          {
+            "Version": "1.74.87.0"
+          },
+          {
+            "Version": "1.74.88.0"
+          },
+          {
+            "Version": "1.74.92.0"
+          },
+          {
+            "Version": "1.74.98.0"
+          },
+          {
+            "Version": "1.74.99.0"
+          },
+          {
+            "Version": "1.74.100.0"
+          },
+          {
+            "Version": "1.74.101.0"
+          },
+          {
+            "Version": "1.74.102.0"
+          },
+          {
+            "Version": "1.74.103.0"
+          },
+          {
+            "Version": "1.74.104.0"
+          },
+          {
+            "Version": "1.74.105.0"
+          },
+          {
+            "Version": "1.74.106.0"
+          },
+          {
+            "Version": "1.74.107.0"
+          },
+          {
+            "Version": "1.74.108.0"
+          },
+          {
+            "Version": "1.74.109.0"
+          },
+          {
+            "Version": "1.74.110.0"
+          },
+          {
+            "Version": "1.74.111.0"
+          },
+          {
+            "Version": "1.74.113.0"
+          },
+          {
+            "Version": "1.74.114.0"
+          },
+          {
+            "Version": "1.74.118.0"
+          },
+          {
+            "Version": "1.74.119.0"
+          },
+          {
+            "Version": "1.74.121.0"
+          },
+          {
+            "Version": "1.74.123.0"
+          },
+          {
+            "Version": "1.74.124.0"
+          },
+          {
+            "Version": "1.74.125.0"
+          },
+          {
+            "Version": "1.74.126.0"
+          },
+          {
+            "Version": "1.74.127.0"
+          },
+          {
+            "Version": "1.74.128.0"
+          },
+          {
+            "Version": "1.74.129.0"
+          },
+          {
+            "Version": "1.74.130.0"
+          },
+          {
+            "Version": "1.74.131.0"
+          },
+          {
+            "Version": "1.74.132.0"
+          },
+          {
+            "Version": "1.74.133.0"
+          },
+          {
+            "Version": "1.74.134.0"
+          },
+          {
+            "Version": "1.74.135.0"
+          },
+          {
+            "Version": "1.74.136.0"
+          },
+          {
+            "Version": "1.74.137.0"
+          },
+          {
+            "Version": "1.74.139.0"
+          },
+          {
+            "Version": "1.74.140.0"
+          },
+          {
+            "Version": "1.74.141.0"
+          },
+          {
+            "Version": "1.74.142.0"
+          },
+          {
+            "Version": "1.74.143.0"
+          },
+          {
+            "Version": "1.74.144.0"
+          },
+          {
+            "Version": "1.74.145.0"
+          },
+          {
+            "Version": "1.74.146.0"
+          },
+          {
+            "Version": "1.74.147.0"
+          },
+          {
+            "Version": "1.74.148.0"
+          },
+          {
+            "Version": "1.74.149.0"
+          },
+          {
+            "Version": "1.74.150.0"
+          },
+          {
+            "Version": "1.74.152.0"
+          },
+          {
+            "Version": "1.74.153.0"
+          },
+          {
+            "Version": "1.74.154.0"
+          },
+          {
+            "Version": "1.74.155.0"
+          },
+          {
+            "Version": "1.74.156.0"
+          },
+          {
+            "Version": "1.74.160.0"
+          },
+          {
+            "Version": "1.74.161.0"
+          },
+          {
+            "Version": "1.74.162.0"
+          },
+          {
+            "Version": "1.74.163.0"
+          },
+          {
+            "Version": "1.74.164.0"
+          },
+          {
+            "Version": "1.74.166.0"
+          },
+          {
+            "Version": "1.74.167.0"
+          },
+          {
+            "Version": "1.74.172.0"
+          },
+          {
+            "Version": "1.74.173.0"
+          },
+          {
+            "Version": "1.74.174.0"
+          },
+          {
+            "Version": "1.74.175.0"
+          },
+          {
+            "Version": "1.74.176.0"
+          },
+          {
+            "Version": "1.74.180.0"
+          },
+          {
+            "Version": "1.74.181.0"
+          },
+          {
+            "Version": "1.74.183.0"
+          },
+          {
+            "Version": "1.74.184.0"
+          },
+          {
+            "Version": "1.74.185.0"
+          },
+          {
+            "Version": "1.74.186.0"
+          },
+          {
+            "Version": "1.74.187.0"
+          },
+          {
+            "Version": "1.74.188.0"
+          },
+          {
+            "Version": "1.74.189.0"
+          },
+          {
+            "Version": "1.74.190.0"
+          },
+          {
+            "Version": "1.74.192.0"
+          },
+          {
+            "Version": "1.74.193.0"
+          },
+          {
+            "Version": "1.74.195.0"
+          },
+          {
+            "Version": "1.74.196.0"
+          },
+          {
+            "Version": "1.74.197.0"
+          },
+          {
+            "Version": "1.74.198.0"
+          },
+          {
+            "Version": "1.74.199.0"
+          },
+          {
+            "Version": "1.74.200.0"
+          },
+          {
+            "Version": "1.74.205.0"
+          },
+          {
+            "Version": "1.74.206.0"
+          },
+          {
+            "Version": "1.74.207.0"
+          },
+          {
+            "Version": "1.74.208.0"
+          },
+          {
+            "Version": "1.74.209.0"
+          },
+          {
+            "Version": "1.74.210.0"
+          },
+          {
+            "Version": "1.74.211.0"
+          },
+          {
+            "Version": "1.74.212.0"
+          },
+          {
+            "Version": "1.74.213.0"
+          },
+          {
+            "Version": "1.74.214.0"
+          },
+          {
+            "Version": "1.74.215.0"
+          },
+          {
+            "Version": "1.74.216.0"
+          },
+          {
+            "Version": "1.74.217.0"
+          },
+          {
+            "Version": "1.74.218.0"
+          },
+          {
+            "Version": "1.74.219.0"
+          },
+          {
+            "Version": "1.74.220.0"
+          },
+          {
+            "Version": "1.74.221.0"
+          },
+          {
+            "Version": "1.74.222.0"
+          },
+          {
+            "Version": "1.74.223.0"
+          },
+          {
+            "Version": "1.74.224.0"
+          },
+          {
+            "Version": "1.74.225.0"
+          },
+          {
+            "Version": "1.74.231.0"
+          },
+          {
+            "Version": "1.74.237.0"
+          },
+          {
+            "Version": "1.74.238.0"
+          },
+          {
+            "Version": "1.74.239.0"
+          },
+          {
+            "Version": "1.74.241.0"
+          },
+          {
+            "Version": "1.74.243.0"
+          },
+          {
+            "Version": "1.74.244.0"
+          },
+          {
+            "Version": "1.74.245.0"
+          },
+          {
+            "Version": "1.74.246.0"
+          },
+          {
+            "Version": "1.74.247.0"
+          },
+          {
+            "Version": "1.74.248.0"
+          },
+          {
+            "Version": "1.74.249.0"
+          },
+          {
+            "Version": "1.74.250.0"
+          },
+          {
+            "Version": "1.74.251.0"
+          },
+          {
+            "Version": "1.74.252.0"
+          },
+          {
+            "Version": "1.74.253.0"
+          },
+          {
+            "Version": "1.74.254.0"
+          },
+          {
+            "Version": "1.74.255.0"
+          },
+          {
+            "Version": "1.74.256.0"
+          },
+          {
+            "Version": "1.74.257.0"
+          },
+          {
+            "Version": "1.74.262.0"
+          },
+          {
+            "Version": "1.74.263.0"
+          },
+          {
+            "Version": "1.74.264.0"
+          },
+          {
+            "Version": "1.74.265.0"
+          },
+          {
+            "Version": "1.74.266.0"
+          },
+          {
+            "Version": "1.74.267.0"
+          },
+          {
+            "Version": "1.74.268.0"
+          },
+          {
+            "Version": "1.74.269.0"
+          },
+          {
+            "Version": "1.74.270.0"
+          },
+          {
+            "Version": "1.74.271.0"
+          },
+          {
+            "Version": "1.74.272.0"
+          },
+          {
+            "Version": "1.74.273.0"
+          },
+          {
+            "Version": "1.74.275.0"
+          },
+          {
+            "Version": "1.74.277.0"
+          },
+          {
+            "Version": "1.74.278.0"
+          },
+          {
+            "Version": "1.74.279.0"
+          },
+          {
+            "Version": "1.74.280.0"
+          },
+          {
+            "Version": "1.74.282.0"
+          },
+          {
+            "Version": "1.74.283.0"
+          },
+          {
+            "Version": "1.74.284.0"
+          },
+          {
+            "Version": "1.74.285.0"
+          },
+          {
+            "Version": "1.74.286.0"
+          },
+          {
+            "Version": "1.74.287.0"
+          },
+          {
+            "Version": "1.74.290.0"
+          },
+          {
+            "Version": "2.0.1-alpha2"
+          },
+          {
+            "Version": "2.0.1-alpha3"
+          },
+          {
+            "Version": "2.0.1-alpha4"
+          },
+          {
+            "Version": "2.0.48.0-alpha"
+          },
+          {
+            "Version": "2.0.55.0-alpha"
+          },
+          {
+            "Version": "2.0.60.0-alpha"
+          },
+          {
+            "Version": "2.0.61.0-alpha"
+          },
+          {
+            "Version": "2.0.62.0-alpha"
+          },
+          {
+            "Version": "2.0.64.0-alpha"
+          },
+          {
+            "Version": "2.0.65.0-alpha"
+          },
+          {
+            "Version": "2.0.66.0-alpha"
+          },
+          {
+            "Version": "2.0.68.0-alpha"
+          },
+          {
+            "Version": "2.0.69.0-alpha"
+          },
+          {
+            "Version": "2.0.70.0-alpha"
+          },
+          {
+            "Version": "2.0.73.0-alpha"
+          },
+          {
+            "Version": "2.0.74.0-alpha"
+          },
+          {
+            "Version": "2.0.75.0-alpha"
+          },
+          {
+            "Version": "2.0.76.0-alpha"
+          },
+          {
+            "Version": "2.0.77.0-alpha"
+          },
+          {
+            "Version": "2.0.78.0-alpha"
+          },
+          {
+            "Version": "2.0.79.0-alpha"
+          },
+          {
+            "Version": "2.0.80.0-alpha"
+          },
+          {
+            "Version": "2.0.81.0-alpha"
+          },
+          {
+            "Version": "2.0.83.0-alpha"
+          },
+          {
+            "Version": "2.0.84.0-alpha"
+          },
+          {
+            "Version": "2.0.85.0-alpha"
+          },
+          {
+            "Version": "2.0.86.0-alpha"
+          },
+          {
+            "Version": "2.0.87.0-alpha"
+          },
+          {
+            "Version": "2.0.90.0-alpha"
+          },
+          {
+            "Version": "2.0.91.0-alpha"
+          },
+          {
+            "Version": "2.0.94.0-alpha"
+          },
+          {
+            "Version": "2.0.95.0-alpha"
+          },
+          {
+            "Version": "2.0.96.0-alpha"
+          },
+          {
+            "Version": "2.0.97.0-alpha"
+          },
+          {
+            "Version": "2.0.98.0-alpha"
+          },
+          {
+            "Version": "2.0.99.0-alpha"
+          },
+          {
+            "Version": "2.1-alpha10"
+          },
+          {
+            "Version": "2.1-alpha13"
+          },
+          {
+            "Version": "2.1-alpha15"
+          },
+          {
+            "Version": "2.1-alpha16"
+          },
+          {
+            "Version": "2.1-alpha17"
+          },
+          {
+            "Version": "2.1-alpha18"
+          },
+          {
+            "Version": "2.1-alpha20"
+          },
+          {
+            "Version": "2.1-alpha22"
+          },
+          {
+            "Version": "2.1-alpha23"
+          },
+          {
+            "Version": "2.1-alpha24"
+          },
+          {
+            "Version": "2.1-alpha5"
+          },
+          {
+            "Version": "2.1-alpha6"
+          },
+          {
+            "Version": "2.1-alpha7"
+          },
+          {
+            "Version": "2.1.1-alpha"
+          },
+          {
+            "Version": "2.1.27-alpha"
+          },
+          {
+            "Version": "2.1.28-alpha"
+          },
+          {
+            "Version": "2.1.29-alpha"
+          },
+          {
+            "Version": "2.1.30-alpha"
+          },
+          {
+            "Version": "2.1.33-alpha"
+          },
+          {
+            "Version": "2.1.35-alpha"
+          },
+          {
+            "Version": "2.1.37-alpha"
+          },
+          {
+            "Version": "2.1.39-alpha"
+          },
+          {
+            "Version": "2.1.41-alpha"
+          },
+          {
+            "Version": "2.1.42-alpha"
+          },
+          {
+            "Version": "2.1.43-alpha"
+          },
+          {
+            "Version": "2.1.46-alpha"
+          },
+          {
+            "Version": "2.1.47-alpha"
+          },
+          {
+            "Version": "2.1.48-alpha"
+          },
+          {
+            "Version": "2.1.50-alpha"
+          },
+          {
+            "Version": "2.1.51-alpha"
+          },
+          {
+            "Version": "2.1.53-alpha"
+          },
+          {
+            "Version": "2.1.58-alpha"
+          },
+          {
+            "Version": "2.1.68-alpha"
+          },
+          {
+            "Version": "2.1.71-alpha"
+          },
+          {
+            "Version": "2.1.72-alpha"
+          },
+          {
+            "Version": "2.1.75-alpha"
+          },
+          {
+            "Version": "2.1.81-alpha"
+          },
+          {
+            "Version": "2.1.83-alpha"
+          },
+          {
+            "Version": "2.1.84-alpha"
+          },
+          {
+            "Version": "2.1.85-alpha"
+          },
+          {
+            "Version": "2.1.86-alpha"
+          },
+          {
+            "Version": "2.1.91-alpha"
+          },
+          {
+            "Version": "2.1.95-alpha"
+          },
+          {
+            "Version": "2.1.97-alpha"
+          },
+          {
+            "Version": "2.1.111-alpha"
+          },
+          {
+            "Version": "2.1.113-alpha"
+          },
+          {
+            "Version": "2.1.118-alpha"
+          },
+          {
+            "Version": "2.1.119-alpha"
+          },
+          {
+            "Version": "2.1.121-alpha"
+          },
+          {
+            "Version": "2.1.123-alpha"
+          },
+          {
+            "Version": "2.1.124-alpha"
+          },
+          {
+            "Version": "2.1.126-alpha"
+          },
+          {
+            "Version": "2.1.128-alpha"
+          },
+          {
+            "Version": "2.1.129-alpha"
+          },
+          {
+            "Version": "2.1.132-alpha"
+          },
+          {
+            "Version": "2.1.133-alpha"
+          },
+          {
+            "Version": "2.1.134-alpha"
+          },
+          {
+            "Version": "2.1.137-alpha"
+          },
+          {
+            "Version": "2.1.138-alpha"
+          },
+          {
+            "Version": "2.1.141-alpha"
+          },
+          {
+            "Version": "2.1.142-alpha"
+          },
+          {
+            "Version": "2.1.144-alpha"
+          },
+          {
+            "Version": "2.1.145-alpha"
+          },
+          {
+            "Version": "2.1.147-alpha"
+          },
+          {
+            "Version": "2.1.148-alpha"
+          },
+          {
+            "Version": "2.1.149-alpha"
+          },
+          {
+            "Version": "2.1.150-alpha"
+          },
+          {
+            "Version": "2.1.151-alpha"
+          },
+          {
+            "Version": "2.1.152-alpha"
+          },
+          {
+            "Version": "2.1.154-alpha"
+          },
+          {
+            "Version": "2.1.155-alpha"
+          },
+          {
+            "Version": "2.1.156-alpha"
+          },
+          {
+            "Version": "2.1.158-alpha"
+          },
+          {
+            "Version": "2.1.159-alpha"
+          },
+          {
+            "Version": "2.1.160-alpha"
+          },
+          {
+            "Version": "2.1.161-alpha"
+          },
+          {
+            "Version": "2.1.162-alpha"
+          },
+          {
+            "Version": "2.1.164-alpha"
+          },
+          {
+            "Version": "2.1.166-alpha"
+          },
+          {
+            "Version": "2.1.167-alpha"
+          },
+          {
+            "Version": "2.1.168-alpha"
+          },
+          {
+            "Version": "2.1.170-alpha"
+          },
+          {
+            "Version": "2.1.171-alpha"
+          },
+          {
+            "Version": "2.1.172-alpha"
+          },
+          {
+            "Version": "2.1.173-alpha"
+          },
+          {
+            "Version": "2.1.174-alpha"
+          },
+          {
+            "Version": "2.1.175-alpha"
+          },
+          {
+            "Version": "2.1.176-alpha"
+          },
+          {
+            "Version": "2.1.178-alpha"
+          },
+          {
+            "Version": "2.1.179-alpha"
+          },
+          {
+            "Version": "2.1.180-alpha"
+          },
+          {
+            "Version": "2.1.182-alpha"
+          },
+          {
+            "Version": "2.1.183-alpha"
+          },
+          {
+            "Version": "2.1.184-alpha"
+          },
+          {
+            "Version": "2.1.185-alpha"
+          },
+          {
+            "Version": "2.1.186-alpha"
+          },
+          {
+            "Version": "2.1.187-alpha"
+          },
+          {
+            "Version": "2.1.192-alpha"
+          },
+          {
+            "Version": "2.1.194-alpha"
+          },
+          {
+            "Version": "2.1.196-alpha"
+          },
+          {
+            "Version": "2.1.199-alpha"
+          },
+          {
+            "Version": "2.1.200-alpha"
+          },
+          {
+            "Version": "2.1.201-alpha"
+          },
+          {
+            "Version": "2.1.204-alpha"
+          },
+          {
+            "Version": "2.1.205-alpha"
+          },
+          {
+            "Version": "2.1.207-alpha"
+          },
+          {
+            "Version": "2.1.208-alpha"
+          },
+          {
+            "Version": "2.1.209-alpha"
+          },
+          {
+            "Version": "2.1.210-alpha"
+          },
+          {
+            "Version": "2.1.211-alpha"
+          },
+          {
+            "Version": "2.1.212-alpha"
+          },
+          {
+            "Version": "2.1.213-alpha"
+          },
+          {
+            "Version": "2.1.215-alpha"
+          },
+          {
+            "Version": "2.1.216-alpha"
+          },
+          {
+            "Version": "2.1.217-alpha"
+          },
+          {
+            "Version": "2.1.218-alpha"
+          },
+          {
+            "Version": "2.1.219-alpha"
+          },
+          {
+            "Version": "2.1.220-alpha"
+          },
+          {
+            "Version": "2.1.222-alpha"
+          },
+          {
+            "Version": "2.1.223-alpha"
+          },
+          {
+            "Version": "2.1.225-alpha"
+          },
+          {
+            "Version": "2.1.226-alpha"
+          },
+          {
+            "Version": "2.1.227-alpha"
+          },
+          {
+            "Version": "2.1.228-alpha"
+          },
+          {
+            "Version": "2.1.230-alpha"
+          },
+          {
+            "Version": "2.1.234-alpha"
+          },
+          {
+            "Version": "2.1.235-alpha"
+          },
+          {
+            "Version": "2.1.236-alpha"
+          },
+          {
+            "Version": "2.1.237-alpha"
+          },
+          {
+            "Version": "2.1.239-alpha"
+          },
+          {
+            "Version": "2.1.240-alpha"
+          },
+          {
+            "Version": "2.1.241-alpha"
+          },
+          {
+            "Version": "2.1.242-alpha"
+          },
+          {
+            "Version": "2.1.243-alpha"
+          },
+          {
+            "Version": "2.1.245-alpha"
+          },
+          {
+            "Version": "2.1.246-alpha"
+          },
+          {
+            "Version": "2.1.247-alpha"
+          },
+          {
+            "Version": "2.1.248-alpha"
+          },
+          {
+            "Version": "2.1.249-alpha"
+          },
+          {
+            "Version": "2.1.251-alpha"
+          },
+          {
+            "Version": "2.1.253-alpha"
+          },
+          {
+            "Version": "2.1.255-alpha"
+          },
+          {
+            "Version": "2.1.256-alpha"
+          },
+          {
+            "Version": "2.1.264-alpha"
+          },
+          {
+            "Version": "2.1.271-alpha"
+          },
+          {
+            "Version": "2.1.272-alpha"
+          },
+          {
+            "Version": "2.1.273-alpha"
+          },
+          {
+            "Version": "2.1.274-alpha"
+          },
+          {
+            "Version": "2.1.275-alpha"
+          },
+          {
+            "Version": "2.1.276-alpha"
+          },
+          {
+            "Version": "2.1.277-alpha"
+          },
+          {
+            "Version": "2.1.279-alpha"
+          },
+          {
+            "Version": "2.1.280-alpha"
+          },
+          {
+            "Version": "2.1.288-alpha"
+          },
+          {
+            "Version": "2.1.289-alpha"
+          },
+          {
+            "Version": "2.1.290-alpha"
+          },
+          {
+            "Version": "2.1.291-alpha"
+          },
+          {
+            "Version": "2.1.292-alpha"
+          },
+          {
+            "Version": "2.1.293-alpha"
+          },
+          {
+            "Version": "2.1.294-alpha"
+          },
+          {
+            "Version": "2.1.295-alpha"
+          },
+          {
+            "Version": "2.1.297-alpha"
+          },
+          {
+            "Version": "2.1.298-alpha"
+          },
+          {
+            "Version": "2.1.299-alpha"
+          },
+          {
+            "Version": "2.1.300-alpha"
+          },
+          {
+            "Version": "2.1.301-alpha"
+          },
+          {
+            "Version": "2.1.302-alpha"
+          },
+          {
+            "Version": "2.1.303-alpha"
+          },
+          {
+            "Version": "2.1.304-alpha"
+          },
+          {
+            "Version": "2.1.305-alpha"
+          },
+          {
+            "Version": "2.1.306-alpha"
+          },
+          {
+            "Version": "2.1.307-alpha"
+          },
+          {
+            "Version": "2.1.308-alpha"
+          },
+          {
+            "Version": "2.1.309-alpha"
+          },
+          {
+            "Version": "2.1.313-alpha"
+          },
+          {
+            "Version": "2.1.314-alpha"
+          },
+          {
+            "Version": "2.1.316-alpha"
+          },
+          {
+            "Version": "2.1.318-alpha"
+          },
+          {
+            "Version": "2.1.319-alpha"
+          },
+          {
+            "Version": "2.1.320-alpha"
+          },
+          {
+            "Version": "2.1.321-alpha"
+          },
+          {
+            "Version": "2.1.322-alpha"
+          },
+          {
+            "Version": "2.1.323-alpha"
+          },
+          {
+            "Version": "2.1.324-alpha"
+          },
+          {
+            "Version": "2.1.325-alpha"
+          },
+          {
+            "Version": "2.1.326-alpha"
+          },
+          {
+            "Version": "2.1.327-alpha"
+          },
+          {
+            "Version": "2.1.328-alpha"
+          },
+          {
+            "Version": "2.1.330-alpha"
+          },
+          {
+            "Version": "2.1.332-alpha"
+          },
+          {
+            "Version": "2.1.334-alpha"
+          },
+          {
+            "Version": "2.1.336-alpha"
+          },
+          {
+            "Version": "2.1.337-alpha"
+          },
+          {
+            "Version": "2.1.338-alpha"
+          },
+          {
+            "Version": "2.1.339-alpha"
+          },
+          {
+            "Version": "2.1.340-alpha"
+          },
+          {
+            "Version": "2.1.341-alpha"
+          },
+          {
+            "Version": "2.1.342-alpha"
+          },
+          {
+            "Version": "2.1.343-alpha"
+          },
+          {
+            "Version": "2.1.344-alpha"
+          },
+          {
+            "Version": "2.1.347-alpha"
+          },
+          {
+            "Version": "2.1.351-alpha"
+          },
+          {
+            "Version": "2.1.352-alpha"
+          },
+          {
+            "Version": "2.1.353-alpha"
+          },
+          {
+            "Version": "2.1.354-alpha"
+          },
+          {
+            "Version": "2.1.355-alpha"
+          },
+          {
+            "Version": "2.1.356-alpha"
+          },
+          {
+            "Version": "2.1.357-alpha"
+          },
+          {
+            "Version": "2.1.358-alpha"
+          },
+          {
+            "Version": "2.1.359-alpha"
+          },
+          {
+            "Version": "2.1.360-alpha"
+          },
+          {
+            "Version": "2.1.361-alpha"
+          },
+          {
+            "Version": "2.1.362-alpha"
+          },
+          {
+            "Version": "2.1.363-alpha"
+          },
+          {
+            "Version": "2.1.364-alpha"
+          },
+          {
+            "Version": "2.1.365-alpha"
+          },
+          {
+            "Version": "2.1.366-alpha"
+          },
+          {
+            "Version": "2.1.367-alpha"
+          },
+          {
+            "Version": "2.1.368-alpha"
+          },
+          {
+            "Version": "2.1.369-alpha"
+          },
+          {
+            "Version": "2.1.371-alpha"
+          },
+          {
+            "Version": "2.1.372-alpha"
+          },
+          {
+            "Version": "2.1.373-alpha"
+          },
+          {
+            "Version": "2.1.374-alpha"
+          },
+          {
+            "Version": "2.1.375-alpha"
+          },
+          {
+            "Version": "2.1.376-alpha"
+          },
+          {
+            "Version": "2.1.378-alpha"
+          },
+          {
+            "Version": "2.1.379-alpha"
+          },
+          {
+            "Version": "2.1.380-alpha"
+          },
+          {
+            "Version": "2.1.381-alpha"
+          },
+          {
+            "Version": "2.1.382-alpha"
+          },
+          {
+            "Version": "2.1.383-alpha"
+          },
+          {
+            "Version": "2.1.384-alpha"
+          },
+          {
+            "Version": "2.1.385-alpha"
+          },
+          {
+            "Version": "2.1.386-alpha"
+          },
+          {
+            "Version": "2.1.387-alpha"
+          },
+          {
+            "Version": "2.1.388-alpha"
+          },
+          {
+            "Version": "2.1.389-alpha"
+          },
+          {
+            "Version": "2.1.390-alpha"
+          },
+          {
+            "Version": "2.1.391-alpha"
+          },
+          {
+            "Version": "2.1.392-alpha"
+          },
+          {
+            "Version": "2.1.393-alpha"
+          },
+          {
+            "Version": "2.1.394-alpha"
+          },
+          {
+            "Version": "2.1.395-alpha"
+          },
+          {
+            "Version": "2.1.396-alpha"
+          },
+          {
+            "Version": "2.1.397-alpha"
+          },
+          {
+            "Version": "2.1.398-alpha"
+          },
+          {
+            "Version": "2.1.399-alpha"
+          },
+          {
+            "Version": "2.1.400-alpha"
+          },
+          {
+            "Version": "2.1.401-alpha"
+          },
+          {
+            "Version": "2.1.402-alpha"
+          },
+          {
+            "Version": "2.1.403-alpha"
+          },
+          {
+            "Version": "2.1.404-alpha"
+          },
+          {
+            "Version": "2.1.405-alpha"
+          },
+          {
+            "Version": "2.1.406-alpha"
+          },
+          {
+            "Version": "2.1.407-alpha"
+          },
+          {
+            "Version": "2.1.408-alpha"
+          },
+          {
+            "Version": "2.1.409-alpha"
+          },
+          {
+            "Version": "2.1.410-alpha"
+          },
+          {
+            "Version": "2.1.411-alpha"
+          },
+          {
+            "Version": "2.1.412-alpha"
+          },
+          {
+            "Version": "2.1.413-alpha"
+          },
+          {
+            "Version": "2.1.414-alpha"
+          },
+          {
+            "Version": "2.1.415-alpha"
+          },
+          {
+            "Version": "2.1.416-alpha"
+          },
+          {
+            "Version": "2.1.417-alpha"
+          },
+          {
+            "Version": "2.1.418-alpha"
+          },
+          {
+            "Version": "2.1.419-alpha"
+          },
+          {
+            "Version": "2.1.420-alpha"
+          },
+          {
+            "Version": "2.1.421-alpha"
+          },
+          {
+            "Version": "2.1.422-alpha"
+          },
+          {
+            "Version": "2.1.423-alpha"
+          },
+          {
+            "Version": "2.1.424-alpha"
+          },
+          {
+            "Version": "2.1.426-alpha"
+          },
+          {
+            "Version": "2.1.427-alpha"
+          },
+          {
+            "Version": "2.1.428-alpha"
+          },
+          {
+            "Version": "2.1.429-alpha"
+          },
+          {
+            "Version": "2.1.430-alpha"
+          },
+          {
+            "Version": "2.1.431-alpha"
+          },
+          {
+            "Version": "2.1.432-alpha"
+          },
+          {
+            "Version": "2.1.434-alpha"
+          },
+          {
+            "Version": "2.1.435-alpha"
+          },
+          {
+            "Version": "2.1.436-alpha"
+          },
+          {
+            "Version": "2.1.437-alpha"
+          },
+          {
+            "Version": "2.1.438-alpha"
+          },
+          {
+            "Version": "2.1.439-alpha"
+          },
+          {
+            "Version": "2.1.440-alpha"
+          },
+          {
+            "Version": "2.1.441-alpha"
+          },
+          {
+            "Version": "2.1.442-alpha"
+          },
+          {
+            "Version": "2.1.443-alpha"
+          },
+          {
+            "Version": "2.1.445-alpha"
+          },
+          {
+            "Version": "2.1.449-alpha"
+          },
+          {
+            "Version": "2.1.461-alpha"
+          },
+          {
+            "Version": "2.1.465-alpha"
+          },
+          {
+            "Version": "2.1.468-alpha"
+          },
+          {
+            "Version": "2.1.469-alpha"
+          },
+          {
+            "Version": "2.1.470-alpha"
+          },
+          {
+            "Version": "2.1.471-alpha"
+          },
+          {
+            "Version": "2.1.472-alpha"
+          },
+          {
+            "Version": "2.1.473-alpha"
+          },
+          {
+            "Version": "2.1.474-alpha"
+          },
+          {
+            "Version": "2.1.475-alpha"
+          },
+          {
+            "Version": "2.1.476-alpha"
+          },
+          {
+            "Version": "2.1.478-alpha"
+          },
+          {
+            "Version": "2.1.479-alpha"
+          },
+          {
+            "Version": "2.1.480-alpha"
+          },
+          {
+            "Version": "2.1.481-alpha"
+          },
+          {
+            "Version": "2.1.482-alpha"
+          },
+          {
+            "Version": "2.1.483-alpha"
+          },
+          {
+            "Version": "2.1.485-alpha"
+          },
+          {
+            "Version": "2.1.486-alpha"
+          },
+          {
+            "Version": "2.1.487-alpha"
+          },
+          {
+            "Version": "2.1.488-alpha"
+          },
+          {
+            "Version": "2.1.489-alpha"
+          },
+          {
+            "Version": "2.1.490-alpha"
+          },
+          {
+            "Version": "2.1.491-alpha"
+          },
+          {
+            "Version": "2.1.492-alpha"
+          },
+          {
+            "Version": "2.1.493-alpha"
+          },
+          {
+            "Version": "2.1.494-alpha"
+          },
+          {
+            "Version": "2.1.495-alpha"
+          },
+          {
+            "Version": "2.1.496-alpha"
+          },
+          {
+            "Version": "2.1.497-alpha"
+          },
+          {
+            "Version": "2.1.498-alpha"
+          },
+          {
+            "Version": "2.1.499-alpha"
+          },
+          {
+            "Version": "2.1.500-alpha"
+          },
+          {
+            "Version": "2.1.502-alpha"
+          },
+          {
+            "Version": "2.1.503-alpha"
+          },
+          {
+            "Version": "2.1.504-alpha"
+          },
+          {
+            "Version": "2.1.505-alpha"
+          },
+          {
+            "Version": "2.1.507-alpha"
+          },
+          {
+            "Version": "2.1.509-alpha"
+          },
+          {
+            "Version": "2.1.520-alpha"
+          },
+          {
+            "Version": "2.1.521-alpha"
+          },
+          {
+            "Version": "2.1.522-alpha"
+          },
+          {
+            "Version": "2.1.524-alpha"
+          },
+          {
+            "Version": "2.1.526-alpha"
+          },
+          {
+            "Version": "2.1.527-alpha"
+          },
+          {
+            "Version": "2.1.528-alpha"
+          },
+          {
+            "Version": "2.1.530-alpha"
+          },
+          {
+            "Version": "2.1.531-alpha"
+          },
+          {
+            "Version": "2.1.533-alpha"
+          },
+          {
+            "Version": "2.1.534-alpha"
+          },
+          {
+            "Version": "2.1.535-alpha"
+          },
+          {
+            "Version": "2.1.536-alpha"
+          },
+          {
+            "Version": "2.1.537-alpha"
+          },
+          {
+            "Version": "2.1.538-alpha"
+          },
+          {
+            "Version": "2.1.539-alpha"
+          },
+          {
+            "Version": "2.1.540-alpha"
+          },
+          {
+            "Version": "2.1.542-alpha"
+          },
+          {
+            "Version": "2.1.543-alpha"
+          },
+          {
+            "Version": "2.1.544-alpha"
+          },
+          {
+            "Version": "2.1.545-alpha"
+          },
+          {
+            "Version": "2.1.546-alpha"
+          },
+          {
+            "Version": "2.1.547-alpha"
+          },
+          {
+            "Version": "2.1.548-alpha"
+          },
+          {
+            "Version": "2.1.549-alpha"
+          },
+          {
+            "Version": "2.1.550-alpha"
+          },
+          {
+            "Version": "2.1.551-alpha"
+          },
+          {
+            "Version": "2.1.552-alpha"
+          },
+          {
+            "Version": "2.1.553-alpha"
+          },
+          {
+            "Version": "2.1.554-alpha"
+          },
+          {
+            "Version": "2.1.555-alpha"
+          },
+          {
+            "Version": "2.1.556-alpha"
+          },
+          {
+            "Version": "2.1.557-alpha"
+          },
+          {
+            "Version": "2.1.560-alpha"
+          },
+          {
+            "Version": "2.1.561-alpha"
+          },
+          {
+            "Version": "2.1.562-alpha"
+          },
+          {
+            "Version": "2.1.563-alpha"
+          },
+          {
+            "Version": "2.1.564-alpha"
+          },
+          {
+            "Version": "2.1.566-alpha"
+          },
+          {
+            "Version": "2.1.567-alpha"
+          },
+          {
+            "Version": "2.1.568-alpha"
+          },
+          {
+            "Version": "2.1.569-alpha"
+          },
+          {
+            "Version": "2.1.570-alpha"
+          },
+          {
+            "Version": "2.1.571-alpha"
+          },
+          {
+            "Version": "2.1.572-alpha"
+          },
+          {
+            "Version": "2.1.573-alpha"
+          },
+          {
+            "Version": "2.1.574-alpha"
+          },
+          {
+            "Version": "2.1.575-alpha"
+          },
+          {
+            "Version": "2.1.576-alpha"
+          },
+          {
+            "Version": "2.1.577-alpha"
+          },
+          {
+            "Version": "2.1.578-alpha"
+          },
+          {
+            "Version": "2.1.580-alpha"
+          },
+          {
+            "Version": "2.1.581-alpha"
+          },
+          {
+            "Version": "2.1.583-alpha"
+          },
+          {
+            "Version": "2.1.584-alpha"
+          },
+          {
+            "Version": "2.1.585-alpha"
+          },
+          {
+            "Version": "2.1.586-alpha"
+          },
+          {
+            "Version": "2.1.587-alpha"
+          },
+          {
+            "Version": "2.1.588-alpha"
+          },
+          {
+            "Version": "2.1.589-alpha"
+          },
+          {
+            "Version": "2.1.591-alpha"
+          },
+          {
+            "Version": "2.1.592-alpha"
+          },
+          {
+            "Version": "2.1.593-alpha"
+          },
+          {
+            "Version": "2.1.594-alpha"
+          },
+          {
+            "Version": "2.1.595-alpha"
+          },
+          {
+            "Version": "2.1.596-alpha"
+          },
+          {
+            "Version": "2.1.597-alpha"
+          },
+          {
+            "Version": "2.1.598-alpha"
+          },
+          {
+            "Version": "2.1.600-alpha"
+          },
+          {
+            "Version": "2.1.601-alpha"
+          },
+          {
+            "Version": "2.1.602-alpha"
+          },
+          {
+            "Version": "2.1.603-alpha"
+          },
+          {
+            "Version": "2.1.604-alpha"
+          },
+          {
+            "Version": "2.1.605-alpha"
+          },
+          {
+            "Version": "2.1.607-alpha"
+          },
+          {
+            "Version": "2.1.609-alpha"
+          },
+          {
+            "Version": "2.1.611-alpha"
+          },
+          {
+            "Version": "2.1.612-alpha"
+          },
+          {
+            "Version": "2.1.614-alpha"
+          },
+          {
+            "Version": "2.1.616-alpha"
+          },
+          {
+            "Version": "2.1.617-alpha"
+          },
+          {
+            "Version": "2.1.618-alpha"
+          },
+          {
+            "Version": "2.1.620-alpha"
+          },
+          {
+            "Version": "2.1.621-alpha"
+          },
+          {
+            "Version": "2.1.622-alpha"
+          },
+          {
+            "Version": "2.1.623-alpha"
+          },
+          {
+            "Version": "2.1.624-alpha"
+          },
+          {
+            "Version": "2.1.625-alpha"
+          },
+          {
+            "Version": "2.1.626-alpha"
+          },
+          {
+            "Version": "2.1.629-alpha"
+          },
+          {
+            "Version": "2.1.630-alpha"
+          },
+          {
+            "Version": "2.1.631-alpha"
+          },
+          {
+            "Version": "2.1.632-alpha"
+          },
+          {
+            "Version": "2.1.633-alpha"
+          },
+          {
+            "Version": "2.1.634-alpha"
+          },
+          {
+            "Version": "2.1.635-alpha"
+          },
+          {
+            "Version": "2.1.636-alpha"
+          },
+          {
+            "Version": "2.1.637-alpha"
+          },
+          {
+            "Version": "2.1.638-alpha"
+          },
+          {
+            "Version": "2.1.639-alpha"
+          },
+          {
+            "Version": "2.1.640-alpha"
+          },
+          {
+            "Version": "2.1.641-alpha"
+          },
+          {
+            "Version": "2.1.642-alpha"
+          },
+          {
+            "Version": "2.1.643-alpha"
+          },
+          {
+            "Version": "2.1.645-alpha"
+          },
+          {
+            "Version": "2.1.646-alpha"
+          },
+          {
+            "Version": "2.1.647-alpha"
+          },
+          {
+            "Version": "2.1.648-alpha"
+          },
+          {
+            "Version": "2.1.649-alpha"
+          },
+          {
+            "Version": "2.1.651-alpha"
+          },
+          {
+            "Version": "2.1.652-alpha"
+          },
+          {
+            "Version": "2.1.653-alpha"
+          },
+          {
+            "Version": "2.1.654-alpha"
+          },
+          {
+            "Version": "2.1.655-alpha"
+          },
+          {
+            "Version": "2.1.656-alpha"
+          },
+          {
+            "Version": "2.1.657-alpha"
+          },
+          {
+            "Version": "2.1.658-alpha"
+          },
+          {
+            "Version": "2.1.659-alpha"
+          },
+          {
+            "Version": "2.1.660-alpha"
+          },
+          {
+            "Version": "2.1.661-alpha"
+          },
+          {
+            "Version": "2.1.662-alpha"
+          },
+          {
+            "Version": "2.1.663-alpha"
+          },
+          {
+            "Version": "2.1.664-alpha"
+          },
+          {
+            "Version": "2.1.665-alpha"
+          },
+          {
+            "Version": "2.1.666-alpha"
+          },
+          {
+            "Version": "2.1.667-alpha"
+          },
+          {
+            "Version": "2.1.668-alpha"
+          },
+          {
+            "Version": "2.1.671-alpha"
+          },
+          {
+            "Version": "2.1.672-alpha"
+          },
+          {
+            "Version": "2.1.673-alpha"
+          },
+          {
+            "Version": "2.1.674-alpha"
+          },
+          {
+            "Version": "2.1.675-alpha"
+          },
+          {
+            "Version": "2.1.676-alpha"
+          },
+          {
+            "Version": "2.1.677-alpha"
+          },
+          {
+            "Version": "2.1.678-alpha"
+          },
+          {
+            "Version": "2.1.679-alpha"
+          },
+          {
+            "Version": "2.1.680-alpha"
+          },
+          {
+            "Version": "2.1.681-alpha"
+          },
+          {
+            "Version": "2.1.682-alpha"
+          },
+          {
+            "Version": "2.1.683-alpha"
+          },
+          {
+            "Version": "2.1.685-alpha"
+          },
+          {
+            "Version": "2.1.686-alpha"
+          },
+          {
+            "Version": "2.1.687-alpha"
+          },
+          {
+            "Version": "2.1.688-alpha"
+          },
+          {
+            "Version": "2.1.711-alpha"
+          },
+          {
+            "Version": "2.1.713-alpha"
+          },
+          {
+            "Version": "2.1.714-alpha"
+          },
+          {
+            "Version": "2.1.718-alpha"
+          },
+          {
+            "Version": "2.1.724-alpha"
+          },
+          {
+            "Version": "2.1.726-alpha"
+          },
+          {
+            "Version": "2.1.727-alpha"
+          },
+          {
+            "Version": "2.1.728-alpha"
+          },
+          {
+            "Version": "2.1.729-alpha"
+          },
+          {
+            "Version": "2.1.730-alpha"
+          },
+          {
+            "Version": "2.1.731-alpha"
+          },
+          {
+            "Version": "2.1.732-alpha"
+          },
+          {
+            "Version": "2.1.733-alpha"
+          },
+          {
+            "Version": "2.1.735-alpha"
+          },
+          {
+            "Version": "2.1.737-alpha"
+          },
+          {
+            "Version": "2.1.738-alpha"
+          },
+          {
+            "Version": "2.1.739-alpha"
+          },
+          {
+            "Version": "2.1.740-alpha"
+          },
+          {
+            "Version": "2.1.742-alpha"
+          },
+          {
+            "Version": "2.1.743-alpha"
+          },
+          {
+            "Version": "2.1.744-alpha"
+          },
+          {
+            "Version": "2.1.745-alpha"
+          },
+          {
+            "Version": "2.1.746-alpha"
+          },
+          {
+            "Version": "2.1.747-alpha"
+          },
+          {
+            "Version": "2.1.748-alpha"
+          },
+          {
+            "Version": "2.1.750-alpha"
+          },
+          {
+            "Version": "2.1.756-alpha"
+          },
+          {
+            "Version": "2.1.758-alpha"
+          },
+          {
+            "Version": "2.1.765-alpha"
+          },
+          {
+            "Version": "2.1.766-alpha"
+          },
+          {
+            "Version": "2.1.767-alpha"
+          },
+          {
+            "Version": "2.1.768-alpha"
+          },
+          {
+            "Version": "2.1.770-alpha"
+          },
+          {
+            "Version": "2.1.771-alpha"
+          },
+          {
+            "Version": "2.1.772-alpha"
+          },
+          {
+            "Version": "2.1.773-alpha"
+          },
+          {
+            "Version": "2.1.774-alpha"
+          },
+          {
+            "Version": "2.1.775-alpha"
+          },
+          {
+            "Version": "2.1.778-alpha"
+          },
+          {
+            "Version": "2.1.779-alpha"
+          },
+          {
+            "Version": "2.1.781-alpha"
+          },
+          {
+            "Version": "2.2.0.0"
+          },
+          {
+            "Version": "2.2.1.0"
+          },
+          {
+            "Version": "2.2.2.0"
+          },
+          {
+            "Version": "2.2.4.0"
+          },
+          {
+            "Version": "2.2.6.0"
+          },
+          {
+            "Version": "2.2.7.0"
+          },
+          {
+            "Version": "2.2.8.0"
+          },
+          {
+            "Version": "2.2.9.0"
+          },
+          {
+            "Version": "2.2.10.0"
+          },
+          {
+            "Version": "2.2.11.0"
+          },
+          {
+            "Version": "2.2.12.0"
+          },
+          {
+            "Version": "2.2.13.0"
+          },
+          {
+            "Version": "2.2.14.0"
+          },
+          {
+            "Version": "2.2.18.0"
+          },
+          {
+            "Version": "2.2.19.0"
+          },
+          {
+            "Version": "2.2.20.0"
+          },
+          {
+            "Version": "2.2.21.0"
+          },
+          {
+            "Version": "2.2.22.0"
+          },
+          {
+            "Version": "2.2.23.0"
+          },
+          {
+            "Version": "2.3.1-alpha"
+          },
+          {
+            "Version": "2.3.2-alpha"
+          },
+          {
+            "Version": "2.3.5-alpha"
+          },
+          {
+            "Version": "2.3.8-alpha"
+          },
+          {
+            "Version": "2.3.10-alpha"
+          },
+          {
+            "Version": "2.3.11-alpha"
+          },
+          {
+            "Version": "2.3.14-alpha"
+          },
+          {
+            "Version": "2.3.15-alpha"
+          },
+          {
+            "Version": "2.3.16-alpha"
+          },
+          {
+            "Version": "2.3.17-alpha"
+          },
+          {
+            "Version": "2.3.18-alpha"
+          },
+          {
+            "Version": "2.3.19-alpha"
+          },
+          {
+            "Version": "2.3.20-alpha"
+          },
+          {
+            "Version": "2.3.21-alpha"
+          },
+          {
+            "Version": "2.3.22-alpha"
+          },
+          {
+            "Version": "2.3.23-alpha"
+          },
+          {
+            "Version": "2.3.24-alpha"
+          },
+          {
+            "Version": "2.3.26-alpha"
+          },
+          {
+            "Version": "2.3.28-alpha"
+          },
+          {
+            "Version": "2.3.30-alpha"
+          },
+          {
+            "Version": "2.3.31-alpha"
+          },
+          {
+            "Version": "2.3.32-alpha"
+          },
+          {
+            "Version": "2.3.33-alpha"
+          },
+          {
+            "Version": "2.3.34-alpha"
+          },
+          {
+            "Version": "2.3.36-alpha"
+          },
+          {
+            "Version": "2.3.37-alpha"
+          },
+          {
+            "Version": "2.3.38-alpha"
+          },
+          {
+            "Version": "2.3.39-alpha"
+          },
+          {
+            "Version": "2.3.41-alpha"
+          },
+          {
+            "Version": "2.3.43-alpha"
+          },
+          {
+            "Version": "2.3.49-alpha"
+          },
+          {
+            "Version": "2.3.50-alpha"
+          },
+          {
+            "Version": "2.3.51-alpha"
+          },
+          {
+            "Version": "2.3.54-alpha"
+          },
+          {
+            "Version": "2.3.55-alpha"
+          },
+          {
+            "Version": "2.3.57-alpha"
+          },
+          {
+            "Version": "2.3.58-alpha"
+          },
+          {
+            "Version": "2.3.59-alpha"
+          },
+          {
+            "Version": "2.3.60-alpha"
+          },
+          {
+            "Version": "2.3.61-alpha"
+          },
+          {
+            "Version": "2.3.62-alpha"
+          },
+          {
+            "Version": "2.3.63-alpha"
+          },
+          {
+            "Version": "2.3.64-alpha"
+          },
+          {
+            "Version": "2.3.65-alpha"
+          },
+          {
+            "Version": "2.3.66-alpha"
+          },
+          {
+            "Version": "2.3.67-alpha"
+          },
+          {
+            "Version": "2.3.68-alpha"
+          },
+          {
+            "Version": "2.3.69-alpha"
+          },
+          {
+            "Version": "2.3.70-alpha"
+          },
+          {
+            "Version": "2.3.71-alpha"
+          },
+          {
+            "Version": "2.3.72-alpha"
+          },
+          {
+            "Version": "2.3.73-alpha"
+          },
+          {
+            "Version": "2.3.74-alpha"
+          },
+          {
+            "Version": "2.3.75-alpha"
+          },
+          {
+            "Version": "2.3.76-alpha"
+          },
+          {
+            "Version": "2.3.77-alpha"
+          },
+          {
+            "Version": "2.3.78-alpha"
+          },
+          {
+            "Version": "2.3.79-alpha"
+          },
+          {
+            "Version": "2.3.80-alpha"
+          },
+          {
+            "Version": "2.3.81-alpha"
+          },
+          {
+            "Version": "2.3.82-alpha"
+          },
+          {
+            "Version": "2.3.83-alpha"
+          },
+          {
+            "Version": "2.3.84-alpha"
+          },
+          {
+            "Version": "2.3.85-alpha"
+          },
+          {
+            "Version": "2.3.86-alpha"
+          },
+          {
+            "Version": "2.3.87-alpha"
+          },
+          {
+            "Version": "2.3.88-alpha"
+          },
+          {
+            "Version": "2.4.0.0"
+          },
+          {
+            "Version": "2.4.1.0"
+          },
+          {
+            "Version": "2.4.2.0"
+          },
+          {
+            "Version": "2.4.3.0"
+          },
+          {
+            "Version": "2.4.4.0"
+          },
+          {
+            "Version": "2.4.5.0"
+          },
+          {
+            "Version": "2.4.6.0"
+          },
+          {
+            "Version": "2.4.7.0"
+          },
+          {
+            "Version": "2.4.8.0"
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.4-alpha"
+          },
+          {
+            "Version": "2.5.5-alpha"
+          },
+          {
+            "Version": "2.5.7-alpha"
+          },
+          {
+            "Version": "2.5.8-alpha"
+          },
+          {
+            "Version": "2.5.9-alpha"
+          },
+          {
+            "Version": "2.5.10-alpha"
+          },
+          {
+            "Version": "2.5.11-alpha"
+          },
+          {
+            "Version": "2.5.12-alpha"
+          },
+          {
+            "Version": "2.5.17-alpha"
+          },
+          {
+            "Version": "2.5.18-alpha"
+          },
+          {
+            "Version": "2.5.19-alpha"
+          },
+          {
+            "Version": "2.5.20-alpha"
+          },
+          {
+            "Version": "2.5.21-alpha"
+          },
+          {
+            "Version": "2.5.22-alpha"
+          },
+          {
+            "Version": "2.5.25-alpha"
+          },
+          {
+            "Version": "2.5.31-alpha"
+          },
+          {
+            "Version": "2.5.32-alpha"
+          },
+          {
+            "Version": "2.5.33-alpha"
+          },
+          {
+            "Version": "2.5.34-alpha"
+          },
+          {
+            "Version": "2.5.35-alpha"
+          },
+          {
+            "Version": "2.5.39-alpha"
+          },
+          {
+            "Version": "2.5.40-alpha"
+          },
+          {
+            "Version": "2.5.41-alpha"
+          },
+          {
+            "Version": "2.5.42-alpha"
+          },
+          {
+            "Version": "2.5.43-alpha"
+          },
+          {
+            "Version": "2.5.44-alpha"
+          },
+          {
+            "Version": "2.5.45-alpha"
+          },
+          {
+            "Version": "2.5.46-alpha"
+          },
+          {
+            "Version": "2.5.47-alpha"
+          },
+          {
+            "Version": "2.5.48-alpha"
+          },
+          {
+            "Version": "2.5.49-alpha"
+          },
+          {
+            "Version": "2.5.54-alpha"
+          },
+          {
+            "Version": "2.5.55-alpha"
+          },
+          {
+            "Version": "2.5.56-alpha"
+          },
+          {
+            "Version": "2.5.57-alpha"
+          },
+          {
+            "Version": "2.5.58-alpha"
+          },
+          {
+            "Version": "2.5.59-alpha"
+          },
+          {
+            "Version": "2.5.60-alpha"
+          },
+          {
+            "Version": "2.5.61-alpha"
+          },
+          {
+            "Version": "2.5.62-alpha"
+          },
+          {
+            "Version": "2.5.63-alpha"
+          },
+          {
+            "Version": "2.5.64-alpha"
+          },
+          {
+            "Version": "2.5.65-alpha"
+          },
+          {
+            "Version": "2.5.66-alpha"
+          },
+          {
+            "Version": "2.5.67-alpha"
+          },
+          {
+            "Version": "2.5.68-alpha"
+          },
+          {
+            "Version": "2.5.69-alpha"
+          },
+          {
+            "Version": "2.5.70-alpha"
+          },
+          {
+            "Version": "2.5.71-alpha"
+          },
+          {
+            "Version": "2.5.72-alpha"
+          },
+          {
+            "Version": "2.5.73-alpha"
+          },
+          {
+            "Version": "2.5.74-alpha"
+          },
+          {
+            "Version": "2.5.75-alpha"
+          },
+          {
+            "Version": "2.6.0.0"
+          },
+          {
+            "Version": "2.6.1.0"
+          },
+          {
+            "Version": "2.6.3.0"
+          },
+          {
+            "Version": "2.6.5.0"
+          },
+          {
+            "Version": "2.6.7.0"
+          },
+          {
+            "Version": "2.6.9.0"
+          },
+          {
+            "Version": "2.6.12.0"
+          },
+          {
+            "Version": "2.6.14.0"
+          },
+          {
+            "Version": "2.6.15.0"
+          },
+          {
+            "Version": "2.6.16.0"
+          },
+          {
+            "Version": "2.6.17.0"
+          },
+          {
+            "Version": "2.7.0-alpha10"
+          },
+          {
+            "Version": "2.7.0-alpha11"
+          },
+          {
+            "Version": "2.7.0-alpha13"
+          },
+          {
+            "Version": "2.7.0-alpha14"
+          },
+          {
+            "Version": "2.7.0-alpha15"
+          },
+          {
+            "Version": "2.7.0-alpha7"
+          },
+          {
+            "Version": "2.7.0-alpha8"
+          },
+          {
+            "Version": "2.7.0-alpha9"
+          },
+          {
+            "Version": "2.7.0.16-alpha"
+          },
+          {
+            "Version": "2.7.0.17-alpha"
+          },
+          {
+            "Version": "2.7.0.18-alpha"
+          },
+          {
+            "Version": "2.7.0.19-alpha"
+          },
+          {
+            "Version": "2.7.0.20-alpha"
+          },
+          {
+            "Version": "2.7.0.21-alpha"
+          },
+          {
+            "Version": "2.7.0.23-alpha"
+          },
+          {
+            "Version": "2.7.0.24-alpha"
+          },
+          {
+            "Version": "2.7.0.25-alpha"
+          },
+          {
+            "Version": "2.7.0.26-alpha"
+          },
+          {
+            "Version": "2.7.0.27-alpha"
+          },
+          {
+            "Version": "2.7.0.28-alpha"
+          },
+          {
+            "Version": "2.7.0.29-alpha"
+          },
+          {
+            "Version": "2.7.0.30-alpha"
+          },
+          {
+            "Version": "2.7.0.32-alpha"
+          },
+          {
+            "Version": "2.7.0.34-alpha"
+          },
+          {
+            "Version": "2.7.0.35-alpha"
+          },
+          {
+            "Version": "2.7.0.36-alpha"
+          },
+          {
+            "Version": "2.7.0.37-alpha"
+          },
+          {
+            "Version": "2.7.0.38-alpha"
+          },
+          {
+            "Version": "2.7.0.39-alpha"
+          },
+          {
+            "Version": "2.7.0.42-alpha"
+          },
+          {
+            "Version": "2.7.0.43-alpha"
+          },
+          {
+            "Version": "2.7.0.44-alpha"
+          },
+          {
+            "Version": "2.7.0.45-alpha"
+          },
+          {
+            "Version": "2.7.0.47-alpha"
+          },
+          {
+            "Version": "2.7.0.50-alpha"
+          },
+          {
+            "Version": "2.7.0.59-alpha"
+          },
+          {
+            "Version": "2.7.0.60-alpha"
+          },
+          {
+            "Version": "2.7.0.61-alpha"
+          },
+          {
+            "Version": "2.7.0.62-alpha"
+          },
+          {
+            "Version": "2.7.0.63-alpha"
+          },
+          {
+            "Version": "2.7.0.64-alpha"
+          },
+          {
+            "Version": "2.7.0.65-alpha"
+          },
+          {
+            "Version": "2.7.0.66-alpha"
+          },
+          {
+            "Version": "2.7.0.72-alpha"
+          },
+          {
+            "Version": "2.7.0.84-alpha"
+          },
+          {
+            "Version": "2.7.0.85-alpha"
+          },
+          {
+            "Version": "2.7.0.86-alpha"
+          },
+          {
+            "Version": "2.7.0.87-alpha"
+          },
+          {
+            "Version": "2.7.0.88-alpha"
+          },
+          {
+            "Version": "2.7.0.90-alpha"
+          },
+          {
+            "Version": "2.7.0.91-alpha"
+          },
+          {
+            "Version": "2.7.0.92-alpha"
+          },
+          {
+            "Version": "2.7.1-alpha"
+          },
+          {
+            "Version": "2.8.0.0"
+          },
+          {
+            "Version": "2.8.1.0"
+          },
+          {
+            "Version": "2.8.2.0"
+          },
+          {
+            "Version": "2.8.3.0"
+          },
+          {
+            "Version": "2.8.5.0"
+          },
+          {
+            "Version": "2.8.6.0"
+          },
+          {
+            "Version": "2.8.7.0"
+          },
+          {
+            "Version": "2.8.8.0"
+          },
+          {
+            "Version": "2.8.9.0"
+          },
+          {
+            "Version": "2.8.10.0"
+          },
+          {
+            "Version": "2.8.11.0"
+          },
+          {
+            "Version": "2.8.12.0"
+          },
+          {
+            "Version": "2.8.17.0"
+          },
+          {
+            "Version": "2.9.0.0-alpha"
+          },
+          {
+            "Version": "2.9.0.1-alpha"
+          },
+          {
+            "Version": "2.9.0.3-alpha"
+          },
+          {
+            "Version": "2.9.11-alpha"
+          },
+          {
+            "Version": "2.9.12-alpha"
+          },
+          {
+            "Version": "2.9.14-alpha"
+          },
+          {
+            "Version": "2.9.15-alpha"
+          },
+          {
+            "Version": "2.9.17-alpha"
+          },
+          {
+            "Version": "2.9.19-alpha"
+          },
+          {
+            "Version": "2.9.20-alpha"
+          },
+          {
+            "Version": "2.9.21-alpha"
+          },
+          {
+            "Version": "2.9.22-alpha"
+          },
+          {
+            "Version": "2.9.23-alpha"
+          },
+          {
+            "Version": "2.9.24-alpha"
+          },
+          {
+            "Version": "2.9.26-alpha"
+          },
+          {
+            "Version": "2.9.27-alpha"
+          },
+          {
+            "Version": "2.9.28-alpha"
+          },
+          {
+            "Version": "2.9.29-alpha"
+          },
+          {
+            "Version": "2.9.30-alpha"
+          },
+          {
+            "Version": "2.9.31-alpha"
+          },
+          {
+            "Version": "2.9.32-alpha"
+          },
+          {
+            "Version": "2.9.33-alpha"
+          },
+          {
+            "Version": "2.9.34-alpha"
+          },
+          {
+            "Version": "2.9.35-alpha"
+          },
+          {
+            "Version": "2.9.36-alpha"
+          },
+          {
+            "Version": "2.9.37-alpha"
+          },
+          {
+            "Version": "2.9.41-alpha"
+          },
+          {
+            "Version": "2.9.42-alpha"
+          },
+          {
+            "Version": "2.9.44-alpha"
+          },
+          {
+            "Version": "2.9.45-alpha"
+          },
+          {
+            "Version": "2.9.46-alpha"
+          },
+          {
+            "Version": "2.9.47-alpha"
+          },
+          {
+            "Version": "2.10.0.0"
+          },
+          {
+            "Version": "2.10.1.0"
+          },
+          {
+            "Version": "2.10.2.0"
+          },
+          {
+            "Version": "2.10.3.0"
+          },
+          {
+            "Version": "2.10.4.0"
+          },
+          {
+            "Version": "2.10.5.0"
+          },
+          {
+            "Version": "2.10.6.0"
+          },
+          {
+            "Version": "2.10.7.0"
+          },
+          {
+            "Version": "2.10.8.0"
+          },
+          {
+            "Version": "2.10.9.0"
+          },
+          {
+            "Version": "2.10.10.0"
+          },
+          {
+            "Version": "2.10.11.0"
+          },
+          {
+            "Version": "2.10.12.0"
+          },
+          {
+            "Version": "2.10.13.0"
+          },
+          {
+            "Version": "2.10.14.0"
+          },
+          {
+            "Version": "2.10.15.0"
+          },
+          {
+            "Version": "2.10.16.0"
+          },
+          {
+            "Version": "2.10.17.0"
+          },
+          {
+            "Version": "2.10.18.0"
+          },
+          {
+            "Version": "2.10.19.0"
+          },
+          {
+            "Version": "2.10.20.0"
+          },
+          {
+            "Version": "2.10.23.0"
+          },
+          {
+            "Version": "2.10.24.0"
+          },
+          {
+            "Version": "2.10.25.0"
+          },
+          {
+            "Version": "2.11.0-alpha"
+          },
+          {
+            "Version": "2.11.1-alpha"
+          },
+          {
+            "Version": "2.11.2-alpha"
+          },
+          {
+            "Version": "2.11.3-alpha"
+          },
+          {
+            "Version": "2.11.4-alpha"
+          },
+          {
+            "Version": "2.11.5-alpha"
+          },
+          {
+            "Version": "2.11.6-alpha"
+          },
+          {
+            "Version": "2.11.8-alpha"
+          },
+          {
+            "Version": "2.11.9-alpha"
+          },
+          {
+            "Version": "2.11.10-alpha"
+          },
+          {
+            "Version": "2.11.11-alpha"
+          },
+          {
+            "Version": "2.11.12-alpha"
+          },
+          {
+            "Version": "2.11.13-alpha"
+          },
+          {
+            "Version": "2.11.14-alpha"
+          },
+          {
+            "Version": "2.11.15-alpha"
+          },
+          {
+            "Version": "2.11.16-alpha"
+          },
+          {
+            "Version": "2.11.17-alpha"
+          },
+          {
+            "Version": "2.11.18-alpha"
+          },
+          {
+            "Version": "2.11.19-alpha"
+          },
+          {
+            "Version": "2.11.20-alpha"
+          },
+          {
+            "Version": "2.11.21-alpha"
+          },
+          {
+            "Version": "2.11.22-alpha"
+          },
+          {
+            "Version": "2.11.25-alpha"
+          },
+          {
+            "Version": "2.11.27-alpha"
+          },
+          {
+            "Version": "2.11.28-alpha"
+          },
+          {
+            "Version": "2.11.29-alpha"
+          },
+          {
+            "Version": "2.11.30-alpha"
+          },
+          {
+            "Version": "2.11.31-alpha"
+          },
+          {
+            "Version": "2.11.32-alpha"
+          },
+          {
+            "Version": "2.11.33-alpha"
+          },
+          {
+            "Version": "2.11.40-alpha"
+          },
+          {
+            "Version": "2.11.41-alpha"
+          },
+          {
+            "Version": "2.11.50-alpha"
+          },
+          {
+            "Version": "2.11.51-alpha"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.2"
+          },
+          {
+            "Version": "2.13.0-alpha1"
+          },
+          {
+            "Version": "2.13.0-alpha2"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.12"
+          },
+          {
+            "Version": "2.14.13"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.15.7"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "2.16.3"
+          },
+          {
+            "Version": "2.17.0"
+          },
+          {
+            "Version": "2.17.1"
+          },
+          {
+            "Version": "2.17.2"
+          },
+          {
+            "Version": "2.17.3-alpha1"
+          },
+          {
+            "Version": "2.17.3-alpha2"
+          },
+          {
+            "Version": "2.17.3"
+          },
+          {
+            "Version": "2.17.4"
+          },
+          {
+            "Version": "2.17.5"
+          },
+          {
+            "Version": "2.17.6"
+          },
+          {
+            "Version": "2.17.7"
+          },
+          {
+            "Version": "2.17.8"
+          },
+          {
+            "Version": "2.17.9"
+          },
+          {
+            "Version": "2.18.0-alpha1"
+          },
+          {
+            "Version": "2.18.0-alpha2"
+          },
+          {
+            "Version": "2.18.0-alpha3"
+          },
+          {
+            "Version": "2.18.0"
+          },
+          {
+            "Version": "2.18.1"
+          },
+          {
+            "Version": "2.18.2"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha10"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "3.2.5"
+          },
+          {
+            "Version": "3.2.6"
+          },
+          {
+            "Version": "3.2.7"
+          },
+          {
+            "Version": "3.2.8"
+          },
+          {
+            "Version": "3.2.9"
+          },
+          {
+            "Version": "3.2.10"
+          },
+          {
+            "Version": "3.2.11"
+          },
+          {
+            "Version": "3.2.12"
+          },
+          {
+            "Version": "3.2.13"
+          },
+          {
+            "Version": "3.2.14"
+          },
+          {
+            "Version": "3.2.15"
+          },
+          {
+            "Version": "3.2.16"
+          },
+          {
+            "Version": "3.2.17"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/3.5.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "3.5.9"
+          },
+          {
+            "Version": "3.5.10"
+          },
+          {
+            "Version": "3.5.11"
+          },
+          {
+            "Version": "3.5.12"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.7.8"
+          },
+          {
+            "Version": "3.7.9"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.8.3"
+          },
+          {
+            "Version": "3.8.4"
+          },
+          {
+            "Version": "3.8.5"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "3.9.4"
+          },
+          {
+            "Version": "3.9.5"
+          },
+          {
+            "Version": "3.9.6"
+          },
+          {
+            "Version": "3.9.7"
+          },
+          {
+            "Version": "3.9.8"
+          },
+          {
+            "Version": "3.9.9"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.11.2"
+          },
+          {
+            "Version": "3.11.3"
+          },
+          {
+            "Version": "3.11.4"
+          },
+          {
+            "Version": "3.12.2"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.13.2"
+          },
+          {
+            "Version": "3.13.3"
+          },
+          {
+            "Version": "3.13.4"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.14.1"
+          },
+          {
+            "Version": "3.14.2"
+          },
+          {
+            "Version": "3.14.3"
+          },
+          {
+            "Version": "3.14.4"
+          },
+          {
+            "Version": "3.14.5"
+          },
+          {
+            "Version": "3.14.6"
+          },
+          {
+            "Version": "3.14.7"
+          },
+          {
+            "Version": "3.14.8"
+          },
+          {
+            "Version": "3.14.9"
+          },
+          {
+            "Version": "3.14.10"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.17.1"
+          },
+          {
+            "Version": "3.17.2"
+          },
+          {
+            "Version": "3.17.3"
+          },
+          {
+            "Version": "3.17.4"
+          },
+          {
+            "Version": "3.17.5"
+          },
+          {
+            "Version": "3.17.6"
+          },
+          {
+            "Version": "3.17.7"
+          },
+          {
+            "Version": "3.17.8"
+          },
+          {
+            "Version": "3.17.9"
+          },
+          {
+            "Version": "3.17.11"
+          },
+          {
+            "Version": "3.17.12"
+          },
+          {
+            "Version": "3.17.13"
+          },
+          {
+            "Version": "3.17.14"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.19.3"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.25.1"
+          },
+          {
+            "Version": "3.25.2"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.26.1"
+          },
+          {
+            "Version": "3.26.3"
+          },
+          {
+            "Version": "3.26.4"
+          },
+          {
+            "Version": "3.26.5"
+          },
+          {
+            "Version": "3.26.6"
+          },
+          {
+            "Version": "3.26.7"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.27.1"
+          },
+          {
+            "Version": "3.27.2"
+          },
+          {
+            "Version": "3.27.3"
+          },
+          {
+            "Version": "3.27.4"
+          },
+          {
+            "Version": "3.27.5"
+          },
+          {
+            "Version": "3.27.6"
+          },
+          {
+            "Version": "3.27.7"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.28.1"
+          },
+          {
+            "Version": "3.28.2"
+          },
+          {
+            "Version": "3.28.3"
+          },
+          {
+            "Version": "3.28.4"
+          },
+          {
+            "Version": "3.28.5"
+          },
+          {
+            "Version": "3.28.6"
+          },
+          {
+            "Version": "3.28.7"
+          },
+          {
+            "Version": "3.28.8"
+          },
+          {
+            "Version": "3.29.1"
+          },
+          {
+            "Version": "3.29.2"
+          },
+          {
+            "Version": "3.29.3"
+          },
+          {
+            "Version": "3.29.4"
+          },
+          {
+            "Version": "3.29.5"
+          },
+          {
+            "Version": "3.29.6"
+          },
+          {
+            "Version": "3.29.7"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.31.4"
+          },
+          {
+            "Version": "3.32.4"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.34.3"
+          },
+          {
+            "Version": "3.34.4"
+          },
+          {
+            "Version": "3.34.5"
+          },
+          {
+            "Version": "3.34.6"
+          },
+          {
+            "Version": "3.34.7"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.35.2"
+          },
+          {
+            "Version": "3.35.3"
+          },
+          {
+            "Version": "3.35.4"
+          },
+          {
+            "Version": "3.35.5"
+          },
+          {
+            "Version": "3.36.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/3.36.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.37.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/3.37.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.37.1",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/3.37.1",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-alpha002"
+          },
+          {
+            "Version": "4.0.0-alpha003"
+          },
+          {
+            "Version": "4.0.0-alpha004"
+          },
+          {
+            "Version": "4.0.0-alpha005"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3"
+          },
+          {
+            "Version": "4.1.4"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1-alpha001"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "4.3.2"
+          },
+          {
+            "Version": "4.3.3"
+          },
+          {
+            "Version": "4.3.4"
+          },
+          {
+            "Version": "4.3.7"
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.4.1"
+          },
+          {
+            "Version": "4.4.2"
+          },
+          {
+            "Version": "4.4.3"
+          },
+          {
+            "Version": "4.4.4"
+          },
+          {
+            "Version": "4.4.5"
+          },
+          {
+            "Version": "4.4.6"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.6.0-alpha001"
+          },
+          {
+            "Version": "4.6.0-alpha002"
+          },
+          {
+            "Version": "4.6.0"
+          },
+          {
+            "Version": "4.6.1"
+          },
+          {
+            "Version": "4.6.2"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.6.4"
+          },
+          {
+            "Version": "4.7.0-alpha001"
+          },
+          {
+            "Version": "4.7.0-alpha002"
+          },
+          {
+            "Version": "4.7.0"
+          },
+          {
+            "Version": "4.7.1"
+          },
+          {
+            "Version": "4.7.2"
+          },
+          {
+            "Version": "4.7.3"
+          },
+          {
+            "Version": "4.8.0"
+          },
+          {
+            "Version": "4.9.0"
+          },
+          {
+            "Version": "4.9.1"
+          },
+          {
+            "Version": "4.9.2"
+          },
+          {
+            "Version": "4.9.3"
+          },
+          {
+            "Version": "4.9.5"
+          },
+          {
+            "Version": "4.9.6"
+          },
+          {
+            "Version": "4.9.7"
+          },
+          {
+            "Version": "4.9.8"
+          },
+          {
+            "Version": "4.10.0"
+          },
+          {
+            "Version": "4.10.1"
+          },
+          {
+            "Version": "4.10.3"
+          },
+          {
+            "Version": "4.10.4"
+          },
+          {
+            "Version": "4.10.5"
+          },
+          {
+            "Version": "4.11.0"
+          },
+          {
+            "Version": "4.11.1"
+          },
+          {
+            "Version": "4.11.2"
+          },
+          {
+            "Version": "4.11.3"
+          },
+          {
+            "Version": "4.12.0"
+          },
+          {
+            "Version": "4.12.2"
+          },
+          {
+            "Version": "4.13.0"
+          },
+          {
+            "Version": "4.13.1"
+          },
+          {
+            "Version": "4.14.0"
+          },
+          {
+            "Version": "4.14.1"
+          },
+          {
+            "Version": "4.14.2"
+          },
+          {
+            "Version": "4.14.3"
+          },
+          {
+            "Version": "4.14.4"
+          },
+          {
+            "Version": "4.14.5"
+          },
+          {
+            "Version": "4.14.7"
+          },
+          {
+            "Version": "4.14.8"
+          },
+          {
+            "Version": "4.14.9"
+          },
+          {
+            "Version": "4.15.0"
+          },
+          {
+            "Version": "4.15.1"
+          },
+          {
+            "Version": "4.15.2"
+          },
+          {
+            "Version": "4.16.0-alpha001"
+          },
+          {
+            "Version": "4.16.0"
+          },
+          {
+            "Version": "4.16.1"
+          },
+          {
+            "Version": "4.17.0-alpha001"
+          },
+          {
+            "Version": "4.17.0-alpha002"
+          },
+          {
+            "Version": "4.17.0-alpha003"
+          },
+          {
+            "Version": "4.17.0-alpha004"
+          },
+          {
+            "Version": "4.17.0-alpha005"
+          },
+          {
+            "Version": "4.17.0-alpha007"
+          },
+          {
+            "Version": "4.17.0"
+          },
+          {
+            "Version": "4.17.1"
+          },
+          {
+            "Version": "4.18.0"
+          },
+          {
+            "Version": "4.19.0"
+          },
+          {
+            "Version": "4.20.0"
+          },
+          {
+            "Version": "4.21.0"
+          },
+          {
+            "Version": "4.21.1"
+          },
+          {
+            "Version": "4.21.2"
+          },
+          {
+            "Version": "4.21.3"
+          },
+          {
+            "Version": "4.21.4"
+          },
+          {
+            "Version": "4.22.0"
+          },
+          {
+            "Version": "4.22.1"
+          },
+          {
+            "Version": "4.22.2"
+          },
+          {
+            "Version": "4.22.3"
+          },
+          {
+            "Version": "4.22.4"
+          },
+          {
+            "Version": "4.22.5"
+          },
+          {
+            "Version": "4.22.6"
+          },
+          {
+            "Version": "4.22.7"
+          },
+          {
+            "Version": "4.22.8"
+          },
+          {
+            "Version": "4.22.9"
+          },
+          {
+            "Version": "4.23.0"
+          },
+          {
+            "Version": "4.23.1"
+          },
+          {
+            "Version": "4.23.2"
+          },
+          {
+            "Version": "4.23.3"
+          },
+          {
+            "Version": "4.23.4"
+          },
+          {
+            "Version": "4.23.5"
+          },
+          {
+            "Version": "4.23.6"
+          },
+          {
+            "Version": "4.24.0"
+          },
+          {
+            "Version": "4.24.1"
+          },
+          {
+            "Version": "4.24.2"
+          },
+          {
+            "Version": "4.24.3"
+          },
+          {
+            "Version": "4.25.0"
+          },
+          {
+            "Version": "4.25.1"
+          },
+          {
+            "Version": "4.25.2"
+          },
+          {
+            "Version": "4.25.3"
+          },
+          {
+            "Version": "4.25.4"
+          },
+          {
+            "Version": "4.25.5"
+          },
+          {
+            "Version": "4.26.0"
+          },
+          {
+            "Version": "4.27.0"
+          },
+          {
+            "Version": "4.28.0"
+          },
+          {
+            "Version": "4.29.0"
+          },
+          {
+            "Version": "4.29.1"
+          },
+          {
+            "Version": "4.29.2"
+          },
+          {
+            "Version": "4.30.0"
+          },
+          {
+            "Version": "4.30.1"
+          },
+          {
+            "Version": "4.30.2"
+          },
+          {
+            "Version": "4.31.0"
+          },
+          {
+            "Version": "4.31.1"
+          },
+          {
+            "Version": "4.32.0"
+          },
+          {
+            "Version": "4.33.0"
+          },
+          {
+            "Version": "4.33.1"
+          },
+          {
+            "Version": "4.33.2"
+          },
+          {
+            "Version": "4.33.3"
+          },
+          {
+            "Version": "4.33.4"
+          },
+          {
+            "Version": "4.34.0"
+          },
+          {
+            "Version": "4.34.1"
+          },
+          {
+            "Version": "4.34.2"
+          },
+          {
+            "Version": "4.34.3"
+          },
+          {
+            "Version": "4.34.4"
+          },
+          {
+            "Version": "4.34.5"
+          },
+          {
+            "Version": "4.35.0"
+          },
+          {
+            "Version": "4.35.1"
+          },
+          {
+            "Version": "4.36.0"
+          },
+          {
+            "Version": "4.37.0"
+          },
+          {
+            "Version": "4.37.1"
+          },
+          {
+            "Version": "4.37.2"
+          },
+          {
+            "Version": "4.38.0"
+          },
+          {
+            "Version": "4.38.1"
+          },
+          {
+            "Version": "4.38.2"
+          },
+          {
+            "Version": "4.38.3"
+          },
+          {
+            "Version": "4.39.0"
+          },
+          {
+            "Version": "4.39.1"
+          },
+          {
+            "Version": "4.40.0"
+          },
+          {
+            "Version": "4.40.1"
+          },
+          {
+            "Version": "4.40.2"
+          },
+          {
+            "Version": "4.41.0"
+          },
+          {
+            "Version": "4.41.1"
+          },
+          {
+            "Version": "4.41.2"
+          },
+          {
+            "Version": "4.41.3"
+          },
+          {
+            "Version": "4.41.4"
+          },
+          {
+            "Version": "4.41.5"
+          },
+          {
+            "Version": "4.41.6"
+          },
+          {
+            "Version": "4.41.7"
+          },
+          {
+            "Version": "4.41.8"
+          },
+          {
+            "Version": "4.42.0"
+          },
+          {
+            "Version": "4.43.0"
+          },
+          {
+            "Version": "4.44.0"
+          },
+          {
+            "Version": "4.44.1"
+          },
+          {
+            "Version": "4.44.2"
+          },
+          {
+            "Version": "4.44.3"
+          },
+          {
+            "Version": "4.44.4"
+          },
+          {
+            "Version": "4.45.0"
+          },
+          {
+            "Version": "4.45.1"
+          },
+          {
+            "Version": "4.45.2"
+          },
+          {
+            "Version": "4.45.3"
+          },
+          {
+            "Version": "4.46.0"
+          },
+          {
+            "Version": "4.46.1"
+          },
+          {
+            "Version": "4.47.0"
+          },
+          {
+            "Version": "4.47.1"
+          },
+          {
+            "Version": "4.47.2"
+          },
+          {
+            "Version": "4.47.4"
+          },
+          {
+            "Version": "4.48.0"
+          },
+          {
+            "Version": "4.49.0"
+          },
+          {
+            "Version": "4.49.1"
+          },
+          {
+            "Version": "4.50.0"
+          },
+          {
+            "Version": "4.50.1"
+          },
+          {
+            "Version": "4.51.1"
+          },
+          {
+            "Version": "4.52.0"
+          },
+          {
+            "Version": "4.53.0"
+          },
+          {
+            "Version": "4.54.0-alpha001"
+          },
+          {
+            "Version": "4.54.0"
+          },
+          {
+            "Version": "4.55.0"
+          },
+          {
+            "Version": "4.55.1"
+          },
+          {
+            "Version": "4.56.0"
+          },
+          {
+            "Version": "4.57.0"
+          },
+          {
+            "Version": "4.57.1"
+          },
+          {
+            "Version": "4.57.2"
+          },
+          {
+            "Version": "4.57.3"
+          },
+          {
+            "Version": "4.57.4"
+          },
+          {
+            "Version": "4.58.2"
+          },
+          {
+            "Version": "4.58.3"
+          },
+          {
+            "Version": "4.58.4"
+          },
+          {
+            "Version": "4.58.5"
+          },
+          {
+            "Version": "4.58.6"
+          },
+          {
+            "Version": "4.59.0-alpha001"
+          },
+          {
+            "Version": "4.59.0-alpha002"
+          },
+          {
+            "Version": "4.59.0"
+          },
+          {
+            "Version": "4.59.1"
+          },
+          {
+            "Version": "4.59.3"
+          },
+          {
+            "Version": "4.60.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:48.5482987+02:00",
+        "PackageName": "FSharp.Formatting",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.1-beta"
+          },
+          {
+            "Version": "2.1.2-beta"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.1.5"
+          },
+          {
+            "Version": "2.1.6"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4-beta"
+          },
+          {
+            "Version": "2.2.5-beta"
+          },
+          {
+            "Version": "2.2.6-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.9-beta"
+          },
+          {
+            "Version": "2.2.10-beta"
+          },
+          {
+            "Version": "2.2.11-beta"
+          },
+          {
+            "Version": "2.2.12-beta"
+          },
+          {
+            "Version": "2.3.1-beta"
+          },
+          {
+            "Version": "2.3.2-beta"
+          },
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.7-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.4.0",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 0.0.20"
+                },
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 2.0.30506"
+                },
+                {
+                  "PackageName": "RazorEngine",
+                  "VersionRequirement": ">= 3.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha1"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.11.1-alpha1"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2"
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.14.4",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": "2.0.0.6"
+                },
+                {
+                  "PackageName": "FSharpVSPowerTools.Core",
+                  "VersionRequirement": ">= 2.3 < 2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.14.5-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:49.3583122+02:00",
+        "PackageName": "FsUnit",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.1.1"
+          },
+          {
+            "Version": "1.0.0.3"
+          },
+          {
+            "Version": "1.0.0.4"
+          },
+          {
+            "Version": "1.0.0.5"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.1.0.1"
+          },
+          {
+            "Version": "1.1.0.2"
+          },
+          {
+            "Version": "1.1.1.0"
+          },
+          {
+            "Version": "1.2.1.0"
+          },
+          {
+            "Version": "1.3.0.0",
+            "PackageDetails": {
+              "Name": "FsUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FsUnit/1.3.0.0",
+              "LicenseUrl": "http://fsunit.codeplex.com/license",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit",
+                  "VersionRequirement": ">= 2.6.3"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.3.0.1",
+            "PackageDetails": {
+              "Name": "FsUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FsUnit/1.3.0.1",
+              "LicenseUrl": "http://fsunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit",
+                  "VersionRequirement": ">= 2.6.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.1.0-beta"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.4.0.0-beta"
+          },
+          {
+            "Version": "1.4.0.0-beta3"
+          },
+          {
+            "Version": "1.4.0.0"
+          },
+          {
+            "Version": "1.4.1.0",
+            "PackageDetails": {
+              "Name": "FsUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FsUnit/1.4.1.0",
+              "LicenseUrl": "http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1.2.5"
+                },
+                {
+                  "PackageName": "NUnit",
+                  "VersionRequirement": "2.6.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.4.0-alpha-1"
+          },
+          {
+            "Version": "2.4.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:48.2597986+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/3.1.2",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/3.1.2.5",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:54.2488767+02:00",
+        "PackageName": "Microsoft.AspNet.Razor",
+        "Versions": [
+          {
+            "Version": "1.0.20105.408"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.0.20715.0"
+          },
+          {
+            "Version": "2.0.30506.0",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Razor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Razor/2.0.30506.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/webpages_2_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta2"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0-rc"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.2-rc"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3-beta1"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "4.0.0-beta1"
+          },
+          {
+            "Version": "4.0.0-beta2"
+          },
+          {
+            "Version": "4.0.0-beta3"
+          },
+          {
+            "Version": "4.0.0-beta4"
+          },
+          {
+            "Version": "4.0.0-beta5"
+          },
+          {
+            "Version": "4.0.0-beta6"
+          },
+          {
+            "Version": "4.0.0-beta7"
+          },
+          {
+            "Version": "4.0.0-beta8"
+          },
+          {
+            "Version": "4.0.0-rc1-final"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:39.0852201+02:00",
+        "PackageName": "FParsec",
+        "Versions": [
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.1.1"
+          },
+          {
+            "Version": "0.9.2.0"
+          },
+          {
+            "Version": "1.0.1-RC2"
+          },
+          {
+            "Version": "1.0.1",
+            "PackageDetails": {
+              "Name": "FParsec",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FParsec/1.0.1",
+              "LicenseUrl": "http://www.quanttec.com/fparsec/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.0.2-RC1"
+          },
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "FParsec",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FParsec/1.0.2",
+              "LicenseUrl": "http://www.quanttec.com/fparsec/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.0.3-alpha-170403"
+          },
+          {
+            "Version": "1.0.3-alpha-170404"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:54.8808757+02:00",
+        "PackageName": "RazorEngine",
+        "Versions": [
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "RazorEngine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/RazorEngine/3.3.0",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 2.0.30506"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.5.0-beta1"
+          },
+          {
+            "Version": "3.5.0-beta2"
+          },
+          {
+            "Version": "3.5.0-beta3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.6.2"
+          },
+          {
+            "Version": "3.6.3-beta1"
+          },
+          {
+            "Version": "3.6.3-beta2"
+          },
+          {
+            "Version": "3.6.3"
+          },
+          {
+            "Version": "3.6.4"
+          },
+          {
+            "Version": "3.6.5-beta1"
+          },
+          {
+            "Version": "3.6.5"
+          },
+          {
+            "Version": "3.6.6-beta1"
+          },
+          {
+            "Version": "3.6.6-beta2"
+          },
+          {
+            "Version": "3.6.6"
+          },
+          {
+            "Version": "3.7.0-beta1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1-alpha1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5-beta1"
+          },
+          {
+            "Version": "3.7.5-beta2"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "4.0.0-beta1"
+          },
+          {
+            "Version": "4.0.0-beta2"
+          },
+          {
+            "Version": "4.0.1-beta1"
+          },
+          {
+            "Version": "4.0.2-beta1"
+          },
+          {
+            "Version": "4.0.3-beta1"
+          },
+          {
+            "Version": "4.1.0-beta1"
+          },
+          {
+            "Version": "4.1.1-beta1"
+          },
+          {
+            "Version": "4.1.2-beta1"
+          },
+          {
+            "Version": "4.1.3-beta2"
+          },
+          {
+            "Version": "4.1.4-beta1"
+          },
+          {
+            "Version": "4.1.5-beta1"
+          },
+          {
+            "Version": "4.1.6-beta1"
+          },
+          {
+            "Version": "4.2.0-beta1"
+          },
+          {
+            "Version": "4.2.0-beta2"
+          },
+          {
+            "Version": "4.2.0-beta3"
+          },
+          {
+            "Version": "4.2.1-beta1"
+          },
+          {
+            "Version": "4.2.2-beta1"
+          },
+          {
+            "Version": "4.2.3-beta1"
+          },
+          {
+            "Version": "4.2.4-beta1"
+          },
+          {
+            "Version": "4.2.5-beta1"
+          },
+          {
+            "Version": "4.2.6-beta1"
+          },
+          {
+            "Version": "4.2.7-beta1"
+          },
+          {
+            "Version": "4.3.0-beta1"
+          },
+          {
+            "Version": "4.3.1-beta1"
+          },
+          {
+            "Version": "4.3.2-beta1"
+          },
+          {
+            "Version": "4.4.0-rc1"
+          },
+          {
+            "Version": "4.4.1-rc1"
+          },
+          {
+            "Version": "4.4.2-rc1"
+          },
+          {
+            "Version": "4.4.3-rc1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:50",
+        "PackageName": "FSharpVSPowerTools.Core",
+        "Versions": [
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "FSharpVSPowerTools.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharpVSPowerTools.Core/2.3.0",
+              "LicenseUrl": "https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 2.0.0.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:51",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/2.6.4",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000144-resolve-nunit/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000144-resolve-nunit/cache/paket-graph.cache
@@ -1,0 +1,9209 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:34.5470904+02:00",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:21.523455+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:32.2727787+02:00",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:11.4674517+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.7032018+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:21.8949527+02:00",
+        "PackageName": "System.Threading.Tasks.Parallel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Parallel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Parallel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:31.701272+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:23.4021902+02:00",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:29.2631485+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:15.189482+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:26.421912+02:00",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:33.9625979+02:00",
+        "PackageName": "System.Private.Uri",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Private.Uri",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Private.Uri/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:34.3326242+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:23.5694247+02:00",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:59.7794619+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.4287024+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.7762004+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:03.6579502+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:20.8704533+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:57.6847022+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:25.2329114+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:33.3655897+02:00",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:59.2212007+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:07.6699512+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:18.5654548+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:35.2495911+02:00",
+        "PackageName": "System.Diagnostics.Contracts",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Contracts",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Diagnostics.Contracts/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:29.4291366+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:09.8939502+02:00",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:59.0692001+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:24.8809127+02:00",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:57.7901996+02:00",
+        "PackageName": "FsUnit",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.1.1"
+          },
+          {
+            "Version": "1.0.0.3"
+          },
+          {
+            "Version": "1.0.0.4"
+          },
+          {
+            "Version": "1.0.0.5"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.1.0.1"
+          },
+          {
+            "Version": "1.1.0.2"
+          },
+          {
+            "Version": "1.1.1.0"
+          },
+          {
+            "Version": "1.2.1.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.0.1"
+          },
+          {
+            "Version": "1.3.1.0-beta"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.4.0.0-beta"
+          },
+          {
+            "Version": "1.4.0.0-beta3"
+          },
+          {
+            "Version": "1.4.0.0"
+          },
+          {
+            "Version": "1.4.1.0",
+            "PackageDetails": {
+              "Name": "FsUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FsUnit/1.4.1.0",
+              "LicenseUrl": "http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1.2.5"
+                },
+                {
+                  "PackageName": "NUnit",
+                  "VersionRequirement": "2.6.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.4.0-alpha-1"
+          },
+          {
+            "Version": "2.4.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:19.1659549+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:08.4764657+02:00",
+        "PackageName": "System.Net.WebHeaderCollection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.WebHeaderCollection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.WebHeaderCollection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:28.1361411+02:00",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:32.6472778+02:00",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:27.1139106+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:22.5929548+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.2097124+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:31.5257718+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:27.7941408+02:00",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:33.5455895+02:00",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:33.7340902+02:00",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:00.8409506+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:07.1004487+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:26.5954118+02:00",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:33.1831228+02:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:09.6484495+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:22.8824548+02:00",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:10.7589528+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:25.0654137+02:00",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:27.9666909+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:04.7424529+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:23.9214098+02:00",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:18.2539536+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:11.0789504+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:28.7401387+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:17.9699532+02:00",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.8482006+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:01.8889518+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:09.0364506+02:00",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:15.0344531+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:22.6899547+02:00",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:26.767411+02:00",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:26.0789103+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:27.4529265+02:00",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:27.622416+02:00",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:00.4544508+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:19.6089549+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:32.0712779+02:00",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:23.0494586+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:10.4489506+02:00",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:20.2754584+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:01.0149514+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:26.2564117+02:00",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:11.746951+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:17.2724619+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:31.172273+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:00.2659502+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.132713+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.5.7.10213"
+          },
+          {
+            "Version": "2.5.9.10348"
+          },
+          {
+            "Version": "2.5.10.11092"
+          },
+          {
+            "Version": "2.6.0.12051"
+          },
+          {
+            "Version": "2.6.0.12054"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/2.6.4",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0-alpha"
+          },
+          {
+            "Version": "3.0.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-alpha-3"
+          },
+          {
+            "Version": "3.0.0-alpha-4"
+          },
+          {
+            "Version": "3.0.0-alpha-5"
+          },
+          {
+            "Version": "3.0.0-beta-1"
+          },
+          {
+            "Version": "3.0.0-beta-2"
+          },
+          {
+            "Version": "3.0.0-beta-3"
+          },
+          {
+            "Version": "3.0.0-beta-4"
+          },
+          {
+            "Version": "3.0.0-beta-5"
+          },
+          {
+            "Version": "3.0.0-rc"
+          },
+          {
+            "Version": "3.0.0-rc-2"
+          },
+          {
+            "Version": "3.0.0-rc-3"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:25.3934107+02:00",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:10.1439506+02:00",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:29.0886383+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.6202007+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:28.9131408+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:31.8956867+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:28.2966607+02:00",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:03.0069645+02:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:16.7464541+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:32.4597815+02:00",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:04.1359489+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:30.1301036+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:29.7685396+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:25.7439311+02:00",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:30.9972742+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:57.8922005+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:27.2839113+02:00",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:31.3442688+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.3652019+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:24.4389119+02:00",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:59.1392006+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:17.725453+02:00",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:22.1254536+02:00",
+        "PackageName": "System.Threading.Thread",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Thread",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Thread/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:16.3549529+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:24.0919105+02:00",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:29.9418619+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:59.0047043+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:30.8052711+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.4867106+02:00",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:30.6417712+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:23.2173619+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:03.9064519+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:34.9375907+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.9297196+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:30.473137+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:06.2749506+02:00",
+        "PackageName": "System.Linq.Queryable",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Queryable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Queryable/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.283206+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:14.2284514+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.5542003+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:08.221951+02:00",
+        "PackageName": "System.Net.Requests",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Requests",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Requests/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.WebHeaderCollection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:01.2434516+02:00",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:02.7034514+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:29.5996841+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:23.7584095+02:00",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:32.9971266+02:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:05.8614526+02:00",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:24.6099207+02:00",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:34.1360909+02:00",
+        "PackageName": "System.Runtime.WindowsRuntime",
+        "Versions": [
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.WindowsRuntime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.WindowsRuntime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:30.2947101+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:34.7500914+02:00",
+        "PackageName": "System.Threading.Overlapped",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Overlapped",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Threading.Overlapped/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:58.0097008+02:00",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:25.5779143+02:00",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:28.5341549+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:18.4114541+02:00",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:24.2694141+02:00",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:22.4079577+02:00",
+        "PackageName": "System.Threading.ThreadPool",
+        "Versions": [
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.0.10-beta-23225"
+          },
+          {
+            "Version": "4.0.10-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23516"
+          },
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.ThreadPool",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.ThreadPool/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:25.913413+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:26.9354139+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:02.4364489+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:28:32.8208097+02:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000156-resolve-prerelease-logary/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000156-resolve-prerelease-logary/cache/paket-graph.cache
@@ -1,0 +1,48 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:00.099612+02:00",
+        "PackageName": "FSharp.Actor-logary",
+        "Versions": [
+          {
+            "Version": "2.0.0-alpha5",
+            "PackageDetails": {
+              "Name": "FSharp.Actor-logary",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Actor-logary/2.0.0-alpha5",
+              "LicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core.3",
+                  "VersionRequirement": ">= 0.0.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:00.4096138+02:00",
+        "PackageName": "FSharp.Core.3",
+        "Versions": [
+          {
+            "Version": "0.0.1"
+          },
+          {
+            "Version": "0.0.2",
+            "PackageDetails": {
+              "Name": "FSharp.Core.3",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core.3/0.0.2",
+              "LicenseUrl": "http://www.microsoft.com/en-us/download/details.aspx?id=34675",
+              "IsUnlisted": true,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000173-resolve-primary-dependency-optimistic/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000173-resolve-primary-dependency-optimistic/cache/paket-graph.cache
@@ -1,0 +1,899 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:49.2770291+02:00",
+        "PackageName": "FSharp.Formatting",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.1-beta"
+          },
+          {
+            "Version": "2.1.2-beta"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.1.5"
+          },
+          {
+            "Version": "2.1.6"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4-beta"
+          },
+          {
+            "Version": "2.2.5-beta"
+          },
+          {
+            "Version": "2.2.6-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.9-beta"
+          },
+          {
+            "Version": "2.2.10-beta"
+          },
+          {
+            "Version": "2.2.11-beta"
+          },
+          {
+            "Version": "2.2.12-beta"
+          },
+          {
+            "Version": "2.3.1-beta"
+          },
+          {
+            "Version": "2.3.2-beta"
+          },
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.7-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.4.0",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 0.0.20"
+                },
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 2.0.30506"
+                },
+                {
+                  "PackageName": "RazorEngine",
+                  "VersionRequirement": ">= 3.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha1"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.11.1-alpha1"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2"
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.14.4",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": "2.0.0.6"
+                },
+                {
+                  "PackageName": "FSharpVSPowerTools.Core",
+                  "VersionRequirement": ">= 2.3 < 2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.14.5-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:49.3760404+02:00",
+        "PackageName": "Microsoft.AspNet.Razor",
+        "Versions": [
+          {
+            "Version": "1.0.20105.408"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.0.20715.0"
+          },
+          {
+            "Version": "2.0.30506.0",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Razor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Razor/2.0.30506.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/webpages_2_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta2"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0-rc"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.2-rc"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3-beta1"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "4.0.0-beta1"
+          },
+          {
+            "Version": "4.0.0-beta2"
+          },
+          {
+            "Version": "4.0.0-beta3"
+          },
+          {
+            "Version": "4.0.0-beta4"
+          },
+          {
+            "Version": "4.0.0-beta5"
+          },
+          {
+            "Version": "4.0.0-beta6"
+          },
+          {
+            "Version": "4.0.0-beta7"
+          },
+          {
+            "Version": "4.0.0-beta8"
+          },
+          {
+            "Version": "4.0.0-rc1-final"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:50.6300888+02:00",
+        "PackageName": "RazorEngine",
+        "Versions": [
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "RazorEngine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/RazorEngine/3.3.0",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 2.0.30506"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.5.0-beta1"
+          },
+          {
+            "Version": "3.5.0-beta2"
+          },
+          {
+            "Version": "3.5.0-beta3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.6.2"
+          },
+          {
+            "Version": "3.6.3-beta1"
+          },
+          {
+            "Version": "3.6.3-beta2"
+          },
+          {
+            "Version": "3.6.3"
+          },
+          {
+            "Version": "3.6.4"
+          },
+          {
+            "Version": "3.6.5-beta1"
+          },
+          {
+            "Version": "3.6.5"
+          },
+          {
+            "Version": "3.6.6-beta1"
+          },
+          {
+            "Version": "3.6.6-beta2"
+          },
+          {
+            "Version": "3.6.6"
+          },
+          {
+            "Version": "3.7.0-beta1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1-alpha1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5-beta1"
+          },
+          {
+            "Version": "3.7.5-beta2"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "4.0.0-beta1"
+          },
+          {
+            "Version": "4.0.0-beta2"
+          },
+          {
+            "Version": "4.0.1-beta1"
+          },
+          {
+            "Version": "4.0.2-beta1"
+          },
+          {
+            "Version": "4.0.3-beta1"
+          },
+          {
+            "Version": "4.1.0-beta1"
+          },
+          {
+            "Version": "4.1.1-beta1"
+          },
+          {
+            "Version": "4.1.2-beta1"
+          },
+          {
+            "Version": "4.1.3-beta2"
+          },
+          {
+            "Version": "4.1.4-beta1"
+          },
+          {
+            "Version": "4.1.5-beta1"
+          },
+          {
+            "Version": "4.1.6-beta1"
+          },
+          {
+            "Version": "4.2.0-beta1"
+          },
+          {
+            "Version": "4.2.0-beta2"
+          },
+          {
+            "Version": "4.2.0-beta3"
+          },
+          {
+            "Version": "4.2.1-beta1"
+          },
+          {
+            "Version": "4.2.2-beta1"
+          },
+          {
+            "Version": "4.2.3-beta1"
+          },
+          {
+            "Version": "4.2.4-beta1"
+          },
+          {
+            "Version": "4.2.5-beta1"
+          },
+          {
+            "Version": "4.2.6-beta1"
+          },
+          {
+            "Version": "4.2.7-beta1"
+          },
+          {
+            "Version": "4.3.0-beta1"
+          },
+          {
+            "Version": "4.3.1-beta1"
+          },
+          {
+            "Version": "4.3.2-beta1"
+          },
+          {
+            "Version": "4.4.0-rc1"
+          },
+          {
+            "Version": "4.4.1-rc1"
+          },
+          {
+            "Version": "4.4.2-rc1"
+          },
+          {
+            "Version": "4.4.3-rc1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:05",
+        "PackageName": "FSharpVSPowerTools.Core",
+        "Versions": [
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "FSharpVSPowerTools.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharpVSPowerTools.Core/2.3.0",
+              "LicenseUrl": "https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 2.0.0.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:05",
+        "PackageName": "FSharp.Compiler.Service",
+        "Versions": [
+          {
+            "Version": "2.0.0.6",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/2.0.0.6",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000183-outdated-with-special-parameters/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000183-outdated-with-special-parameters/cache/paket-graph.cache
@@ -1,0 +1,703 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:58:42.027005+02:00",
+        "PackageName": "FSharp.Formatting",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.1-beta"
+          },
+          {
+            "Version": "2.1.2-beta"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.1.5"
+          },
+          {
+            "Version": "2.1.6"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4-beta"
+          },
+          {
+            "Version": "2.2.5-beta"
+          },
+          {
+            "Version": "2.2.6-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.9-beta"
+          },
+          {
+            "Version": "2.2.10-beta"
+          },
+          {
+            "Version": "2.2.11-beta"
+          },
+          {
+            "Version": "2.2.12-beta"
+          },
+          {
+            "Version": "2.3.1-beta"
+          },
+          {
+            "Version": "2.3.2-beta"
+          },
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.7-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha1"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.11.1-alpha1"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2"
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.14.4",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": "2.0.0.6"
+                },
+                {
+                  "PackageName": "FSharpVSPowerTools.Core",
+                  "VersionRequirement": ">= 2.3 < 2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.14.5-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:58:42.12701+02:00",
+        "PackageName": "FSharpVSPowerTools.Core",
+        "Versions": [
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "FSharpVSPowerTools.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharpVSPowerTools.Core/2.3.0",
+              "LicenseUrl": "https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 2.0.0.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:58:41.5135053+02:00",
+        "PackageName": "FSharp.Compiler.Service",
+        "Versions": [
+          {
+            "Version": "2.0.0.6",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/2.0.0.6",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:58:42.5220062+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/6.0.8",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000220-use-exactly-this-constraint/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000220-use-exactly-this-constraint/cache/paket-graph.cache
@@ -1,0 +1,9059 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:32",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:35",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:30",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:39",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:33",
+        "PackageName": "System.Reflection.Metadata",
+        "Versions": [
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.18-beta"
+          },
+          {
+            "Version": "1.0.19-rc"
+          },
+          {
+            "Version": "1.0.21"
+          },
+          {
+            "Version": "1.0.22-beta-23019"
+          },
+          {
+            "Version": "1.0.22-beta-23109"
+          },
+          {
+            "Version": "1.0.22"
+          },
+          {
+            "Version": "1.0.23-beta-23225"
+          },
+          {
+            "Version": "1.0.23-beta-23409"
+          },
+          {
+            "Version": "1.1.0-alpha-00009"
+          },
+          {
+            "Version": "1.1.0-alpha-00012"
+          },
+          {
+            "Version": "1.1.0-alpha-00014"
+          },
+          {
+            "Version": "1.1.0-alpha-00015"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-23826"
+          },
+          {
+            "Version": "1.2.0-rc3-23811"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1-beta-23918"
+          },
+          {
+            "Version": "1.3.0-rc2-24027"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.1-beta-24227-04"
+          },
+          {
+            "Version": "1.4.1-beta-24322-03"
+          },
+          {
+            "Version": "1.4.1-beta-24430-01"
+          },
+          {
+            "Version": "1.4.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2",
+            "PackageDetails": {
+              "Name": "System.Reflection.Metadata",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Metadata/1.4.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.1.37",
+                  "FrameworkRestrictions": "portable-net45+win8"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.3.1",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, winv4.5, wpav8.1, >= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:29",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:39",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:37",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:31",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:30",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:37",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:06.262126+02:00",
+        "PackageName": "NuGet.CommandLine",
+        "Versions": [
+          {
+            "Version": "1.0.11220.26",
+            "PackageDetails": {
+              "Name": "NuGet.CommandLine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NuGet.CommandLine/1.0.11220.26",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.1.2120.134"
+          },
+          {
+            "Version": "1.1.2120.136"
+          },
+          {
+            "Version": "1.1.2121.140"
+          },
+          {
+            "Version": "1.1.2122.156"
+          },
+          {
+            "Version": "1.2.2128.11"
+          },
+          {
+            "Version": "1.2.20216.59"
+          },
+          {
+            "Version": "1.2.20310.1"
+          },
+          {
+            "Version": "1.2.20311.3"
+          },
+          {
+            "Version": "1.2.20325.10"
+          },
+          {
+            "Version": "1.2.20401.11"
+          },
+          {
+            "Version": "1.2.20409.25"
+          },
+          {
+            "Version": "1.2.20415.26"
+          },
+          {
+            "Version": "1.2.20416.28"
+          },
+          {
+            "Version": "1.2.20416.30"
+          },
+          {
+            "Version": "1.2.20417.31"
+          },
+          {
+            "Version": "1.3.20425.372"
+          },
+          {
+            "Version": "1.4.20615.182"
+          },
+          {
+            "Version": "1.5.20830.9001"
+          },
+          {
+            "Version": "1.5.20905.5"
+          },
+          {
+            "Version": "1.5.21005.9019"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.4"
+          },
+          {
+            "Version": "1.8.40000"
+          },
+          {
+            "Version": "1.8.40001"
+          },
+          {
+            "Version": "1.8.40002"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.40000"
+          },
+          {
+            "Version": "2.0.40001"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.3"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.8.1"
+          },
+          {
+            "Version": "2.8.2-beta"
+          },
+          {
+            "Version": "2.8.2"
+          },
+          {
+            "Version": "2.8.3"
+          },
+          {
+            "Version": "2.8.5"
+          },
+          {
+            "Version": "2.8.6"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.4.4-rtm-final"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NuGet.CommandLine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NuGet.CommandLine/3.5.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0-rc2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:33",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:07.2561259+02:00",
+        "PackageName": "NUnit.Runners",
+        "Versions": [
+          {
+            "Version": "2.6.0.12051",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.0.12051",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": ">= 3.6.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": ">= 3.6"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.TeamCityEventListener",
+                  "VersionRequirement": ">= 1.0.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:56.3756213+02:00",
+        "PackageName": "FAKE",
+        "Versions": [
+          {
+            "Version": "1.46.1.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FAKE/1.46.1.0",
+              "LicenseUrl": "https://github.com/forki/FAKE/blob/develop/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.46.2.0"
+          },
+          {
+            "Version": "1.48.0.0"
+          },
+          {
+            "Version": "1.50.0.0"
+          },
+          {
+            "Version": "1.50.1.0"
+          },
+          {
+            "Version": "1.50.2.0"
+          },
+          {
+            "Version": "1.50.3.0"
+          },
+          {
+            "Version": "1.50.4.0"
+          },
+          {
+            "Version": "1.52.0.0"
+          },
+          {
+            "Version": "1.52.1.0"
+          },
+          {
+            "Version": "1.52.5.0"
+          },
+          {
+            "Version": "1.52.6.0"
+          },
+          {
+            "Version": "1.54.0.0"
+          },
+          {
+            "Version": "1.54.1.0"
+          },
+          {
+            "Version": "1.54.2.0"
+          },
+          {
+            "Version": "1.54.3.0"
+          },
+          {
+            "Version": "1.56"
+          },
+          {
+            "Version": "1.56.2"
+          },
+          {
+            "Version": "1.56.3"
+          },
+          {
+            "Version": "1.56.4"
+          },
+          {
+            "Version": "1.56.5"
+          },
+          {
+            "Version": "1.56.6"
+          },
+          {
+            "Version": "1.56.7"
+          },
+          {
+            "Version": "1.56.9"
+          },
+          {
+            "Version": "1.56.10"
+          },
+          {
+            "Version": "1.56.12"
+          },
+          {
+            "Version": "1.58"
+          },
+          {
+            "Version": "1.58.2"
+          },
+          {
+            "Version": "1.58.3"
+          },
+          {
+            "Version": "1.58.5"
+          },
+          {
+            "Version": "1.58.6"
+          },
+          {
+            "Version": "1.58.7"
+          },
+          {
+            "Version": "1.58.8"
+          },
+          {
+            "Version": "1.58.9"
+          },
+          {
+            "Version": "1.58.10"
+          },
+          {
+            "Version": "1.58.11"
+          },
+          {
+            "Version": "1.58.14"
+          },
+          {
+            "Version": "1.60"
+          },
+          {
+            "Version": "1.62"
+          },
+          {
+            "Version": "1.62.1"
+          },
+          {
+            "Version": "1.62.2"
+          },
+          {
+            "Version": "1.62.4"
+          },
+          {
+            "Version": "1.62.5"
+          },
+          {
+            "Version": "1.64"
+          },
+          {
+            "Version": "1.64.1"
+          },
+          {
+            "Version": "1.64.2"
+          },
+          {
+            "Version": "1.64.3"
+          },
+          {
+            "Version": "1.64.4"
+          },
+          {
+            "Version": "1.64.5"
+          },
+          {
+            "Version": "1.64.6"
+          },
+          {
+            "Version": "1.64.7"
+          },
+          {
+            "Version": "1.64.8"
+          },
+          {
+            "Version": "1.64.9"
+          },
+          {
+            "Version": "1.64.10"
+          },
+          {
+            "Version": "1.64.11"
+          },
+          {
+            "Version": "1.64.14"
+          },
+          {
+            "Version": "1.64.15"
+          },
+          {
+            "Version": "1.64.16.0"
+          },
+          {
+            "Version": "1.64.17.0"
+          },
+          {
+            "Version": "1.64.18.0"
+          },
+          {
+            "Version": "1.64.19.0"
+          },
+          {
+            "Version": "1.66.0.0"
+          },
+          {
+            "Version": "1.66.1.0"
+          },
+          {
+            "Version": "1.66.2.0"
+          },
+          {
+            "Version": "1.68.1.0"
+          },
+          {
+            "Version": "1.68.5.0"
+          },
+          {
+            "Version": "1.68.6.0"
+          },
+          {
+            "Version": "1.70.0.0"
+          },
+          {
+            "Version": "1.70.1.0"
+          },
+          {
+            "Version": "1.70.2.0"
+          },
+          {
+            "Version": "1.70.3.0"
+          },
+          {
+            "Version": "1.70.6.0"
+          },
+          {
+            "Version": "1.70.8.0"
+          },
+          {
+            "Version": "1.70.9.0"
+          },
+          {
+            "Version": "1.70.10.0"
+          },
+          {
+            "Version": "1.70.11.0"
+          },
+          {
+            "Version": "1.70.13.0"
+          },
+          {
+            "Version": "1.70.16.0"
+          },
+          {
+            "Version": "1.70.17.0"
+          },
+          {
+            "Version": "1.70.18.0"
+          },
+          {
+            "Version": "1.70.20.0"
+          },
+          {
+            "Version": "1.70.21.0"
+          },
+          {
+            "Version": "1.70.22.0"
+          },
+          {
+            "Version": "1.70.24.0"
+          },
+          {
+            "Version": "1.70.25.0"
+          },
+          {
+            "Version": "1.70.29.0"
+          },
+          {
+            "Version": "1.70.32.0"
+          },
+          {
+            "Version": "1.72.33.0"
+          },
+          {
+            "Version": "1.74.0.0"
+          },
+          {
+            "Version": "1.74.1.0"
+          },
+          {
+            "Version": "1.74.2.0"
+          },
+          {
+            "Version": "1.74.4.0"
+          },
+          {
+            "Version": "1.74.6.0"
+          },
+          {
+            "Version": "1.74.8.0"
+          },
+          {
+            "Version": "1.74.9.0"
+          },
+          {
+            "Version": "1.74.10.0"
+          },
+          {
+            "Version": "1.74.13.0"
+          },
+          {
+            "Version": "1.74.14.0"
+          },
+          {
+            "Version": "1.74.15.0"
+          },
+          {
+            "Version": "1.74.16.0"
+          },
+          {
+            "Version": "1.74.17.0"
+          },
+          {
+            "Version": "1.74.18.0"
+          },
+          {
+            "Version": "1.74.19.0"
+          },
+          {
+            "Version": "1.74.20.0"
+          },
+          {
+            "Version": "1.74.21.0"
+          },
+          {
+            "Version": "1.74.22.0"
+          },
+          {
+            "Version": "1.74.24.0"
+          },
+          {
+            "Version": "1.74.25.0"
+          },
+          {
+            "Version": "1.74.26.0"
+          },
+          {
+            "Version": "1.74.27.0"
+          },
+          {
+            "Version": "1.74.28.0"
+          },
+          {
+            "Version": "1.74.29.0"
+          },
+          {
+            "Version": "1.74.30.0"
+          },
+          {
+            "Version": "1.74.31.0"
+          },
+          {
+            "Version": "1.74.32.0"
+          },
+          {
+            "Version": "1.74.33.0"
+          },
+          {
+            "Version": "1.74.34.0"
+          },
+          {
+            "Version": "1.74.35.0"
+          },
+          {
+            "Version": "1.74.39.0"
+          },
+          {
+            "Version": "1.74.40.0"
+          },
+          {
+            "Version": "1.74.41.0"
+          },
+          {
+            "Version": "1.74.42.0"
+          },
+          {
+            "Version": "1.74.43.0"
+          },
+          {
+            "Version": "1.74.44.0"
+          },
+          {
+            "Version": "1.74.48.0"
+          },
+          {
+            "Version": "1.74.49.0"
+          },
+          {
+            "Version": "1.74.50.0"
+          },
+          {
+            "Version": "1.74.51.0"
+          },
+          {
+            "Version": "1.74.55.0"
+          },
+          {
+            "Version": "1.74.56.0"
+          },
+          {
+            "Version": "1.74.57.0"
+          },
+          {
+            "Version": "1.74.60.0"
+          },
+          {
+            "Version": "1.74.61.0"
+          },
+          {
+            "Version": "1.74.62.0"
+          },
+          {
+            "Version": "1.74.63.0"
+          },
+          {
+            "Version": "1.74.65.0"
+          },
+          {
+            "Version": "1.74.74.0"
+          },
+          {
+            "Version": "1.74.75.0"
+          },
+          {
+            "Version": "1.74.77.0"
+          },
+          {
+            "Version": "1.74.78.0"
+          },
+          {
+            "Version": "1.74.79.0"
+          },
+          {
+            "Version": "1.74.81.0"
+          },
+          {
+            "Version": "1.74.82.0"
+          },
+          {
+            "Version": "1.74.84.0"
+          },
+          {
+            "Version": "1.74.85.0"
+          },
+          {
+            "Version": "1.74.86.0"
+          },
+          {
+            "Version": "1.74.87.0"
+          },
+          {
+            "Version": "1.74.88.0"
+          },
+          {
+            "Version": "1.74.92.0"
+          },
+          {
+            "Version": "1.74.98.0"
+          },
+          {
+            "Version": "1.74.99.0"
+          },
+          {
+            "Version": "1.74.100.0"
+          },
+          {
+            "Version": "1.74.101.0"
+          },
+          {
+            "Version": "1.74.102.0"
+          },
+          {
+            "Version": "1.74.103.0"
+          },
+          {
+            "Version": "1.74.104.0"
+          },
+          {
+            "Version": "1.74.105.0"
+          },
+          {
+            "Version": "1.74.106.0"
+          },
+          {
+            "Version": "1.74.107.0"
+          },
+          {
+            "Version": "1.74.108.0"
+          },
+          {
+            "Version": "1.74.109.0"
+          },
+          {
+            "Version": "1.74.110.0"
+          },
+          {
+            "Version": "1.74.111.0"
+          },
+          {
+            "Version": "1.74.113.0"
+          },
+          {
+            "Version": "1.74.114.0"
+          },
+          {
+            "Version": "1.74.118.0"
+          },
+          {
+            "Version": "1.74.119.0"
+          },
+          {
+            "Version": "1.74.121.0"
+          },
+          {
+            "Version": "1.74.123.0"
+          },
+          {
+            "Version": "1.74.124.0"
+          },
+          {
+            "Version": "1.74.125.0"
+          },
+          {
+            "Version": "1.74.126.0"
+          },
+          {
+            "Version": "1.74.127.0"
+          },
+          {
+            "Version": "1.74.128.0"
+          },
+          {
+            "Version": "1.74.129.0"
+          },
+          {
+            "Version": "1.74.130.0"
+          },
+          {
+            "Version": "1.74.131.0"
+          },
+          {
+            "Version": "1.74.132.0"
+          },
+          {
+            "Version": "1.74.133.0"
+          },
+          {
+            "Version": "1.74.134.0"
+          },
+          {
+            "Version": "1.74.135.0"
+          },
+          {
+            "Version": "1.74.136.0"
+          },
+          {
+            "Version": "1.74.137.0"
+          },
+          {
+            "Version": "1.74.139.0"
+          },
+          {
+            "Version": "1.74.140.0"
+          },
+          {
+            "Version": "1.74.141.0"
+          },
+          {
+            "Version": "1.74.142.0"
+          },
+          {
+            "Version": "1.74.143.0"
+          },
+          {
+            "Version": "1.74.144.0"
+          },
+          {
+            "Version": "1.74.145.0"
+          },
+          {
+            "Version": "1.74.146.0"
+          },
+          {
+            "Version": "1.74.147.0"
+          },
+          {
+            "Version": "1.74.148.0"
+          },
+          {
+            "Version": "1.74.149.0"
+          },
+          {
+            "Version": "1.74.150.0"
+          },
+          {
+            "Version": "1.74.152.0"
+          },
+          {
+            "Version": "1.74.153.0"
+          },
+          {
+            "Version": "1.74.154.0"
+          },
+          {
+            "Version": "1.74.155.0"
+          },
+          {
+            "Version": "1.74.156.0"
+          },
+          {
+            "Version": "1.74.160.0"
+          },
+          {
+            "Version": "1.74.161.0"
+          },
+          {
+            "Version": "1.74.162.0"
+          },
+          {
+            "Version": "1.74.163.0"
+          },
+          {
+            "Version": "1.74.164.0"
+          },
+          {
+            "Version": "1.74.166.0"
+          },
+          {
+            "Version": "1.74.167.0"
+          },
+          {
+            "Version": "1.74.172.0"
+          },
+          {
+            "Version": "1.74.173.0"
+          },
+          {
+            "Version": "1.74.174.0"
+          },
+          {
+            "Version": "1.74.175.0"
+          },
+          {
+            "Version": "1.74.176.0"
+          },
+          {
+            "Version": "1.74.180.0"
+          },
+          {
+            "Version": "1.74.181.0"
+          },
+          {
+            "Version": "1.74.183.0"
+          },
+          {
+            "Version": "1.74.184.0"
+          },
+          {
+            "Version": "1.74.185.0"
+          },
+          {
+            "Version": "1.74.186.0"
+          },
+          {
+            "Version": "1.74.187.0"
+          },
+          {
+            "Version": "1.74.188.0"
+          },
+          {
+            "Version": "1.74.189.0"
+          },
+          {
+            "Version": "1.74.190.0"
+          },
+          {
+            "Version": "1.74.192.0"
+          },
+          {
+            "Version": "1.74.193.0"
+          },
+          {
+            "Version": "1.74.195.0"
+          },
+          {
+            "Version": "1.74.196.0"
+          },
+          {
+            "Version": "1.74.197.0"
+          },
+          {
+            "Version": "1.74.198.0"
+          },
+          {
+            "Version": "1.74.199.0"
+          },
+          {
+            "Version": "1.74.200.0"
+          },
+          {
+            "Version": "1.74.205.0"
+          },
+          {
+            "Version": "1.74.206.0"
+          },
+          {
+            "Version": "1.74.207.0"
+          },
+          {
+            "Version": "1.74.208.0"
+          },
+          {
+            "Version": "1.74.209.0"
+          },
+          {
+            "Version": "1.74.210.0"
+          },
+          {
+            "Version": "1.74.211.0"
+          },
+          {
+            "Version": "1.74.212.0"
+          },
+          {
+            "Version": "1.74.213.0"
+          },
+          {
+            "Version": "1.74.214.0"
+          },
+          {
+            "Version": "1.74.215.0"
+          },
+          {
+            "Version": "1.74.216.0"
+          },
+          {
+            "Version": "1.74.217.0"
+          },
+          {
+            "Version": "1.74.218.0"
+          },
+          {
+            "Version": "1.74.219.0"
+          },
+          {
+            "Version": "1.74.220.0"
+          },
+          {
+            "Version": "1.74.221.0"
+          },
+          {
+            "Version": "1.74.222.0"
+          },
+          {
+            "Version": "1.74.223.0"
+          },
+          {
+            "Version": "1.74.224.0"
+          },
+          {
+            "Version": "1.74.225.0"
+          },
+          {
+            "Version": "1.74.231.0"
+          },
+          {
+            "Version": "1.74.237.0"
+          },
+          {
+            "Version": "1.74.238.0"
+          },
+          {
+            "Version": "1.74.239.0"
+          },
+          {
+            "Version": "1.74.241.0"
+          },
+          {
+            "Version": "1.74.243.0"
+          },
+          {
+            "Version": "1.74.244.0"
+          },
+          {
+            "Version": "1.74.245.0"
+          },
+          {
+            "Version": "1.74.246.0"
+          },
+          {
+            "Version": "1.74.247.0"
+          },
+          {
+            "Version": "1.74.248.0"
+          },
+          {
+            "Version": "1.74.249.0"
+          },
+          {
+            "Version": "1.74.250.0"
+          },
+          {
+            "Version": "1.74.251.0"
+          },
+          {
+            "Version": "1.74.252.0"
+          },
+          {
+            "Version": "1.74.253.0"
+          },
+          {
+            "Version": "1.74.254.0"
+          },
+          {
+            "Version": "1.74.255.0"
+          },
+          {
+            "Version": "1.74.256.0"
+          },
+          {
+            "Version": "1.74.257.0"
+          },
+          {
+            "Version": "1.74.262.0"
+          },
+          {
+            "Version": "1.74.263.0"
+          },
+          {
+            "Version": "1.74.264.0"
+          },
+          {
+            "Version": "1.74.265.0"
+          },
+          {
+            "Version": "1.74.266.0"
+          },
+          {
+            "Version": "1.74.267.0"
+          },
+          {
+            "Version": "1.74.268.0"
+          },
+          {
+            "Version": "1.74.269.0"
+          },
+          {
+            "Version": "1.74.270.0"
+          },
+          {
+            "Version": "1.74.271.0"
+          },
+          {
+            "Version": "1.74.272.0"
+          },
+          {
+            "Version": "1.74.273.0"
+          },
+          {
+            "Version": "1.74.275.0"
+          },
+          {
+            "Version": "1.74.277.0"
+          },
+          {
+            "Version": "1.74.278.0"
+          },
+          {
+            "Version": "1.74.279.0"
+          },
+          {
+            "Version": "1.74.280.0"
+          },
+          {
+            "Version": "1.74.282.0"
+          },
+          {
+            "Version": "1.74.283.0"
+          },
+          {
+            "Version": "1.74.284.0"
+          },
+          {
+            "Version": "1.74.285.0"
+          },
+          {
+            "Version": "1.74.286.0"
+          },
+          {
+            "Version": "1.74.287.0"
+          },
+          {
+            "Version": "1.74.290.0"
+          },
+          {
+            "Version": "2.0.1-alpha2"
+          },
+          {
+            "Version": "2.0.1-alpha3"
+          },
+          {
+            "Version": "2.0.1-alpha4"
+          },
+          {
+            "Version": "2.0.48.0-alpha"
+          },
+          {
+            "Version": "2.0.55.0-alpha"
+          },
+          {
+            "Version": "2.0.60.0-alpha"
+          },
+          {
+            "Version": "2.0.61.0-alpha"
+          },
+          {
+            "Version": "2.0.62.0-alpha"
+          },
+          {
+            "Version": "2.0.64.0-alpha"
+          },
+          {
+            "Version": "2.0.65.0-alpha"
+          },
+          {
+            "Version": "2.0.66.0-alpha"
+          },
+          {
+            "Version": "2.0.68.0-alpha"
+          },
+          {
+            "Version": "2.0.69.0-alpha"
+          },
+          {
+            "Version": "2.0.70.0-alpha"
+          },
+          {
+            "Version": "2.0.73.0-alpha"
+          },
+          {
+            "Version": "2.0.74.0-alpha"
+          },
+          {
+            "Version": "2.0.75.0-alpha"
+          },
+          {
+            "Version": "2.0.76.0-alpha"
+          },
+          {
+            "Version": "2.0.77.0-alpha"
+          },
+          {
+            "Version": "2.0.78.0-alpha"
+          },
+          {
+            "Version": "2.0.79.0-alpha"
+          },
+          {
+            "Version": "2.0.80.0-alpha"
+          },
+          {
+            "Version": "2.0.81.0-alpha"
+          },
+          {
+            "Version": "2.0.83.0-alpha"
+          },
+          {
+            "Version": "2.0.84.0-alpha"
+          },
+          {
+            "Version": "2.0.85.0-alpha"
+          },
+          {
+            "Version": "2.0.86.0-alpha"
+          },
+          {
+            "Version": "2.0.87.0-alpha"
+          },
+          {
+            "Version": "2.0.90.0-alpha"
+          },
+          {
+            "Version": "2.0.91.0-alpha"
+          },
+          {
+            "Version": "2.0.94.0-alpha"
+          },
+          {
+            "Version": "2.0.95.0-alpha"
+          },
+          {
+            "Version": "2.0.96.0-alpha"
+          },
+          {
+            "Version": "2.0.97.0-alpha"
+          },
+          {
+            "Version": "2.0.98.0-alpha"
+          },
+          {
+            "Version": "2.0.99.0-alpha"
+          },
+          {
+            "Version": "2.1-alpha10"
+          },
+          {
+            "Version": "2.1-alpha13"
+          },
+          {
+            "Version": "2.1-alpha15"
+          },
+          {
+            "Version": "2.1-alpha16"
+          },
+          {
+            "Version": "2.1-alpha17"
+          },
+          {
+            "Version": "2.1-alpha18"
+          },
+          {
+            "Version": "2.1-alpha20"
+          },
+          {
+            "Version": "2.1-alpha22"
+          },
+          {
+            "Version": "2.1-alpha23"
+          },
+          {
+            "Version": "2.1-alpha24"
+          },
+          {
+            "Version": "2.1-alpha5"
+          },
+          {
+            "Version": "2.1-alpha6"
+          },
+          {
+            "Version": "2.1-alpha7"
+          },
+          {
+            "Version": "2.1.1-alpha"
+          },
+          {
+            "Version": "2.1.27-alpha"
+          },
+          {
+            "Version": "2.1.28-alpha"
+          },
+          {
+            "Version": "2.1.29-alpha"
+          },
+          {
+            "Version": "2.1.30-alpha"
+          },
+          {
+            "Version": "2.1.33-alpha"
+          },
+          {
+            "Version": "2.1.35-alpha"
+          },
+          {
+            "Version": "2.1.37-alpha"
+          },
+          {
+            "Version": "2.1.39-alpha"
+          },
+          {
+            "Version": "2.1.41-alpha"
+          },
+          {
+            "Version": "2.1.42-alpha"
+          },
+          {
+            "Version": "2.1.43-alpha"
+          },
+          {
+            "Version": "2.1.46-alpha"
+          },
+          {
+            "Version": "2.1.47-alpha"
+          },
+          {
+            "Version": "2.1.48-alpha"
+          },
+          {
+            "Version": "2.1.50-alpha"
+          },
+          {
+            "Version": "2.1.51-alpha"
+          },
+          {
+            "Version": "2.1.53-alpha"
+          },
+          {
+            "Version": "2.1.58-alpha"
+          },
+          {
+            "Version": "2.1.68-alpha"
+          },
+          {
+            "Version": "2.1.71-alpha"
+          },
+          {
+            "Version": "2.1.72-alpha"
+          },
+          {
+            "Version": "2.1.75-alpha"
+          },
+          {
+            "Version": "2.1.81-alpha"
+          },
+          {
+            "Version": "2.1.83-alpha"
+          },
+          {
+            "Version": "2.1.84-alpha"
+          },
+          {
+            "Version": "2.1.85-alpha"
+          },
+          {
+            "Version": "2.1.86-alpha"
+          },
+          {
+            "Version": "2.1.91-alpha"
+          },
+          {
+            "Version": "2.1.95-alpha"
+          },
+          {
+            "Version": "2.1.97-alpha"
+          },
+          {
+            "Version": "2.1.111-alpha"
+          },
+          {
+            "Version": "2.1.113-alpha"
+          },
+          {
+            "Version": "2.1.118-alpha"
+          },
+          {
+            "Version": "2.1.119-alpha"
+          },
+          {
+            "Version": "2.1.121-alpha"
+          },
+          {
+            "Version": "2.1.123-alpha"
+          },
+          {
+            "Version": "2.1.124-alpha"
+          },
+          {
+            "Version": "2.1.126-alpha"
+          },
+          {
+            "Version": "2.1.128-alpha"
+          },
+          {
+            "Version": "2.1.129-alpha"
+          },
+          {
+            "Version": "2.1.132-alpha"
+          },
+          {
+            "Version": "2.1.133-alpha"
+          },
+          {
+            "Version": "2.1.134-alpha"
+          },
+          {
+            "Version": "2.1.137-alpha"
+          },
+          {
+            "Version": "2.1.138-alpha"
+          },
+          {
+            "Version": "2.1.141-alpha"
+          },
+          {
+            "Version": "2.1.142-alpha"
+          },
+          {
+            "Version": "2.1.144-alpha"
+          },
+          {
+            "Version": "2.1.145-alpha"
+          },
+          {
+            "Version": "2.1.147-alpha"
+          },
+          {
+            "Version": "2.1.148-alpha"
+          },
+          {
+            "Version": "2.1.149-alpha"
+          },
+          {
+            "Version": "2.1.150-alpha"
+          },
+          {
+            "Version": "2.1.151-alpha"
+          },
+          {
+            "Version": "2.1.152-alpha"
+          },
+          {
+            "Version": "2.1.154-alpha"
+          },
+          {
+            "Version": "2.1.155-alpha"
+          },
+          {
+            "Version": "2.1.156-alpha"
+          },
+          {
+            "Version": "2.1.158-alpha"
+          },
+          {
+            "Version": "2.1.159-alpha"
+          },
+          {
+            "Version": "2.1.160-alpha"
+          },
+          {
+            "Version": "2.1.161-alpha"
+          },
+          {
+            "Version": "2.1.162-alpha"
+          },
+          {
+            "Version": "2.1.164-alpha"
+          },
+          {
+            "Version": "2.1.166-alpha"
+          },
+          {
+            "Version": "2.1.167-alpha"
+          },
+          {
+            "Version": "2.1.168-alpha"
+          },
+          {
+            "Version": "2.1.170-alpha"
+          },
+          {
+            "Version": "2.1.171-alpha"
+          },
+          {
+            "Version": "2.1.172-alpha"
+          },
+          {
+            "Version": "2.1.173-alpha"
+          },
+          {
+            "Version": "2.1.174-alpha"
+          },
+          {
+            "Version": "2.1.175-alpha"
+          },
+          {
+            "Version": "2.1.176-alpha"
+          },
+          {
+            "Version": "2.1.178-alpha"
+          },
+          {
+            "Version": "2.1.179-alpha"
+          },
+          {
+            "Version": "2.1.180-alpha"
+          },
+          {
+            "Version": "2.1.182-alpha"
+          },
+          {
+            "Version": "2.1.183-alpha"
+          },
+          {
+            "Version": "2.1.184-alpha"
+          },
+          {
+            "Version": "2.1.185-alpha"
+          },
+          {
+            "Version": "2.1.186-alpha"
+          },
+          {
+            "Version": "2.1.187-alpha"
+          },
+          {
+            "Version": "2.1.192-alpha"
+          },
+          {
+            "Version": "2.1.194-alpha"
+          },
+          {
+            "Version": "2.1.196-alpha"
+          },
+          {
+            "Version": "2.1.199-alpha"
+          },
+          {
+            "Version": "2.1.200-alpha"
+          },
+          {
+            "Version": "2.1.201-alpha"
+          },
+          {
+            "Version": "2.1.204-alpha"
+          },
+          {
+            "Version": "2.1.205-alpha"
+          },
+          {
+            "Version": "2.1.207-alpha"
+          },
+          {
+            "Version": "2.1.208-alpha"
+          },
+          {
+            "Version": "2.1.209-alpha"
+          },
+          {
+            "Version": "2.1.210-alpha"
+          },
+          {
+            "Version": "2.1.211-alpha"
+          },
+          {
+            "Version": "2.1.212-alpha"
+          },
+          {
+            "Version": "2.1.213-alpha"
+          },
+          {
+            "Version": "2.1.215-alpha"
+          },
+          {
+            "Version": "2.1.216-alpha"
+          },
+          {
+            "Version": "2.1.217-alpha"
+          },
+          {
+            "Version": "2.1.218-alpha"
+          },
+          {
+            "Version": "2.1.219-alpha"
+          },
+          {
+            "Version": "2.1.220-alpha"
+          },
+          {
+            "Version": "2.1.222-alpha"
+          },
+          {
+            "Version": "2.1.223-alpha"
+          },
+          {
+            "Version": "2.1.225-alpha"
+          },
+          {
+            "Version": "2.1.226-alpha"
+          },
+          {
+            "Version": "2.1.227-alpha"
+          },
+          {
+            "Version": "2.1.228-alpha"
+          },
+          {
+            "Version": "2.1.230-alpha"
+          },
+          {
+            "Version": "2.1.234-alpha"
+          },
+          {
+            "Version": "2.1.235-alpha"
+          },
+          {
+            "Version": "2.1.236-alpha"
+          },
+          {
+            "Version": "2.1.237-alpha"
+          },
+          {
+            "Version": "2.1.239-alpha"
+          },
+          {
+            "Version": "2.1.240-alpha"
+          },
+          {
+            "Version": "2.1.241-alpha"
+          },
+          {
+            "Version": "2.1.242-alpha"
+          },
+          {
+            "Version": "2.1.243-alpha"
+          },
+          {
+            "Version": "2.1.245-alpha"
+          },
+          {
+            "Version": "2.1.246-alpha"
+          },
+          {
+            "Version": "2.1.247-alpha"
+          },
+          {
+            "Version": "2.1.248-alpha"
+          },
+          {
+            "Version": "2.1.249-alpha"
+          },
+          {
+            "Version": "2.1.251-alpha"
+          },
+          {
+            "Version": "2.1.253-alpha"
+          },
+          {
+            "Version": "2.1.255-alpha"
+          },
+          {
+            "Version": "2.1.256-alpha"
+          },
+          {
+            "Version": "2.1.264-alpha"
+          },
+          {
+            "Version": "2.1.271-alpha"
+          },
+          {
+            "Version": "2.1.272-alpha"
+          },
+          {
+            "Version": "2.1.273-alpha"
+          },
+          {
+            "Version": "2.1.274-alpha"
+          },
+          {
+            "Version": "2.1.275-alpha"
+          },
+          {
+            "Version": "2.1.276-alpha"
+          },
+          {
+            "Version": "2.1.277-alpha"
+          },
+          {
+            "Version": "2.1.279-alpha"
+          },
+          {
+            "Version": "2.1.280-alpha"
+          },
+          {
+            "Version": "2.1.288-alpha"
+          },
+          {
+            "Version": "2.1.289-alpha"
+          },
+          {
+            "Version": "2.1.290-alpha"
+          },
+          {
+            "Version": "2.1.291-alpha"
+          },
+          {
+            "Version": "2.1.292-alpha"
+          },
+          {
+            "Version": "2.1.293-alpha"
+          },
+          {
+            "Version": "2.1.294-alpha"
+          },
+          {
+            "Version": "2.1.295-alpha"
+          },
+          {
+            "Version": "2.1.297-alpha"
+          },
+          {
+            "Version": "2.1.298-alpha"
+          },
+          {
+            "Version": "2.1.299-alpha"
+          },
+          {
+            "Version": "2.1.300-alpha"
+          },
+          {
+            "Version": "2.1.301-alpha"
+          },
+          {
+            "Version": "2.1.302-alpha"
+          },
+          {
+            "Version": "2.1.303-alpha"
+          },
+          {
+            "Version": "2.1.304-alpha"
+          },
+          {
+            "Version": "2.1.305-alpha"
+          },
+          {
+            "Version": "2.1.306-alpha"
+          },
+          {
+            "Version": "2.1.307-alpha"
+          },
+          {
+            "Version": "2.1.308-alpha"
+          },
+          {
+            "Version": "2.1.309-alpha"
+          },
+          {
+            "Version": "2.1.313-alpha"
+          },
+          {
+            "Version": "2.1.314-alpha"
+          },
+          {
+            "Version": "2.1.316-alpha"
+          },
+          {
+            "Version": "2.1.318-alpha"
+          },
+          {
+            "Version": "2.1.319-alpha"
+          },
+          {
+            "Version": "2.1.320-alpha"
+          },
+          {
+            "Version": "2.1.321-alpha"
+          },
+          {
+            "Version": "2.1.322-alpha"
+          },
+          {
+            "Version": "2.1.323-alpha"
+          },
+          {
+            "Version": "2.1.324-alpha"
+          },
+          {
+            "Version": "2.1.325-alpha"
+          },
+          {
+            "Version": "2.1.326-alpha"
+          },
+          {
+            "Version": "2.1.327-alpha"
+          },
+          {
+            "Version": "2.1.328-alpha"
+          },
+          {
+            "Version": "2.1.330-alpha"
+          },
+          {
+            "Version": "2.1.332-alpha"
+          },
+          {
+            "Version": "2.1.334-alpha"
+          },
+          {
+            "Version": "2.1.336-alpha"
+          },
+          {
+            "Version": "2.1.337-alpha"
+          },
+          {
+            "Version": "2.1.338-alpha"
+          },
+          {
+            "Version": "2.1.339-alpha"
+          },
+          {
+            "Version": "2.1.340-alpha"
+          },
+          {
+            "Version": "2.1.341-alpha"
+          },
+          {
+            "Version": "2.1.342-alpha"
+          },
+          {
+            "Version": "2.1.343-alpha"
+          },
+          {
+            "Version": "2.1.344-alpha"
+          },
+          {
+            "Version": "2.1.347-alpha"
+          },
+          {
+            "Version": "2.1.351-alpha"
+          },
+          {
+            "Version": "2.1.352-alpha"
+          },
+          {
+            "Version": "2.1.353-alpha"
+          },
+          {
+            "Version": "2.1.354-alpha"
+          },
+          {
+            "Version": "2.1.355-alpha"
+          },
+          {
+            "Version": "2.1.356-alpha"
+          },
+          {
+            "Version": "2.1.357-alpha"
+          },
+          {
+            "Version": "2.1.358-alpha"
+          },
+          {
+            "Version": "2.1.359-alpha"
+          },
+          {
+            "Version": "2.1.360-alpha"
+          },
+          {
+            "Version": "2.1.361-alpha"
+          },
+          {
+            "Version": "2.1.362-alpha"
+          },
+          {
+            "Version": "2.1.363-alpha"
+          },
+          {
+            "Version": "2.1.364-alpha"
+          },
+          {
+            "Version": "2.1.365-alpha"
+          },
+          {
+            "Version": "2.1.366-alpha"
+          },
+          {
+            "Version": "2.1.367-alpha"
+          },
+          {
+            "Version": "2.1.368-alpha"
+          },
+          {
+            "Version": "2.1.369-alpha"
+          },
+          {
+            "Version": "2.1.371-alpha"
+          },
+          {
+            "Version": "2.1.372-alpha"
+          },
+          {
+            "Version": "2.1.373-alpha"
+          },
+          {
+            "Version": "2.1.374-alpha"
+          },
+          {
+            "Version": "2.1.375-alpha"
+          },
+          {
+            "Version": "2.1.376-alpha"
+          },
+          {
+            "Version": "2.1.378-alpha"
+          },
+          {
+            "Version": "2.1.379-alpha"
+          },
+          {
+            "Version": "2.1.380-alpha"
+          },
+          {
+            "Version": "2.1.381-alpha"
+          },
+          {
+            "Version": "2.1.382-alpha"
+          },
+          {
+            "Version": "2.1.383-alpha"
+          },
+          {
+            "Version": "2.1.384-alpha"
+          },
+          {
+            "Version": "2.1.385-alpha"
+          },
+          {
+            "Version": "2.1.386-alpha"
+          },
+          {
+            "Version": "2.1.387-alpha"
+          },
+          {
+            "Version": "2.1.388-alpha"
+          },
+          {
+            "Version": "2.1.389-alpha"
+          },
+          {
+            "Version": "2.1.390-alpha"
+          },
+          {
+            "Version": "2.1.391-alpha"
+          },
+          {
+            "Version": "2.1.392-alpha"
+          },
+          {
+            "Version": "2.1.393-alpha"
+          },
+          {
+            "Version": "2.1.394-alpha"
+          },
+          {
+            "Version": "2.1.395-alpha"
+          },
+          {
+            "Version": "2.1.396-alpha"
+          },
+          {
+            "Version": "2.1.397-alpha"
+          },
+          {
+            "Version": "2.1.398-alpha"
+          },
+          {
+            "Version": "2.1.399-alpha"
+          },
+          {
+            "Version": "2.1.400-alpha"
+          },
+          {
+            "Version": "2.1.401-alpha"
+          },
+          {
+            "Version": "2.1.402-alpha"
+          },
+          {
+            "Version": "2.1.403-alpha"
+          },
+          {
+            "Version": "2.1.404-alpha"
+          },
+          {
+            "Version": "2.1.405-alpha"
+          },
+          {
+            "Version": "2.1.406-alpha"
+          },
+          {
+            "Version": "2.1.407-alpha"
+          },
+          {
+            "Version": "2.1.408-alpha"
+          },
+          {
+            "Version": "2.1.409-alpha"
+          },
+          {
+            "Version": "2.1.410-alpha"
+          },
+          {
+            "Version": "2.1.411-alpha"
+          },
+          {
+            "Version": "2.1.412-alpha"
+          },
+          {
+            "Version": "2.1.413-alpha"
+          },
+          {
+            "Version": "2.1.414-alpha"
+          },
+          {
+            "Version": "2.1.415-alpha"
+          },
+          {
+            "Version": "2.1.416-alpha"
+          },
+          {
+            "Version": "2.1.417-alpha"
+          },
+          {
+            "Version": "2.1.418-alpha"
+          },
+          {
+            "Version": "2.1.419-alpha"
+          },
+          {
+            "Version": "2.1.420-alpha"
+          },
+          {
+            "Version": "2.1.421-alpha"
+          },
+          {
+            "Version": "2.1.422-alpha"
+          },
+          {
+            "Version": "2.1.423-alpha"
+          },
+          {
+            "Version": "2.1.424-alpha"
+          },
+          {
+            "Version": "2.1.426-alpha"
+          },
+          {
+            "Version": "2.1.427-alpha"
+          },
+          {
+            "Version": "2.1.428-alpha"
+          },
+          {
+            "Version": "2.1.429-alpha"
+          },
+          {
+            "Version": "2.1.430-alpha"
+          },
+          {
+            "Version": "2.1.431-alpha"
+          },
+          {
+            "Version": "2.1.432-alpha"
+          },
+          {
+            "Version": "2.1.434-alpha"
+          },
+          {
+            "Version": "2.1.435-alpha"
+          },
+          {
+            "Version": "2.1.436-alpha"
+          },
+          {
+            "Version": "2.1.437-alpha"
+          },
+          {
+            "Version": "2.1.438-alpha"
+          },
+          {
+            "Version": "2.1.439-alpha"
+          },
+          {
+            "Version": "2.1.440-alpha"
+          },
+          {
+            "Version": "2.1.441-alpha"
+          },
+          {
+            "Version": "2.1.442-alpha"
+          },
+          {
+            "Version": "2.1.443-alpha"
+          },
+          {
+            "Version": "2.1.445-alpha"
+          },
+          {
+            "Version": "2.1.449-alpha"
+          },
+          {
+            "Version": "2.1.461-alpha"
+          },
+          {
+            "Version": "2.1.465-alpha"
+          },
+          {
+            "Version": "2.1.468-alpha"
+          },
+          {
+            "Version": "2.1.469-alpha"
+          },
+          {
+            "Version": "2.1.470-alpha"
+          },
+          {
+            "Version": "2.1.471-alpha"
+          },
+          {
+            "Version": "2.1.472-alpha"
+          },
+          {
+            "Version": "2.1.473-alpha"
+          },
+          {
+            "Version": "2.1.474-alpha"
+          },
+          {
+            "Version": "2.1.475-alpha"
+          },
+          {
+            "Version": "2.1.476-alpha"
+          },
+          {
+            "Version": "2.1.478-alpha"
+          },
+          {
+            "Version": "2.1.479-alpha"
+          },
+          {
+            "Version": "2.1.480-alpha"
+          },
+          {
+            "Version": "2.1.481-alpha"
+          },
+          {
+            "Version": "2.1.482-alpha"
+          },
+          {
+            "Version": "2.1.483-alpha"
+          },
+          {
+            "Version": "2.1.485-alpha"
+          },
+          {
+            "Version": "2.1.486-alpha"
+          },
+          {
+            "Version": "2.1.487-alpha"
+          },
+          {
+            "Version": "2.1.488-alpha"
+          },
+          {
+            "Version": "2.1.489-alpha"
+          },
+          {
+            "Version": "2.1.490-alpha"
+          },
+          {
+            "Version": "2.1.491-alpha"
+          },
+          {
+            "Version": "2.1.492-alpha"
+          },
+          {
+            "Version": "2.1.493-alpha"
+          },
+          {
+            "Version": "2.1.494-alpha"
+          },
+          {
+            "Version": "2.1.495-alpha"
+          },
+          {
+            "Version": "2.1.496-alpha"
+          },
+          {
+            "Version": "2.1.497-alpha"
+          },
+          {
+            "Version": "2.1.498-alpha"
+          },
+          {
+            "Version": "2.1.499-alpha"
+          },
+          {
+            "Version": "2.1.500-alpha"
+          },
+          {
+            "Version": "2.1.502-alpha"
+          },
+          {
+            "Version": "2.1.503-alpha"
+          },
+          {
+            "Version": "2.1.504-alpha"
+          },
+          {
+            "Version": "2.1.505-alpha"
+          },
+          {
+            "Version": "2.1.507-alpha"
+          },
+          {
+            "Version": "2.1.509-alpha"
+          },
+          {
+            "Version": "2.1.520-alpha"
+          },
+          {
+            "Version": "2.1.521-alpha"
+          },
+          {
+            "Version": "2.1.522-alpha"
+          },
+          {
+            "Version": "2.1.524-alpha"
+          },
+          {
+            "Version": "2.1.526-alpha"
+          },
+          {
+            "Version": "2.1.527-alpha"
+          },
+          {
+            "Version": "2.1.528-alpha"
+          },
+          {
+            "Version": "2.1.530-alpha"
+          },
+          {
+            "Version": "2.1.531-alpha"
+          },
+          {
+            "Version": "2.1.533-alpha"
+          },
+          {
+            "Version": "2.1.534-alpha"
+          },
+          {
+            "Version": "2.1.535-alpha"
+          },
+          {
+            "Version": "2.1.536-alpha"
+          },
+          {
+            "Version": "2.1.537-alpha"
+          },
+          {
+            "Version": "2.1.538-alpha"
+          },
+          {
+            "Version": "2.1.539-alpha"
+          },
+          {
+            "Version": "2.1.540-alpha"
+          },
+          {
+            "Version": "2.1.542-alpha"
+          },
+          {
+            "Version": "2.1.543-alpha"
+          },
+          {
+            "Version": "2.1.544-alpha"
+          },
+          {
+            "Version": "2.1.545-alpha"
+          },
+          {
+            "Version": "2.1.546-alpha"
+          },
+          {
+            "Version": "2.1.547-alpha"
+          },
+          {
+            "Version": "2.1.548-alpha"
+          },
+          {
+            "Version": "2.1.549-alpha"
+          },
+          {
+            "Version": "2.1.550-alpha"
+          },
+          {
+            "Version": "2.1.551-alpha"
+          },
+          {
+            "Version": "2.1.552-alpha"
+          },
+          {
+            "Version": "2.1.553-alpha"
+          },
+          {
+            "Version": "2.1.554-alpha"
+          },
+          {
+            "Version": "2.1.555-alpha"
+          },
+          {
+            "Version": "2.1.556-alpha"
+          },
+          {
+            "Version": "2.1.557-alpha"
+          },
+          {
+            "Version": "2.1.560-alpha"
+          },
+          {
+            "Version": "2.1.561-alpha"
+          },
+          {
+            "Version": "2.1.562-alpha"
+          },
+          {
+            "Version": "2.1.563-alpha"
+          },
+          {
+            "Version": "2.1.564-alpha"
+          },
+          {
+            "Version": "2.1.566-alpha"
+          },
+          {
+            "Version": "2.1.567-alpha"
+          },
+          {
+            "Version": "2.1.568-alpha"
+          },
+          {
+            "Version": "2.1.569-alpha"
+          },
+          {
+            "Version": "2.1.570-alpha"
+          },
+          {
+            "Version": "2.1.571-alpha"
+          },
+          {
+            "Version": "2.1.572-alpha"
+          },
+          {
+            "Version": "2.1.573-alpha"
+          },
+          {
+            "Version": "2.1.574-alpha"
+          },
+          {
+            "Version": "2.1.575-alpha"
+          },
+          {
+            "Version": "2.1.576-alpha"
+          },
+          {
+            "Version": "2.1.577-alpha"
+          },
+          {
+            "Version": "2.1.578-alpha"
+          },
+          {
+            "Version": "2.1.580-alpha"
+          },
+          {
+            "Version": "2.1.581-alpha"
+          },
+          {
+            "Version": "2.1.583-alpha"
+          },
+          {
+            "Version": "2.1.584-alpha"
+          },
+          {
+            "Version": "2.1.585-alpha"
+          },
+          {
+            "Version": "2.1.586-alpha"
+          },
+          {
+            "Version": "2.1.587-alpha"
+          },
+          {
+            "Version": "2.1.588-alpha"
+          },
+          {
+            "Version": "2.1.589-alpha"
+          },
+          {
+            "Version": "2.1.591-alpha"
+          },
+          {
+            "Version": "2.1.592-alpha"
+          },
+          {
+            "Version": "2.1.593-alpha"
+          },
+          {
+            "Version": "2.1.594-alpha"
+          },
+          {
+            "Version": "2.1.595-alpha"
+          },
+          {
+            "Version": "2.1.596-alpha"
+          },
+          {
+            "Version": "2.1.597-alpha"
+          },
+          {
+            "Version": "2.1.598-alpha"
+          },
+          {
+            "Version": "2.1.600-alpha"
+          },
+          {
+            "Version": "2.1.601-alpha"
+          },
+          {
+            "Version": "2.1.602-alpha"
+          },
+          {
+            "Version": "2.1.603-alpha"
+          },
+          {
+            "Version": "2.1.604-alpha"
+          },
+          {
+            "Version": "2.1.605-alpha"
+          },
+          {
+            "Version": "2.1.607-alpha"
+          },
+          {
+            "Version": "2.1.609-alpha"
+          },
+          {
+            "Version": "2.1.611-alpha"
+          },
+          {
+            "Version": "2.1.612-alpha"
+          },
+          {
+            "Version": "2.1.614-alpha"
+          },
+          {
+            "Version": "2.1.616-alpha"
+          },
+          {
+            "Version": "2.1.617-alpha"
+          },
+          {
+            "Version": "2.1.618-alpha"
+          },
+          {
+            "Version": "2.1.620-alpha"
+          },
+          {
+            "Version": "2.1.621-alpha"
+          },
+          {
+            "Version": "2.1.622-alpha"
+          },
+          {
+            "Version": "2.1.623-alpha"
+          },
+          {
+            "Version": "2.1.624-alpha"
+          },
+          {
+            "Version": "2.1.625-alpha"
+          },
+          {
+            "Version": "2.1.626-alpha"
+          },
+          {
+            "Version": "2.1.629-alpha"
+          },
+          {
+            "Version": "2.1.630-alpha"
+          },
+          {
+            "Version": "2.1.631-alpha"
+          },
+          {
+            "Version": "2.1.632-alpha"
+          },
+          {
+            "Version": "2.1.633-alpha"
+          },
+          {
+            "Version": "2.1.634-alpha"
+          },
+          {
+            "Version": "2.1.635-alpha"
+          },
+          {
+            "Version": "2.1.636-alpha"
+          },
+          {
+            "Version": "2.1.637-alpha"
+          },
+          {
+            "Version": "2.1.638-alpha"
+          },
+          {
+            "Version": "2.1.639-alpha"
+          },
+          {
+            "Version": "2.1.640-alpha"
+          },
+          {
+            "Version": "2.1.641-alpha"
+          },
+          {
+            "Version": "2.1.642-alpha"
+          },
+          {
+            "Version": "2.1.643-alpha"
+          },
+          {
+            "Version": "2.1.645-alpha"
+          },
+          {
+            "Version": "2.1.646-alpha"
+          },
+          {
+            "Version": "2.1.647-alpha"
+          },
+          {
+            "Version": "2.1.648-alpha"
+          },
+          {
+            "Version": "2.1.649-alpha"
+          },
+          {
+            "Version": "2.1.651-alpha"
+          },
+          {
+            "Version": "2.1.652-alpha"
+          },
+          {
+            "Version": "2.1.653-alpha"
+          },
+          {
+            "Version": "2.1.654-alpha"
+          },
+          {
+            "Version": "2.1.655-alpha"
+          },
+          {
+            "Version": "2.1.656-alpha"
+          },
+          {
+            "Version": "2.1.657-alpha"
+          },
+          {
+            "Version": "2.1.658-alpha"
+          },
+          {
+            "Version": "2.1.659-alpha"
+          },
+          {
+            "Version": "2.1.660-alpha"
+          },
+          {
+            "Version": "2.1.661-alpha"
+          },
+          {
+            "Version": "2.1.662-alpha"
+          },
+          {
+            "Version": "2.1.663-alpha"
+          },
+          {
+            "Version": "2.1.664-alpha"
+          },
+          {
+            "Version": "2.1.665-alpha"
+          },
+          {
+            "Version": "2.1.666-alpha"
+          },
+          {
+            "Version": "2.1.667-alpha"
+          },
+          {
+            "Version": "2.1.668-alpha"
+          },
+          {
+            "Version": "2.1.671-alpha"
+          },
+          {
+            "Version": "2.1.672-alpha"
+          },
+          {
+            "Version": "2.1.673-alpha"
+          },
+          {
+            "Version": "2.1.674-alpha"
+          },
+          {
+            "Version": "2.1.675-alpha"
+          },
+          {
+            "Version": "2.1.676-alpha"
+          },
+          {
+            "Version": "2.1.677-alpha"
+          },
+          {
+            "Version": "2.1.678-alpha"
+          },
+          {
+            "Version": "2.1.679-alpha"
+          },
+          {
+            "Version": "2.1.680-alpha"
+          },
+          {
+            "Version": "2.1.681-alpha"
+          },
+          {
+            "Version": "2.1.682-alpha"
+          },
+          {
+            "Version": "2.1.683-alpha"
+          },
+          {
+            "Version": "2.1.685-alpha"
+          },
+          {
+            "Version": "2.1.686-alpha"
+          },
+          {
+            "Version": "2.1.687-alpha"
+          },
+          {
+            "Version": "2.1.688-alpha"
+          },
+          {
+            "Version": "2.1.711-alpha"
+          },
+          {
+            "Version": "2.1.713-alpha"
+          },
+          {
+            "Version": "2.1.714-alpha"
+          },
+          {
+            "Version": "2.1.718-alpha"
+          },
+          {
+            "Version": "2.1.724-alpha"
+          },
+          {
+            "Version": "2.1.726-alpha"
+          },
+          {
+            "Version": "2.1.727-alpha"
+          },
+          {
+            "Version": "2.1.728-alpha"
+          },
+          {
+            "Version": "2.1.729-alpha"
+          },
+          {
+            "Version": "2.1.730-alpha"
+          },
+          {
+            "Version": "2.1.731-alpha"
+          },
+          {
+            "Version": "2.1.732-alpha"
+          },
+          {
+            "Version": "2.1.733-alpha"
+          },
+          {
+            "Version": "2.1.735-alpha"
+          },
+          {
+            "Version": "2.1.737-alpha"
+          },
+          {
+            "Version": "2.1.738-alpha"
+          },
+          {
+            "Version": "2.1.739-alpha"
+          },
+          {
+            "Version": "2.1.740-alpha"
+          },
+          {
+            "Version": "2.1.742-alpha"
+          },
+          {
+            "Version": "2.1.743-alpha"
+          },
+          {
+            "Version": "2.1.744-alpha"
+          },
+          {
+            "Version": "2.1.745-alpha"
+          },
+          {
+            "Version": "2.1.746-alpha"
+          },
+          {
+            "Version": "2.1.747-alpha"
+          },
+          {
+            "Version": "2.1.748-alpha"
+          },
+          {
+            "Version": "2.1.750-alpha"
+          },
+          {
+            "Version": "2.1.756-alpha"
+          },
+          {
+            "Version": "2.1.758-alpha"
+          },
+          {
+            "Version": "2.1.765-alpha"
+          },
+          {
+            "Version": "2.1.766-alpha"
+          },
+          {
+            "Version": "2.1.767-alpha"
+          },
+          {
+            "Version": "2.1.768-alpha"
+          },
+          {
+            "Version": "2.1.770-alpha"
+          },
+          {
+            "Version": "2.1.771-alpha"
+          },
+          {
+            "Version": "2.1.772-alpha"
+          },
+          {
+            "Version": "2.1.773-alpha"
+          },
+          {
+            "Version": "2.1.774-alpha"
+          },
+          {
+            "Version": "2.1.775-alpha"
+          },
+          {
+            "Version": "2.1.778-alpha"
+          },
+          {
+            "Version": "2.1.779-alpha"
+          },
+          {
+            "Version": "2.1.781-alpha"
+          },
+          {
+            "Version": "2.2.0.0"
+          },
+          {
+            "Version": "2.2.1.0"
+          },
+          {
+            "Version": "2.2.2.0"
+          },
+          {
+            "Version": "2.2.4.0"
+          },
+          {
+            "Version": "2.2.6.0"
+          },
+          {
+            "Version": "2.2.7.0"
+          },
+          {
+            "Version": "2.2.8.0"
+          },
+          {
+            "Version": "2.2.9.0"
+          },
+          {
+            "Version": "2.2.10.0"
+          },
+          {
+            "Version": "2.2.11.0"
+          },
+          {
+            "Version": "2.2.12.0"
+          },
+          {
+            "Version": "2.2.13.0"
+          },
+          {
+            "Version": "2.2.14.0"
+          },
+          {
+            "Version": "2.2.18.0"
+          },
+          {
+            "Version": "2.2.19.0"
+          },
+          {
+            "Version": "2.2.20.0"
+          },
+          {
+            "Version": "2.2.21.0"
+          },
+          {
+            "Version": "2.2.22.0"
+          },
+          {
+            "Version": "2.2.23.0"
+          },
+          {
+            "Version": "2.3.1-alpha"
+          },
+          {
+            "Version": "2.3.2-alpha"
+          },
+          {
+            "Version": "2.3.5-alpha"
+          },
+          {
+            "Version": "2.3.8-alpha"
+          },
+          {
+            "Version": "2.3.10-alpha"
+          },
+          {
+            "Version": "2.3.11-alpha"
+          },
+          {
+            "Version": "2.3.14-alpha"
+          },
+          {
+            "Version": "2.3.15-alpha"
+          },
+          {
+            "Version": "2.3.16-alpha"
+          },
+          {
+            "Version": "2.3.17-alpha"
+          },
+          {
+            "Version": "2.3.18-alpha"
+          },
+          {
+            "Version": "2.3.19-alpha"
+          },
+          {
+            "Version": "2.3.20-alpha"
+          },
+          {
+            "Version": "2.3.21-alpha"
+          },
+          {
+            "Version": "2.3.22-alpha"
+          },
+          {
+            "Version": "2.3.23-alpha"
+          },
+          {
+            "Version": "2.3.24-alpha"
+          },
+          {
+            "Version": "2.3.26-alpha"
+          },
+          {
+            "Version": "2.3.28-alpha"
+          },
+          {
+            "Version": "2.3.30-alpha"
+          },
+          {
+            "Version": "2.3.31-alpha"
+          },
+          {
+            "Version": "2.3.32-alpha"
+          },
+          {
+            "Version": "2.3.33-alpha"
+          },
+          {
+            "Version": "2.3.34-alpha"
+          },
+          {
+            "Version": "2.3.36-alpha"
+          },
+          {
+            "Version": "2.3.37-alpha"
+          },
+          {
+            "Version": "2.3.38-alpha"
+          },
+          {
+            "Version": "2.3.39-alpha"
+          },
+          {
+            "Version": "2.3.41-alpha"
+          },
+          {
+            "Version": "2.3.43-alpha"
+          },
+          {
+            "Version": "2.3.49-alpha"
+          },
+          {
+            "Version": "2.3.50-alpha"
+          },
+          {
+            "Version": "2.3.51-alpha"
+          },
+          {
+            "Version": "2.3.54-alpha"
+          },
+          {
+            "Version": "2.3.55-alpha"
+          },
+          {
+            "Version": "2.3.57-alpha"
+          },
+          {
+            "Version": "2.3.58-alpha"
+          },
+          {
+            "Version": "2.3.59-alpha"
+          },
+          {
+            "Version": "2.3.60-alpha"
+          },
+          {
+            "Version": "2.3.61-alpha"
+          },
+          {
+            "Version": "2.3.62-alpha"
+          },
+          {
+            "Version": "2.3.63-alpha"
+          },
+          {
+            "Version": "2.3.64-alpha"
+          },
+          {
+            "Version": "2.3.65-alpha"
+          },
+          {
+            "Version": "2.3.66-alpha"
+          },
+          {
+            "Version": "2.3.67-alpha"
+          },
+          {
+            "Version": "2.3.68-alpha"
+          },
+          {
+            "Version": "2.3.69-alpha"
+          },
+          {
+            "Version": "2.3.70-alpha"
+          },
+          {
+            "Version": "2.3.71-alpha"
+          },
+          {
+            "Version": "2.3.72-alpha"
+          },
+          {
+            "Version": "2.3.73-alpha"
+          },
+          {
+            "Version": "2.3.74-alpha"
+          },
+          {
+            "Version": "2.3.75-alpha"
+          },
+          {
+            "Version": "2.3.76-alpha"
+          },
+          {
+            "Version": "2.3.77-alpha"
+          },
+          {
+            "Version": "2.3.78-alpha"
+          },
+          {
+            "Version": "2.3.79-alpha"
+          },
+          {
+            "Version": "2.3.80-alpha"
+          },
+          {
+            "Version": "2.3.81-alpha"
+          },
+          {
+            "Version": "2.3.82-alpha"
+          },
+          {
+            "Version": "2.3.83-alpha"
+          },
+          {
+            "Version": "2.3.84-alpha"
+          },
+          {
+            "Version": "2.3.85-alpha"
+          },
+          {
+            "Version": "2.3.86-alpha"
+          },
+          {
+            "Version": "2.3.87-alpha"
+          },
+          {
+            "Version": "2.3.88-alpha"
+          },
+          {
+            "Version": "2.4.0.0"
+          },
+          {
+            "Version": "2.4.1.0"
+          },
+          {
+            "Version": "2.4.2.0"
+          },
+          {
+            "Version": "2.4.3.0"
+          },
+          {
+            "Version": "2.4.4.0"
+          },
+          {
+            "Version": "2.4.5.0"
+          },
+          {
+            "Version": "2.4.6.0"
+          },
+          {
+            "Version": "2.4.7.0"
+          },
+          {
+            "Version": "2.4.8.0"
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.4-alpha"
+          },
+          {
+            "Version": "2.5.5-alpha"
+          },
+          {
+            "Version": "2.5.7-alpha"
+          },
+          {
+            "Version": "2.5.8-alpha"
+          },
+          {
+            "Version": "2.5.9-alpha"
+          },
+          {
+            "Version": "2.5.10-alpha"
+          },
+          {
+            "Version": "2.5.11-alpha"
+          },
+          {
+            "Version": "2.5.12-alpha"
+          },
+          {
+            "Version": "2.5.17-alpha"
+          },
+          {
+            "Version": "2.5.18-alpha"
+          },
+          {
+            "Version": "2.5.19-alpha"
+          },
+          {
+            "Version": "2.5.20-alpha"
+          },
+          {
+            "Version": "2.5.21-alpha"
+          },
+          {
+            "Version": "2.5.22-alpha"
+          },
+          {
+            "Version": "2.5.25-alpha"
+          },
+          {
+            "Version": "2.5.31-alpha"
+          },
+          {
+            "Version": "2.5.32-alpha"
+          },
+          {
+            "Version": "2.5.33-alpha"
+          },
+          {
+            "Version": "2.5.34-alpha"
+          },
+          {
+            "Version": "2.5.35-alpha"
+          },
+          {
+            "Version": "2.5.39-alpha"
+          },
+          {
+            "Version": "2.5.40-alpha"
+          },
+          {
+            "Version": "2.5.41-alpha"
+          },
+          {
+            "Version": "2.5.42-alpha"
+          },
+          {
+            "Version": "2.5.43-alpha"
+          },
+          {
+            "Version": "2.5.44-alpha"
+          },
+          {
+            "Version": "2.5.45-alpha"
+          },
+          {
+            "Version": "2.5.46-alpha"
+          },
+          {
+            "Version": "2.5.47-alpha"
+          },
+          {
+            "Version": "2.5.48-alpha"
+          },
+          {
+            "Version": "2.5.49-alpha"
+          },
+          {
+            "Version": "2.5.54-alpha"
+          },
+          {
+            "Version": "2.5.55-alpha"
+          },
+          {
+            "Version": "2.5.56-alpha"
+          },
+          {
+            "Version": "2.5.57-alpha"
+          },
+          {
+            "Version": "2.5.58-alpha"
+          },
+          {
+            "Version": "2.5.59-alpha"
+          },
+          {
+            "Version": "2.5.60-alpha"
+          },
+          {
+            "Version": "2.5.61-alpha"
+          },
+          {
+            "Version": "2.5.62-alpha"
+          },
+          {
+            "Version": "2.5.63-alpha"
+          },
+          {
+            "Version": "2.5.64-alpha"
+          },
+          {
+            "Version": "2.5.65-alpha"
+          },
+          {
+            "Version": "2.5.66-alpha"
+          },
+          {
+            "Version": "2.5.67-alpha"
+          },
+          {
+            "Version": "2.5.68-alpha"
+          },
+          {
+            "Version": "2.5.69-alpha"
+          },
+          {
+            "Version": "2.5.70-alpha"
+          },
+          {
+            "Version": "2.5.71-alpha"
+          },
+          {
+            "Version": "2.5.72-alpha"
+          },
+          {
+            "Version": "2.5.73-alpha"
+          },
+          {
+            "Version": "2.5.74-alpha"
+          },
+          {
+            "Version": "2.5.75-alpha"
+          },
+          {
+            "Version": "2.6.0.0"
+          },
+          {
+            "Version": "2.6.1.0"
+          },
+          {
+            "Version": "2.6.3.0"
+          },
+          {
+            "Version": "2.6.5.0"
+          },
+          {
+            "Version": "2.6.7.0"
+          },
+          {
+            "Version": "2.6.9.0"
+          },
+          {
+            "Version": "2.6.12.0"
+          },
+          {
+            "Version": "2.6.14.0"
+          },
+          {
+            "Version": "2.6.15.0"
+          },
+          {
+            "Version": "2.6.16.0"
+          },
+          {
+            "Version": "2.6.17.0"
+          },
+          {
+            "Version": "2.7.0-alpha10"
+          },
+          {
+            "Version": "2.7.0-alpha11"
+          },
+          {
+            "Version": "2.7.0-alpha13"
+          },
+          {
+            "Version": "2.7.0-alpha14"
+          },
+          {
+            "Version": "2.7.0-alpha15"
+          },
+          {
+            "Version": "2.7.0-alpha7"
+          },
+          {
+            "Version": "2.7.0-alpha8"
+          },
+          {
+            "Version": "2.7.0-alpha9"
+          },
+          {
+            "Version": "2.7.0.16-alpha"
+          },
+          {
+            "Version": "2.7.0.17-alpha"
+          },
+          {
+            "Version": "2.7.0.18-alpha"
+          },
+          {
+            "Version": "2.7.0.19-alpha"
+          },
+          {
+            "Version": "2.7.0.20-alpha"
+          },
+          {
+            "Version": "2.7.0.21-alpha"
+          },
+          {
+            "Version": "2.7.0.23-alpha"
+          },
+          {
+            "Version": "2.7.0.24-alpha"
+          },
+          {
+            "Version": "2.7.0.25-alpha"
+          },
+          {
+            "Version": "2.7.0.26-alpha"
+          },
+          {
+            "Version": "2.7.0.27-alpha"
+          },
+          {
+            "Version": "2.7.0.28-alpha"
+          },
+          {
+            "Version": "2.7.0.29-alpha"
+          },
+          {
+            "Version": "2.7.0.30-alpha"
+          },
+          {
+            "Version": "2.7.0.32-alpha"
+          },
+          {
+            "Version": "2.7.0.34-alpha"
+          },
+          {
+            "Version": "2.7.0.35-alpha"
+          },
+          {
+            "Version": "2.7.0.36-alpha"
+          },
+          {
+            "Version": "2.7.0.37-alpha"
+          },
+          {
+            "Version": "2.7.0.38-alpha"
+          },
+          {
+            "Version": "2.7.0.39-alpha"
+          },
+          {
+            "Version": "2.7.0.42-alpha"
+          },
+          {
+            "Version": "2.7.0.43-alpha"
+          },
+          {
+            "Version": "2.7.0.44-alpha"
+          },
+          {
+            "Version": "2.7.0.45-alpha"
+          },
+          {
+            "Version": "2.7.0.47-alpha"
+          },
+          {
+            "Version": "2.7.0.50-alpha"
+          },
+          {
+            "Version": "2.7.0.59-alpha"
+          },
+          {
+            "Version": "2.7.0.60-alpha"
+          },
+          {
+            "Version": "2.7.0.61-alpha"
+          },
+          {
+            "Version": "2.7.0.62-alpha"
+          },
+          {
+            "Version": "2.7.0.63-alpha"
+          },
+          {
+            "Version": "2.7.0.64-alpha"
+          },
+          {
+            "Version": "2.7.0.65-alpha"
+          },
+          {
+            "Version": "2.7.0.66-alpha"
+          },
+          {
+            "Version": "2.7.0.72-alpha"
+          },
+          {
+            "Version": "2.7.0.84-alpha"
+          },
+          {
+            "Version": "2.7.0.85-alpha"
+          },
+          {
+            "Version": "2.7.0.86-alpha"
+          },
+          {
+            "Version": "2.7.0.87-alpha"
+          },
+          {
+            "Version": "2.7.0.88-alpha"
+          },
+          {
+            "Version": "2.7.0.90-alpha"
+          },
+          {
+            "Version": "2.7.0.91-alpha"
+          },
+          {
+            "Version": "2.7.0.92-alpha"
+          },
+          {
+            "Version": "2.7.1-alpha"
+          },
+          {
+            "Version": "2.8.0.0"
+          },
+          {
+            "Version": "2.8.1.0"
+          },
+          {
+            "Version": "2.8.2.0"
+          },
+          {
+            "Version": "2.8.3.0"
+          },
+          {
+            "Version": "2.8.5.0"
+          },
+          {
+            "Version": "2.8.6.0"
+          },
+          {
+            "Version": "2.8.7.0"
+          },
+          {
+            "Version": "2.8.8.0"
+          },
+          {
+            "Version": "2.8.9.0"
+          },
+          {
+            "Version": "2.8.10.0"
+          },
+          {
+            "Version": "2.8.11.0"
+          },
+          {
+            "Version": "2.8.12.0"
+          },
+          {
+            "Version": "2.8.17.0"
+          },
+          {
+            "Version": "2.9.0.0-alpha"
+          },
+          {
+            "Version": "2.9.0.1-alpha"
+          },
+          {
+            "Version": "2.9.0.3-alpha"
+          },
+          {
+            "Version": "2.9.11-alpha"
+          },
+          {
+            "Version": "2.9.12-alpha"
+          },
+          {
+            "Version": "2.9.14-alpha"
+          },
+          {
+            "Version": "2.9.15-alpha"
+          },
+          {
+            "Version": "2.9.17-alpha"
+          },
+          {
+            "Version": "2.9.19-alpha"
+          },
+          {
+            "Version": "2.9.20-alpha"
+          },
+          {
+            "Version": "2.9.21-alpha"
+          },
+          {
+            "Version": "2.9.22-alpha"
+          },
+          {
+            "Version": "2.9.23-alpha"
+          },
+          {
+            "Version": "2.9.24-alpha"
+          },
+          {
+            "Version": "2.9.26-alpha"
+          },
+          {
+            "Version": "2.9.27-alpha"
+          },
+          {
+            "Version": "2.9.28-alpha"
+          },
+          {
+            "Version": "2.9.29-alpha"
+          },
+          {
+            "Version": "2.9.30-alpha"
+          },
+          {
+            "Version": "2.9.31-alpha"
+          },
+          {
+            "Version": "2.9.32-alpha"
+          },
+          {
+            "Version": "2.9.33-alpha"
+          },
+          {
+            "Version": "2.9.34-alpha"
+          },
+          {
+            "Version": "2.9.35-alpha"
+          },
+          {
+            "Version": "2.9.36-alpha"
+          },
+          {
+            "Version": "2.9.37-alpha"
+          },
+          {
+            "Version": "2.9.41-alpha"
+          },
+          {
+            "Version": "2.9.42-alpha"
+          },
+          {
+            "Version": "2.9.44-alpha"
+          },
+          {
+            "Version": "2.9.45-alpha"
+          },
+          {
+            "Version": "2.9.46-alpha"
+          },
+          {
+            "Version": "2.9.47-alpha"
+          },
+          {
+            "Version": "2.10.0.0"
+          },
+          {
+            "Version": "2.10.1.0"
+          },
+          {
+            "Version": "2.10.2.0"
+          },
+          {
+            "Version": "2.10.3.0"
+          },
+          {
+            "Version": "2.10.4.0"
+          },
+          {
+            "Version": "2.10.5.0"
+          },
+          {
+            "Version": "2.10.6.0"
+          },
+          {
+            "Version": "2.10.7.0"
+          },
+          {
+            "Version": "2.10.8.0"
+          },
+          {
+            "Version": "2.10.9.0"
+          },
+          {
+            "Version": "2.10.10.0"
+          },
+          {
+            "Version": "2.10.11.0"
+          },
+          {
+            "Version": "2.10.12.0"
+          },
+          {
+            "Version": "2.10.13.0"
+          },
+          {
+            "Version": "2.10.14.0"
+          },
+          {
+            "Version": "2.10.15.0"
+          },
+          {
+            "Version": "2.10.16.0"
+          },
+          {
+            "Version": "2.10.17.0"
+          },
+          {
+            "Version": "2.10.18.0"
+          },
+          {
+            "Version": "2.10.19.0"
+          },
+          {
+            "Version": "2.10.20.0"
+          },
+          {
+            "Version": "2.10.23.0"
+          },
+          {
+            "Version": "2.10.24.0"
+          },
+          {
+            "Version": "2.10.25.0"
+          },
+          {
+            "Version": "2.11.0-alpha"
+          },
+          {
+            "Version": "2.11.1-alpha"
+          },
+          {
+            "Version": "2.11.2-alpha"
+          },
+          {
+            "Version": "2.11.3-alpha"
+          },
+          {
+            "Version": "2.11.4-alpha"
+          },
+          {
+            "Version": "2.11.5-alpha"
+          },
+          {
+            "Version": "2.11.6-alpha"
+          },
+          {
+            "Version": "2.11.8-alpha"
+          },
+          {
+            "Version": "2.11.9-alpha"
+          },
+          {
+            "Version": "2.11.10-alpha"
+          },
+          {
+            "Version": "2.11.11-alpha"
+          },
+          {
+            "Version": "2.11.12-alpha"
+          },
+          {
+            "Version": "2.11.13-alpha"
+          },
+          {
+            "Version": "2.11.14-alpha"
+          },
+          {
+            "Version": "2.11.15-alpha"
+          },
+          {
+            "Version": "2.11.16-alpha"
+          },
+          {
+            "Version": "2.11.17-alpha"
+          },
+          {
+            "Version": "2.11.18-alpha"
+          },
+          {
+            "Version": "2.11.19-alpha"
+          },
+          {
+            "Version": "2.11.20-alpha"
+          },
+          {
+            "Version": "2.11.21-alpha"
+          },
+          {
+            "Version": "2.11.22-alpha"
+          },
+          {
+            "Version": "2.11.25-alpha"
+          },
+          {
+            "Version": "2.11.27-alpha"
+          },
+          {
+            "Version": "2.11.28-alpha"
+          },
+          {
+            "Version": "2.11.29-alpha"
+          },
+          {
+            "Version": "2.11.30-alpha"
+          },
+          {
+            "Version": "2.11.31-alpha"
+          },
+          {
+            "Version": "2.11.32-alpha"
+          },
+          {
+            "Version": "2.11.33-alpha"
+          },
+          {
+            "Version": "2.11.40-alpha"
+          },
+          {
+            "Version": "2.11.41-alpha"
+          },
+          {
+            "Version": "2.11.50-alpha"
+          },
+          {
+            "Version": "2.11.51-alpha"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.2"
+          },
+          {
+            "Version": "2.13.0-alpha1"
+          },
+          {
+            "Version": "2.13.0-alpha2"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.12"
+          },
+          {
+            "Version": "2.14.13"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.15.7"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "2.16.3"
+          },
+          {
+            "Version": "2.17.0"
+          },
+          {
+            "Version": "2.17.1"
+          },
+          {
+            "Version": "2.17.2"
+          },
+          {
+            "Version": "2.17.3-alpha1"
+          },
+          {
+            "Version": "2.17.3-alpha2"
+          },
+          {
+            "Version": "2.17.3"
+          },
+          {
+            "Version": "2.17.4"
+          },
+          {
+            "Version": "2.17.5"
+          },
+          {
+            "Version": "2.17.6"
+          },
+          {
+            "Version": "2.17.7"
+          },
+          {
+            "Version": "2.17.8"
+          },
+          {
+            "Version": "2.17.9"
+          },
+          {
+            "Version": "2.18.0-alpha1"
+          },
+          {
+            "Version": "2.18.0-alpha2"
+          },
+          {
+            "Version": "2.18.0-alpha3"
+          },
+          {
+            "Version": "2.18.0"
+          },
+          {
+            "Version": "2.18.1"
+          },
+          {
+            "Version": "2.18.2"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha10"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "3.2.5"
+          },
+          {
+            "Version": "3.2.6"
+          },
+          {
+            "Version": "3.2.7"
+          },
+          {
+            "Version": "3.2.8"
+          },
+          {
+            "Version": "3.2.9"
+          },
+          {
+            "Version": "3.2.10"
+          },
+          {
+            "Version": "3.2.11"
+          },
+          {
+            "Version": "3.2.12"
+          },
+          {
+            "Version": "3.2.13"
+          },
+          {
+            "Version": "3.2.14"
+          },
+          {
+            "Version": "3.2.15"
+          },
+          {
+            "Version": "3.2.16"
+          },
+          {
+            "Version": "3.2.17"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "3.5.9"
+          },
+          {
+            "Version": "3.5.10"
+          },
+          {
+            "Version": "3.5.11"
+          },
+          {
+            "Version": "3.5.12"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.7.8"
+          },
+          {
+            "Version": "3.7.9"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.8.3"
+          },
+          {
+            "Version": "3.8.4"
+          },
+          {
+            "Version": "3.8.5"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "3.9.4"
+          },
+          {
+            "Version": "3.9.5"
+          },
+          {
+            "Version": "3.9.6"
+          },
+          {
+            "Version": "3.9.7"
+          },
+          {
+            "Version": "3.9.8"
+          },
+          {
+            "Version": "3.9.9"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.11.2"
+          },
+          {
+            "Version": "3.11.3"
+          },
+          {
+            "Version": "3.11.4"
+          },
+          {
+            "Version": "3.12.2"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.13.2"
+          },
+          {
+            "Version": "3.13.3"
+          },
+          {
+            "Version": "3.13.4"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.14.1"
+          },
+          {
+            "Version": "3.14.2"
+          },
+          {
+            "Version": "3.14.3"
+          },
+          {
+            "Version": "3.14.4"
+          },
+          {
+            "Version": "3.14.5"
+          },
+          {
+            "Version": "3.14.6"
+          },
+          {
+            "Version": "3.14.7"
+          },
+          {
+            "Version": "3.14.8"
+          },
+          {
+            "Version": "3.14.9"
+          },
+          {
+            "Version": "3.14.10"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.17.1"
+          },
+          {
+            "Version": "3.17.2"
+          },
+          {
+            "Version": "3.17.3"
+          },
+          {
+            "Version": "3.17.4"
+          },
+          {
+            "Version": "3.17.5"
+          },
+          {
+            "Version": "3.17.6"
+          },
+          {
+            "Version": "3.17.7"
+          },
+          {
+            "Version": "3.17.8"
+          },
+          {
+            "Version": "3.17.9"
+          },
+          {
+            "Version": "3.17.11"
+          },
+          {
+            "Version": "3.17.12"
+          },
+          {
+            "Version": "3.17.13"
+          },
+          {
+            "Version": "3.17.14"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.19.3"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.25.1"
+          },
+          {
+            "Version": "3.25.2"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.26.1"
+          },
+          {
+            "Version": "3.26.3"
+          },
+          {
+            "Version": "3.26.4"
+          },
+          {
+            "Version": "3.26.5"
+          },
+          {
+            "Version": "3.26.6"
+          },
+          {
+            "Version": "3.26.7"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.27.1"
+          },
+          {
+            "Version": "3.27.2"
+          },
+          {
+            "Version": "3.27.3"
+          },
+          {
+            "Version": "3.27.4"
+          },
+          {
+            "Version": "3.27.5"
+          },
+          {
+            "Version": "3.27.6"
+          },
+          {
+            "Version": "3.27.7"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.28.1"
+          },
+          {
+            "Version": "3.28.2"
+          },
+          {
+            "Version": "3.28.3"
+          },
+          {
+            "Version": "3.28.4"
+          },
+          {
+            "Version": "3.28.5"
+          },
+          {
+            "Version": "3.28.6"
+          },
+          {
+            "Version": "3.28.7"
+          },
+          {
+            "Version": "3.28.8"
+          },
+          {
+            "Version": "3.29.1"
+          },
+          {
+            "Version": "3.29.2"
+          },
+          {
+            "Version": "3.29.3"
+          },
+          {
+            "Version": "3.29.4"
+          },
+          {
+            "Version": "3.29.5"
+          },
+          {
+            "Version": "3.29.6"
+          },
+          {
+            "Version": "3.29.7"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.31.4"
+          },
+          {
+            "Version": "3.32.4"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.34.3"
+          },
+          {
+            "Version": "3.34.4"
+          },
+          {
+            "Version": "3.34.5"
+          },
+          {
+            "Version": "3.34.6"
+          },
+          {
+            "Version": "3.34.7"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.35.2"
+          },
+          {
+            "Version": "3.35.3"
+          },
+          {
+            "Version": "3.35.4"
+          },
+          {
+            "Version": "3.35.5"
+          },
+          {
+            "Version": "3.36.0"
+          },
+          {
+            "Version": "3.37.0"
+          },
+          {
+            "Version": "3.37.1"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-alpha002"
+          },
+          {
+            "Version": "4.0.0-alpha003"
+          },
+          {
+            "Version": "4.0.0-alpha004"
+          },
+          {
+            "Version": "4.0.0-alpha005"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3"
+          },
+          {
+            "Version": "4.1.4"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1-alpha001"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "4.3.2"
+          },
+          {
+            "Version": "4.3.3"
+          },
+          {
+            "Version": "4.3.4"
+          },
+          {
+            "Version": "4.3.7"
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.4.1"
+          },
+          {
+            "Version": "4.4.2"
+          },
+          {
+            "Version": "4.4.3"
+          },
+          {
+            "Version": "4.4.4"
+          },
+          {
+            "Version": "4.4.5"
+          },
+          {
+            "Version": "4.4.6"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.6.0-alpha001"
+          },
+          {
+            "Version": "4.6.0-alpha002"
+          },
+          {
+            "Version": "4.6.0"
+          },
+          {
+            "Version": "4.6.1"
+          },
+          {
+            "Version": "4.6.2"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.6.4"
+          },
+          {
+            "Version": "4.7.0-alpha001"
+          },
+          {
+            "Version": "4.7.0-alpha002"
+          },
+          {
+            "Version": "4.7.0"
+          },
+          {
+            "Version": "4.7.1"
+          },
+          {
+            "Version": "4.7.2"
+          },
+          {
+            "Version": "4.7.3"
+          },
+          {
+            "Version": "4.8.0"
+          },
+          {
+            "Version": "4.9.0"
+          },
+          {
+            "Version": "4.9.1"
+          },
+          {
+            "Version": "4.9.2"
+          },
+          {
+            "Version": "4.9.3"
+          },
+          {
+            "Version": "4.9.5"
+          },
+          {
+            "Version": "4.9.6"
+          },
+          {
+            "Version": "4.9.7"
+          },
+          {
+            "Version": "4.9.8"
+          },
+          {
+            "Version": "4.10.0"
+          },
+          {
+            "Version": "4.10.1"
+          },
+          {
+            "Version": "4.10.3"
+          },
+          {
+            "Version": "4.10.4"
+          },
+          {
+            "Version": "4.10.5"
+          },
+          {
+            "Version": "4.11.0"
+          },
+          {
+            "Version": "4.11.1"
+          },
+          {
+            "Version": "4.11.2"
+          },
+          {
+            "Version": "4.11.3"
+          },
+          {
+            "Version": "4.12.0"
+          },
+          {
+            "Version": "4.12.2"
+          },
+          {
+            "Version": "4.13.0"
+          },
+          {
+            "Version": "4.13.1"
+          },
+          {
+            "Version": "4.14.0"
+          },
+          {
+            "Version": "4.14.1"
+          },
+          {
+            "Version": "4.14.2"
+          },
+          {
+            "Version": "4.14.3"
+          },
+          {
+            "Version": "4.14.4"
+          },
+          {
+            "Version": "4.14.5"
+          },
+          {
+            "Version": "4.14.7"
+          },
+          {
+            "Version": "4.14.8"
+          },
+          {
+            "Version": "4.14.9"
+          },
+          {
+            "Version": "4.15.0"
+          },
+          {
+            "Version": "4.15.1"
+          },
+          {
+            "Version": "4.15.2"
+          },
+          {
+            "Version": "4.16.0-alpha001"
+          },
+          {
+            "Version": "4.16.0"
+          },
+          {
+            "Version": "4.16.1"
+          },
+          {
+            "Version": "4.17.0-alpha001"
+          },
+          {
+            "Version": "4.17.0-alpha002"
+          },
+          {
+            "Version": "4.17.0-alpha003"
+          },
+          {
+            "Version": "4.17.0-alpha004"
+          },
+          {
+            "Version": "4.17.0-alpha005"
+          },
+          {
+            "Version": "4.17.0-alpha007"
+          },
+          {
+            "Version": "4.17.0"
+          },
+          {
+            "Version": "4.17.1"
+          },
+          {
+            "Version": "4.18.0"
+          },
+          {
+            "Version": "4.19.0"
+          },
+          {
+            "Version": "4.20.0"
+          },
+          {
+            "Version": "4.21.0"
+          },
+          {
+            "Version": "4.21.1"
+          },
+          {
+            "Version": "4.21.2"
+          },
+          {
+            "Version": "4.21.3"
+          },
+          {
+            "Version": "4.21.4"
+          },
+          {
+            "Version": "4.22.0"
+          },
+          {
+            "Version": "4.22.1"
+          },
+          {
+            "Version": "4.22.2"
+          },
+          {
+            "Version": "4.22.3"
+          },
+          {
+            "Version": "4.22.4"
+          },
+          {
+            "Version": "4.22.5"
+          },
+          {
+            "Version": "4.22.6"
+          },
+          {
+            "Version": "4.22.7"
+          },
+          {
+            "Version": "4.22.8"
+          },
+          {
+            "Version": "4.22.9"
+          },
+          {
+            "Version": "4.23.0"
+          },
+          {
+            "Version": "4.23.1"
+          },
+          {
+            "Version": "4.23.2"
+          },
+          {
+            "Version": "4.23.3"
+          },
+          {
+            "Version": "4.23.4"
+          },
+          {
+            "Version": "4.23.5"
+          },
+          {
+            "Version": "4.23.6"
+          },
+          {
+            "Version": "4.24.0"
+          },
+          {
+            "Version": "4.24.1"
+          },
+          {
+            "Version": "4.24.2"
+          },
+          {
+            "Version": "4.24.3"
+          },
+          {
+            "Version": "4.25.0"
+          },
+          {
+            "Version": "4.25.1"
+          },
+          {
+            "Version": "4.25.2"
+          },
+          {
+            "Version": "4.25.3"
+          },
+          {
+            "Version": "4.25.4"
+          },
+          {
+            "Version": "4.25.5"
+          },
+          {
+            "Version": "4.26.0"
+          },
+          {
+            "Version": "4.27.0"
+          },
+          {
+            "Version": "4.28.0"
+          },
+          {
+            "Version": "4.29.0"
+          },
+          {
+            "Version": "4.29.1"
+          },
+          {
+            "Version": "4.29.2"
+          },
+          {
+            "Version": "4.30.0"
+          },
+          {
+            "Version": "4.30.1"
+          },
+          {
+            "Version": "4.30.2"
+          },
+          {
+            "Version": "4.31.0"
+          },
+          {
+            "Version": "4.31.1"
+          },
+          {
+            "Version": "4.32.0"
+          },
+          {
+            "Version": "4.33.0"
+          },
+          {
+            "Version": "4.33.1"
+          },
+          {
+            "Version": "4.33.2"
+          },
+          {
+            "Version": "4.33.3"
+          },
+          {
+            "Version": "4.33.4"
+          },
+          {
+            "Version": "4.34.0"
+          },
+          {
+            "Version": "4.34.1"
+          },
+          {
+            "Version": "4.34.2"
+          },
+          {
+            "Version": "4.34.3"
+          },
+          {
+            "Version": "4.34.4"
+          },
+          {
+            "Version": "4.34.5"
+          },
+          {
+            "Version": "4.35.0"
+          },
+          {
+            "Version": "4.35.1"
+          },
+          {
+            "Version": "4.36.0"
+          },
+          {
+            "Version": "4.37.0"
+          },
+          {
+            "Version": "4.37.1"
+          },
+          {
+            "Version": "4.37.2"
+          },
+          {
+            "Version": "4.38.0"
+          },
+          {
+            "Version": "4.38.1"
+          },
+          {
+            "Version": "4.38.2"
+          },
+          {
+            "Version": "4.38.3"
+          },
+          {
+            "Version": "4.39.0"
+          },
+          {
+            "Version": "4.39.1"
+          },
+          {
+            "Version": "4.40.0"
+          },
+          {
+            "Version": "4.40.1"
+          },
+          {
+            "Version": "4.40.2"
+          },
+          {
+            "Version": "4.41.0"
+          },
+          {
+            "Version": "4.41.1"
+          },
+          {
+            "Version": "4.41.2"
+          },
+          {
+            "Version": "4.41.3"
+          },
+          {
+            "Version": "4.41.4"
+          },
+          {
+            "Version": "4.41.5"
+          },
+          {
+            "Version": "4.41.6"
+          },
+          {
+            "Version": "4.41.7"
+          },
+          {
+            "Version": "4.41.8"
+          },
+          {
+            "Version": "4.42.0"
+          },
+          {
+            "Version": "4.43.0"
+          },
+          {
+            "Version": "4.44.0"
+          },
+          {
+            "Version": "4.44.1"
+          },
+          {
+            "Version": "4.44.2"
+          },
+          {
+            "Version": "4.44.3"
+          },
+          {
+            "Version": "4.44.4"
+          },
+          {
+            "Version": "4.45.0"
+          },
+          {
+            "Version": "4.45.1"
+          },
+          {
+            "Version": "4.45.2"
+          },
+          {
+            "Version": "4.45.3"
+          },
+          {
+            "Version": "4.46.0"
+          },
+          {
+            "Version": "4.46.1"
+          },
+          {
+            "Version": "4.47.0"
+          },
+          {
+            "Version": "4.47.1"
+          },
+          {
+            "Version": "4.47.2"
+          },
+          {
+            "Version": "4.47.4"
+          },
+          {
+            "Version": "4.48.0"
+          },
+          {
+            "Version": "4.49.0"
+          },
+          {
+            "Version": "4.49.1"
+          },
+          {
+            "Version": "4.50.0"
+          },
+          {
+            "Version": "4.50.1"
+          },
+          {
+            "Version": "4.51.1"
+          },
+          {
+            "Version": "4.52.0"
+          },
+          {
+            "Version": "4.53.0"
+          },
+          {
+            "Version": "4.54.0-alpha001"
+          },
+          {
+            "Version": "4.54.0"
+          },
+          {
+            "Version": "4.55.0"
+          },
+          {
+            "Version": "4.55.1"
+          },
+          {
+            "Version": "4.56.0"
+          },
+          {
+            "Version": "4.57.0"
+          },
+          {
+            "Version": "4.57.1"
+          },
+          {
+            "Version": "4.57.2"
+          },
+          {
+            "Version": "4.57.3"
+          },
+          {
+            "Version": "4.57.4"
+          },
+          {
+            "Version": "4.58.2"
+          },
+          {
+            "Version": "4.58.3"
+          },
+          {
+            "Version": "4.58.4"
+          },
+          {
+            "Version": "4.58.5"
+          },
+          {
+            "Version": "4.58.6"
+          },
+          {
+            "Version": "4.59.0-alpha001"
+          },
+          {
+            "Version": "4.59.0-alpha002"
+          },
+          {
+            "Version": "4.59.0"
+          },
+          {
+            "Version": "4.59.1"
+          },
+          {
+            "Version": "4.59.3"
+          },
+          {
+            "Version": "4.60.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/4.60.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:37",
+        "PackageName": "System.Runtime.Loader",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Loader",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Loader/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:26",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:28",
+        "PackageName": "RazorEngine.N",
+        "Versions": [
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "RazorEngine.N",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/RazorEngine.N/3.5.0",
+              "LicenseUrl": "https://github.com/matthid/RazorEngine/blob/master/doc/LICENSE.md",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 3.2.2",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": "2.0.30506",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:27",
+        "PackageName": "NUnit.ConsoleRunner",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit.ConsoleRunner",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.ConsoleRunner/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:35",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:38",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:38",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:30",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:26",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:37",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:27",
+        "PackageName": "NUnit.Extension.NUnitProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitProjectLoader",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitProjectLoader/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:29",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:28",
+        "PackageName": "NUnit.Extension.VSProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.VSProjectLoader",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.VSProjectLoader/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:05.6601254+02:00",
+        "PackageName": "FSharp.Compiler.Service",
+        "Versions": [
+          {
+            "Version": "0.0.1-beta"
+          },
+          {
+            "Version": "0.0.2-alpha"
+          },
+          {
+            "Version": "0.0.3-alpha"
+          },
+          {
+            "Version": "0.0.4-alpha"
+          },
+          {
+            "Version": "0.0.5-alpha"
+          },
+          {
+            "Version": "0.0.6-alpha"
+          },
+          {
+            "Version": "0.0.7-alpha"
+          },
+          {
+            "Version": "0.0.8-alpha"
+          },
+          {
+            "Version": "0.0.9-alpha"
+          },
+          {
+            "Version": "0.0.10-alpha"
+          },
+          {
+            "Version": "0.0.11-alpha"
+          },
+          {
+            "Version": "0.0.12-alpha"
+          },
+          {
+            "Version": "0.0.15",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/0.0.15",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.0.16"
+          },
+          {
+            "Version": "0.0.17"
+          },
+          {
+            "Version": "0.0.18"
+          },
+          {
+            "Version": "0.0.20"
+          },
+          {
+            "Version": "0.0.21"
+          },
+          {
+            "Version": "0.0.22"
+          },
+          {
+            "Version": "0.0.24"
+          },
+          {
+            "Version": "0.0.25"
+          },
+          {
+            "Version": "0.0.26"
+          },
+          {
+            "Version": "0.0.27"
+          },
+          {
+            "Version": "0.0.28"
+          },
+          {
+            "Version": "0.0.29"
+          },
+          {
+            "Version": "0.0.30"
+          },
+          {
+            "Version": "0.0.31"
+          },
+          {
+            "Version": "0.0.32"
+          },
+          {
+            "Version": "0.0.33"
+          },
+          {
+            "Version": "0.0.35"
+          },
+          {
+            "Version": "0.0.36"
+          },
+          {
+            "Version": "0.0.38"
+          },
+          {
+            "Version": "0.0.39"
+          },
+          {
+            "Version": "0.0.40"
+          },
+          {
+            "Version": "0.0.41"
+          },
+          {
+            "Version": "0.0.42"
+          },
+          {
+            "Version": "0.0.43"
+          },
+          {
+            "Version": "0.0.44"
+          },
+          {
+            "Version": "0.0.45"
+          },
+          {
+            "Version": "0.0.46"
+          },
+          {
+            "Version": "0.0.47"
+          },
+          {
+            "Version": "0.0.48"
+          },
+          {
+            "Version": "0.0.49"
+          },
+          {
+            "Version": "0.0.50"
+          },
+          {
+            "Version": "0.0.52"
+          },
+          {
+            "Version": "0.0.53"
+          },
+          {
+            "Version": "0.0.54"
+          },
+          {
+            "Version": "0.0.55"
+          },
+          {
+            "Version": "0.0.56"
+          },
+          {
+            "Version": "0.0.57"
+          },
+          {
+            "Version": "0.0.58"
+          },
+          {
+            "Version": "0.0.59"
+          },
+          {
+            "Version": "0.0.60"
+          },
+          {
+            "Version": "0.0.61"
+          },
+          {
+            "Version": "0.0.62"
+          },
+          {
+            "Version": "0.0.64"
+          },
+          {
+            "Version": "0.0.65"
+          },
+          {
+            "Version": "0.0.66"
+          },
+          {
+            "Version": "0.0.67"
+          },
+          {
+            "Version": "0.0.70"
+          },
+          {
+            "Version": "0.0.71"
+          },
+          {
+            "Version": "0.0.72"
+          },
+          {
+            "Version": "0.0.73"
+          },
+          {
+            "Version": "0.0.74"
+          },
+          {
+            "Version": "0.0.75"
+          },
+          {
+            "Version": "0.0.76"
+          },
+          {
+            "Version": "0.0.79"
+          },
+          {
+            "Version": "0.0.80"
+          },
+          {
+            "Version": "0.0.81"
+          },
+          {
+            "Version": "0.0.82"
+          },
+          {
+            "Version": "0.0.83"
+          },
+          {
+            "Version": "0.0.84"
+          },
+          {
+            "Version": "0.0.85"
+          },
+          {
+            "Version": "0.0.86"
+          },
+          {
+            "Version": "0.0.87"
+          },
+          {
+            "Version": "0.0.88"
+          },
+          {
+            "Version": "0.0.89"
+          },
+          {
+            "Version": "0.0.90"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.1.2"
+          },
+          {
+            "Version": "1.4.0.0-beta"
+          },
+          {
+            "Version": "1.4.0.1"
+          },
+          {
+            "Version": "1.4.0.4"
+          },
+          {
+            "Version": "1.4.0.5"
+          },
+          {
+            "Version": "1.4.0.6"
+          },
+          {
+            "Version": "1.4.0.8"
+          },
+          {
+            "Version": "1.4.0.9"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2.0"
+          },
+          {
+            "Version": "1.4.2.1"
+          },
+          {
+            "Version": "1.4.2.2"
+          },
+          {
+            "Version": "1.4.2.3"
+          },
+          {
+            "Version": "2.0.0.0-beta"
+          },
+          {
+            "Version": "2.0.0.1-beta"
+          },
+          {
+            "Version": "2.0.0.2"
+          },
+          {
+            "Version": "2.0.0.3"
+          },
+          {
+            "Version": "2.0.0.4"
+          },
+          {
+            "Version": "2.0.0.5"
+          },
+          {
+            "Version": "2.0.0.6"
+          },
+          {
+            "Version": "2.0.0.7"
+          },
+          {
+            "Version": "2.0.0.8"
+          },
+          {
+            "Version": "3.0.0.0"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "8.0.0"
+          },
+          {
+            "Version": "9.0.0"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.3"
+          },
+          {
+            "Version": "11.0.1"
+          },
+          {
+            "Version": "11.0.2"
+          },
+          {
+            "Version": "11.0.4"
+          },
+          {
+            "Version": "11.0.6"
+          },
+          {
+            "Version": "11.0.9"
+          },
+          {
+            "Version": "11.0.10"
+          },
+          {
+            "Version": "12.0.1"
+          },
+          {
+            "Version": "12.0.2"
+          },
+          {
+            "Version": "12.0.5"
+          },
+          {
+            "Version": "12.0.7"
+          },
+          {
+            "Version": "12.0.8",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/12.0.8",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.1.17",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.DiaSymReader",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.DiaSymReader.PortablePdb",
+                  "VersionRequirement": ">= 1.2",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.3.1",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Metadata",
+                  "VersionRequirement": ">= 1.4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Metadata",
+                  "VersionRequirement": ">= 1.4.2",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Loader",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:38",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:28",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:06.7506249+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.5.7.10213",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.5.7.10213",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.5.9.10348"
+          },
+          {
+            "Version": "2.5.10.11092"
+          },
+          {
+            "Version": "2.6.0.12051"
+          },
+          {
+            "Version": "2.6.0.12054"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "3.0.0-alpha"
+          },
+          {
+            "Version": "3.0.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-alpha-3"
+          },
+          {
+            "Version": "3.0.0-alpha-4"
+          },
+          {
+            "Version": "3.0.0-alpha-5"
+          },
+          {
+            "Version": "3.0.0-beta-1"
+          },
+          {
+            "Version": "3.0.0-beta-2"
+          },
+          {
+            "Version": "3.0.0-beta-3"
+          },
+          {
+            "Version": "3.0.0-beta-4"
+          },
+          {
+            "Version": "3.0.0-beta-5"
+          },
+          {
+            "Version": "3.0.0-rc"
+          },
+          {
+            "Version": "3.0.0-rc-2"
+          },
+          {
+            "Version": "3.0.0-rc-3"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Loader",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:32",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:31",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:26",
+        "PackageName": "Microsoft.AspNet.Razor",
+        "Versions": [
+          {
+            "Version": "2.0.30506.0",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Razor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.Razor/2.0.30506.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/webpages_2_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:27",
+        "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitV2ResultWriter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitV2ResultWriter/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:27",
+        "PackageName": "NUnit.Extension.NUnitV2Driver",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitV2Driver",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitV2Driver/3.6.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:18",
+        "PackageName": "CommandLineParser",
+        "Versions": [
+          {
+            "Version": "1.9.71",
+            "PackageDetails": {
+              "Name": "CommandLineParser",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/CommandLineParser/1.9.71",
+              "LicenseUrl": "https://raw.github.com/gsscoder/commandline/master/doc/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:29",
+        "PackageName": "System.Collections.Immutable",
+        "Versions": [
+          {
+            "Version": "1.1.32-beta"
+          },
+          {
+            "Version": "1.1.33-beta"
+          },
+          {
+            "Version": "1.1.34-rc"
+          },
+          {
+            "Version": "1.1.36"
+          },
+          {
+            "Version": "1.1.37-beta-23019"
+          },
+          {
+            "Version": "1.1.37-beta-23109"
+          },
+          {
+            "Version": "1.1.37"
+          },
+          {
+            "Version": "1.1.38-beta-23225"
+          },
+          {
+            "Version": "1.1.38-beta-23409"
+          },
+          {
+            "Version": "1.1.38-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-24027"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1",
+            "PackageDetails": {
+              "Name": "System.Collections.Immutable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Immutable/1.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:28",
+        "PackageName": "NUnit.Extension.TeamCityEventListener",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.TeamCityEventListener",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.TeamCityEventListener/1.0.2",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:31:31",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000299-restore-package-that-ends-in-lib/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000299-restore-package-that-ends-in-lib/cache/paket-graph.cache
@@ -1,0 +1,67 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:12.1096269+02:00",
+        "PackageName": "FunScript.TypeScript.Binding.lib",
+        "Versions": [
+          {
+            "Version": "1.1.0.0",
+            "PackageDetails": {
+              "Name": "FunScript.TypeScript.Binding.lib",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FunScript.TypeScript.Binding.lib/1.1.0.0",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.1.0.1"
+          },
+          {
+            "Version": "1.1.0.2"
+          },
+          {
+            "Version": "1.1.0.8"
+          },
+          {
+            "Version": "1.1.0.10"
+          },
+          {
+            "Version": "1.1.0.11"
+          },
+          {
+            "Version": "1.1.0.13"
+          },
+          {
+            "Version": "1.1.0.30"
+          },
+          {
+            "Version": "1.1.0.31"
+          },
+          {
+            "Version": "1.1.0.34"
+          },
+          {
+            "Version": "1.1.0.35"
+          },
+          {
+            "Version": "1.1.0.36"
+          },
+          {
+            "Version": "1.1.0.37",
+            "PackageDetails": {
+              "Name": "FunScript.TypeScript.Binding.lib",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FunScript.TypeScript.Binding.lib/1.1.0.37",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000310-add-should-not-create-invalid-resolution/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000310-add-should-not-create-invalid-resolution/cache/paket-graph.cache
@@ -1,0 +1,114 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "0001-01-01T00:00:00",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.3.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.3"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:25:52.9731581+02:00",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core/3.2.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.2",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core/3.2.2",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000346-aliases/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000346-aliases/cache/paket-graph.cache
@@ -1,0 +1,60 @@
+{
+  "nuget_repo": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:12.5713168+02:00",
+        "PackageName": "Dapper",
+        "Versions": [
+          {
+            "Version": "1.40"
+          },
+          {
+            "Version": "1.42.0",
+            "PackageDetails": {
+              "Name": "Dapper",
+              "DownloadLink": "Dapper",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:12.6623188+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "NUnit",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:12.5963168+02:00",
+        "PackageName": "MultiTarget",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "MultiTarget",
+              "DownloadLink": "MultiTarget",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i000359-packagename-contains-nuget/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i000359-packagename-contains-nuget/cache/paket-graph.cache
@@ -1,0 +1,199 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:14.5161272+02:00",
+        "PackageName": "nuget.CommandLine",
+        "Versions": [
+          {
+            "Version": "1.0.11220.26",
+            "PackageDetails": {
+              "Name": "NuGet.CommandLine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NuGet.CommandLine/1.0.11220.26",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.1.2120.134"
+          },
+          {
+            "Version": "1.1.2120.136"
+          },
+          {
+            "Version": "1.1.2121.140"
+          },
+          {
+            "Version": "1.1.2122.156"
+          },
+          {
+            "Version": "1.2.2128.11"
+          },
+          {
+            "Version": "1.2.20216.59"
+          },
+          {
+            "Version": "1.2.20310.1"
+          },
+          {
+            "Version": "1.2.20311.3"
+          },
+          {
+            "Version": "1.2.20325.10"
+          },
+          {
+            "Version": "1.2.20401.11"
+          },
+          {
+            "Version": "1.2.20409.25"
+          },
+          {
+            "Version": "1.2.20415.26"
+          },
+          {
+            "Version": "1.2.20416.28"
+          },
+          {
+            "Version": "1.2.20416.30"
+          },
+          {
+            "Version": "1.2.20417.31"
+          },
+          {
+            "Version": "1.3.20425.372"
+          },
+          {
+            "Version": "1.4.20615.182"
+          },
+          {
+            "Version": "1.5.20830.9001"
+          },
+          {
+            "Version": "1.5.20905.5"
+          },
+          {
+            "Version": "1.5.21005.9019"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.4"
+          },
+          {
+            "Version": "1.8.40000"
+          },
+          {
+            "Version": "1.8.40001"
+          },
+          {
+            "Version": "1.8.40002"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.40000"
+          },
+          {
+            "Version": "2.0.40001"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.3"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.8.1"
+          },
+          {
+            "Version": "2.8.2-beta"
+          },
+          {
+            "Version": "2.8.2"
+          },
+          {
+            "Version": "2.8.3"
+          },
+          {
+            "Version": "2.8.5"
+          },
+          {
+            "Version": "2.8.6"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.4.4-rtm-final"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NuGet.CommandLine",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NuGet.CommandLine/3.5.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0-rc2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001117-aws/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001117-aws/cache/paket-graph.cache
@@ -1,0 +1,10585 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:35.5948518+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:42.3630913+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:16.1840033+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:48.5740916+02:00",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:25.9292922+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:13.716501+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:40.9730335+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:45.9125895+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:37.0778493+02:00",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:32.156296+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:26.1082911+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:13.9780013+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:33.6882941+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.3339997+02:00",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:31.5287936+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:20.0922895+02:00",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:45.2110891+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:32.7352985+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:42.7140878+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:39.5592908+02:00",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:10.7715002+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.4714994+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:39.1897788+02:00",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:40.7990342+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:36.7198516+02:00",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:47.5185913+02:00",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:21.9667906+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:11.317001+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:43.0710906+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:30.6722919+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:44.482589+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:27.9452922+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:43.6031027+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:15.7150039+02:00",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:47.3336184+02:00",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:44.6615916+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:38.5017629+02:00",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:14.9110018+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:19.2452897+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.6985002+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:27.5767921+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:38.3307635+02:00",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:46.091591+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:40.6095329+02:00",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:41.832062+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:11.8750005+02:00",
+        "PackageName": "System.Diagnostics.Contracts",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Contracts",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Diagnostics.Contracts/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:21.1333017+02:00",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:42.1880899+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:40.4272971+02:00",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:37.8083495+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:22.3227928+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:19.4737894+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:46.6150909+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:46.7930892+02:00",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:37.2483503+02:00",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:35.3998477+02:00",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.1565014+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:21.625792+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:48.9655921+02:00",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:39.7297964+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:12.3850008+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:08.5904998+02:00",
+        "PackageName": "PInvoke.Kernel32",
+        "Versions": [
+          {
+            "Version": "0.1.45-beta"
+          },
+          {
+            "Version": "0.1.122-beta"
+          },
+          {
+            "Version": "0.1.300-beta"
+          },
+          {
+            "Version": "0.1.419-rc"
+          },
+          {
+            "Version": "0.1.501"
+          },
+          {
+            "Version": "0.1.539"
+          },
+          {
+            "Version": "0.2.1"
+          },
+          {
+            "Version": "0.2.8"
+          },
+          {
+            "Version": "0.2.10"
+          },
+          {
+            "Version": "0.3.2"
+          },
+          {
+            "Version": "0.3.90"
+          },
+          {
+            "Version": "0.3.152"
+          },
+          {
+            "Version": "0.4.10"
+          },
+          {
+            "Version": "0.5.60"
+          },
+          {
+            "Version": "0.5.64",
+            "PackageDetails": {
+              "Name": "PInvoke.Kernel32",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/PInvoke.Kernel32/0.5.64",
+              "LicenseUrl": "https://raw.githubusercontent.com/AArnott/pinvoke/0b9dd5fdd5/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "PInvoke.Windows.Core",
+                  "VersionRequirement": ">= 0.5.64",
+                  "FrameworkRestrictions": "portable-net40+win8+wpa81, portable-net45+win8+wpa81, net20, >= net40, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:08.7764998+02:00",
+        "PackageName": "PInvoke.NCrypt",
+        "Versions": [
+          {
+            "Version": "0.1.122-beta"
+          },
+          {
+            "Version": "0.1.300-beta"
+          },
+          {
+            "Version": "0.1.419-rc"
+          },
+          {
+            "Version": "0.1.501"
+          },
+          {
+            "Version": "0.1.539"
+          },
+          {
+            "Version": "0.2.1"
+          },
+          {
+            "Version": "0.2.8"
+          },
+          {
+            "Version": "0.2.10"
+          },
+          {
+            "Version": "0.3.2"
+          },
+          {
+            "Version": "0.3.90"
+          },
+          {
+            "Version": "0.3.152"
+          },
+          {
+            "Version": "0.4.10"
+          },
+          {
+            "Version": "0.5.60"
+          },
+          {
+            "Version": "0.5.64",
+            "PackageDetails": {
+              "Name": "PInvoke.NCrypt",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/PInvoke.NCrypt/0.5.64",
+              "LicenseUrl": "https://raw.githubusercontent.com/AArnott/pinvoke/0b9dd5fdd5/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "PInvoke.BCrypt",
+                  "VersionRequirement": ">= 0.5.64",
+                  "FrameworkRestrictions": "portable-net40+win8+wpa81, portable-net45+win8+wpa81, net20, >= net40, >= netstandard11"
+                },
+                {
+                  "PackageName": "PInvoke.Kernel32",
+                  "VersionRequirement": ">= 0.5.64",
+                  "FrameworkRestrictions": "portable-net40+win8+wpa81, portable-net45+win8+wpa81, net20, >= net40, >= netstandard11"
+                },
+                {
+                  "PackageName": "PInvoke.Windows.Core",
+                  "VersionRequirement": ">= 0.5.64",
+                  "FrameworkRestrictions": "portable-net40+win8+wpa81, portable-net45+win8+wpa81, net20, >= net40, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:48.7655892+02:00",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:07.3870016+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.6375004+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.2854998+02:00",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:21.349291+02:00",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:38.6732619+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.7515009+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:47.8711262+02:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:40.2417623+02:00",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.3749998+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:25.1162928+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:29.7627939+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:49.1495902+02:00",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:07.7025021+02:00",
+        "PackageName": "PCLCrypto",
+        "Versions": [
+          {
+            "Version": "0.1.0-alpha"
+          },
+          {
+            "Version": "0.1.1-alpha"
+          },
+          {
+            "Version": "0.2.0-beta"
+          },
+          {
+            "Version": "0.3.0-beta"
+          },
+          {
+            "Version": "0.3.1-beta"
+          },
+          {
+            "Version": "0.4.0-beta"
+          },
+          {
+            "Version": "0.4.1-beta"
+          },
+          {
+            "Version": "0.5.0.14108"
+          },
+          {
+            "Version": "0.5.1.14165"
+          },
+          {
+            "Version": "0.5.2.14286"
+          },
+          {
+            "Version": "1.0.0-beta"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0.15071"
+          },
+          {
+            "Version": "1.0.1.15115"
+          },
+          {
+            "Version": "1.0.2.15130"
+          },
+          {
+            "Version": "1.0.80"
+          },
+          {
+            "Version": "1.0.82"
+          },
+          {
+            "Version": "1.0.86"
+          },
+          {
+            "Version": "1.1.86-beta"
+          },
+          {
+            "Version": "2.0.125-rc"
+          },
+          {
+            "Version": "2.0.131-rc"
+          },
+          {
+            "Version": "2.0.140"
+          },
+          {
+            "Version": "2.0.144"
+          },
+          {
+            "Version": "2.0.145"
+          },
+          {
+            "Version": "2.0.147",
+            "PackageDetails": {
+              "Name": "PCLCrypto",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/PCLCrypto/2.0.147",
+              "LicenseUrl": "https://raw.githubusercontent.com/AArnott/PCLCrypto/313d8a787a/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "PInvoke.NCrypt",
+                  "VersionRequirement": ">= 0.3.2",
+                  "FrameworkRestrictions": "dnxcore50, portable-dnxcore50+monoandroid10+monotouch10+unsupported+win+wpa81+xamarinios10, >= net45"
+                },
+                {
+                  "PackageName": "Validation",
+                  "VersionRequirement": ">= 2.2.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:37.4228522+02:00",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:30.0647922+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:45.5525914+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.2025029+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:14.2460025+02:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:12.2215005+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:44.1265898+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:33.3812922+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:10.2235002+02:00",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:36.9068488+02:00",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:07.0719979+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:34.9393495+02:00",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:41.4910343+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:46.2601056+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:41.3250345+02:00",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:13.2330013+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:07.4340146+02:00",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:35.7713613+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:07.2060004+02:00",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.8730001+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:27.252793+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:39.8962618+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:45.3775896+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:40.0737613+02:00",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:41.6675343+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:38.1567714+02:00",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:05.4849987+02:00",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:08.1549998+02:00",
+        "PackageName": "PCLStorage",
+        "Versions": [
+          {
+            "Version": "0.1.0-pre"
+          },
+          {
+            "Version": "0.1.1-pre"
+          },
+          {
+            "Version": "0.2.0-pre"
+          },
+          {
+            "Version": "0.2.1-pre"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.3"
+          },
+          {
+            "Version": "0.9.4"
+          },
+          {
+            "Version": "0.9.5"
+          },
+          {
+            "Version": "0.9.6"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "PCLStorage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/PCLStorage/1.0.2",
+              "LicenseUrl": "https://github.com/dsplaisted/PCLStorage/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.6",
+                  "FrameworkRestrictions": "net10, net11, net20, net30, net35, net40, net40-full"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.165",
+                  "FrameworkRestrictions": "net10, net11, net20, net30, net35, net40, net40-full"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.2435003+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:38.844794+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:11.5305048+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:36.3473529+02:00",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:34.392293+02:00",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:20.67879+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:48.035103+02:00",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:49.3220923+02:00",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:44.310089+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:29.8792929+02:00",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:48.2091204+02:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:35.1968509+02:00",
+        "PackageName": "Validation",
+        "Versions": [
+          {
+            "Version": "1.0.0.12259"
+          },
+          {
+            "Version": "2.0.0.12319"
+          },
+          {
+            "Version": "2.0.1.12362"
+          },
+          {
+            "Version": "2.0.2.13022"
+          },
+          {
+            "Version": "2.0.3.13323"
+          },
+          {
+            "Version": "2.0.4.14103"
+          },
+          {
+            "Version": "2.0.5.14286"
+          },
+          {
+            "Version": "2.0.6.15003"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.2.8"
+          },
+          {
+            "Version": "2.3.5"
+          },
+          {
+            "Version": "2.3.7"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.15-g8377954d86"
+          },
+          {
+            "Version": "2.4.15",
+            "PackageDetails": {
+              "Name": "Validation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Validation/2.4.15",
+              "LicenseUrl": "https://raw.githubusercontent.com/AArnott/Validation/8377954d86/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.5860002+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:17.8672884+02:00",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:35.9448486+02:00",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.1015003+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:39.0217615+02:00",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:12.5835006+02:00",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:46.9820887+02:00",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:39.3752913+02:00",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:43.956091+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:16.7440036+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:36.5108505+02:00",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:28.916792+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:45.7340898+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:46.4380891+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:10.159001+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:42.5340888+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:31.0887913+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:18.6768183+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:44.842089+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:15.4930008+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:04.5844982+02:00",
+        "PackageName": "AWSSDK.Core",
+        "Versions": [
+          {
+            "Version": "3.1.5.3",
+            "PackageDetails": {
+              "Name": "AWSSDK.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AWSSDK.Core/3.1.5.3",
+              "LicenseUrl": "http://aws.amazon.com/apache2.0/",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Net.Http",
+                  "VersionRequirement": ">= 2.2.29",
+                  "FrameworkRestrictions": "portable-net45+win8+wp8+wpa81"
+                },
+                {
+                  "PackageName": "PCLCrypto",
+                  "VersionRequirement": ">= 1.0.2.15130",
+                  "FrameworkRestrictions": "portable-net45+win8+wp8+wpa81"
+                },
+                {
+                  "PackageName": "PCLStorage",
+                  "VersionRequirement": ">= 1.0.2",
+                  "FrameworkRestrictions": "portable-net45+win8+wp8+wpa81"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:41.1425362+02:00",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:37.6413491+02:00",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:22.5907902+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:48.3890911+02:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:47.6925918+02:00",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:43.7775929+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:07.0020163+02:00",
+        "PackageName": "Microsoft.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.1.3-beta"
+          },
+          {
+            "Version": "2.1.6-rc"
+          },
+          {
+            "Version": "2.1.10"
+          },
+          {
+            "Version": "2.2.3-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.10-rc"
+          },
+          {
+            "Version": "2.2.13"
+          },
+          {
+            "Version": "2.2.15"
+          },
+          {
+            "Version": "2.2.18"
+          },
+          {
+            "Version": "2.2.19"
+          },
+          {
+            "Version": "2.2.20"
+          },
+          {
+            "Version": "2.2.22"
+          },
+          {
+            "Version": "2.2.23-beta"
+          },
+          {
+            "Version": "2.2.27-beta"
+          },
+          {
+            "Version": "2.2.28"
+          },
+          {
+            "Version": "2.2.29",
+            "PackageDetails": {
+              "Name": "Microsoft.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Net.Http/2.2.29",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.5274992+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:06.3139985+02:00",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:08.3570005+02:00",
+        "PackageName": "PInvoke.BCrypt",
+        "Versions": [
+          {
+            "Version": "0.1.13-alpha"
+          },
+          {
+            "Version": "0.1.45-beta"
+          },
+          {
+            "Version": "0.1.122-beta"
+          },
+          {
+            "Version": "0.1.300-beta"
+          },
+          {
+            "Version": "0.1.419-rc"
+          },
+          {
+            "Version": "0.1.501"
+          },
+          {
+            "Version": "0.1.539"
+          },
+          {
+            "Version": "0.2.1"
+          },
+          {
+            "Version": "0.2.8"
+          },
+          {
+            "Version": "0.2.10"
+          },
+          {
+            "Version": "0.3.2"
+          },
+          {
+            "Version": "0.3.90"
+          },
+          {
+            "Version": "0.3.152"
+          },
+          {
+            "Version": "0.4.10"
+          },
+          {
+            "Version": "0.5.60"
+          },
+          {
+            "Version": "0.5.64",
+            "PackageDetails": {
+              "Name": "PInvoke.BCrypt",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/PInvoke.BCrypt/0.5.64",
+              "LicenseUrl": "https://raw.githubusercontent.com/AArnott/pinvoke/0b9dd5fdd5/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "PInvoke.Kernel32",
+                  "VersionRequirement": ">= 0.5.64",
+                  "FrameworkRestrictions": "portable-net40+win8+wpa81, portable-net45+win8+wpa81, net20, >= net40, >= netstandard11"
+                },
+                {
+                  "PackageName": "PInvoke.Windows.Core",
+                  "VersionRequirement": ">= 0.5.64",
+                  "FrameworkRestrictions": "portable-net40+win8+wpa81, portable-net45+win8+wpa81, net20, >= net40, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.8204997+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:45.0250903+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:43.2570978+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:42.0055886+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.4200139+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:09.0480008+02:00",
+        "PackageName": "PInvoke.Windows.Core",
+        "Versions": [
+          {
+            "Version": "0.1.13-alpha"
+          },
+          {
+            "Version": "0.1.45-beta"
+          },
+          {
+            "Version": "0.1.122-beta"
+          },
+          {
+            "Version": "0.1.300-beta"
+          },
+          {
+            "Version": "0.1.397-beta"
+          },
+          {
+            "Version": "0.1.419-rc"
+          },
+          {
+            "Version": "0.1.501"
+          },
+          {
+            "Version": "0.1.539"
+          },
+          {
+            "Version": "0.2.1"
+          },
+          {
+            "Version": "0.2.8"
+          },
+          {
+            "Version": "0.2.10"
+          },
+          {
+            "Version": "0.3.2"
+          },
+          {
+            "Version": "0.3.90"
+          },
+          {
+            "Version": "0.3.152"
+          },
+          {
+            "Version": "0.4.10"
+          },
+          {
+            "Version": "0.5.60"
+          },
+          {
+            "Version": "0.5.64",
+            "PackageDetails": {
+              "Name": "PInvoke.Windows.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/PInvoke.Windows.Core/0.5.64",
+              "LicenseUrl": "https://raw.githubusercontent.com/AArnott/pinvoke/0b9dd5fdd5/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:28.4127912+02:00",
+        "PackageName": "System.Runtime.WindowsRuntime",
+        "Versions": [
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.WindowsRuntime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.WindowsRuntime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:29.2852921+02:00",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:36.1163513+02:00",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:20.9097913+02:00",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:37.9843594+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:06.2235002+02:00",
+        "PackageName": "Microsoft.Bcl.Async",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.12-beta"
+          },
+          {
+            "Version": "1.0.14-rc"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.165"
+          },
+          {
+            "Version": "1.0.166-beta"
+          },
+          {
+            "Version": "1.0.166"
+          },
+          {
+            "Version": "1.0.168",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.168",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:43.421101+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:29.491791+02:00",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:33.469795+02:00",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:42.9010895+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:47.152598+02:00",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:01:15.9720027+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001125-update-and-keep-minor/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001125-update-and-keep-minor/cache/paket-graph.cache
@@ -1,0 +1,901 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:37.7647747+02:00",
+        "PackageName": "FSharp.Formatting",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.1-beta"
+          },
+          {
+            "Version": "2.1.2-beta"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.1.5"
+          },
+          {
+            "Version": "2.1.6"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4-beta"
+          },
+          {
+            "Version": "2.2.5-beta"
+          },
+          {
+            "Version": "2.2.6-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.9-beta"
+          },
+          {
+            "Version": "2.2.10-beta"
+          },
+          {
+            "Version": "2.2.11-beta"
+          },
+          {
+            "Version": "2.2.12-beta"
+          },
+          {
+            "Version": "2.3.1-beta"
+          },
+          {
+            "Version": "2.3.2-beta"
+          },
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.7-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha1"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.11.1-alpha1"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.14.2",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": "2.0.0.6"
+                },
+                {
+                  "PackageName": "FSharpVSPowerTools.Core",
+                  "VersionRequirement": ">= 2.3 < 2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.14.4",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": "2.0.0.6"
+                },
+                {
+                  "PackageName": "FSharpVSPowerTools.Core",
+                  "VersionRequirement": ">= 2.3 < 2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.14.5-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:31",
+        "PackageName": "FSharpVSPowerTools.Core",
+        "Versions": [
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "FSharpVSPowerTools.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharpVSPowerTools.Core/2.3.0",
+              "LicenseUrl": "https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 2.0.0.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:30",
+        "PackageName": "FSharp.Compiler.Service",
+        "Versions": [
+          {
+            "Version": "0.0.1-beta"
+          },
+          {
+            "Version": "0.0.2-alpha"
+          },
+          {
+            "Version": "0.0.3-alpha"
+          },
+          {
+            "Version": "0.0.4-alpha"
+          },
+          {
+            "Version": "0.0.5-alpha"
+          },
+          {
+            "Version": "0.0.6-alpha"
+          },
+          {
+            "Version": "0.0.7-alpha"
+          },
+          {
+            "Version": "0.0.8-alpha"
+          },
+          {
+            "Version": "0.0.9-alpha"
+          },
+          {
+            "Version": "0.0.10-alpha"
+          },
+          {
+            "Version": "0.0.11-alpha"
+          },
+          {
+            "Version": "0.0.12-alpha"
+          },
+          {
+            "Version": "0.0.15"
+          },
+          {
+            "Version": "0.0.16"
+          },
+          {
+            "Version": "0.0.17"
+          },
+          {
+            "Version": "0.0.18"
+          },
+          {
+            "Version": "0.0.20"
+          },
+          {
+            "Version": "0.0.21"
+          },
+          {
+            "Version": "0.0.22"
+          },
+          {
+            "Version": "0.0.24"
+          },
+          {
+            "Version": "0.0.25"
+          },
+          {
+            "Version": "0.0.26"
+          },
+          {
+            "Version": "0.0.27"
+          },
+          {
+            "Version": "0.0.28"
+          },
+          {
+            "Version": "0.0.29"
+          },
+          {
+            "Version": "0.0.30"
+          },
+          {
+            "Version": "0.0.31"
+          },
+          {
+            "Version": "0.0.32"
+          },
+          {
+            "Version": "0.0.33"
+          },
+          {
+            "Version": "0.0.35"
+          },
+          {
+            "Version": "0.0.36"
+          },
+          {
+            "Version": "0.0.38"
+          },
+          {
+            "Version": "0.0.39"
+          },
+          {
+            "Version": "0.0.40"
+          },
+          {
+            "Version": "0.0.41"
+          },
+          {
+            "Version": "0.0.42"
+          },
+          {
+            "Version": "0.0.43"
+          },
+          {
+            "Version": "0.0.44"
+          },
+          {
+            "Version": "0.0.45"
+          },
+          {
+            "Version": "0.0.46"
+          },
+          {
+            "Version": "0.0.47"
+          },
+          {
+            "Version": "0.0.48"
+          },
+          {
+            "Version": "0.0.49"
+          },
+          {
+            "Version": "0.0.50"
+          },
+          {
+            "Version": "0.0.52"
+          },
+          {
+            "Version": "0.0.53"
+          },
+          {
+            "Version": "0.0.54"
+          },
+          {
+            "Version": "0.0.55"
+          },
+          {
+            "Version": "0.0.56"
+          },
+          {
+            "Version": "0.0.57"
+          },
+          {
+            "Version": "0.0.58"
+          },
+          {
+            "Version": "0.0.59"
+          },
+          {
+            "Version": "0.0.60"
+          },
+          {
+            "Version": "0.0.61"
+          },
+          {
+            "Version": "0.0.62"
+          },
+          {
+            "Version": "0.0.64"
+          },
+          {
+            "Version": "0.0.65"
+          },
+          {
+            "Version": "0.0.66"
+          },
+          {
+            "Version": "0.0.67"
+          },
+          {
+            "Version": "0.0.70"
+          },
+          {
+            "Version": "0.0.71"
+          },
+          {
+            "Version": "0.0.72"
+          },
+          {
+            "Version": "0.0.73"
+          },
+          {
+            "Version": "0.0.74"
+          },
+          {
+            "Version": "0.0.75"
+          },
+          {
+            "Version": "0.0.76"
+          },
+          {
+            "Version": "0.0.79"
+          },
+          {
+            "Version": "0.0.80"
+          },
+          {
+            "Version": "0.0.81"
+          },
+          {
+            "Version": "0.0.82"
+          },
+          {
+            "Version": "0.0.83"
+          },
+          {
+            "Version": "0.0.84"
+          },
+          {
+            "Version": "0.0.85"
+          },
+          {
+            "Version": "0.0.86"
+          },
+          {
+            "Version": "0.0.87"
+          },
+          {
+            "Version": "0.0.88"
+          },
+          {
+            "Version": "0.0.89"
+          },
+          {
+            "Version": "0.0.90"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.1.2"
+          },
+          {
+            "Version": "1.4.0.0-beta"
+          },
+          {
+            "Version": "1.4.0.1"
+          },
+          {
+            "Version": "1.4.0.4"
+          },
+          {
+            "Version": "1.4.0.5"
+          },
+          {
+            "Version": "1.4.0.6"
+          },
+          {
+            "Version": "1.4.0.8"
+          },
+          {
+            "Version": "1.4.0.9"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2.0"
+          },
+          {
+            "Version": "1.4.2.1"
+          },
+          {
+            "Version": "1.4.2.2"
+          },
+          {
+            "Version": "1.4.2.3"
+          },
+          {
+            "Version": "2.0.0.0-beta"
+          },
+          {
+            "Version": "2.0.0.1-beta"
+          },
+          {
+            "Version": "2.0.0.2"
+          },
+          {
+            "Version": "2.0.0.3"
+          },
+          {
+            "Version": "2.0.0.4"
+          },
+          {
+            "Version": "2.0.0.5"
+          },
+          {
+            "Version": "2.0.0.6",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/2.0.0.6",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0.7"
+          },
+          {
+            "Version": "2.0.0.8"
+          },
+          {
+            "Version": "3.0.0.0"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "8.0.0"
+          },
+          {
+            "Version": "9.0.0"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.3"
+          },
+          {
+            "Version": "11.0.1"
+          },
+          {
+            "Version": "11.0.2"
+          },
+          {
+            "Version": "11.0.4"
+          },
+          {
+            "Version": "11.0.6"
+          },
+          {
+            "Version": "11.0.9"
+          },
+          {
+            "Version": "11.0.10"
+          },
+          {
+            "Version": "12.0.1"
+          },
+          {
+            "Version": "12.0.2"
+          },
+          {
+            "Version": "12.0.5"
+          },
+          {
+            "Version": "12.0.7"
+          },
+          {
+            "Version": "12.0.8"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001145-excludes/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001145-excludes/cache/paket-graph.cache
@@ -1,0 +1,60 @@
+{
+  "nuget_repo": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:43.0228875+02:00",
+        "PackageName": "Dapper",
+        "Versions": [
+          {
+            "Version": "1.40"
+          },
+          {
+            "Version": "1.42.0",
+            "PackageDetails": {
+              "Name": "Dapper",
+              "DownloadLink": "Dapper",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:43.1553875+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "NUnit",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:43.0728868+02:00",
+        "PackageName": "MultiTarget",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "MultiTarget",
+              "DownloadLink": "MultiTarget",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001166-resolve-nancy-fast/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001166-resolve-nancy-fast/cache/paket-graph.cache
@@ -1,0 +1,18834 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:11.133333+02:00",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:15.9030454+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:01.875329+02:00",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.3945544+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.6100536+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:21.2498187+02:00",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.0425538+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.5.7.10213",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.5.7.10213",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.5.9.10348",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.5.9.10348",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.5.10.11092",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.5.10.11092",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.0.12051",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.6.0.12051",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.0.12054",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.6.0.12054",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.2",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.6.2",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.3",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.6.3",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/2.6.4",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.0-alpha"
+          },
+          {
+            "Version": "3.0.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-alpha-3"
+          },
+          {
+            "Version": "3.0.0-alpha-4"
+          },
+          {
+            "Version": "3.0.0-alpha-5"
+          },
+          {
+            "Version": "3.0.0-beta-1"
+          },
+          {
+            "Version": "3.0.0-beta-2"
+          },
+          {
+            "Version": "3.0.0-beta-3"
+          },
+          {
+            "Version": "3.0.0-beta-4"
+          },
+          {
+            "Version": "3.0.0-beta-5"
+          },
+          {
+            "Version": "3.0.0-rc"
+          },
+          {
+            "Version": "3.0.0-rc-2"
+          },
+          {
+            "Version": "3.0.0-rc-3"
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.0.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.0.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.2.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.2.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.4.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.4.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.6.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Loader",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Loader",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:18.9858158+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:07.9053317+02:00",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:13.0911021+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:11.7051029+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:49.7510576+02:00",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:22.9644016+02:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:20.4268379+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:10.1388306+02:00",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.0405688+02:00",
+        "PackageName": "Microsoft.Owin",
+        "Versions": [
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:41.0530558+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:11.5196285+02:00",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:09.3428314+02:00",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.9110558+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:42.0845555+02:00",
+        "PackageName": "System.ComponentModel.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:00.3128461+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.2530539+02:00",
+        "PackageName": "Microsoft.Owin.Security",
+        "Versions": [
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Security",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin.Security/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:12.6906034+02:00",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:21.4488169+02:00",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.0630546+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:07.0783387+02:00",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:52.8298282+02:00",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:23.6414295+02:00",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:15.1020447+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.6360561+02:00",
+        "PackageName": "NUnit.Extension.TeamCityEventListener",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.TeamCityEventListener",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.TeamCityEventListener/1.0.2",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:59.8073297+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:43.5895574+02:00",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:17.2865449+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:20.8158162+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:51.1743444+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:12.103606+02:00",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:23.179401+02:00",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:21.0253217+02:00",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:14.0945467+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.2585545+02:00",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:39.9145571+02:00",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:31.4475509+02:00",
+        "PackageName": "FAKE",
+        "Versions": [
+          {
+            "Version": "1.46.1.0"
+          },
+          {
+            "Version": "1.46.2.0"
+          },
+          {
+            "Version": "1.48.0.0"
+          },
+          {
+            "Version": "1.50.0.0"
+          },
+          {
+            "Version": "1.50.1.0"
+          },
+          {
+            "Version": "1.50.2.0"
+          },
+          {
+            "Version": "1.50.3.0"
+          },
+          {
+            "Version": "1.50.4.0"
+          },
+          {
+            "Version": "1.52.0.0"
+          },
+          {
+            "Version": "1.52.1.0"
+          },
+          {
+            "Version": "1.52.5.0"
+          },
+          {
+            "Version": "1.52.6.0"
+          },
+          {
+            "Version": "1.54.0.0"
+          },
+          {
+            "Version": "1.54.1.0"
+          },
+          {
+            "Version": "1.54.2.0"
+          },
+          {
+            "Version": "1.54.3.0"
+          },
+          {
+            "Version": "1.56"
+          },
+          {
+            "Version": "1.56.2"
+          },
+          {
+            "Version": "1.56.3"
+          },
+          {
+            "Version": "1.56.4"
+          },
+          {
+            "Version": "1.56.5"
+          },
+          {
+            "Version": "1.56.6"
+          },
+          {
+            "Version": "1.56.7"
+          },
+          {
+            "Version": "1.56.9"
+          },
+          {
+            "Version": "1.56.10"
+          },
+          {
+            "Version": "1.56.12"
+          },
+          {
+            "Version": "1.58"
+          },
+          {
+            "Version": "1.58.2"
+          },
+          {
+            "Version": "1.58.3"
+          },
+          {
+            "Version": "1.58.5"
+          },
+          {
+            "Version": "1.58.6"
+          },
+          {
+            "Version": "1.58.7"
+          },
+          {
+            "Version": "1.58.8"
+          },
+          {
+            "Version": "1.58.9"
+          },
+          {
+            "Version": "1.58.10"
+          },
+          {
+            "Version": "1.58.11"
+          },
+          {
+            "Version": "1.58.14"
+          },
+          {
+            "Version": "1.60"
+          },
+          {
+            "Version": "1.62"
+          },
+          {
+            "Version": "1.62.1"
+          },
+          {
+            "Version": "1.62.2"
+          },
+          {
+            "Version": "1.62.4"
+          },
+          {
+            "Version": "1.62.5"
+          },
+          {
+            "Version": "1.64"
+          },
+          {
+            "Version": "1.64.1"
+          },
+          {
+            "Version": "1.64.2"
+          },
+          {
+            "Version": "1.64.3"
+          },
+          {
+            "Version": "1.64.4"
+          },
+          {
+            "Version": "1.64.5"
+          },
+          {
+            "Version": "1.64.6"
+          },
+          {
+            "Version": "1.64.7"
+          },
+          {
+            "Version": "1.64.8"
+          },
+          {
+            "Version": "1.64.9"
+          },
+          {
+            "Version": "1.64.10"
+          },
+          {
+            "Version": "1.64.11"
+          },
+          {
+            "Version": "1.64.14"
+          },
+          {
+            "Version": "1.64.15"
+          },
+          {
+            "Version": "1.64.16.0"
+          },
+          {
+            "Version": "1.64.17.0"
+          },
+          {
+            "Version": "1.64.18.0"
+          },
+          {
+            "Version": "1.64.19.0"
+          },
+          {
+            "Version": "1.66.0.0"
+          },
+          {
+            "Version": "1.66.1.0"
+          },
+          {
+            "Version": "1.66.2.0"
+          },
+          {
+            "Version": "1.68.1.0"
+          },
+          {
+            "Version": "1.68.5.0"
+          },
+          {
+            "Version": "1.68.6.0"
+          },
+          {
+            "Version": "1.70.0.0"
+          },
+          {
+            "Version": "1.70.1.0"
+          },
+          {
+            "Version": "1.70.2.0"
+          },
+          {
+            "Version": "1.70.3.0"
+          },
+          {
+            "Version": "1.70.6.0"
+          },
+          {
+            "Version": "1.70.8.0"
+          },
+          {
+            "Version": "1.70.9.0"
+          },
+          {
+            "Version": "1.70.10.0"
+          },
+          {
+            "Version": "1.70.11.0"
+          },
+          {
+            "Version": "1.70.13.0"
+          },
+          {
+            "Version": "1.70.16.0"
+          },
+          {
+            "Version": "1.70.17.0"
+          },
+          {
+            "Version": "1.70.18.0"
+          },
+          {
+            "Version": "1.70.20.0"
+          },
+          {
+            "Version": "1.70.21.0"
+          },
+          {
+            "Version": "1.70.22.0"
+          },
+          {
+            "Version": "1.70.24.0"
+          },
+          {
+            "Version": "1.70.25.0"
+          },
+          {
+            "Version": "1.70.29.0"
+          },
+          {
+            "Version": "1.70.32.0"
+          },
+          {
+            "Version": "1.72.33.0"
+          },
+          {
+            "Version": "1.74.0.0"
+          },
+          {
+            "Version": "1.74.1.0"
+          },
+          {
+            "Version": "1.74.2.0"
+          },
+          {
+            "Version": "1.74.4.0"
+          },
+          {
+            "Version": "1.74.6.0"
+          },
+          {
+            "Version": "1.74.8.0"
+          },
+          {
+            "Version": "1.74.9.0"
+          },
+          {
+            "Version": "1.74.10.0"
+          },
+          {
+            "Version": "1.74.13.0"
+          },
+          {
+            "Version": "1.74.14.0"
+          },
+          {
+            "Version": "1.74.15.0"
+          },
+          {
+            "Version": "1.74.16.0"
+          },
+          {
+            "Version": "1.74.17.0"
+          },
+          {
+            "Version": "1.74.18.0"
+          },
+          {
+            "Version": "1.74.19.0"
+          },
+          {
+            "Version": "1.74.20.0"
+          },
+          {
+            "Version": "1.74.21.0"
+          },
+          {
+            "Version": "1.74.22.0"
+          },
+          {
+            "Version": "1.74.24.0"
+          },
+          {
+            "Version": "1.74.25.0"
+          },
+          {
+            "Version": "1.74.26.0"
+          },
+          {
+            "Version": "1.74.27.0"
+          },
+          {
+            "Version": "1.74.28.0"
+          },
+          {
+            "Version": "1.74.29.0"
+          },
+          {
+            "Version": "1.74.30.0"
+          },
+          {
+            "Version": "1.74.31.0"
+          },
+          {
+            "Version": "1.74.32.0"
+          },
+          {
+            "Version": "1.74.33.0"
+          },
+          {
+            "Version": "1.74.34.0"
+          },
+          {
+            "Version": "1.74.35.0"
+          },
+          {
+            "Version": "1.74.39.0"
+          },
+          {
+            "Version": "1.74.40.0"
+          },
+          {
+            "Version": "1.74.41.0"
+          },
+          {
+            "Version": "1.74.42.0"
+          },
+          {
+            "Version": "1.74.43.0"
+          },
+          {
+            "Version": "1.74.44.0"
+          },
+          {
+            "Version": "1.74.48.0"
+          },
+          {
+            "Version": "1.74.49.0"
+          },
+          {
+            "Version": "1.74.50.0"
+          },
+          {
+            "Version": "1.74.51.0"
+          },
+          {
+            "Version": "1.74.55.0"
+          },
+          {
+            "Version": "1.74.56.0"
+          },
+          {
+            "Version": "1.74.57.0"
+          },
+          {
+            "Version": "1.74.60.0"
+          },
+          {
+            "Version": "1.74.61.0"
+          },
+          {
+            "Version": "1.74.62.0"
+          },
+          {
+            "Version": "1.74.63.0"
+          },
+          {
+            "Version": "1.74.65.0"
+          },
+          {
+            "Version": "1.74.74.0"
+          },
+          {
+            "Version": "1.74.75.0"
+          },
+          {
+            "Version": "1.74.77.0"
+          },
+          {
+            "Version": "1.74.78.0"
+          },
+          {
+            "Version": "1.74.79.0"
+          },
+          {
+            "Version": "1.74.81.0"
+          },
+          {
+            "Version": "1.74.82.0"
+          },
+          {
+            "Version": "1.74.84.0"
+          },
+          {
+            "Version": "1.74.85.0"
+          },
+          {
+            "Version": "1.74.86.0"
+          },
+          {
+            "Version": "1.74.87.0"
+          },
+          {
+            "Version": "1.74.88.0"
+          },
+          {
+            "Version": "1.74.92.0"
+          },
+          {
+            "Version": "1.74.98.0"
+          },
+          {
+            "Version": "1.74.99.0"
+          },
+          {
+            "Version": "1.74.100.0"
+          },
+          {
+            "Version": "1.74.101.0"
+          },
+          {
+            "Version": "1.74.102.0"
+          },
+          {
+            "Version": "1.74.103.0"
+          },
+          {
+            "Version": "1.74.104.0"
+          },
+          {
+            "Version": "1.74.105.0"
+          },
+          {
+            "Version": "1.74.106.0"
+          },
+          {
+            "Version": "1.74.107.0"
+          },
+          {
+            "Version": "1.74.108.0"
+          },
+          {
+            "Version": "1.74.109.0"
+          },
+          {
+            "Version": "1.74.110.0"
+          },
+          {
+            "Version": "1.74.111.0"
+          },
+          {
+            "Version": "1.74.113.0"
+          },
+          {
+            "Version": "1.74.114.0"
+          },
+          {
+            "Version": "1.74.118.0"
+          },
+          {
+            "Version": "1.74.119.0"
+          },
+          {
+            "Version": "1.74.121.0"
+          },
+          {
+            "Version": "1.74.123.0"
+          },
+          {
+            "Version": "1.74.124.0"
+          },
+          {
+            "Version": "1.74.125.0"
+          },
+          {
+            "Version": "1.74.126.0"
+          },
+          {
+            "Version": "1.74.127.0"
+          },
+          {
+            "Version": "1.74.128.0"
+          },
+          {
+            "Version": "1.74.129.0"
+          },
+          {
+            "Version": "1.74.130.0"
+          },
+          {
+            "Version": "1.74.131.0"
+          },
+          {
+            "Version": "1.74.132.0"
+          },
+          {
+            "Version": "1.74.133.0"
+          },
+          {
+            "Version": "1.74.134.0"
+          },
+          {
+            "Version": "1.74.135.0"
+          },
+          {
+            "Version": "1.74.136.0"
+          },
+          {
+            "Version": "1.74.137.0"
+          },
+          {
+            "Version": "1.74.139.0"
+          },
+          {
+            "Version": "1.74.140.0"
+          },
+          {
+            "Version": "1.74.141.0"
+          },
+          {
+            "Version": "1.74.142.0"
+          },
+          {
+            "Version": "1.74.143.0"
+          },
+          {
+            "Version": "1.74.144.0"
+          },
+          {
+            "Version": "1.74.145.0"
+          },
+          {
+            "Version": "1.74.146.0"
+          },
+          {
+            "Version": "1.74.147.0"
+          },
+          {
+            "Version": "1.74.148.0"
+          },
+          {
+            "Version": "1.74.149.0"
+          },
+          {
+            "Version": "1.74.150.0"
+          },
+          {
+            "Version": "1.74.152.0"
+          },
+          {
+            "Version": "1.74.153.0"
+          },
+          {
+            "Version": "1.74.154.0"
+          },
+          {
+            "Version": "1.74.155.0"
+          },
+          {
+            "Version": "1.74.156.0"
+          },
+          {
+            "Version": "1.74.160.0"
+          },
+          {
+            "Version": "1.74.161.0"
+          },
+          {
+            "Version": "1.74.162.0"
+          },
+          {
+            "Version": "1.74.163.0"
+          },
+          {
+            "Version": "1.74.164.0"
+          },
+          {
+            "Version": "1.74.166.0"
+          },
+          {
+            "Version": "1.74.167.0"
+          },
+          {
+            "Version": "1.74.172.0"
+          },
+          {
+            "Version": "1.74.173.0"
+          },
+          {
+            "Version": "1.74.174.0"
+          },
+          {
+            "Version": "1.74.175.0"
+          },
+          {
+            "Version": "1.74.176.0"
+          },
+          {
+            "Version": "1.74.180.0"
+          },
+          {
+            "Version": "1.74.181.0"
+          },
+          {
+            "Version": "1.74.183.0"
+          },
+          {
+            "Version": "1.74.184.0"
+          },
+          {
+            "Version": "1.74.185.0"
+          },
+          {
+            "Version": "1.74.186.0"
+          },
+          {
+            "Version": "1.74.187.0"
+          },
+          {
+            "Version": "1.74.188.0"
+          },
+          {
+            "Version": "1.74.189.0"
+          },
+          {
+            "Version": "1.74.190.0"
+          },
+          {
+            "Version": "1.74.192.0"
+          },
+          {
+            "Version": "1.74.193.0"
+          },
+          {
+            "Version": "1.74.195.0"
+          },
+          {
+            "Version": "1.74.196.0"
+          },
+          {
+            "Version": "1.74.197.0"
+          },
+          {
+            "Version": "1.74.198.0"
+          },
+          {
+            "Version": "1.74.199.0"
+          },
+          {
+            "Version": "1.74.200.0"
+          },
+          {
+            "Version": "1.74.205.0"
+          },
+          {
+            "Version": "1.74.206.0"
+          },
+          {
+            "Version": "1.74.207.0"
+          },
+          {
+            "Version": "1.74.208.0"
+          },
+          {
+            "Version": "1.74.209.0"
+          },
+          {
+            "Version": "1.74.210.0"
+          },
+          {
+            "Version": "1.74.211.0"
+          },
+          {
+            "Version": "1.74.212.0"
+          },
+          {
+            "Version": "1.74.213.0"
+          },
+          {
+            "Version": "1.74.214.0"
+          },
+          {
+            "Version": "1.74.215.0"
+          },
+          {
+            "Version": "1.74.216.0"
+          },
+          {
+            "Version": "1.74.217.0"
+          },
+          {
+            "Version": "1.74.218.0"
+          },
+          {
+            "Version": "1.74.219.0"
+          },
+          {
+            "Version": "1.74.220.0"
+          },
+          {
+            "Version": "1.74.221.0"
+          },
+          {
+            "Version": "1.74.222.0"
+          },
+          {
+            "Version": "1.74.223.0"
+          },
+          {
+            "Version": "1.74.224.0"
+          },
+          {
+            "Version": "1.74.225.0"
+          },
+          {
+            "Version": "1.74.231.0"
+          },
+          {
+            "Version": "1.74.237.0"
+          },
+          {
+            "Version": "1.74.238.0"
+          },
+          {
+            "Version": "1.74.239.0"
+          },
+          {
+            "Version": "1.74.241.0"
+          },
+          {
+            "Version": "1.74.243.0"
+          },
+          {
+            "Version": "1.74.244.0"
+          },
+          {
+            "Version": "1.74.245.0"
+          },
+          {
+            "Version": "1.74.246.0"
+          },
+          {
+            "Version": "1.74.247.0"
+          },
+          {
+            "Version": "1.74.248.0"
+          },
+          {
+            "Version": "1.74.249.0"
+          },
+          {
+            "Version": "1.74.250.0"
+          },
+          {
+            "Version": "1.74.251.0"
+          },
+          {
+            "Version": "1.74.252.0"
+          },
+          {
+            "Version": "1.74.253.0"
+          },
+          {
+            "Version": "1.74.254.0"
+          },
+          {
+            "Version": "1.74.255.0"
+          },
+          {
+            "Version": "1.74.256.0"
+          },
+          {
+            "Version": "1.74.257.0"
+          },
+          {
+            "Version": "1.74.262.0"
+          },
+          {
+            "Version": "1.74.263.0"
+          },
+          {
+            "Version": "1.74.264.0"
+          },
+          {
+            "Version": "1.74.265.0"
+          },
+          {
+            "Version": "1.74.266.0"
+          },
+          {
+            "Version": "1.74.267.0"
+          },
+          {
+            "Version": "1.74.268.0"
+          },
+          {
+            "Version": "1.74.269.0"
+          },
+          {
+            "Version": "1.74.270.0"
+          },
+          {
+            "Version": "1.74.271.0"
+          },
+          {
+            "Version": "1.74.272.0"
+          },
+          {
+            "Version": "1.74.273.0"
+          },
+          {
+            "Version": "1.74.275.0"
+          },
+          {
+            "Version": "1.74.277.0"
+          },
+          {
+            "Version": "1.74.278.0"
+          },
+          {
+            "Version": "1.74.279.0"
+          },
+          {
+            "Version": "1.74.280.0"
+          },
+          {
+            "Version": "1.74.282.0"
+          },
+          {
+            "Version": "1.74.283.0"
+          },
+          {
+            "Version": "1.74.284.0"
+          },
+          {
+            "Version": "1.74.285.0"
+          },
+          {
+            "Version": "1.74.286.0"
+          },
+          {
+            "Version": "1.74.287.0"
+          },
+          {
+            "Version": "1.74.290.0"
+          },
+          {
+            "Version": "2.0.1-alpha2"
+          },
+          {
+            "Version": "2.0.1-alpha3"
+          },
+          {
+            "Version": "2.0.1-alpha4"
+          },
+          {
+            "Version": "2.0.48.0-alpha"
+          },
+          {
+            "Version": "2.0.55.0-alpha"
+          },
+          {
+            "Version": "2.0.60.0-alpha"
+          },
+          {
+            "Version": "2.0.61.0-alpha"
+          },
+          {
+            "Version": "2.0.62.0-alpha"
+          },
+          {
+            "Version": "2.0.64.0-alpha"
+          },
+          {
+            "Version": "2.0.65.0-alpha"
+          },
+          {
+            "Version": "2.0.66.0-alpha"
+          },
+          {
+            "Version": "2.0.68.0-alpha"
+          },
+          {
+            "Version": "2.0.69.0-alpha"
+          },
+          {
+            "Version": "2.0.70.0-alpha"
+          },
+          {
+            "Version": "2.0.73.0-alpha"
+          },
+          {
+            "Version": "2.0.74.0-alpha"
+          },
+          {
+            "Version": "2.0.75.0-alpha"
+          },
+          {
+            "Version": "2.0.76.0-alpha"
+          },
+          {
+            "Version": "2.0.77.0-alpha"
+          },
+          {
+            "Version": "2.0.78.0-alpha"
+          },
+          {
+            "Version": "2.0.79.0-alpha"
+          },
+          {
+            "Version": "2.0.80.0-alpha"
+          },
+          {
+            "Version": "2.0.81.0-alpha"
+          },
+          {
+            "Version": "2.0.83.0-alpha"
+          },
+          {
+            "Version": "2.0.84.0-alpha"
+          },
+          {
+            "Version": "2.0.85.0-alpha"
+          },
+          {
+            "Version": "2.0.86.0-alpha"
+          },
+          {
+            "Version": "2.0.87.0-alpha"
+          },
+          {
+            "Version": "2.0.90.0-alpha"
+          },
+          {
+            "Version": "2.0.91.0-alpha"
+          },
+          {
+            "Version": "2.0.94.0-alpha"
+          },
+          {
+            "Version": "2.0.95.0-alpha"
+          },
+          {
+            "Version": "2.0.96.0-alpha"
+          },
+          {
+            "Version": "2.0.97.0-alpha"
+          },
+          {
+            "Version": "2.0.98.0-alpha"
+          },
+          {
+            "Version": "2.0.99.0-alpha"
+          },
+          {
+            "Version": "2.1-alpha10"
+          },
+          {
+            "Version": "2.1-alpha13"
+          },
+          {
+            "Version": "2.1-alpha15"
+          },
+          {
+            "Version": "2.1-alpha16"
+          },
+          {
+            "Version": "2.1-alpha17"
+          },
+          {
+            "Version": "2.1-alpha18"
+          },
+          {
+            "Version": "2.1-alpha20"
+          },
+          {
+            "Version": "2.1-alpha22"
+          },
+          {
+            "Version": "2.1-alpha23"
+          },
+          {
+            "Version": "2.1-alpha24"
+          },
+          {
+            "Version": "2.1-alpha5"
+          },
+          {
+            "Version": "2.1-alpha6"
+          },
+          {
+            "Version": "2.1-alpha7"
+          },
+          {
+            "Version": "2.1.1-alpha"
+          },
+          {
+            "Version": "2.1.27-alpha"
+          },
+          {
+            "Version": "2.1.28-alpha"
+          },
+          {
+            "Version": "2.1.29-alpha"
+          },
+          {
+            "Version": "2.1.30-alpha"
+          },
+          {
+            "Version": "2.1.33-alpha"
+          },
+          {
+            "Version": "2.1.35-alpha"
+          },
+          {
+            "Version": "2.1.37-alpha"
+          },
+          {
+            "Version": "2.1.39-alpha"
+          },
+          {
+            "Version": "2.1.41-alpha"
+          },
+          {
+            "Version": "2.1.42-alpha"
+          },
+          {
+            "Version": "2.1.43-alpha"
+          },
+          {
+            "Version": "2.1.46-alpha"
+          },
+          {
+            "Version": "2.1.47-alpha"
+          },
+          {
+            "Version": "2.1.48-alpha"
+          },
+          {
+            "Version": "2.1.50-alpha"
+          },
+          {
+            "Version": "2.1.51-alpha"
+          },
+          {
+            "Version": "2.1.53-alpha"
+          },
+          {
+            "Version": "2.1.58-alpha"
+          },
+          {
+            "Version": "2.1.68-alpha"
+          },
+          {
+            "Version": "2.1.71-alpha"
+          },
+          {
+            "Version": "2.1.72-alpha"
+          },
+          {
+            "Version": "2.1.75-alpha"
+          },
+          {
+            "Version": "2.1.81-alpha"
+          },
+          {
+            "Version": "2.1.83-alpha"
+          },
+          {
+            "Version": "2.1.84-alpha"
+          },
+          {
+            "Version": "2.1.85-alpha"
+          },
+          {
+            "Version": "2.1.86-alpha"
+          },
+          {
+            "Version": "2.1.91-alpha"
+          },
+          {
+            "Version": "2.1.95-alpha"
+          },
+          {
+            "Version": "2.1.97-alpha"
+          },
+          {
+            "Version": "2.1.111-alpha"
+          },
+          {
+            "Version": "2.1.113-alpha"
+          },
+          {
+            "Version": "2.1.118-alpha"
+          },
+          {
+            "Version": "2.1.119-alpha"
+          },
+          {
+            "Version": "2.1.121-alpha"
+          },
+          {
+            "Version": "2.1.123-alpha"
+          },
+          {
+            "Version": "2.1.124-alpha"
+          },
+          {
+            "Version": "2.1.126-alpha"
+          },
+          {
+            "Version": "2.1.128-alpha"
+          },
+          {
+            "Version": "2.1.129-alpha"
+          },
+          {
+            "Version": "2.1.132-alpha"
+          },
+          {
+            "Version": "2.1.133-alpha"
+          },
+          {
+            "Version": "2.1.134-alpha"
+          },
+          {
+            "Version": "2.1.137-alpha"
+          },
+          {
+            "Version": "2.1.138-alpha"
+          },
+          {
+            "Version": "2.1.141-alpha"
+          },
+          {
+            "Version": "2.1.142-alpha"
+          },
+          {
+            "Version": "2.1.144-alpha"
+          },
+          {
+            "Version": "2.1.145-alpha"
+          },
+          {
+            "Version": "2.1.147-alpha"
+          },
+          {
+            "Version": "2.1.148-alpha"
+          },
+          {
+            "Version": "2.1.149-alpha"
+          },
+          {
+            "Version": "2.1.150-alpha"
+          },
+          {
+            "Version": "2.1.151-alpha"
+          },
+          {
+            "Version": "2.1.152-alpha"
+          },
+          {
+            "Version": "2.1.154-alpha"
+          },
+          {
+            "Version": "2.1.155-alpha"
+          },
+          {
+            "Version": "2.1.156-alpha"
+          },
+          {
+            "Version": "2.1.158-alpha"
+          },
+          {
+            "Version": "2.1.159-alpha"
+          },
+          {
+            "Version": "2.1.160-alpha"
+          },
+          {
+            "Version": "2.1.161-alpha"
+          },
+          {
+            "Version": "2.1.162-alpha"
+          },
+          {
+            "Version": "2.1.164-alpha"
+          },
+          {
+            "Version": "2.1.166-alpha"
+          },
+          {
+            "Version": "2.1.167-alpha"
+          },
+          {
+            "Version": "2.1.168-alpha"
+          },
+          {
+            "Version": "2.1.170-alpha"
+          },
+          {
+            "Version": "2.1.171-alpha"
+          },
+          {
+            "Version": "2.1.172-alpha"
+          },
+          {
+            "Version": "2.1.173-alpha"
+          },
+          {
+            "Version": "2.1.174-alpha"
+          },
+          {
+            "Version": "2.1.175-alpha"
+          },
+          {
+            "Version": "2.1.176-alpha"
+          },
+          {
+            "Version": "2.1.178-alpha"
+          },
+          {
+            "Version": "2.1.179-alpha"
+          },
+          {
+            "Version": "2.1.180-alpha"
+          },
+          {
+            "Version": "2.1.182-alpha"
+          },
+          {
+            "Version": "2.1.183-alpha"
+          },
+          {
+            "Version": "2.1.184-alpha"
+          },
+          {
+            "Version": "2.1.185-alpha"
+          },
+          {
+            "Version": "2.1.186-alpha"
+          },
+          {
+            "Version": "2.1.187-alpha"
+          },
+          {
+            "Version": "2.1.192-alpha"
+          },
+          {
+            "Version": "2.1.194-alpha"
+          },
+          {
+            "Version": "2.1.196-alpha"
+          },
+          {
+            "Version": "2.1.199-alpha"
+          },
+          {
+            "Version": "2.1.200-alpha"
+          },
+          {
+            "Version": "2.1.201-alpha"
+          },
+          {
+            "Version": "2.1.204-alpha"
+          },
+          {
+            "Version": "2.1.205-alpha"
+          },
+          {
+            "Version": "2.1.207-alpha"
+          },
+          {
+            "Version": "2.1.208-alpha"
+          },
+          {
+            "Version": "2.1.209-alpha"
+          },
+          {
+            "Version": "2.1.210-alpha"
+          },
+          {
+            "Version": "2.1.211-alpha"
+          },
+          {
+            "Version": "2.1.212-alpha"
+          },
+          {
+            "Version": "2.1.213-alpha"
+          },
+          {
+            "Version": "2.1.215-alpha"
+          },
+          {
+            "Version": "2.1.216-alpha"
+          },
+          {
+            "Version": "2.1.217-alpha"
+          },
+          {
+            "Version": "2.1.218-alpha"
+          },
+          {
+            "Version": "2.1.219-alpha"
+          },
+          {
+            "Version": "2.1.220-alpha"
+          },
+          {
+            "Version": "2.1.222-alpha"
+          },
+          {
+            "Version": "2.1.223-alpha"
+          },
+          {
+            "Version": "2.1.225-alpha"
+          },
+          {
+            "Version": "2.1.226-alpha"
+          },
+          {
+            "Version": "2.1.227-alpha"
+          },
+          {
+            "Version": "2.1.228-alpha"
+          },
+          {
+            "Version": "2.1.230-alpha"
+          },
+          {
+            "Version": "2.1.234-alpha"
+          },
+          {
+            "Version": "2.1.235-alpha"
+          },
+          {
+            "Version": "2.1.236-alpha"
+          },
+          {
+            "Version": "2.1.237-alpha"
+          },
+          {
+            "Version": "2.1.239-alpha"
+          },
+          {
+            "Version": "2.1.240-alpha"
+          },
+          {
+            "Version": "2.1.241-alpha"
+          },
+          {
+            "Version": "2.1.242-alpha"
+          },
+          {
+            "Version": "2.1.243-alpha"
+          },
+          {
+            "Version": "2.1.245-alpha"
+          },
+          {
+            "Version": "2.1.246-alpha"
+          },
+          {
+            "Version": "2.1.247-alpha"
+          },
+          {
+            "Version": "2.1.248-alpha"
+          },
+          {
+            "Version": "2.1.249-alpha"
+          },
+          {
+            "Version": "2.1.251-alpha"
+          },
+          {
+            "Version": "2.1.253-alpha"
+          },
+          {
+            "Version": "2.1.255-alpha"
+          },
+          {
+            "Version": "2.1.256-alpha"
+          },
+          {
+            "Version": "2.1.264-alpha"
+          },
+          {
+            "Version": "2.1.271-alpha"
+          },
+          {
+            "Version": "2.1.272-alpha"
+          },
+          {
+            "Version": "2.1.273-alpha"
+          },
+          {
+            "Version": "2.1.274-alpha"
+          },
+          {
+            "Version": "2.1.275-alpha"
+          },
+          {
+            "Version": "2.1.276-alpha"
+          },
+          {
+            "Version": "2.1.277-alpha"
+          },
+          {
+            "Version": "2.1.279-alpha"
+          },
+          {
+            "Version": "2.1.280-alpha"
+          },
+          {
+            "Version": "2.1.288-alpha"
+          },
+          {
+            "Version": "2.1.289-alpha"
+          },
+          {
+            "Version": "2.1.290-alpha"
+          },
+          {
+            "Version": "2.1.291-alpha"
+          },
+          {
+            "Version": "2.1.292-alpha"
+          },
+          {
+            "Version": "2.1.293-alpha"
+          },
+          {
+            "Version": "2.1.294-alpha"
+          },
+          {
+            "Version": "2.1.295-alpha"
+          },
+          {
+            "Version": "2.1.297-alpha"
+          },
+          {
+            "Version": "2.1.298-alpha"
+          },
+          {
+            "Version": "2.1.299-alpha"
+          },
+          {
+            "Version": "2.1.300-alpha"
+          },
+          {
+            "Version": "2.1.301-alpha"
+          },
+          {
+            "Version": "2.1.302-alpha"
+          },
+          {
+            "Version": "2.1.303-alpha"
+          },
+          {
+            "Version": "2.1.304-alpha"
+          },
+          {
+            "Version": "2.1.305-alpha"
+          },
+          {
+            "Version": "2.1.306-alpha"
+          },
+          {
+            "Version": "2.1.307-alpha"
+          },
+          {
+            "Version": "2.1.308-alpha"
+          },
+          {
+            "Version": "2.1.309-alpha"
+          },
+          {
+            "Version": "2.1.313-alpha"
+          },
+          {
+            "Version": "2.1.314-alpha"
+          },
+          {
+            "Version": "2.1.316-alpha"
+          },
+          {
+            "Version": "2.1.318-alpha"
+          },
+          {
+            "Version": "2.1.319-alpha"
+          },
+          {
+            "Version": "2.1.320-alpha"
+          },
+          {
+            "Version": "2.1.321-alpha"
+          },
+          {
+            "Version": "2.1.322-alpha"
+          },
+          {
+            "Version": "2.1.323-alpha"
+          },
+          {
+            "Version": "2.1.324-alpha"
+          },
+          {
+            "Version": "2.1.325-alpha"
+          },
+          {
+            "Version": "2.1.326-alpha"
+          },
+          {
+            "Version": "2.1.327-alpha"
+          },
+          {
+            "Version": "2.1.328-alpha"
+          },
+          {
+            "Version": "2.1.330-alpha"
+          },
+          {
+            "Version": "2.1.332-alpha"
+          },
+          {
+            "Version": "2.1.334-alpha"
+          },
+          {
+            "Version": "2.1.336-alpha"
+          },
+          {
+            "Version": "2.1.337-alpha"
+          },
+          {
+            "Version": "2.1.338-alpha"
+          },
+          {
+            "Version": "2.1.339-alpha"
+          },
+          {
+            "Version": "2.1.340-alpha"
+          },
+          {
+            "Version": "2.1.341-alpha"
+          },
+          {
+            "Version": "2.1.342-alpha"
+          },
+          {
+            "Version": "2.1.343-alpha"
+          },
+          {
+            "Version": "2.1.344-alpha"
+          },
+          {
+            "Version": "2.1.347-alpha"
+          },
+          {
+            "Version": "2.1.351-alpha"
+          },
+          {
+            "Version": "2.1.352-alpha"
+          },
+          {
+            "Version": "2.1.353-alpha"
+          },
+          {
+            "Version": "2.1.354-alpha"
+          },
+          {
+            "Version": "2.1.355-alpha"
+          },
+          {
+            "Version": "2.1.356-alpha"
+          },
+          {
+            "Version": "2.1.357-alpha"
+          },
+          {
+            "Version": "2.1.358-alpha"
+          },
+          {
+            "Version": "2.1.359-alpha"
+          },
+          {
+            "Version": "2.1.360-alpha"
+          },
+          {
+            "Version": "2.1.361-alpha"
+          },
+          {
+            "Version": "2.1.362-alpha"
+          },
+          {
+            "Version": "2.1.363-alpha"
+          },
+          {
+            "Version": "2.1.364-alpha"
+          },
+          {
+            "Version": "2.1.365-alpha"
+          },
+          {
+            "Version": "2.1.366-alpha"
+          },
+          {
+            "Version": "2.1.367-alpha"
+          },
+          {
+            "Version": "2.1.368-alpha"
+          },
+          {
+            "Version": "2.1.369-alpha"
+          },
+          {
+            "Version": "2.1.371-alpha"
+          },
+          {
+            "Version": "2.1.372-alpha"
+          },
+          {
+            "Version": "2.1.373-alpha"
+          },
+          {
+            "Version": "2.1.374-alpha"
+          },
+          {
+            "Version": "2.1.375-alpha"
+          },
+          {
+            "Version": "2.1.376-alpha"
+          },
+          {
+            "Version": "2.1.378-alpha"
+          },
+          {
+            "Version": "2.1.379-alpha"
+          },
+          {
+            "Version": "2.1.380-alpha"
+          },
+          {
+            "Version": "2.1.381-alpha"
+          },
+          {
+            "Version": "2.1.382-alpha"
+          },
+          {
+            "Version": "2.1.383-alpha"
+          },
+          {
+            "Version": "2.1.384-alpha"
+          },
+          {
+            "Version": "2.1.385-alpha"
+          },
+          {
+            "Version": "2.1.386-alpha"
+          },
+          {
+            "Version": "2.1.387-alpha"
+          },
+          {
+            "Version": "2.1.388-alpha"
+          },
+          {
+            "Version": "2.1.389-alpha"
+          },
+          {
+            "Version": "2.1.390-alpha"
+          },
+          {
+            "Version": "2.1.391-alpha"
+          },
+          {
+            "Version": "2.1.392-alpha"
+          },
+          {
+            "Version": "2.1.393-alpha"
+          },
+          {
+            "Version": "2.1.394-alpha"
+          },
+          {
+            "Version": "2.1.395-alpha"
+          },
+          {
+            "Version": "2.1.396-alpha"
+          },
+          {
+            "Version": "2.1.397-alpha"
+          },
+          {
+            "Version": "2.1.398-alpha"
+          },
+          {
+            "Version": "2.1.399-alpha"
+          },
+          {
+            "Version": "2.1.400-alpha"
+          },
+          {
+            "Version": "2.1.401-alpha"
+          },
+          {
+            "Version": "2.1.402-alpha"
+          },
+          {
+            "Version": "2.1.403-alpha"
+          },
+          {
+            "Version": "2.1.404-alpha"
+          },
+          {
+            "Version": "2.1.405-alpha"
+          },
+          {
+            "Version": "2.1.406-alpha"
+          },
+          {
+            "Version": "2.1.407-alpha"
+          },
+          {
+            "Version": "2.1.408-alpha"
+          },
+          {
+            "Version": "2.1.409-alpha"
+          },
+          {
+            "Version": "2.1.410-alpha"
+          },
+          {
+            "Version": "2.1.411-alpha"
+          },
+          {
+            "Version": "2.1.412-alpha"
+          },
+          {
+            "Version": "2.1.413-alpha"
+          },
+          {
+            "Version": "2.1.414-alpha"
+          },
+          {
+            "Version": "2.1.415-alpha"
+          },
+          {
+            "Version": "2.1.416-alpha"
+          },
+          {
+            "Version": "2.1.417-alpha"
+          },
+          {
+            "Version": "2.1.418-alpha"
+          },
+          {
+            "Version": "2.1.419-alpha"
+          },
+          {
+            "Version": "2.1.420-alpha"
+          },
+          {
+            "Version": "2.1.421-alpha"
+          },
+          {
+            "Version": "2.1.422-alpha"
+          },
+          {
+            "Version": "2.1.423-alpha"
+          },
+          {
+            "Version": "2.1.424-alpha"
+          },
+          {
+            "Version": "2.1.426-alpha"
+          },
+          {
+            "Version": "2.1.427-alpha"
+          },
+          {
+            "Version": "2.1.428-alpha"
+          },
+          {
+            "Version": "2.1.429-alpha"
+          },
+          {
+            "Version": "2.1.430-alpha"
+          },
+          {
+            "Version": "2.1.431-alpha"
+          },
+          {
+            "Version": "2.1.432-alpha"
+          },
+          {
+            "Version": "2.1.434-alpha"
+          },
+          {
+            "Version": "2.1.435-alpha"
+          },
+          {
+            "Version": "2.1.436-alpha"
+          },
+          {
+            "Version": "2.1.437-alpha"
+          },
+          {
+            "Version": "2.1.438-alpha"
+          },
+          {
+            "Version": "2.1.439-alpha"
+          },
+          {
+            "Version": "2.1.440-alpha"
+          },
+          {
+            "Version": "2.1.441-alpha"
+          },
+          {
+            "Version": "2.1.442-alpha"
+          },
+          {
+            "Version": "2.1.443-alpha"
+          },
+          {
+            "Version": "2.1.445-alpha"
+          },
+          {
+            "Version": "2.1.449-alpha"
+          },
+          {
+            "Version": "2.1.461-alpha"
+          },
+          {
+            "Version": "2.1.465-alpha"
+          },
+          {
+            "Version": "2.1.468-alpha"
+          },
+          {
+            "Version": "2.1.469-alpha"
+          },
+          {
+            "Version": "2.1.470-alpha"
+          },
+          {
+            "Version": "2.1.471-alpha"
+          },
+          {
+            "Version": "2.1.472-alpha"
+          },
+          {
+            "Version": "2.1.473-alpha"
+          },
+          {
+            "Version": "2.1.474-alpha"
+          },
+          {
+            "Version": "2.1.475-alpha"
+          },
+          {
+            "Version": "2.1.476-alpha"
+          },
+          {
+            "Version": "2.1.478-alpha"
+          },
+          {
+            "Version": "2.1.479-alpha"
+          },
+          {
+            "Version": "2.1.480-alpha"
+          },
+          {
+            "Version": "2.1.481-alpha"
+          },
+          {
+            "Version": "2.1.482-alpha"
+          },
+          {
+            "Version": "2.1.483-alpha"
+          },
+          {
+            "Version": "2.1.485-alpha"
+          },
+          {
+            "Version": "2.1.486-alpha"
+          },
+          {
+            "Version": "2.1.487-alpha"
+          },
+          {
+            "Version": "2.1.488-alpha"
+          },
+          {
+            "Version": "2.1.489-alpha"
+          },
+          {
+            "Version": "2.1.490-alpha"
+          },
+          {
+            "Version": "2.1.491-alpha"
+          },
+          {
+            "Version": "2.1.492-alpha"
+          },
+          {
+            "Version": "2.1.493-alpha"
+          },
+          {
+            "Version": "2.1.494-alpha"
+          },
+          {
+            "Version": "2.1.495-alpha"
+          },
+          {
+            "Version": "2.1.496-alpha"
+          },
+          {
+            "Version": "2.1.497-alpha"
+          },
+          {
+            "Version": "2.1.498-alpha"
+          },
+          {
+            "Version": "2.1.499-alpha"
+          },
+          {
+            "Version": "2.1.500-alpha"
+          },
+          {
+            "Version": "2.1.502-alpha"
+          },
+          {
+            "Version": "2.1.503-alpha"
+          },
+          {
+            "Version": "2.1.504-alpha"
+          },
+          {
+            "Version": "2.1.505-alpha"
+          },
+          {
+            "Version": "2.1.507-alpha"
+          },
+          {
+            "Version": "2.1.509-alpha"
+          },
+          {
+            "Version": "2.1.520-alpha"
+          },
+          {
+            "Version": "2.1.521-alpha"
+          },
+          {
+            "Version": "2.1.522-alpha"
+          },
+          {
+            "Version": "2.1.524-alpha"
+          },
+          {
+            "Version": "2.1.526-alpha"
+          },
+          {
+            "Version": "2.1.527-alpha"
+          },
+          {
+            "Version": "2.1.528-alpha"
+          },
+          {
+            "Version": "2.1.530-alpha"
+          },
+          {
+            "Version": "2.1.531-alpha"
+          },
+          {
+            "Version": "2.1.533-alpha"
+          },
+          {
+            "Version": "2.1.534-alpha"
+          },
+          {
+            "Version": "2.1.535-alpha"
+          },
+          {
+            "Version": "2.1.536-alpha"
+          },
+          {
+            "Version": "2.1.537-alpha"
+          },
+          {
+            "Version": "2.1.538-alpha"
+          },
+          {
+            "Version": "2.1.539-alpha"
+          },
+          {
+            "Version": "2.1.540-alpha"
+          },
+          {
+            "Version": "2.1.542-alpha"
+          },
+          {
+            "Version": "2.1.543-alpha"
+          },
+          {
+            "Version": "2.1.544-alpha"
+          },
+          {
+            "Version": "2.1.545-alpha"
+          },
+          {
+            "Version": "2.1.546-alpha"
+          },
+          {
+            "Version": "2.1.547-alpha"
+          },
+          {
+            "Version": "2.1.548-alpha"
+          },
+          {
+            "Version": "2.1.549-alpha"
+          },
+          {
+            "Version": "2.1.550-alpha"
+          },
+          {
+            "Version": "2.1.551-alpha"
+          },
+          {
+            "Version": "2.1.552-alpha"
+          },
+          {
+            "Version": "2.1.553-alpha"
+          },
+          {
+            "Version": "2.1.554-alpha"
+          },
+          {
+            "Version": "2.1.555-alpha"
+          },
+          {
+            "Version": "2.1.556-alpha"
+          },
+          {
+            "Version": "2.1.557-alpha"
+          },
+          {
+            "Version": "2.1.560-alpha"
+          },
+          {
+            "Version": "2.1.561-alpha"
+          },
+          {
+            "Version": "2.1.562-alpha"
+          },
+          {
+            "Version": "2.1.563-alpha"
+          },
+          {
+            "Version": "2.1.564-alpha"
+          },
+          {
+            "Version": "2.1.566-alpha"
+          },
+          {
+            "Version": "2.1.567-alpha"
+          },
+          {
+            "Version": "2.1.568-alpha"
+          },
+          {
+            "Version": "2.1.569-alpha"
+          },
+          {
+            "Version": "2.1.570-alpha"
+          },
+          {
+            "Version": "2.1.571-alpha"
+          },
+          {
+            "Version": "2.1.572-alpha"
+          },
+          {
+            "Version": "2.1.573-alpha"
+          },
+          {
+            "Version": "2.1.574-alpha"
+          },
+          {
+            "Version": "2.1.575-alpha"
+          },
+          {
+            "Version": "2.1.576-alpha"
+          },
+          {
+            "Version": "2.1.577-alpha"
+          },
+          {
+            "Version": "2.1.578-alpha"
+          },
+          {
+            "Version": "2.1.580-alpha"
+          },
+          {
+            "Version": "2.1.581-alpha"
+          },
+          {
+            "Version": "2.1.583-alpha"
+          },
+          {
+            "Version": "2.1.584-alpha"
+          },
+          {
+            "Version": "2.1.585-alpha"
+          },
+          {
+            "Version": "2.1.586-alpha"
+          },
+          {
+            "Version": "2.1.587-alpha"
+          },
+          {
+            "Version": "2.1.588-alpha"
+          },
+          {
+            "Version": "2.1.589-alpha"
+          },
+          {
+            "Version": "2.1.591-alpha"
+          },
+          {
+            "Version": "2.1.592-alpha"
+          },
+          {
+            "Version": "2.1.593-alpha"
+          },
+          {
+            "Version": "2.1.594-alpha"
+          },
+          {
+            "Version": "2.1.595-alpha"
+          },
+          {
+            "Version": "2.1.596-alpha"
+          },
+          {
+            "Version": "2.1.597-alpha"
+          },
+          {
+            "Version": "2.1.598-alpha"
+          },
+          {
+            "Version": "2.1.600-alpha"
+          },
+          {
+            "Version": "2.1.601-alpha"
+          },
+          {
+            "Version": "2.1.602-alpha"
+          },
+          {
+            "Version": "2.1.603-alpha"
+          },
+          {
+            "Version": "2.1.604-alpha"
+          },
+          {
+            "Version": "2.1.605-alpha"
+          },
+          {
+            "Version": "2.1.607-alpha"
+          },
+          {
+            "Version": "2.1.609-alpha"
+          },
+          {
+            "Version": "2.1.611-alpha"
+          },
+          {
+            "Version": "2.1.612-alpha"
+          },
+          {
+            "Version": "2.1.614-alpha"
+          },
+          {
+            "Version": "2.1.616-alpha"
+          },
+          {
+            "Version": "2.1.617-alpha"
+          },
+          {
+            "Version": "2.1.618-alpha"
+          },
+          {
+            "Version": "2.1.620-alpha"
+          },
+          {
+            "Version": "2.1.621-alpha"
+          },
+          {
+            "Version": "2.1.622-alpha"
+          },
+          {
+            "Version": "2.1.623-alpha"
+          },
+          {
+            "Version": "2.1.624-alpha"
+          },
+          {
+            "Version": "2.1.625-alpha"
+          },
+          {
+            "Version": "2.1.626-alpha"
+          },
+          {
+            "Version": "2.1.629-alpha"
+          },
+          {
+            "Version": "2.1.630-alpha"
+          },
+          {
+            "Version": "2.1.631-alpha"
+          },
+          {
+            "Version": "2.1.632-alpha"
+          },
+          {
+            "Version": "2.1.633-alpha"
+          },
+          {
+            "Version": "2.1.634-alpha"
+          },
+          {
+            "Version": "2.1.635-alpha"
+          },
+          {
+            "Version": "2.1.636-alpha"
+          },
+          {
+            "Version": "2.1.637-alpha"
+          },
+          {
+            "Version": "2.1.638-alpha"
+          },
+          {
+            "Version": "2.1.639-alpha"
+          },
+          {
+            "Version": "2.1.640-alpha"
+          },
+          {
+            "Version": "2.1.641-alpha"
+          },
+          {
+            "Version": "2.1.642-alpha"
+          },
+          {
+            "Version": "2.1.643-alpha"
+          },
+          {
+            "Version": "2.1.645-alpha"
+          },
+          {
+            "Version": "2.1.646-alpha"
+          },
+          {
+            "Version": "2.1.647-alpha"
+          },
+          {
+            "Version": "2.1.648-alpha"
+          },
+          {
+            "Version": "2.1.649-alpha"
+          },
+          {
+            "Version": "2.1.651-alpha"
+          },
+          {
+            "Version": "2.1.652-alpha"
+          },
+          {
+            "Version": "2.1.653-alpha"
+          },
+          {
+            "Version": "2.1.654-alpha"
+          },
+          {
+            "Version": "2.1.655-alpha"
+          },
+          {
+            "Version": "2.1.656-alpha"
+          },
+          {
+            "Version": "2.1.657-alpha"
+          },
+          {
+            "Version": "2.1.658-alpha"
+          },
+          {
+            "Version": "2.1.659-alpha"
+          },
+          {
+            "Version": "2.1.660-alpha"
+          },
+          {
+            "Version": "2.1.661-alpha"
+          },
+          {
+            "Version": "2.1.662-alpha"
+          },
+          {
+            "Version": "2.1.663-alpha"
+          },
+          {
+            "Version": "2.1.664-alpha"
+          },
+          {
+            "Version": "2.1.665-alpha"
+          },
+          {
+            "Version": "2.1.666-alpha"
+          },
+          {
+            "Version": "2.1.667-alpha"
+          },
+          {
+            "Version": "2.1.668-alpha"
+          },
+          {
+            "Version": "2.1.671-alpha"
+          },
+          {
+            "Version": "2.1.672-alpha"
+          },
+          {
+            "Version": "2.1.673-alpha"
+          },
+          {
+            "Version": "2.1.674-alpha"
+          },
+          {
+            "Version": "2.1.675-alpha"
+          },
+          {
+            "Version": "2.1.676-alpha"
+          },
+          {
+            "Version": "2.1.677-alpha"
+          },
+          {
+            "Version": "2.1.678-alpha"
+          },
+          {
+            "Version": "2.1.679-alpha"
+          },
+          {
+            "Version": "2.1.680-alpha"
+          },
+          {
+            "Version": "2.1.681-alpha"
+          },
+          {
+            "Version": "2.1.682-alpha"
+          },
+          {
+            "Version": "2.1.683-alpha"
+          },
+          {
+            "Version": "2.1.685-alpha"
+          },
+          {
+            "Version": "2.1.686-alpha"
+          },
+          {
+            "Version": "2.1.687-alpha"
+          },
+          {
+            "Version": "2.1.688-alpha"
+          },
+          {
+            "Version": "2.1.711-alpha"
+          },
+          {
+            "Version": "2.1.713-alpha"
+          },
+          {
+            "Version": "2.1.714-alpha"
+          },
+          {
+            "Version": "2.1.718-alpha"
+          },
+          {
+            "Version": "2.1.724-alpha"
+          },
+          {
+            "Version": "2.1.726-alpha"
+          },
+          {
+            "Version": "2.1.727-alpha"
+          },
+          {
+            "Version": "2.1.728-alpha"
+          },
+          {
+            "Version": "2.1.729-alpha"
+          },
+          {
+            "Version": "2.1.730-alpha"
+          },
+          {
+            "Version": "2.1.731-alpha"
+          },
+          {
+            "Version": "2.1.732-alpha"
+          },
+          {
+            "Version": "2.1.733-alpha"
+          },
+          {
+            "Version": "2.1.735-alpha"
+          },
+          {
+            "Version": "2.1.737-alpha"
+          },
+          {
+            "Version": "2.1.738-alpha"
+          },
+          {
+            "Version": "2.1.739-alpha"
+          },
+          {
+            "Version": "2.1.740-alpha"
+          },
+          {
+            "Version": "2.1.742-alpha"
+          },
+          {
+            "Version": "2.1.743-alpha"
+          },
+          {
+            "Version": "2.1.744-alpha"
+          },
+          {
+            "Version": "2.1.745-alpha"
+          },
+          {
+            "Version": "2.1.746-alpha"
+          },
+          {
+            "Version": "2.1.747-alpha"
+          },
+          {
+            "Version": "2.1.748-alpha"
+          },
+          {
+            "Version": "2.1.750-alpha"
+          },
+          {
+            "Version": "2.1.756-alpha"
+          },
+          {
+            "Version": "2.1.758-alpha"
+          },
+          {
+            "Version": "2.1.765-alpha"
+          },
+          {
+            "Version": "2.1.766-alpha"
+          },
+          {
+            "Version": "2.1.767-alpha"
+          },
+          {
+            "Version": "2.1.768-alpha"
+          },
+          {
+            "Version": "2.1.770-alpha"
+          },
+          {
+            "Version": "2.1.771-alpha"
+          },
+          {
+            "Version": "2.1.772-alpha"
+          },
+          {
+            "Version": "2.1.773-alpha"
+          },
+          {
+            "Version": "2.1.774-alpha"
+          },
+          {
+            "Version": "2.1.775-alpha"
+          },
+          {
+            "Version": "2.1.778-alpha"
+          },
+          {
+            "Version": "2.1.779-alpha"
+          },
+          {
+            "Version": "2.1.781-alpha"
+          },
+          {
+            "Version": "2.2.0.0"
+          },
+          {
+            "Version": "2.2.1.0"
+          },
+          {
+            "Version": "2.2.2.0"
+          },
+          {
+            "Version": "2.2.4.0"
+          },
+          {
+            "Version": "2.2.6.0"
+          },
+          {
+            "Version": "2.2.7.0"
+          },
+          {
+            "Version": "2.2.8.0"
+          },
+          {
+            "Version": "2.2.9.0"
+          },
+          {
+            "Version": "2.2.10.0"
+          },
+          {
+            "Version": "2.2.11.0"
+          },
+          {
+            "Version": "2.2.12.0"
+          },
+          {
+            "Version": "2.2.13.0"
+          },
+          {
+            "Version": "2.2.14.0"
+          },
+          {
+            "Version": "2.2.18.0"
+          },
+          {
+            "Version": "2.2.19.0"
+          },
+          {
+            "Version": "2.2.20.0"
+          },
+          {
+            "Version": "2.2.21.0"
+          },
+          {
+            "Version": "2.2.22.0"
+          },
+          {
+            "Version": "2.2.23.0"
+          },
+          {
+            "Version": "2.3.1-alpha"
+          },
+          {
+            "Version": "2.3.2-alpha"
+          },
+          {
+            "Version": "2.3.5-alpha"
+          },
+          {
+            "Version": "2.3.8-alpha"
+          },
+          {
+            "Version": "2.3.10-alpha"
+          },
+          {
+            "Version": "2.3.11-alpha"
+          },
+          {
+            "Version": "2.3.14-alpha"
+          },
+          {
+            "Version": "2.3.15-alpha"
+          },
+          {
+            "Version": "2.3.16-alpha"
+          },
+          {
+            "Version": "2.3.17-alpha"
+          },
+          {
+            "Version": "2.3.18-alpha"
+          },
+          {
+            "Version": "2.3.19-alpha"
+          },
+          {
+            "Version": "2.3.20-alpha"
+          },
+          {
+            "Version": "2.3.21-alpha"
+          },
+          {
+            "Version": "2.3.22-alpha"
+          },
+          {
+            "Version": "2.3.23-alpha"
+          },
+          {
+            "Version": "2.3.24-alpha"
+          },
+          {
+            "Version": "2.3.26-alpha"
+          },
+          {
+            "Version": "2.3.28-alpha"
+          },
+          {
+            "Version": "2.3.30-alpha"
+          },
+          {
+            "Version": "2.3.31-alpha"
+          },
+          {
+            "Version": "2.3.32-alpha"
+          },
+          {
+            "Version": "2.3.33-alpha"
+          },
+          {
+            "Version": "2.3.34-alpha"
+          },
+          {
+            "Version": "2.3.36-alpha"
+          },
+          {
+            "Version": "2.3.37-alpha"
+          },
+          {
+            "Version": "2.3.38-alpha"
+          },
+          {
+            "Version": "2.3.39-alpha"
+          },
+          {
+            "Version": "2.3.41-alpha"
+          },
+          {
+            "Version": "2.3.43-alpha"
+          },
+          {
+            "Version": "2.3.49-alpha"
+          },
+          {
+            "Version": "2.3.50-alpha"
+          },
+          {
+            "Version": "2.3.51-alpha"
+          },
+          {
+            "Version": "2.3.54-alpha"
+          },
+          {
+            "Version": "2.3.55-alpha"
+          },
+          {
+            "Version": "2.3.57-alpha"
+          },
+          {
+            "Version": "2.3.58-alpha"
+          },
+          {
+            "Version": "2.3.59-alpha"
+          },
+          {
+            "Version": "2.3.60-alpha"
+          },
+          {
+            "Version": "2.3.61-alpha"
+          },
+          {
+            "Version": "2.3.62-alpha"
+          },
+          {
+            "Version": "2.3.63-alpha"
+          },
+          {
+            "Version": "2.3.64-alpha"
+          },
+          {
+            "Version": "2.3.65-alpha"
+          },
+          {
+            "Version": "2.3.66-alpha"
+          },
+          {
+            "Version": "2.3.67-alpha"
+          },
+          {
+            "Version": "2.3.68-alpha"
+          },
+          {
+            "Version": "2.3.69-alpha"
+          },
+          {
+            "Version": "2.3.70-alpha"
+          },
+          {
+            "Version": "2.3.71-alpha"
+          },
+          {
+            "Version": "2.3.72-alpha"
+          },
+          {
+            "Version": "2.3.73-alpha"
+          },
+          {
+            "Version": "2.3.74-alpha"
+          },
+          {
+            "Version": "2.3.75-alpha"
+          },
+          {
+            "Version": "2.3.76-alpha"
+          },
+          {
+            "Version": "2.3.77-alpha"
+          },
+          {
+            "Version": "2.3.78-alpha"
+          },
+          {
+            "Version": "2.3.79-alpha"
+          },
+          {
+            "Version": "2.3.80-alpha"
+          },
+          {
+            "Version": "2.3.81-alpha"
+          },
+          {
+            "Version": "2.3.82-alpha"
+          },
+          {
+            "Version": "2.3.83-alpha"
+          },
+          {
+            "Version": "2.3.84-alpha"
+          },
+          {
+            "Version": "2.3.85-alpha"
+          },
+          {
+            "Version": "2.3.86-alpha"
+          },
+          {
+            "Version": "2.3.87-alpha"
+          },
+          {
+            "Version": "2.3.88-alpha"
+          },
+          {
+            "Version": "2.4.0.0"
+          },
+          {
+            "Version": "2.4.1.0"
+          },
+          {
+            "Version": "2.4.2.0"
+          },
+          {
+            "Version": "2.4.3.0"
+          },
+          {
+            "Version": "2.4.4.0"
+          },
+          {
+            "Version": "2.4.5.0"
+          },
+          {
+            "Version": "2.4.6.0"
+          },
+          {
+            "Version": "2.4.7.0"
+          },
+          {
+            "Version": "2.4.8.0"
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.4-alpha"
+          },
+          {
+            "Version": "2.5.5-alpha"
+          },
+          {
+            "Version": "2.5.7-alpha"
+          },
+          {
+            "Version": "2.5.8-alpha"
+          },
+          {
+            "Version": "2.5.9-alpha"
+          },
+          {
+            "Version": "2.5.10-alpha"
+          },
+          {
+            "Version": "2.5.11-alpha"
+          },
+          {
+            "Version": "2.5.12-alpha"
+          },
+          {
+            "Version": "2.5.17-alpha"
+          },
+          {
+            "Version": "2.5.18-alpha"
+          },
+          {
+            "Version": "2.5.19-alpha"
+          },
+          {
+            "Version": "2.5.20-alpha"
+          },
+          {
+            "Version": "2.5.21-alpha"
+          },
+          {
+            "Version": "2.5.22-alpha"
+          },
+          {
+            "Version": "2.5.25-alpha"
+          },
+          {
+            "Version": "2.5.31-alpha"
+          },
+          {
+            "Version": "2.5.32-alpha"
+          },
+          {
+            "Version": "2.5.33-alpha"
+          },
+          {
+            "Version": "2.5.34-alpha"
+          },
+          {
+            "Version": "2.5.35-alpha"
+          },
+          {
+            "Version": "2.5.39-alpha"
+          },
+          {
+            "Version": "2.5.40-alpha"
+          },
+          {
+            "Version": "2.5.41-alpha"
+          },
+          {
+            "Version": "2.5.42-alpha"
+          },
+          {
+            "Version": "2.5.43-alpha"
+          },
+          {
+            "Version": "2.5.44-alpha"
+          },
+          {
+            "Version": "2.5.45-alpha"
+          },
+          {
+            "Version": "2.5.46-alpha"
+          },
+          {
+            "Version": "2.5.47-alpha"
+          },
+          {
+            "Version": "2.5.48-alpha"
+          },
+          {
+            "Version": "2.5.49-alpha"
+          },
+          {
+            "Version": "2.5.54-alpha"
+          },
+          {
+            "Version": "2.5.55-alpha"
+          },
+          {
+            "Version": "2.5.56-alpha"
+          },
+          {
+            "Version": "2.5.57-alpha"
+          },
+          {
+            "Version": "2.5.58-alpha"
+          },
+          {
+            "Version": "2.5.59-alpha"
+          },
+          {
+            "Version": "2.5.60-alpha"
+          },
+          {
+            "Version": "2.5.61-alpha"
+          },
+          {
+            "Version": "2.5.62-alpha"
+          },
+          {
+            "Version": "2.5.63-alpha"
+          },
+          {
+            "Version": "2.5.64-alpha"
+          },
+          {
+            "Version": "2.5.65-alpha"
+          },
+          {
+            "Version": "2.5.66-alpha"
+          },
+          {
+            "Version": "2.5.67-alpha"
+          },
+          {
+            "Version": "2.5.68-alpha"
+          },
+          {
+            "Version": "2.5.69-alpha"
+          },
+          {
+            "Version": "2.5.70-alpha"
+          },
+          {
+            "Version": "2.5.71-alpha"
+          },
+          {
+            "Version": "2.5.72-alpha"
+          },
+          {
+            "Version": "2.5.73-alpha"
+          },
+          {
+            "Version": "2.5.74-alpha"
+          },
+          {
+            "Version": "2.5.75-alpha"
+          },
+          {
+            "Version": "2.6.0.0"
+          },
+          {
+            "Version": "2.6.1.0"
+          },
+          {
+            "Version": "2.6.3.0"
+          },
+          {
+            "Version": "2.6.5.0"
+          },
+          {
+            "Version": "2.6.7.0"
+          },
+          {
+            "Version": "2.6.9.0"
+          },
+          {
+            "Version": "2.6.12.0"
+          },
+          {
+            "Version": "2.6.14.0"
+          },
+          {
+            "Version": "2.6.15.0"
+          },
+          {
+            "Version": "2.6.16.0"
+          },
+          {
+            "Version": "2.6.17.0"
+          },
+          {
+            "Version": "2.7.0-alpha10"
+          },
+          {
+            "Version": "2.7.0-alpha11"
+          },
+          {
+            "Version": "2.7.0-alpha13"
+          },
+          {
+            "Version": "2.7.0-alpha14"
+          },
+          {
+            "Version": "2.7.0-alpha15"
+          },
+          {
+            "Version": "2.7.0-alpha7"
+          },
+          {
+            "Version": "2.7.0-alpha8"
+          },
+          {
+            "Version": "2.7.0-alpha9"
+          },
+          {
+            "Version": "2.7.0.16-alpha"
+          },
+          {
+            "Version": "2.7.0.17-alpha"
+          },
+          {
+            "Version": "2.7.0.18-alpha"
+          },
+          {
+            "Version": "2.7.0.19-alpha"
+          },
+          {
+            "Version": "2.7.0.20-alpha"
+          },
+          {
+            "Version": "2.7.0.21-alpha"
+          },
+          {
+            "Version": "2.7.0.23-alpha"
+          },
+          {
+            "Version": "2.7.0.24-alpha"
+          },
+          {
+            "Version": "2.7.0.25-alpha"
+          },
+          {
+            "Version": "2.7.0.26-alpha"
+          },
+          {
+            "Version": "2.7.0.27-alpha"
+          },
+          {
+            "Version": "2.7.0.28-alpha"
+          },
+          {
+            "Version": "2.7.0.29-alpha"
+          },
+          {
+            "Version": "2.7.0.30-alpha"
+          },
+          {
+            "Version": "2.7.0.32-alpha"
+          },
+          {
+            "Version": "2.7.0.34-alpha"
+          },
+          {
+            "Version": "2.7.0.35-alpha"
+          },
+          {
+            "Version": "2.7.0.36-alpha"
+          },
+          {
+            "Version": "2.7.0.37-alpha"
+          },
+          {
+            "Version": "2.7.0.38-alpha"
+          },
+          {
+            "Version": "2.7.0.39-alpha"
+          },
+          {
+            "Version": "2.7.0.42-alpha"
+          },
+          {
+            "Version": "2.7.0.43-alpha"
+          },
+          {
+            "Version": "2.7.0.44-alpha"
+          },
+          {
+            "Version": "2.7.0.45-alpha"
+          },
+          {
+            "Version": "2.7.0.47-alpha"
+          },
+          {
+            "Version": "2.7.0.50-alpha"
+          },
+          {
+            "Version": "2.7.0.59-alpha"
+          },
+          {
+            "Version": "2.7.0.60-alpha"
+          },
+          {
+            "Version": "2.7.0.61-alpha"
+          },
+          {
+            "Version": "2.7.0.62-alpha"
+          },
+          {
+            "Version": "2.7.0.63-alpha"
+          },
+          {
+            "Version": "2.7.0.64-alpha"
+          },
+          {
+            "Version": "2.7.0.65-alpha"
+          },
+          {
+            "Version": "2.7.0.66-alpha"
+          },
+          {
+            "Version": "2.7.0.72-alpha"
+          },
+          {
+            "Version": "2.7.0.84-alpha"
+          },
+          {
+            "Version": "2.7.0.85-alpha"
+          },
+          {
+            "Version": "2.7.0.86-alpha"
+          },
+          {
+            "Version": "2.7.0.87-alpha"
+          },
+          {
+            "Version": "2.7.0.88-alpha"
+          },
+          {
+            "Version": "2.7.0.90-alpha"
+          },
+          {
+            "Version": "2.7.0.91-alpha"
+          },
+          {
+            "Version": "2.7.0.92-alpha"
+          },
+          {
+            "Version": "2.7.1-alpha"
+          },
+          {
+            "Version": "2.8.0.0"
+          },
+          {
+            "Version": "2.8.1.0"
+          },
+          {
+            "Version": "2.8.2.0"
+          },
+          {
+            "Version": "2.8.3.0"
+          },
+          {
+            "Version": "2.8.5.0"
+          },
+          {
+            "Version": "2.8.6.0"
+          },
+          {
+            "Version": "2.8.7.0"
+          },
+          {
+            "Version": "2.8.8.0"
+          },
+          {
+            "Version": "2.8.9.0"
+          },
+          {
+            "Version": "2.8.10.0"
+          },
+          {
+            "Version": "2.8.11.0"
+          },
+          {
+            "Version": "2.8.12.0"
+          },
+          {
+            "Version": "2.8.17.0"
+          },
+          {
+            "Version": "2.9.0.0-alpha"
+          },
+          {
+            "Version": "2.9.0.1-alpha"
+          },
+          {
+            "Version": "2.9.0.3-alpha"
+          },
+          {
+            "Version": "2.9.11-alpha"
+          },
+          {
+            "Version": "2.9.12-alpha"
+          },
+          {
+            "Version": "2.9.14-alpha"
+          },
+          {
+            "Version": "2.9.15-alpha"
+          },
+          {
+            "Version": "2.9.17-alpha"
+          },
+          {
+            "Version": "2.9.19-alpha"
+          },
+          {
+            "Version": "2.9.20-alpha"
+          },
+          {
+            "Version": "2.9.21-alpha"
+          },
+          {
+            "Version": "2.9.22-alpha"
+          },
+          {
+            "Version": "2.9.23-alpha"
+          },
+          {
+            "Version": "2.9.24-alpha"
+          },
+          {
+            "Version": "2.9.26-alpha"
+          },
+          {
+            "Version": "2.9.27-alpha"
+          },
+          {
+            "Version": "2.9.28-alpha"
+          },
+          {
+            "Version": "2.9.29-alpha"
+          },
+          {
+            "Version": "2.9.30-alpha"
+          },
+          {
+            "Version": "2.9.31-alpha"
+          },
+          {
+            "Version": "2.9.32-alpha"
+          },
+          {
+            "Version": "2.9.33-alpha"
+          },
+          {
+            "Version": "2.9.34-alpha"
+          },
+          {
+            "Version": "2.9.35-alpha"
+          },
+          {
+            "Version": "2.9.36-alpha"
+          },
+          {
+            "Version": "2.9.37-alpha"
+          },
+          {
+            "Version": "2.9.41-alpha"
+          },
+          {
+            "Version": "2.9.42-alpha"
+          },
+          {
+            "Version": "2.9.44-alpha"
+          },
+          {
+            "Version": "2.9.45-alpha"
+          },
+          {
+            "Version": "2.9.46-alpha"
+          },
+          {
+            "Version": "2.9.47-alpha"
+          },
+          {
+            "Version": "2.10.0.0"
+          },
+          {
+            "Version": "2.10.1.0"
+          },
+          {
+            "Version": "2.10.2.0"
+          },
+          {
+            "Version": "2.10.3.0"
+          },
+          {
+            "Version": "2.10.4.0"
+          },
+          {
+            "Version": "2.10.5.0"
+          },
+          {
+            "Version": "2.10.6.0"
+          },
+          {
+            "Version": "2.10.7.0"
+          },
+          {
+            "Version": "2.10.8.0"
+          },
+          {
+            "Version": "2.10.9.0"
+          },
+          {
+            "Version": "2.10.10.0"
+          },
+          {
+            "Version": "2.10.11.0"
+          },
+          {
+            "Version": "2.10.12.0"
+          },
+          {
+            "Version": "2.10.13.0"
+          },
+          {
+            "Version": "2.10.14.0"
+          },
+          {
+            "Version": "2.10.15.0"
+          },
+          {
+            "Version": "2.10.16.0"
+          },
+          {
+            "Version": "2.10.17.0"
+          },
+          {
+            "Version": "2.10.18.0"
+          },
+          {
+            "Version": "2.10.19.0"
+          },
+          {
+            "Version": "2.10.20.0"
+          },
+          {
+            "Version": "2.10.23.0"
+          },
+          {
+            "Version": "2.10.24.0"
+          },
+          {
+            "Version": "2.10.25.0"
+          },
+          {
+            "Version": "2.11.0-alpha"
+          },
+          {
+            "Version": "2.11.1-alpha"
+          },
+          {
+            "Version": "2.11.2-alpha"
+          },
+          {
+            "Version": "2.11.3-alpha"
+          },
+          {
+            "Version": "2.11.4-alpha"
+          },
+          {
+            "Version": "2.11.5-alpha"
+          },
+          {
+            "Version": "2.11.6-alpha"
+          },
+          {
+            "Version": "2.11.8-alpha"
+          },
+          {
+            "Version": "2.11.9-alpha"
+          },
+          {
+            "Version": "2.11.10-alpha"
+          },
+          {
+            "Version": "2.11.11-alpha"
+          },
+          {
+            "Version": "2.11.12-alpha"
+          },
+          {
+            "Version": "2.11.13-alpha"
+          },
+          {
+            "Version": "2.11.14-alpha"
+          },
+          {
+            "Version": "2.11.15-alpha"
+          },
+          {
+            "Version": "2.11.16-alpha"
+          },
+          {
+            "Version": "2.11.17-alpha"
+          },
+          {
+            "Version": "2.11.18-alpha"
+          },
+          {
+            "Version": "2.11.19-alpha"
+          },
+          {
+            "Version": "2.11.20-alpha"
+          },
+          {
+            "Version": "2.11.21-alpha"
+          },
+          {
+            "Version": "2.11.22-alpha"
+          },
+          {
+            "Version": "2.11.25-alpha"
+          },
+          {
+            "Version": "2.11.27-alpha"
+          },
+          {
+            "Version": "2.11.28-alpha"
+          },
+          {
+            "Version": "2.11.29-alpha"
+          },
+          {
+            "Version": "2.11.30-alpha"
+          },
+          {
+            "Version": "2.11.31-alpha"
+          },
+          {
+            "Version": "2.11.32-alpha"
+          },
+          {
+            "Version": "2.11.33-alpha"
+          },
+          {
+            "Version": "2.11.40-alpha"
+          },
+          {
+            "Version": "2.11.41-alpha"
+          },
+          {
+            "Version": "2.11.50-alpha"
+          },
+          {
+            "Version": "2.11.51-alpha"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.2"
+          },
+          {
+            "Version": "2.13.0-alpha1"
+          },
+          {
+            "Version": "2.13.0-alpha2"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.12"
+          },
+          {
+            "Version": "2.14.13"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.15.7"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "2.16.3"
+          },
+          {
+            "Version": "2.17.0"
+          },
+          {
+            "Version": "2.17.1"
+          },
+          {
+            "Version": "2.17.2"
+          },
+          {
+            "Version": "2.17.3-alpha1"
+          },
+          {
+            "Version": "2.17.3-alpha2"
+          },
+          {
+            "Version": "2.17.3"
+          },
+          {
+            "Version": "2.17.4"
+          },
+          {
+            "Version": "2.17.5"
+          },
+          {
+            "Version": "2.17.6"
+          },
+          {
+            "Version": "2.17.7"
+          },
+          {
+            "Version": "2.17.8"
+          },
+          {
+            "Version": "2.17.9"
+          },
+          {
+            "Version": "2.18.0-alpha1"
+          },
+          {
+            "Version": "2.18.0-alpha2"
+          },
+          {
+            "Version": "2.18.0-alpha3"
+          },
+          {
+            "Version": "2.18.0"
+          },
+          {
+            "Version": "2.18.1"
+          },
+          {
+            "Version": "2.18.2"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha10"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "3.2.5"
+          },
+          {
+            "Version": "3.2.6"
+          },
+          {
+            "Version": "3.2.7"
+          },
+          {
+            "Version": "3.2.8"
+          },
+          {
+            "Version": "3.2.9"
+          },
+          {
+            "Version": "3.2.10"
+          },
+          {
+            "Version": "3.2.11"
+          },
+          {
+            "Version": "3.2.12"
+          },
+          {
+            "Version": "3.2.13"
+          },
+          {
+            "Version": "3.2.14"
+          },
+          {
+            "Version": "3.2.15"
+          },
+          {
+            "Version": "3.2.16"
+          },
+          {
+            "Version": "3.2.17"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "3.5.9"
+          },
+          {
+            "Version": "3.5.10"
+          },
+          {
+            "Version": "3.5.11"
+          },
+          {
+            "Version": "3.5.12"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.7.8"
+          },
+          {
+            "Version": "3.7.9"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.8.3"
+          },
+          {
+            "Version": "3.8.4"
+          },
+          {
+            "Version": "3.8.5"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "3.9.4"
+          },
+          {
+            "Version": "3.9.5"
+          },
+          {
+            "Version": "3.9.6"
+          },
+          {
+            "Version": "3.9.7"
+          },
+          {
+            "Version": "3.9.8"
+          },
+          {
+            "Version": "3.9.9"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.11.2"
+          },
+          {
+            "Version": "3.11.3"
+          },
+          {
+            "Version": "3.11.4"
+          },
+          {
+            "Version": "3.12.2"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.13.2"
+          },
+          {
+            "Version": "3.13.3"
+          },
+          {
+            "Version": "3.13.4"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.14.1"
+          },
+          {
+            "Version": "3.14.2"
+          },
+          {
+            "Version": "3.14.3"
+          },
+          {
+            "Version": "3.14.4"
+          },
+          {
+            "Version": "3.14.5"
+          },
+          {
+            "Version": "3.14.6"
+          },
+          {
+            "Version": "3.14.7"
+          },
+          {
+            "Version": "3.14.8"
+          },
+          {
+            "Version": "3.14.9"
+          },
+          {
+            "Version": "3.14.10"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.17.1"
+          },
+          {
+            "Version": "3.17.2"
+          },
+          {
+            "Version": "3.17.3"
+          },
+          {
+            "Version": "3.17.4"
+          },
+          {
+            "Version": "3.17.5"
+          },
+          {
+            "Version": "3.17.6"
+          },
+          {
+            "Version": "3.17.7"
+          },
+          {
+            "Version": "3.17.8"
+          },
+          {
+            "Version": "3.17.9"
+          },
+          {
+            "Version": "3.17.11"
+          },
+          {
+            "Version": "3.17.12"
+          },
+          {
+            "Version": "3.17.13"
+          },
+          {
+            "Version": "3.17.14"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.19.3"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.25.1"
+          },
+          {
+            "Version": "3.25.2"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.26.1"
+          },
+          {
+            "Version": "3.26.3"
+          },
+          {
+            "Version": "3.26.4"
+          },
+          {
+            "Version": "3.26.5"
+          },
+          {
+            "Version": "3.26.6"
+          },
+          {
+            "Version": "3.26.7"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.27.1"
+          },
+          {
+            "Version": "3.27.2"
+          },
+          {
+            "Version": "3.27.3"
+          },
+          {
+            "Version": "3.27.4"
+          },
+          {
+            "Version": "3.27.5"
+          },
+          {
+            "Version": "3.27.6"
+          },
+          {
+            "Version": "3.27.7"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.28.1"
+          },
+          {
+            "Version": "3.28.2"
+          },
+          {
+            "Version": "3.28.3"
+          },
+          {
+            "Version": "3.28.4"
+          },
+          {
+            "Version": "3.28.5"
+          },
+          {
+            "Version": "3.28.6"
+          },
+          {
+            "Version": "3.28.7"
+          },
+          {
+            "Version": "3.28.8"
+          },
+          {
+            "Version": "3.29.1"
+          },
+          {
+            "Version": "3.29.2"
+          },
+          {
+            "Version": "3.29.3"
+          },
+          {
+            "Version": "3.29.4"
+          },
+          {
+            "Version": "3.29.5"
+          },
+          {
+            "Version": "3.29.6"
+          },
+          {
+            "Version": "3.29.7"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.31.4"
+          },
+          {
+            "Version": "3.32.4"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.34.3"
+          },
+          {
+            "Version": "3.34.4"
+          },
+          {
+            "Version": "3.34.5"
+          },
+          {
+            "Version": "3.34.6"
+          },
+          {
+            "Version": "3.34.7"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.35.2"
+          },
+          {
+            "Version": "3.35.3"
+          },
+          {
+            "Version": "3.35.4"
+          },
+          {
+            "Version": "3.35.5"
+          },
+          {
+            "Version": "3.36.0"
+          },
+          {
+            "Version": "3.37.0"
+          },
+          {
+            "Version": "3.37.1"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-alpha002"
+          },
+          {
+            "Version": "4.0.0-alpha003"
+          },
+          {
+            "Version": "4.0.0-alpha004"
+          },
+          {
+            "Version": "4.0.0-alpha005"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3"
+          },
+          {
+            "Version": "4.1.4"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1-alpha001"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "4.3.2"
+          },
+          {
+            "Version": "4.3.3"
+          },
+          {
+            "Version": "4.3.4"
+          },
+          {
+            "Version": "4.3.7"
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.4.1"
+          },
+          {
+            "Version": "4.4.2"
+          },
+          {
+            "Version": "4.4.3"
+          },
+          {
+            "Version": "4.4.4"
+          },
+          {
+            "Version": "4.4.5"
+          },
+          {
+            "Version": "4.4.6"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.6.0-alpha001"
+          },
+          {
+            "Version": "4.6.0-alpha002"
+          },
+          {
+            "Version": "4.6.0"
+          },
+          {
+            "Version": "4.6.1"
+          },
+          {
+            "Version": "4.6.2"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.6.4"
+          },
+          {
+            "Version": "4.7.0-alpha001"
+          },
+          {
+            "Version": "4.7.0-alpha002"
+          },
+          {
+            "Version": "4.7.0"
+          },
+          {
+            "Version": "4.7.1"
+          },
+          {
+            "Version": "4.7.2"
+          },
+          {
+            "Version": "4.7.3"
+          },
+          {
+            "Version": "4.8.0"
+          },
+          {
+            "Version": "4.9.0"
+          },
+          {
+            "Version": "4.9.1"
+          },
+          {
+            "Version": "4.9.2"
+          },
+          {
+            "Version": "4.9.3"
+          },
+          {
+            "Version": "4.9.5"
+          },
+          {
+            "Version": "4.9.6"
+          },
+          {
+            "Version": "4.9.7"
+          },
+          {
+            "Version": "4.9.8"
+          },
+          {
+            "Version": "4.10.0"
+          },
+          {
+            "Version": "4.10.1"
+          },
+          {
+            "Version": "4.10.3"
+          },
+          {
+            "Version": "4.10.4"
+          },
+          {
+            "Version": "4.10.5"
+          },
+          {
+            "Version": "4.11.0"
+          },
+          {
+            "Version": "4.11.1"
+          },
+          {
+            "Version": "4.11.2"
+          },
+          {
+            "Version": "4.11.3"
+          },
+          {
+            "Version": "4.12.0"
+          },
+          {
+            "Version": "4.12.2"
+          },
+          {
+            "Version": "4.13.0"
+          },
+          {
+            "Version": "4.13.1"
+          },
+          {
+            "Version": "4.14.0"
+          },
+          {
+            "Version": "4.14.1"
+          },
+          {
+            "Version": "4.14.2"
+          },
+          {
+            "Version": "4.14.3"
+          },
+          {
+            "Version": "4.14.4"
+          },
+          {
+            "Version": "4.14.5"
+          },
+          {
+            "Version": "4.14.7"
+          },
+          {
+            "Version": "4.14.8"
+          },
+          {
+            "Version": "4.14.9"
+          },
+          {
+            "Version": "4.15.0"
+          },
+          {
+            "Version": "4.15.1"
+          },
+          {
+            "Version": "4.15.2"
+          },
+          {
+            "Version": "4.16.0-alpha001"
+          },
+          {
+            "Version": "4.16.0"
+          },
+          {
+            "Version": "4.16.1"
+          },
+          {
+            "Version": "4.17.0-alpha001"
+          },
+          {
+            "Version": "4.17.0-alpha002"
+          },
+          {
+            "Version": "4.17.0-alpha003"
+          },
+          {
+            "Version": "4.17.0-alpha004"
+          },
+          {
+            "Version": "4.17.0-alpha005"
+          },
+          {
+            "Version": "4.17.0-alpha007"
+          },
+          {
+            "Version": "4.17.0"
+          },
+          {
+            "Version": "4.17.1"
+          },
+          {
+            "Version": "4.18.0"
+          },
+          {
+            "Version": "4.19.0"
+          },
+          {
+            "Version": "4.20.0"
+          },
+          {
+            "Version": "4.21.0"
+          },
+          {
+            "Version": "4.21.1"
+          },
+          {
+            "Version": "4.21.2"
+          },
+          {
+            "Version": "4.21.3"
+          },
+          {
+            "Version": "4.21.4"
+          },
+          {
+            "Version": "4.22.0"
+          },
+          {
+            "Version": "4.22.1"
+          },
+          {
+            "Version": "4.22.2"
+          },
+          {
+            "Version": "4.22.3"
+          },
+          {
+            "Version": "4.22.4"
+          },
+          {
+            "Version": "4.22.5"
+          },
+          {
+            "Version": "4.22.6"
+          },
+          {
+            "Version": "4.22.7"
+          },
+          {
+            "Version": "4.22.8"
+          },
+          {
+            "Version": "4.22.9"
+          },
+          {
+            "Version": "4.23.0"
+          },
+          {
+            "Version": "4.23.1"
+          },
+          {
+            "Version": "4.23.2"
+          },
+          {
+            "Version": "4.23.3"
+          },
+          {
+            "Version": "4.23.4"
+          },
+          {
+            "Version": "4.23.5"
+          },
+          {
+            "Version": "4.23.6"
+          },
+          {
+            "Version": "4.24.0"
+          },
+          {
+            "Version": "4.24.1"
+          },
+          {
+            "Version": "4.24.2"
+          },
+          {
+            "Version": "4.24.3"
+          },
+          {
+            "Version": "4.25.0"
+          },
+          {
+            "Version": "4.25.1"
+          },
+          {
+            "Version": "4.25.2"
+          },
+          {
+            "Version": "4.25.3"
+          },
+          {
+            "Version": "4.25.4"
+          },
+          {
+            "Version": "4.25.5"
+          },
+          {
+            "Version": "4.26.0"
+          },
+          {
+            "Version": "4.27.0"
+          },
+          {
+            "Version": "4.28.0"
+          },
+          {
+            "Version": "4.29.0"
+          },
+          {
+            "Version": "4.29.1"
+          },
+          {
+            "Version": "4.29.2"
+          },
+          {
+            "Version": "4.30.0"
+          },
+          {
+            "Version": "4.30.1"
+          },
+          {
+            "Version": "4.30.2"
+          },
+          {
+            "Version": "4.31.0"
+          },
+          {
+            "Version": "4.31.1"
+          },
+          {
+            "Version": "4.32.0"
+          },
+          {
+            "Version": "4.33.0"
+          },
+          {
+            "Version": "4.33.1"
+          },
+          {
+            "Version": "4.33.2"
+          },
+          {
+            "Version": "4.33.3"
+          },
+          {
+            "Version": "4.33.4"
+          },
+          {
+            "Version": "4.34.0"
+          },
+          {
+            "Version": "4.34.1"
+          },
+          {
+            "Version": "4.34.2"
+          },
+          {
+            "Version": "4.34.3"
+          },
+          {
+            "Version": "4.34.4"
+          },
+          {
+            "Version": "4.34.5"
+          },
+          {
+            "Version": "4.35.0"
+          },
+          {
+            "Version": "4.35.1"
+          },
+          {
+            "Version": "4.36.0"
+          },
+          {
+            "Version": "4.37.0"
+          },
+          {
+            "Version": "4.37.1"
+          },
+          {
+            "Version": "4.37.2"
+          },
+          {
+            "Version": "4.38.0"
+          },
+          {
+            "Version": "4.38.1"
+          },
+          {
+            "Version": "4.38.2"
+          },
+          {
+            "Version": "4.38.3"
+          },
+          {
+            "Version": "4.39.0"
+          },
+          {
+            "Version": "4.39.1"
+          },
+          {
+            "Version": "4.40.0"
+          },
+          {
+            "Version": "4.40.1"
+          },
+          {
+            "Version": "4.40.2"
+          },
+          {
+            "Version": "4.41.0"
+          },
+          {
+            "Version": "4.41.1"
+          },
+          {
+            "Version": "4.41.2"
+          },
+          {
+            "Version": "4.41.3"
+          },
+          {
+            "Version": "4.41.4"
+          },
+          {
+            "Version": "4.41.5"
+          },
+          {
+            "Version": "4.41.6"
+          },
+          {
+            "Version": "4.41.7"
+          },
+          {
+            "Version": "4.41.8"
+          },
+          {
+            "Version": "4.42.0"
+          },
+          {
+            "Version": "4.43.0"
+          },
+          {
+            "Version": "4.44.0"
+          },
+          {
+            "Version": "4.44.1"
+          },
+          {
+            "Version": "4.44.2"
+          },
+          {
+            "Version": "4.44.3"
+          },
+          {
+            "Version": "4.44.4"
+          },
+          {
+            "Version": "4.45.0"
+          },
+          {
+            "Version": "4.45.1"
+          },
+          {
+            "Version": "4.45.2"
+          },
+          {
+            "Version": "4.45.3"
+          },
+          {
+            "Version": "4.46.0"
+          },
+          {
+            "Version": "4.46.1"
+          },
+          {
+            "Version": "4.47.0"
+          },
+          {
+            "Version": "4.47.1"
+          },
+          {
+            "Version": "4.47.2"
+          },
+          {
+            "Version": "4.47.4"
+          },
+          {
+            "Version": "4.48.0"
+          },
+          {
+            "Version": "4.49.0"
+          },
+          {
+            "Version": "4.49.1"
+          },
+          {
+            "Version": "4.50.0"
+          },
+          {
+            "Version": "4.50.1"
+          },
+          {
+            "Version": "4.51.1"
+          },
+          {
+            "Version": "4.52.0"
+          },
+          {
+            "Version": "4.53.0"
+          },
+          {
+            "Version": "4.54.0-alpha001"
+          },
+          {
+            "Version": "4.54.0"
+          },
+          {
+            "Version": "4.55.0"
+          },
+          {
+            "Version": "4.55.1"
+          },
+          {
+            "Version": "4.56.0"
+          },
+          {
+            "Version": "4.57.0"
+          },
+          {
+            "Version": "4.57.1"
+          },
+          {
+            "Version": "4.57.2"
+          },
+          {
+            "Version": "4.57.3"
+          },
+          {
+            "Version": "4.57.4"
+          },
+          {
+            "Version": "4.58.2"
+          },
+          {
+            "Version": "4.58.3"
+          },
+          {
+            "Version": "4.58.4"
+          },
+          {
+            "Version": "4.58.5"
+          },
+          {
+            "Version": "4.58.6"
+          },
+          {
+            "Version": "4.59.0-alpha001"
+          },
+          {
+            "Version": "4.59.0-alpha002"
+          },
+          {
+            "Version": "4.59.0"
+          },
+          {
+            "Version": "4.59.1"
+          },
+          {
+            "Version": "4.59.3"
+          },
+          {
+            "Version": "4.60.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/4.60.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:02.0923288+02:00",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:45.9380566+02:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:51.3973379+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:10.5473313+02:00",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:15.7060582+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:14.9005454+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:09.1483321+02:00",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.1515558+02:00",
+        "PackageName": "Microsoft.Owin.Hosting",
+        "Versions": [
+          {
+            "Version": "0.18.0-alpha"
+          },
+          {
+            "Version": "0.20-alpha-20220-81"
+          },
+          {
+            "Version": "0.20-alpha-20220-88"
+          },
+          {
+            "Version": "0.21.0-pre"
+          },
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Hosting",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Owin.Hosting/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:03.6703322+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:11.317106+02:00",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.3400554+02:00",
+        "PackageName": "Microsoft.Owin.Security.Cookies",
+        "Versions": [
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Security.Cookies",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin.Security.Cookies/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Microsoft.Owin.Security",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:06.1533309+02:00",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.4735617+02:00",
+        "PackageName": "NUnit.Extension.NUnitV2Driver",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitV2Driver",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitV2Driver/3.6.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:19.1888156+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:14.5045438+02:00",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:10.3363321+02:00",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:13.9040739+02:00",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:48.0465573+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.9840555+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:43.1575545+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:17.0950625+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:06.0498305+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:59.4663322+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:08.343332+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:57.211828+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.5400553+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:34.9540608+02:00",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.5480563+02:00",
+        "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitV2ResultWriter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitV2ResultWriter/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:41.8690559+02:00",
+        "PackageName": "System.ComponentModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:08.7363338+02:00",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:13.5243566+02:00",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:53.6513274+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:02.6868295+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:48.6175607+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:14.2970451+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:22.154316+02:00",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:17.4915448+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:41.3545564+02:00",
+        "PackageName": "System.Collections.NonGeneric",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.NonGeneric",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.NonGeneric/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:01.4983292+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:07.61733+02:00",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:17.7490462+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:34.386553+02:00",
+        "PackageName": "Microsoft.AspNet.SignalR.JS",
+        "Versions": [
+          {
+            "Version": "1.0.0-alpha1"
+          },
+          {
+            "Version": "1.0.0-alpha2"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0-rc2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.SignalR.JS",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.AspNet.SignalR.JS/2.2.1",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "jQuery",
+                  "VersionRequirement": ">= 1.6.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.2.2-preview1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:52.5878262+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:19.594825+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.8475553+02:00",
+        "PackageName": "Owin",
+        "Versions": [
+          {
+            "Version": "0.5"
+          },
+          {
+            "Version": "0.7"
+          },
+          {
+            "Version": "0.11"
+          },
+          {
+            "Version": "0.12"
+          },
+          {
+            "Version": "0.14"
+          },
+          {
+            "Version": "1.0",
+            "PackageDetails": {
+              "Name": "Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Owin/1.0",
+              "LicenseUrl": "https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:16.1055472+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.2505535+02:00",
+        "PackageName": "NUnit.ConsoleRunner",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit.ConsoleRunner",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.ConsoleRunner/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:08.9463355+02:00",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.7440531+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:05.3893309+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:15.2955457+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:39.8380655+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:45.6605562+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:47.8290568+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:04.7388417+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:02.3908291+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:12.4901006+02:00",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.9720544+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:33.6925551+02:00",
+        "PackageName": "FSharpVSPowerTools.Core",
+        "Versions": [
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "FSharpVSPowerTools.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharpVSPowerTools.Core/2.3.0",
+              "LicenseUrl": "https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 2.0.0.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:54.3768258+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:16.5035447+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:44.2645663+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:33.5835534+02:00",
+        "PackageName": "FSharp.Formatting",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.1-beta"
+          },
+          {
+            "Version": "2.1.2-beta"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.1.5"
+          },
+          {
+            "Version": "2.1.6"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4-beta"
+          },
+          {
+            "Version": "2.2.5-beta"
+          },
+          {
+            "Version": "2.2.6-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.9-beta"
+          },
+          {
+            "Version": "2.2.10-beta"
+          },
+          {
+            "Version": "2.2.11-beta"
+          },
+          {
+            "Version": "2.2.12-beta"
+          },
+          {
+            "Version": "2.3.1-beta"
+          },
+          {
+            "Version": "2.3.2-beta"
+          },
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.7-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha1"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.11.1-alpha1"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2"
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.14.4",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": "2.0.0.6"
+                },
+                {
+                  "PackageName": "FSharpVSPowerTools.Core",
+                  "VersionRequirement": ">= 2.3 < 2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.14.5-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.7050546+02:00",
+        "PackageName": "NUnit.Extension.VSProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.VSProjectLoader",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.VSProjectLoader/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:43.3630554+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:54.6673267+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:09.9423331+02:00",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:06.3643301+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:54.0148261+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:16.3085447+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:40.5150836+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:09.5428317+02:00",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:42.7750555+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:18.5768506+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:20.0103268+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:23.8464048+02:00",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:04.1023574+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:08.5458331+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:20.222819+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:47.5340586+02:00",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:02.5123295+02:00",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:34.1175531+02:00",
+        "PackageName": "jQuery",
+        "Versions": [
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.4.4"
+          },
+          {
+            "Version": "1.5"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.6"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.6.3"
+          },
+          {
+            "Version": "1.6.4",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.6.4",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.7",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.7",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.7.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.7.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.7.1.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.7.1.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.7.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.7.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.8.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.8.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.8.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.8.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.8.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.8.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.8.3",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.8.3",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.9.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/jQuery/1.9.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.9.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.9.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.10.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.10.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.10.0.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.10.0.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.10.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.10.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.10.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.10.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.11.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.11.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.11.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.11.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.11.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.11.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.11.3",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.11.3",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.12.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.12.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.12.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.12.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.12.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.12.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.12.3",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.12.3",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.12.4",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/1.12.4",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.0.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.0.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.0.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.0.1.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.0.1.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.0.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.0.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.0.3",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.0.3",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.1.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.1.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.1.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.1.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.1.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.1.3",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.1.3",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.1.4",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.1.4",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.2.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.2.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.2.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.2.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.2.2",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.2.2",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.2.3",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.2.3",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.2.4",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.2.4",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/3.0.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.0.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/3.0.0.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/3.1.0",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/jQuery/3.1.1",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:33.1590527+02:00",
+        "PackageName": "FSharp.Compiler.Service",
+        "Versions": [
+          {
+            "Version": "2.0.0.6",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/2.0.0.6",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:17.9515457+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:36.469053+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/6.0.4",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "6.0.5",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/6.0.5",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "6.0.6",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/6.0.6",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "6.0.7",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/6.0.7",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "6.0.8",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/6.0.8",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/8.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "8.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/8.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "8.0.3",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/8.0.3",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/9.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:11.9096025+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:10.9398313+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.3320526+02:00",
+        "PackageName": "NUnit.Extension.NUnitProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitProjectLoader",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitProjectLoader/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:18.3678541+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:53.3503264+02:00",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:58.2048284+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.4720537+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:19.3928179+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.3240539+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:34.7735528+02:00",
+        "PackageName": "Microsoft.CSharp",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.CSharp",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.CSharp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:08.138837+02:00",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:12.891602+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.6800538+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:51.9853291+02:00",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:46.6230722+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.5455537+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:24.0329209+02:00",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:22.3563322+02:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:16.8910451+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:13.3308417+02:00",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:19.8043169+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:44.8440559+02:00",
+        "PackageName": "System.Dynamic.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Dynamic.Runtime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Dynamic.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:34.2485523+02:00",
+        "PackageName": "Microsoft.AspNet.SignalR.Core",
+        "Versions": [
+          {
+            "Version": "1.0.0-alpha1"
+          },
+          {
+            "Version": "1.0.0-alpha2"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0-rc2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.SignalR.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.AspNet.SignalR.Core/2.2.1",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 2.1"
+                },
+                {
+                  "PackageName": "Microsoft.Owin.Security",
+                  "VersionRequirement": ">= 2.1"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.4"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.2.2-preview1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:47.1920575+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:18.1535468+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:34.8530521+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:42.5435547+02:00",
+        "PackageName": "System.ComponentModel.TypeConverter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.TypeConverter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.TypeConverter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, net45, >= net462, netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:21.8463176+02:00",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:53.0943379+02:00",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:50.5973257+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.812555+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:00.5023289+02:00",
+        "PackageName": "System.Runtime.Serialization.Formatters",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Formatters",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Formatters/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.127055+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:21.6468444+02:00",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:16.7005519+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:03.2788287+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:10.747332+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.7595539+02:00",
+        "PackageName": "Nancy.MSOwinSecurity",
+        "Versions": [
+          {
+            "Version": "0.1.0"
+          },
+          {
+            "Version": "0.1.1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "Nancy.MSOwinSecurity",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Nancy.MSOwinSecurity/2.0.0",
+              "LicenseUrl": "https://github.com/damianh/Nancy.MSOwinSecurity/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.0"
+                },
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 1.0 < 2.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.859053+02:00",
+        "PackageName": "Nancy.Serialization.JsonNet",
+        "Versions": [
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.14.1"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.15.1"
+          },
+          {
+            "Version": "0.15.2"
+          },
+          {
+            "Version": "0.15.3"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.16.1"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.17.1"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.22.1"
+          },
+          {
+            "Version": "0.22.2"
+          },
+          {
+            "Version": "0.23.0"
+          },
+          {
+            "Version": "0.23.1"
+          },
+          {
+            "Version": "0.23.2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1"
+          },
+          {
+            "Version": "1.2.0",
+            "PackageDetails": {
+              "Name": "Nancy.Serialization.JsonNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Nancy.Serialization.JsonNet/1.2.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Serialization.JsonNet/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 1.2"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.0",
+            "PackageDetails": {
+              "Name": "Nancy.Serialization.JsonNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Nancy.Serialization.JsonNet/1.3.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Serialization.JsonNet/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 1.3"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.4.0",
+            "PackageDetails": {
+              "Name": "Nancy.Serialization.JsonNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Nancy.Serialization.JsonNet/1.4.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Serialization.JsonNet/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 1.4"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.4.1",
+            "PackageDetails": {
+              "Name": "Nancy.Serialization.JsonNet",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy.Serialization.JsonNet/1.4.1",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Serialization.JsonNet/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 1.4.1"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-barneyrubble"
+          },
+          {
+            "Version": "2.0.0-clienteastwood"
+          },
+          {
+            "Version": "2.0.0-clinteastwood"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.897555+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:22.5558167+02:00",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:38.185554+02:00",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:13.7108584+02:00",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:22.7553201+02:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:20.6103311+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:18.7873352+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:12.2991029+02:00",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:58.0438285+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.6705697+02:00",
+        "PackageName": "Nancy",
+        "Versions": [
+          {
+            "Version": "1.2.0",
+            "PackageDetails": {
+              "Name": "Nancy",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Nancy/1.2.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:00.9943291+02:00",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:09.7348318+02:00",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:35.9235673+02:00",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:14.7055439+02:00",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:41.6175562+02:00",
+        "PackageName": "System.Collections.Specialized",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Specialized",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.Specialized/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:45.3985571+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:59.9573291+02:00",
+        "PackageName": "System.Runtime.Loader",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Loader",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Loader/4.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Loader",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Loader/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:39.5005562+02:00",
+        "PackageName": "SourceLink.Fake",
+        "Versions": [
+          {
+            "Version": "0.3.0-a1401160010-f42a74a5"
+          },
+          {
+            "Version": "0.3.0-a1401160102-fc7f738e"
+          },
+          {
+            "Version": "0.3.0-a1401200506-1fa7c639"
+          },
+          {
+            "Version": "0.3.0-a1401210630-e51f2c0b"
+          },
+          {
+            "Version": "0.3.0-a1401210639-e51f2c0b"
+          },
+          {
+            "Version": "0.3.0-a1401221522-b7bd7f00"
+          },
+          {
+            "Version": "0.3.0-a1401221527-a1ade11c"
+          },
+          {
+            "Version": "0.3.0-a1401231502-bd67c57f"
+          },
+          {
+            "Version": "0.3.0",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.3.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.3.1",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.3.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.3.2",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.3.2",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.3.3",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.3.3",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.3.4",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.3.4",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.3.5-a1402170509-22a0f1bd"
+          },
+          {
+            "Version": "0.3.5-a1402171459-a1cba03d"
+          },
+          {
+            "Version": "0.4.0-ci1404051901"
+          },
+          {
+            "Version": "0.4.0-ci1404252207"
+          },
+          {
+            "Version": "0.4.0-ci1404260027"
+          },
+          {
+            "Version": "0.4.0-ci1404260502"
+          },
+          {
+            "Version": "0.4.0-ci1405020136"
+          },
+          {
+            "Version": "0.4.0",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.4.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.4.2",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.4.2",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.5.0-ci1411242108"
+          },
+          {
+            "Version": "0.5.0-ci1503171318"
+          },
+          {
+            "Version": "0.5.0-ci1503171444"
+          },
+          {
+            "Version": "0.5.0-ci1503212313"
+          },
+          {
+            "Version": "0.5.0",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.5.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.6.0",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.6.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.6.1",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/0.6.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SourceLink.Fake/1.0.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/SourceLink.Fake/1.1.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:23.432402+02:00",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:59:37.7740557+02:00",
+        "PackageName": "NUnit.Runners",
+        "Versions": [
+          {
+            "Version": "2.6.0.12051",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.0.12051",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.1",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.2",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.2",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.3",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.3",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Runners/2.6.4",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.0.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.Console",
+                  "VersionRequirement": "3.0"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.1",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.0.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.Console",
+                  "VersionRequirement": "3.0.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.2.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": "3.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": "3.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": "3.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": "3.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": "3.2"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.2.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": "3.2.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": "3.2.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": "3.2.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": "3.2.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": "3.2.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.4.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": "3.4"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": "3.4"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": "3.4"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": "3.4"
+                },
+                {
+                  "PackageName": "NUnit.Extension.TeamCityEventListener",
+                  "VersionRequirement": "1.0"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": "3.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.1",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.4.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": ">= 3.4.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": ">= 3.4.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": ">= 3.4.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": ">= 3.4.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.TeamCityEventListener",
+                  "VersionRequirement": ">= 1.0.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": ">= 3.4.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.TeamCityEventListener",
+                  "VersionRequirement": ">= 1.0.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.6.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": ">= 3.6"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": ">= 3.6"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.TeamCityEventListener",
+                  "VersionRequirement": ">= 1.0.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": ">= 3.6.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": ">= 3.6"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.TeamCityEventListener",
+                  "VersionRequirement": ">= 1.0.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:15.5005471+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001177-resolve-with-pessimistic-strategy/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001177-resolve-with-pessimistic-strategy/cache/paket-graph.cache
@@ -1,0 +1,102 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:09.7326448+02:00",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.2.1",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:09.3516456+02:00",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Core/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001178-update-with-regex/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001178-update-with-regex/cache/paket-graph.cache
@@ -1,0 +1,11310 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:55",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:58",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:47",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:57",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:52",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:49",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:57",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:52",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:01",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:32",
+        "PackageName": "System.ComponentModel.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:58",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:02",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:01",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:49",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:57",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:27",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:31",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:29",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:27",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:43",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:54",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:52",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:48",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:41",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:51",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:34",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:27",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:46",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:58",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:44",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:30",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:36",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:31",
+        "PackageName": "Microsoft.CSharp",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.CSharp",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.CSharp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:31",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:38",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:02",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:03",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:03",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:34",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:43",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:51",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:24",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:28",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:47",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:23",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:33",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:01",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:59",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:21",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.3",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Core/3.3.3",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-beta001"
+          },
+          {
+            "Version": "4.0.0-beta002"
+          },
+          {
+            "Version": "4.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:55",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:32",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:56",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:42",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:57",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:32",
+        "PackageName": "System.Runtime.Serialization.Formatters",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Formatters",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Formatters/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:31",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:02",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:36",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:54",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:01",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:59",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:56",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:50",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:44",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:50",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:35",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:48",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:21",
+        "PackageName": "Microsoft.AspNet.WebApi.Client",
+        "Versions": [
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "4.1.0-alpha-120809"
+          },
+          {
+            "Version": "5.0.0-alpha1"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2"
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.Client",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.Client/5.2.3",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Net.Http",
+                  "VersionRequirement": ">= 2.2.22",
+                  "FrameworkRestrictions": "portable-wp80+win+wp81+wpa81"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.4",
+                  "FrameworkRestrictions": "portable-wp80+win+wp81+wpa81, >= net45"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:24",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:59",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:52",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:45",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:09:52.7893672+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.5.7.10213"
+          },
+          {
+            "Version": "2.5.9.10348"
+          },
+          {
+            "Version": "2.5.10.11092"
+          },
+          {
+            "Version": "2.6.0.12051"
+          },
+          {
+            "Version": "2.6.0.12054"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.6.2",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "3.0.0-alpha"
+          },
+          {
+            "Version": "3.0.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-alpha-3"
+          },
+          {
+            "Version": "3.0.0-alpha-4"
+          },
+          {
+            "Version": "3.0.0-alpha-5"
+          },
+          {
+            "Version": "3.0.0-beta-1"
+          },
+          {
+            "Version": "3.0.0-beta-2"
+          },
+          {
+            "Version": "3.0.0-beta-3"
+          },
+          {
+            "Version": "3.0.0-beta-4"
+          },
+          {
+            "Version": "3.0.0-beta-5"
+          },
+          {
+            "Version": "3.0.0-rc"
+          },
+          {
+            "Version": "3.0.0-rc-2"
+          },
+          {
+            "Version": "3.0.0-rc-3"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Loader",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:29",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:02",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:44",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:55",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:22",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:50",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:03",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:56",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:23",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:55",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:54",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:43",
+        "PackageName": "System.Runtime.Loader",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Loader",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Loader/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:59",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:56",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:56",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:41",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:31",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:40",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:54",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:48",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:51",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:59",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:53",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:42",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:53",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:50",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:50",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:37",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:36",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:52",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:53",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:30",
+        "PackageName": "Microsoft.AspNet.WebApi.SelfHost",
+        "Versions": [
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.20918.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.0.1",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.SelfHost",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.SelfHost/5.0.1",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.WebApi.Core",
+                  "VersionRequirement": ">= 5.0 < 5.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2"
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.SelfHost",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.SelfHost/5.2.3",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.WebApi.Core",
+                  "VersionRequirement": ">= 5.2.3 < 5.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:03",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:26",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:27",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:55",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:51",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:26",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:53",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:33",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:30",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.5.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Windsor/2.5.1",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 2.5.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "3.0.0.2001"
+          },
+          {
+            "Version": "3.0.0.3001"
+          },
+          {
+            "Version": "3.0.0.4001"
+          },
+          {
+            "Version": "3.1.0-RC"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.4.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.3 < 4.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:51",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:36",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:44",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:54",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:33",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:30",
+        "PackageName": "Microsoft.AspNet.WebApi.Core",
+        "Versions": [
+          {
+            "Version": "4.0.20505.0"
+          },
+          {
+            "Version": "4.0.20710.0"
+          },
+          {
+            "Version": "4.0.30506.0"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.Core/5.0.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.WebApi.Client",
+                  "VersionRequirement": ">= 5.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "5.1.2"
+          },
+          {
+            "Version": "5.2.0-rc"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.2.2-rc"
+          },
+          {
+            "Version": "5.2.2"
+          },
+          {
+            "Version": "5.2.3-beta1"
+          },
+          {
+            "Version": "5.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebApi.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.AspNet.WebApi.Core/5.2.3",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.WebApi.Client",
+                  "VersionRequirement": ">= 5.2.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:55",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:44",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:58",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:29",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:54",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:23",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:45",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:53",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:02",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:57",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:32",
+        "PackageName": "System.ComponentModel.TypeConverter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.TypeConverter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.TypeConverter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, net45, >= net462, netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:28",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:03",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:37",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:01",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:51",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:57",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:58",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:49",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:34",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:23",
+        "PackageName": "Microsoft.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.1.3-beta"
+          },
+          {
+            "Version": "2.1.6-rc"
+          },
+          {
+            "Version": "2.1.10"
+          },
+          {
+            "Version": "2.2.3-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.10-rc"
+          },
+          {
+            "Version": "2.2.13"
+          },
+          {
+            "Version": "2.2.15"
+          },
+          {
+            "Version": "2.2.18"
+          },
+          {
+            "Version": "2.2.19"
+          },
+          {
+            "Version": "2.2.20"
+          },
+          {
+            "Version": "2.2.22"
+          },
+          {
+            "Version": "2.2.23-beta"
+          },
+          {
+            "Version": "2.2.27-beta"
+          },
+          {
+            "Version": "2.2.28"
+          },
+          {
+            "Version": "2.2.29",
+            "PackageDetails": {
+              "Name": "Microsoft.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Net.Http/2.2.29",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:05:32",
+        "PackageName": "System.Collections.NonGeneric",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.NonGeneric",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.NonGeneric/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:25",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:03:03",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:52",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:58",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:26",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:30",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:02:37",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001182-framework-restrictions/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001182-framework-restrictions/cache/paket-graph.cache
@@ -1,0 +1,616 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:33.3236457+02:00",
+        "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+        "Versions": [
+          {
+            "Version": "1.7.0.0"
+          },
+          {
+            "Version": "1.7.0.1"
+          },
+          {
+            "Version": "1.7.0.2"
+          },
+          {
+            "Version": "1.7.0.3"
+          },
+          {
+            "Version": "1.8.0.0"
+          },
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.0.1.0"
+          },
+          {
+            "Version": "2.0.2.0"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.ConfigurationManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.ConfigurationManager/3.2.3",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:14",
+        "PackageName": "WindowsAzure.Storage",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.Storage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=331471",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": ">= 5.6.2",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.Services.Client",
+                  "VersionRequirement": ">= 5.6.2",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ">= 1.8",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 5.0.8",
+                  "FrameworkRestrictions": "wpv8.0, >= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:33.2541345+02:00",
+        "PackageName": "Microsoft.Data.Services.Client",
+        "Versions": [
+          {
+            "Version": "5.0.0.50403"
+          },
+          {
+            "Version": "5.0.1-rc"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2-rc"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.1.0-rc"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0-rc2"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.2.0-rc1"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.3.0-rc1"
+          },
+          {
+            "Version": "5.3.0"
+          },
+          {
+            "Version": "5.4.0-rc1"
+          },
+          {
+            "Version": "5.4.0"
+          },
+          {
+            "Version": "5.5.0-alpha1"
+          },
+          {
+            "Version": "5.5.0-alpha2"
+          },
+          {
+            "Version": "5.5.0-rc1"
+          },
+          {
+            "Version": "5.5.0"
+          },
+          {
+            "Version": "5.6.0-alpha1"
+          },
+          {
+            "Version": "5.6.0-rc1"
+          },
+          {
+            "Version": "5.6.0"
+          },
+          {
+            "Version": "5.6.1"
+          },
+          {
+            "Version": "5.6.2"
+          },
+          {
+            "Version": "5.6.3"
+          },
+          {
+            "Version": "5.6.4"
+          },
+          {
+            "Version": "5.6.5-beta"
+          },
+          {
+            "Version": "5.7.0-beta"
+          },
+          {
+            "Version": "5.7.0-rc"
+          },
+          {
+            "Version": "5.7.0"
+          },
+          {
+            "Version": "5.8.0-beta"
+          },
+          {
+            "Version": "5.8.0"
+          },
+          {
+            "Version": "5.8.1"
+          },
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.Services.Client",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.Services.Client/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": "5.8.2"
+                },
+                {
+                  "PackageName": "System.ComponentModel.EventBasedAsync",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:33.8486363+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:14",
+        "PackageName": "System.Spatial",
+        "Versions": [
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "System.Spatial",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Spatial/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:10",
+        "PackageName": "Microsoft.Data.Edm",
+        "Versions": [
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.Edm",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.Edm/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:32.2076335+02:00",
+        "PackageName": "Microsoft.Data.OData",
+        "Versions": [
+          {
+            "Version": "5.0.0.50403"
+          },
+          {
+            "Version": "5.0.1-rc"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2-rc"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.1.0-rc"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0-rc2"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.2.0-rc1"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.3.0-rc1"
+          },
+          {
+            "Version": "5.3.0"
+          },
+          {
+            "Version": "5.4.0-rc1"
+          },
+          {
+            "Version": "5.4.0"
+          },
+          {
+            "Version": "5.5.0-alpha1"
+          },
+          {
+            "Version": "5.5.0-alpha2"
+          },
+          {
+            "Version": "5.5.0-rc1"
+          },
+          {
+            "Version": "5.5.0"
+          },
+          {
+            "Version": "5.6.0-alpha1"
+          },
+          {
+            "Version": "5.6.0-rc1"
+          },
+          {
+            "Version": "5.6.0"
+          },
+          {
+            "Version": "5.6.1"
+          },
+          {
+            "Version": "5.6.2"
+          },
+          {
+            "Version": "5.6.3"
+          },
+          {
+            "Version": "5.6.4"
+          },
+          {
+            "Version": "5.6.5-beta"
+          },
+          {
+            "Version": "5.7.0-beta"
+          },
+          {
+            "Version": "5.7.0-rc"
+          },
+          {
+            "Version": "5.7.0"
+          },
+          {
+            "Version": "5.8.0-beta"
+          },
+          {
+            "Version": "5.8.0"
+          },
+          {
+            "Version": "5.8.1"
+          },
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.OData",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.OData/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Data.Edm",
+                  "VersionRequirement": "5.8.2"
+                },
+                {
+                  "PackageName": "System.Spatial",
+                  "VersionRequirement": "5.8.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001187-binding-redirect/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001187-binding-redirect/cache/paket-graph.cache
@@ -1,0 +1,291 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:18",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "3.0.0.3001",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.0.0.3001",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:18",
+        "PackageName": "Albedo",
+        "Versions": [
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "Albedo",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Albedo/1.0.2",
+              "LicenseUrl": "https://raw2.github.com/ploeh/Albedo/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:18",
+        "PackageName": "AutoFixture.Idioms",
+        "Versions": [
+          {
+            "Version": "3.35.1",
+            "PackageDetails": {
+              "Name": "AutoFixture.Idioms",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture.Idioms/3.35.1",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Albedo",
+                  "VersionRequirement": ">= 1.0.1"
+                },
+                {
+                  "PackageName": "autofixture",
+                  "VersionRequirement": ">= 3.35.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:18",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "3.3.3",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Core/3.3.3",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:19",
+        "PackageName": "Castle.Windsor.Extensions",
+        "Versions": [
+          {
+            "Version": "2.1.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor.Extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor.Extensions/2.1.1",
+              "LicenseUrl": "http://www.gnu.org/licenses/lgpl-2.1.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.0.0.3001",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.0.0.3001",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:53.185702+02:00",
+        "PackageName": "xunit.extensions",
+        "Versions": [
+          {
+            "Version": "1.7.0.1540"
+          },
+          {
+            "Version": "1.8.0.1545"
+          },
+          {
+            "Version": "1.8.0.1549",
+            "PackageDetails": {
+              "Name": "xunit.extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit.extensions/1.8.0.1549",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit",
+                  "VersionRequirement": ">= 1.8.0.1549"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.9.0.1566"
+          },
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.9.2",
+            "PackageDetails": {
+              "Name": "xunit.extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit.extensions/1.9.2",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit",
+                  "VersionRequirement": "1.9.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-alpha-build1611"
+          },
+          {
+            "Version": "2.0.0-rc4-build2924"
+          },
+          {
+            "Version": "2.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:19",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "2.0.3",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.3",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:20",
+        "PackageName": "Newtonsoft.Json.Schema",
+        "Versions": [
+          {
+            "Version": "1.0.11",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json.Schema",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json.Schema/1.0.11",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:20",
+        "PackageName": "xunit",
+        "Versions": [
+          {
+            "Version": "1.9.2",
+            "PackageDetails": {
+              "Name": "xunit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit/1.9.2",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:18",
+        "PackageName": "AutoFixture.Xunit",
+        "Versions": [
+          {
+            "Version": "3.36.9",
+            "PackageDetails": {
+              "Name": "AutoFixture.Xunit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture.Xunit/3.36.9",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "autofixture",
+                  "VersionRequirement": ">= 3.36.9"
+                },
+                {
+                  "PackageName": "xunit.extensions",
+                  "VersionRequirement": ">= 1.8.0.1549 < 2.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:18",
+        "PackageName": "AutoFixture",
+        "Versions": [
+          {
+            "Version": "3.36.9",
+            "PackageDetails": {
+              "Name": "AutoFixture",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture/3.36.9",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:19",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001189-allow-#-in-path/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001189-allow-#-in-path/cache/paket-graph.cache
@@ -1,0 +1,4945 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:15.2555032+02:00",
+        "PackageName": "FAKE",
+        "Versions": [
+          {
+            "Version": "1.46.1.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FAKE/1.46.1.0",
+              "LicenseUrl": "https://github.com/forki/FAKE/blob/develop/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.46.2.0"
+          },
+          {
+            "Version": "1.48.0.0"
+          },
+          {
+            "Version": "1.50.0.0"
+          },
+          {
+            "Version": "1.50.1.0"
+          },
+          {
+            "Version": "1.50.2.0"
+          },
+          {
+            "Version": "1.50.3.0"
+          },
+          {
+            "Version": "1.50.4.0"
+          },
+          {
+            "Version": "1.52.0.0"
+          },
+          {
+            "Version": "1.52.1.0"
+          },
+          {
+            "Version": "1.52.5.0"
+          },
+          {
+            "Version": "1.52.6.0"
+          },
+          {
+            "Version": "1.54.0.0"
+          },
+          {
+            "Version": "1.54.1.0"
+          },
+          {
+            "Version": "1.54.2.0"
+          },
+          {
+            "Version": "1.54.3.0"
+          },
+          {
+            "Version": "1.56"
+          },
+          {
+            "Version": "1.56.2"
+          },
+          {
+            "Version": "1.56.3"
+          },
+          {
+            "Version": "1.56.4"
+          },
+          {
+            "Version": "1.56.5"
+          },
+          {
+            "Version": "1.56.6"
+          },
+          {
+            "Version": "1.56.7"
+          },
+          {
+            "Version": "1.56.9"
+          },
+          {
+            "Version": "1.56.10"
+          },
+          {
+            "Version": "1.56.12"
+          },
+          {
+            "Version": "1.58"
+          },
+          {
+            "Version": "1.58.2"
+          },
+          {
+            "Version": "1.58.3"
+          },
+          {
+            "Version": "1.58.5"
+          },
+          {
+            "Version": "1.58.6"
+          },
+          {
+            "Version": "1.58.7"
+          },
+          {
+            "Version": "1.58.8"
+          },
+          {
+            "Version": "1.58.9"
+          },
+          {
+            "Version": "1.58.10"
+          },
+          {
+            "Version": "1.58.11"
+          },
+          {
+            "Version": "1.58.14"
+          },
+          {
+            "Version": "1.60"
+          },
+          {
+            "Version": "1.62"
+          },
+          {
+            "Version": "1.62.1"
+          },
+          {
+            "Version": "1.62.2"
+          },
+          {
+            "Version": "1.62.4"
+          },
+          {
+            "Version": "1.62.5"
+          },
+          {
+            "Version": "1.64"
+          },
+          {
+            "Version": "1.64.1"
+          },
+          {
+            "Version": "1.64.2"
+          },
+          {
+            "Version": "1.64.3"
+          },
+          {
+            "Version": "1.64.4"
+          },
+          {
+            "Version": "1.64.5"
+          },
+          {
+            "Version": "1.64.6"
+          },
+          {
+            "Version": "1.64.7"
+          },
+          {
+            "Version": "1.64.8"
+          },
+          {
+            "Version": "1.64.9"
+          },
+          {
+            "Version": "1.64.10"
+          },
+          {
+            "Version": "1.64.11"
+          },
+          {
+            "Version": "1.64.14"
+          },
+          {
+            "Version": "1.64.15"
+          },
+          {
+            "Version": "1.64.16.0"
+          },
+          {
+            "Version": "1.64.17.0"
+          },
+          {
+            "Version": "1.64.18.0"
+          },
+          {
+            "Version": "1.64.19.0"
+          },
+          {
+            "Version": "1.66.0.0"
+          },
+          {
+            "Version": "1.66.1.0"
+          },
+          {
+            "Version": "1.66.2.0"
+          },
+          {
+            "Version": "1.68.1.0"
+          },
+          {
+            "Version": "1.68.5.0"
+          },
+          {
+            "Version": "1.68.6.0"
+          },
+          {
+            "Version": "1.70.0.0"
+          },
+          {
+            "Version": "1.70.1.0"
+          },
+          {
+            "Version": "1.70.2.0"
+          },
+          {
+            "Version": "1.70.3.0"
+          },
+          {
+            "Version": "1.70.6.0"
+          },
+          {
+            "Version": "1.70.8.0"
+          },
+          {
+            "Version": "1.70.9.0"
+          },
+          {
+            "Version": "1.70.10.0"
+          },
+          {
+            "Version": "1.70.11.0"
+          },
+          {
+            "Version": "1.70.13.0"
+          },
+          {
+            "Version": "1.70.16.0"
+          },
+          {
+            "Version": "1.70.17.0"
+          },
+          {
+            "Version": "1.70.18.0"
+          },
+          {
+            "Version": "1.70.20.0"
+          },
+          {
+            "Version": "1.70.21.0"
+          },
+          {
+            "Version": "1.70.22.0"
+          },
+          {
+            "Version": "1.70.24.0"
+          },
+          {
+            "Version": "1.70.25.0"
+          },
+          {
+            "Version": "1.70.29.0"
+          },
+          {
+            "Version": "1.70.32.0"
+          },
+          {
+            "Version": "1.72.33.0"
+          },
+          {
+            "Version": "1.74.0.0"
+          },
+          {
+            "Version": "1.74.1.0"
+          },
+          {
+            "Version": "1.74.2.0"
+          },
+          {
+            "Version": "1.74.4.0"
+          },
+          {
+            "Version": "1.74.6.0"
+          },
+          {
+            "Version": "1.74.8.0"
+          },
+          {
+            "Version": "1.74.9.0"
+          },
+          {
+            "Version": "1.74.10.0"
+          },
+          {
+            "Version": "1.74.13.0"
+          },
+          {
+            "Version": "1.74.14.0"
+          },
+          {
+            "Version": "1.74.15.0"
+          },
+          {
+            "Version": "1.74.16.0"
+          },
+          {
+            "Version": "1.74.17.0"
+          },
+          {
+            "Version": "1.74.18.0"
+          },
+          {
+            "Version": "1.74.19.0"
+          },
+          {
+            "Version": "1.74.20.0"
+          },
+          {
+            "Version": "1.74.21.0"
+          },
+          {
+            "Version": "1.74.22.0"
+          },
+          {
+            "Version": "1.74.24.0"
+          },
+          {
+            "Version": "1.74.25.0"
+          },
+          {
+            "Version": "1.74.26.0"
+          },
+          {
+            "Version": "1.74.27.0"
+          },
+          {
+            "Version": "1.74.28.0"
+          },
+          {
+            "Version": "1.74.29.0"
+          },
+          {
+            "Version": "1.74.30.0"
+          },
+          {
+            "Version": "1.74.31.0"
+          },
+          {
+            "Version": "1.74.32.0"
+          },
+          {
+            "Version": "1.74.33.0"
+          },
+          {
+            "Version": "1.74.34.0"
+          },
+          {
+            "Version": "1.74.35.0"
+          },
+          {
+            "Version": "1.74.39.0"
+          },
+          {
+            "Version": "1.74.40.0"
+          },
+          {
+            "Version": "1.74.41.0"
+          },
+          {
+            "Version": "1.74.42.0"
+          },
+          {
+            "Version": "1.74.43.0"
+          },
+          {
+            "Version": "1.74.44.0"
+          },
+          {
+            "Version": "1.74.48.0"
+          },
+          {
+            "Version": "1.74.49.0"
+          },
+          {
+            "Version": "1.74.50.0"
+          },
+          {
+            "Version": "1.74.51.0"
+          },
+          {
+            "Version": "1.74.55.0"
+          },
+          {
+            "Version": "1.74.56.0"
+          },
+          {
+            "Version": "1.74.57.0"
+          },
+          {
+            "Version": "1.74.60.0"
+          },
+          {
+            "Version": "1.74.61.0"
+          },
+          {
+            "Version": "1.74.62.0"
+          },
+          {
+            "Version": "1.74.63.0"
+          },
+          {
+            "Version": "1.74.65.0"
+          },
+          {
+            "Version": "1.74.74.0"
+          },
+          {
+            "Version": "1.74.75.0"
+          },
+          {
+            "Version": "1.74.77.0"
+          },
+          {
+            "Version": "1.74.78.0"
+          },
+          {
+            "Version": "1.74.79.0"
+          },
+          {
+            "Version": "1.74.81.0"
+          },
+          {
+            "Version": "1.74.82.0"
+          },
+          {
+            "Version": "1.74.84.0"
+          },
+          {
+            "Version": "1.74.85.0"
+          },
+          {
+            "Version": "1.74.86.0"
+          },
+          {
+            "Version": "1.74.87.0"
+          },
+          {
+            "Version": "1.74.88.0"
+          },
+          {
+            "Version": "1.74.92.0"
+          },
+          {
+            "Version": "1.74.98.0"
+          },
+          {
+            "Version": "1.74.99.0"
+          },
+          {
+            "Version": "1.74.100.0"
+          },
+          {
+            "Version": "1.74.101.0"
+          },
+          {
+            "Version": "1.74.102.0"
+          },
+          {
+            "Version": "1.74.103.0"
+          },
+          {
+            "Version": "1.74.104.0"
+          },
+          {
+            "Version": "1.74.105.0"
+          },
+          {
+            "Version": "1.74.106.0"
+          },
+          {
+            "Version": "1.74.107.0"
+          },
+          {
+            "Version": "1.74.108.0"
+          },
+          {
+            "Version": "1.74.109.0"
+          },
+          {
+            "Version": "1.74.110.0"
+          },
+          {
+            "Version": "1.74.111.0"
+          },
+          {
+            "Version": "1.74.113.0"
+          },
+          {
+            "Version": "1.74.114.0"
+          },
+          {
+            "Version": "1.74.118.0"
+          },
+          {
+            "Version": "1.74.119.0"
+          },
+          {
+            "Version": "1.74.121.0"
+          },
+          {
+            "Version": "1.74.123.0"
+          },
+          {
+            "Version": "1.74.124.0"
+          },
+          {
+            "Version": "1.74.125.0"
+          },
+          {
+            "Version": "1.74.126.0"
+          },
+          {
+            "Version": "1.74.127.0"
+          },
+          {
+            "Version": "1.74.128.0"
+          },
+          {
+            "Version": "1.74.129.0"
+          },
+          {
+            "Version": "1.74.130.0"
+          },
+          {
+            "Version": "1.74.131.0"
+          },
+          {
+            "Version": "1.74.132.0"
+          },
+          {
+            "Version": "1.74.133.0"
+          },
+          {
+            "Version": "1.74.134.0"
+          },
+          {
+            "Version": "1.74.135.0"
+          },
+          {
+            "Version": "1.74.136.0"
+          },
+          {
+            "Version": "1.74.137.0"
+          },
+          {
+            "Version": "1.74.139.0"
+          },
+          {
+            "Version": "1.74.140.0"
+          },
+          {
+            "Version": "1.74.141.0"
+          },
+          {
+            "Version": "1.74.142.0"
+          },
+          {
+            "Version": "1.74.143.0"
+          },
+          {
+            "Version": "1.74.144.0"
+          },
+          {
+            "Version": "1.74.145.0"
+          },
+          {
+            "Version": "1.74.146.0"
+          },
+          {
+            "Version": "1.74.147.0"
+          },
+          {
+            "Version": "1.74.148.0"
+          },
+          {
+            "Version": "1.74.149.0"
+          },
+          {
+            "Version": "1.74.150.0"
+          },
+          {
+            "Version": "1.74.152.0"
+          },
+          {
+            "Version": "1.74.153.0"
+          },
+          {
+            "Version": "1.74.154.0"
+          },
+          {
+            "Version": "1.74.155.0"
+          },
+          {
+            "Version": "1.74.156.0"
+          },
+          {
+            "Version": "1.74.160.0"
+          },
+          {
+            "Version": "1.74.161.0"
+          },
+          {
+            "Version": "1.74.162.0"
+          },
+          {
+            "Version": "1.74.163.0"
+          },
+          {
+            "Version": "1.74.164.0"
+          },
+          {
+            "Version": "1.74.166.0"
+          },
+          {
+            "Version": "1.74.167.0"
+          },
+          {
+            "Version": "1.74.172.0"
+          },
+          {
+            "Version": "1.74.173.0"
+          },
+          {
+            "Version": "1.74.174.0"
+          },
+          {
+            "Version": "1.74.175.0"
+          },
+          {
+            "Version": "1.74.176.0"
+          },
+          {
+            "Version": "1.74.180.0"
+          },
+          {
+            "Version": "1.74.181.0"
+          },
+          {
+            "Version": "1.74.183.0"
+          },
+          {
+            "Version": "1.74.184.0"
+          },
+          {
+            "Version": "1.74.185.0"
+          },
+          {
+            "Version": "1.74.186.0"
+          },
+          {
+            "Version": "1.74.187.0"
+          },
+          {
+            "Version": "1.74.188.0"
+          },
+          {
+            "Version": "1.74.189.0"
+          },
+          {
+            "Version": "1.74.190.0"
+          },
+          {
+            "Version": "1.74.192.0"
+          },
+          {
+            "Version": "1.74.193.0"
+          },
+          {
+            "Version": "1.74.195.0"
+          },
+          {
+            "Version": "1.74.196.0"
+          },
+          {
+            "Version": "1.74.197.0"
+          },
+          {
+            "Version": "1.74.198.0"
+          },
+          {
+            "Version": "1.74.199.0"
+          },
+          {
+            "Version": "1.74.200.0"
+          },
+          {
+            "Version": "1.74.205.0"
+          },
+          {
+            "Version": "1.74.206.0"
+          },
+          {
+            "Version": "1.74.207.0"
+          },
+          {
+            "Version": "1.74.208.0"
+          },
+          {
+            "Version": "1.74.209.0"
+          },
+          {
+            "Version": "1.74.210.0"
+          },
+          {
+            "Version": "1.74.211.0"
+          },
+          {
+            "Version": "1.74.212.0"
+          },
+          {
+            "Version": "1.74.213.0"
+          },
+          {
+            "Version": "1.74.214.0"
+          },
+          {
+            "Version": "1.74.215.0"
+          },
+          {
+            "Version": "1.74.216.0"
+          },
+          {
+            "Version": "1.74.217.0"
+          },
+          {
+            "Version": "1.74.218.0"
+          },
+          {
+            "Version": "1.74.219.0"
+          },
+          {
+            "Version": "1.74.220.0"
+          },
+          {
+            "Version": "1.74.221.0"
+          },
+          {
+            "Version": "1.74.222.0"
+          },
+          {
+            "Version": "1.74.223.0"
+          },
+          {
+            "Version": "1.74.224.0"
+          },
+          {
+            "Version": "1.74.225.0"
+          },
+          {
+            "Version": "1.74.231.0"
+          },
+          {
+            "Version": "1.74.237.0"
+          },
+          {
+            "Version": "1.74.238.0"
+          },
+          {
+            "Version": "1.74.239.0"
+          },
+          {
+            "Version": "1.74.241.0"
+          },
+          {
+            "Version": "1.74.243.0"
+          },
+          {
+            "Version": "1.74.244.0"
+          },
+          {
+            "Version": "1.74.245.0"
+          },
+          {
+            "Version": "1.74.246.0"
+          },
+          {
+            "Version": "1.74.247.0"
+          },
+          {
+            "Version": "1.74.248.0"
+          },
+          {
+            "Version": "1.74.249.0"
+          },
+          {
+            "Version": "1.74.250.0"
+          },
+          {
+            "Version": "1.74.251.0"
+          },
+          {
+            "Version": "1.74.252.0"
+          },
+          {
+            "Version": "1.74.253.0"
+          },
+          {
+            "Version": "1.74.254.0"
+          },
+          {
+            "Version": "1.74.255.0"
+          },
+          {
+            "Version": "1.74.256.0"
+          },
+          {
+            "Version": "1.74.257.0"
+          },
+          {
+            "Version": "1.74.262.0"
+          },
+          {
+            "Version": "1.74.263.0"
+          },
+          {
+            "Version": "1.74.264.0"
+          },
+          {
+            "Version": "1.74.265.0"
+          },
+          {
+            "Version": "1.74.266.0"
+          },
+          {
+            "Version": "1.74.267.0"
+          },
+          {
+            "Version": "1.74.268.0"
+          },
+          {
+            "Version": "1.74.269.0"
+          },
+          {
+            "Version": "1.74.270.0"
+          },
+          {
+            "Version": "1.74.271.0"
+          },
+          {
+            "Version": "1.74.272.0"
+          },
+          {
+            "Version": "1.74.273.0"
+          },
+          {
+            "Version": "1.74.275.0"
+          },
+          {
+            "Version": "1.74.277.0"
+          },
+          {
+            "Version": "1.74.278.0"
+          },
+          {
+            "Version": "1.74.279.0"
+          },
+          {
+            "Version": "1.74.280.0"
+          },
+          {
+            "Version": "1.74.282.0"
+          },
+          {
+            "Version": "1.74.283.0"
+          },
+          {
+            "Version": "1.74.284.0"
+          },
+          {
+            "Version": "1.74.285.0"
+          },
+          {
+            "Version": "1.74.286.0"
+          },
+          {
+            "Version": "1.74.287.0"
+          },
+          {
+            "Version": "1.74.290.0"
+          },
+          {
+            "Version": "2.0.1-alpha2"
+          },
+          {
+            "Version": "2.0.1-alpha3"
+          },
+          {
+            "Version": "2.0.1-alpha4"
+          },
+          {
+            "Version": "2.0.48.0-alpha"
+          },
+          {
+            "Version": "2.0.55.0-alpha"
+          },
+          {
+            "Version": "2.0.60.0-alpha"
+          },
+          {
+            "Version": "2.0.61.0-alpha"
+          },
+          {
+            "Version": "2.0.62.0-alpha"
+          },
+          {
+            "Version": "2.0.64.0-alpha"
+          },
+          {
+            "Version": "2.0.65.0-alpha"
+          },
+          {
+            "Version": "2.0.66.0-alpha"
+          },
+          {
+            "Version": "2.0.68.0-alpha"
+          },
+          {
+            "Version": "2.0.69.0-alpha"
+          },
+          {
+            "Version": "2.0.70.0-alpha"
+          },
+          {
+            "Version": "2.0.73.0-alpha"
+          },
+          {
+            "Version": "2.0.74.0-alpha"
+          },
+          {
+            "Version": "2.0.75.0-alpha"
+          },
+          {
+            "Version": "2.0.76.0-alpha"
+          },
+          {
+            "Version": "2.0.77.0-alpha"
+          },
+          {
+            "Version": "2.0.78.0-alpha"
+          },
+          {
+            "Version": "2.0.79.0-alpha"
+          },
+          {
+            "Version": "2.0.80.0-alpha"
+          },
+          {
+            "Version": "2.0.81.0-alpha"
+          },
+          {
+            "Version": "2.0.83.0-alpha"
+          },
+          {
+            "Version": "2.0.84.0-alpha"
+          },
+          {
+            "Version": "2.0.85.0-alpha"
+          },
+          {
+            "Version": "2.0.86.0-alpha"
+          },
+          {
+            "Version": "2.0.87.0-alpha"
+          },
+          {
+            "Version": "2.0.90.0-alpha"
+          },
+          {
+            "Version": "2.0.91.0-alpha"
+          },
+          {
+            "Version": "2.0.94.0-alpha"
+          },
+          {
+            "Version": "2.0.95.0-alpha"
+          },
+          {
+            "Version": "2.0.96.0-alpha"
+          },
+          {
+            "Version": "2.0.97.0-alpha"
+          },
+          {
+            "Version": "2.0.98.0-alpha"
+          },
+          {
+            "Version": "2.0.99.0-alpha"
+          },
+          {
+            "Version": "2.1-alpha10"
+          },
+          {
+            "Version": "2.1-alpha13"
+          },
+          {
+            "Version": "2.1-alpha15"
+          },
+          {
+            "Version": "2.1-alpha16"
+          },
+          {
+            "Version": "2.1-alpha17"
+          },
+          {
+            "Version": "2.1-alpha18"
+          },
+          {
+            "Version": "2.1-alpha20"
+          },
+          {
+            "Version": "2.1-alpha22"
+          },
+          {
+            "Version": "2.1-alpha23"
+          },
+          {
+            "Version": "2.1-alpha24"
+          },
+          {
+            "Version": "2.1-alpha5"
+          },
+          {
+            "Version": "2.1-alpha6"
+          },
+          {
+            "Version": "2.1-alpha7"
+          },
+          {
+            "Version": "2.1.1-alpha"
+          },
+          {
+            "Version": "2.1.27-alpha"
+          },
+          {
+            "Version": "2.1.28-alpha"
+          },
+          {
+            "Version": "2.1.29-alpha"
+          },
+          {
+            "Version": "2.1.30-alpha"
+          },
+          {
+            "Version": "2.1.33-alpha"
+          },
+          {
+            "Version": "2.1.35-alpha"
+          },
+          {
+            "Version": "2.1.37-alpha"
+          },
+          {
+            "Version": "2.1.39-alpha"
+          },
+          {
+            "Version": "2.1.41-alpha"
+          },
+          {
+            "Version": "2.1.42-alpha"
+          },
+          {
+            "Version": "2.1.43-alpha"
+          },
+          {
+            "Version": "2.1.46-alpha"
+          },
+          {
+            "Version": "2.1.47-alpha"
+          },
+          {
+            "Version": "2.1.48-alpha"
+          },
+          {
+            "Version": "2.1.50-alpha"
+          },
+          {
+            "Version": "2.1.51-alpha"
+          },
+          {
+            "Version": "2.1.53-alpha"
+          },
+          {
+            "Version": "2.1.58-alpha"
+          },
+          {
+            "Version": "2.1.68-alpha"
+          },
+          {
+            "Version": "2.1.71-alpha"
+          },
+          {
+            "Version": "2.1.72-alpha"
+          },
+          {
+            "Version": "2.1.75-alpha"
+          },
+          {
+            "Version": "2.1.81-alpha"
+          },
+          {
+            "Version": "2.1.83-alpha"
+          },
+          {
+            "Version": "2.1.84-alpha"
+          },
+          {
+            "Version": "2.1.85-alpha"
+          },
+          {
+            "Version": "2.1.86-alpha"
+          },
+          {
+            "Version": "2.1.91-alpha"
+          },
+          {
+            "Version": "2.1.95-alpha"
+          },
+          {
+            "Version": "2.1.97-alpha"
+          },
+          {
+            "Version": "2.1.111-alpha"
+          },
+          {
+            "Version": "2.1.113-alpha"
+          },
+          {
+            "Version": "2.1.118-alpha"
+          },
+          {
+            "Version": "2.1.119-alpha"
+          },
+          {
+            "Version": "2.1.121-alpha"
+          },
+          {
+            "Version": "2.1.123-alpha"
+          },
+          {
+            "Version": "2.1.124-alpha"
+          },
+          {
+            "Version": "2.1.126-alpha"
+          },
+          {
+            "Version": "2.1.128-alpha"
+          },
+          {
+            "Version": "2.1.129-alpha"
+          },
+          {
+            "Version": "2.1.132-alpha"
+          },
+          {
+            "Version": "2.1.133-alpha"
+          },
+          {
+            "Version": "2.1.134-alpha"
+          },
+          {
+            "Version": "2.1.137-alpha"
+          },
+          {
+            "Version": "2.1.138-alpha"
+          },
+          {
+            "Version": "2.1.141-alpha"
+          },
+          {
+            "Version": "2.1.142-alpha"
+          },
+          {
+            "Version": "2.1.144-alpha"
+          },
+          {
+            "Version": "2.1.145-alpha"
+          },
+          {
+            "Version": "2.1.147-alpha"
+          },
+          {
+            "Version": "2.1.148-alpha"
+          },
+          {
+            "Version": "2.1.149-alpha"
+          },
+          {
+            "Version": "2.1.150-alpha"
+          },
+          {
+            "Version": "2.1.151-alpha"
+          },
+          {
+            "Version": "2.1.152-alpha"
+          },
+          {
+            "Version": "2.1.154-alpha"
+          },
+          {
+            "Version": "2.1.155-alpha"
+          },
+          {
+            "Version": "2.1.156-alpha"
+          },
+          {
+            "Version": "2.1.158-alpha"
+          },
+          {
+            "Version": "2.1.159-alpha"
+          },
+          {
+            "Version": "2.1.160-alpha"
+          },
+          {
+            "Version": "2.1.161-alpha"
+          },
+          {
+            "Version": "2.1.162-alpha"
+          },
+          {
+            "Version": "2.1.164-alpha"
+          },
+          {
+            "Version": "2.1.166-alpha"
+          },
+          {
+            "Version": "2.1.167-alpha"
+          },
+          {
+            "Version": "2.1.168-alpha"
+          },
+          {
+            "Version": "2.1.170-alpha"
+          },
+          {
+            "Version": "2.1.171-alpha"
+          },
+          {
+            "Version": "2.1.172-alpha"
+          },
+          {
+            "Version": "2.1.173-alpha"
+          },
+          {
+            "Version": "2.1.174-alpha"
+          },
+          {
+            "Version": "2.1.175-alpha"
+          },
+          {
+            "Version": "2.1.176-alpha"
+          },
+          {
+            "Version": "2.1.178-alpha"
+          },
+          {
+            "Version": "2.1.179-alpha"
+          },
+          {
+            "Version": "2.1.180-alpha"
+          },
+          {
+            "Version": "2.1.182-alpha"
+          },
+          {
+            "Version": "2.1.183-alpha"
+          },
+          {
+            "Version": "2.1.184-alpha"
+          },
+          {
+            "Version": "2.1.185-alpha"
+          },
+          {
+            "Version": "2.1.186-alpha"
+          },
+          {
+            "Version": "2.1.187-alpha"
+          },
+          {
+            "Version": "2.1.192-alpha"
+          },
+          {
+            "Version": "2.1.194-alpha"
+          },
+          {
+            "Version": "2.1.196-alpha"
+          },
+          {
+            "Version": "2.1.199-alpha"
+          },
+          {
+            "Version": "2.1.200-alpha"
+          },
+          {
+            "Version": "2.1.201-alpha"
+          },
+          {
+            "Version": "2.1.204-alpha"
+          },
+          {
+            "Version": "2.1.205-alpha"
+          },
+          {
+            "Version": "2.1.207-alpha"
+          },
+          {
+            "Version": "2.1.208-alpha"
+          },
+          {
+            "Version": "2.1.209-alpha"
+          },
+          {
+            "Version": "2.1.210-alpha"
+          },
+          {
+            "Version": "2.1.211-alpha"
+          },
+          {
+            "Version": "2.1.212-alpha"
+          },
+          {
+            "Version": "2.1.213-alpha"
+          },
+          {
+            "Version": "2.1.215-alpha"
+          },
+          {
+            "Version": "2.1.216-alpha"
+          },
+          {
+            "Version": "2.1.217-alpha"
+          },
+          {
+            "Version": "2.1.218-alpha"
+          },
+          {
+            "Version": "2.1.219-alpha"
+          },
+          {
+            "Version": "2.1.220-alpha"
+          },
+          {
+            "Version": "2.1.222-alpha"
+          },
+          {
+            "Version": "2.1.223-alpha"
+          },
+          {
+            "Version": "2.1.225-alpha"
+          },
+          {
+            "Version": "2.1.226-alpha"
+          },
+          {
+            "Version": "2.1.227-alpha"
+          },
+          {
+            "Version": "2.1.228-alpha"
+          },
+          {
+            "Version": "2.1.230-alpha"
+          },
+          {
+            "Version": "2.1.234-alpha"
+          },
+          {
+            "Version": "2.1.235-alpha"
+          },
+          {
+            "Version": "2.1.236-alpha"
+          },
+          {
+            "Version": "2.1.237-alpha"
+          },
+          {
+            "Version": "2.1.239-alpha"
+          },
+          {
+            "Version": "2.1.240-alpha"
+          },
+          {
+            "Version": "2.1.241-alpha"
+          },
+          {
+            "Version": "2.1.242-alpha"
+          },
+          {
+            "Version": "2.1.243-alpha"
+          },
+          {
+            "Version": "2.1.245-alpha"
+          },
+          {
+            "Version": "2.1.246-alpha"
+          },
+          {
+            "Version": "2.1.247-alpha"
+          },
+          {
+            "Version": "2.1.248-alpha"
+          },
+          {
+            "Version": "2.1.249-alpha"
+          },
+          {
+            "Version": "2.1.251-alpha"
+          },
+          {
+            "Version": "2.1.253-alpha"
+          },
+          {
+            "Version": "2.1.255-alpha"
+          },
+          {
+            "Version": "2.1.256-alpha"
+          },
+          {
+            "Version": "2.1.264-alpha"
+          },
+          {
+            "Version": "2.1.271-alpha"
+          },
+          {
+            "Version": "2.1.272-alpha"
+          },
+          {
+            "Version": "2.1.273-alpha"
+          },
+          {
+            "Version": "2.1.274-alpha"
+          },
+          {
+            "Version": "2.1.275-alpha"
+          },
+          {
+            "Version": "2.1.276-alpha"
+          },
+          {
+            "Version": "2.1.277-alpha"
+          },
+          {
+            "Version": "2.1.279-alpha"
+          },
+          {
+            "Version": "2.1.280-alpha"
+          },
+          {
+            "Version": "2.1.288-alpha"
+          },
+          {
+            "Version": "2.1.289-alpha"
+          },
+          {
+            "Version": "2.1.290-alpha"
+          },
+          {
+            "Version": "2.1.291-alpha"
+          },
+          {
+            "Version": "2.1.292-alpha"
+          },
+          {
+            "Version": "2.1.293-alpha"
+          },
+          {
+            "Version": "2.1.294-alpha"
+          },
+          {
+            "Version": "2.1.295-alpha"
+          },
+          {
+            "Version": "2.1.297-alpha"
+          },
+          {
+            "Version": "2.1.298-alpha"
+          },
+          {
+            "Version": "2.1.299-alpha"
+          },
+          {
+            "Version": "2.1.300-alpha"
+          },
+          {
+            "Version": "2.1.301-alpha"
+          },
+          {
+            "Version": "2.1.302-alpha"
+          },
+          {
+            "Version": "2.1.303-alpha"
+          },
+          {
+            "Version": "2.1.304-alpha"
+          },
+          {
+            "Version": "2.1.305-alpha"
+          },
+          {
+            "Version": "2.1.306-alpha"
+          },
+          {
+            "Version": "2.1.307-alpha"
+          },
+          {
+            "Version": "2.1.308-alpha"
+          },
+          {
+            "Version": "2.1.309-alpha"
+          },
+          {
+            "Version": "2.1.313-alpha"
+          },
+          {
+            "Version": "2.1.314-alpha"
+          },
+          {
+            "Version": "2.1.316-alpha"
+          },
+          {
+            "Version": "2.1.318-alpha"
+          },
+          {
+            "Version": "2.1.319-alpha"
+          },
+          {
+            "Version": "2.1.320-alpha"
+          },
+          {
+            "Version": "2.1.321-alpha"
+          },
+          {
+            "Version": "2.1.322-alpha"
+          },
+          {
+            "Version": "2.1.323-alpha"
+          },
+          {
+            "Version": "2.1.324-alpha"
+          },
+          {
+            "Version": "2.1.325-alpha"
+          },
+          {
+            "Version": "2.1.326-alpha"
+          },
+          {
+            "Version": "2.1.327-alpha"
+          },
+          {
+            "Version": "2.1.328-alpha"
+          },
+          {
+            "Version": "2.1.330-alpha"
+          },
+          {
+            "Version": "2.1.332-alpha"
+          },
+          {
+            "Version": "2.1.334-alpha"
+          },
+          {
+            "Version": "2.1.336-alpha"
+          },
+          {
+            "Version": "2.1.337-alpha"
+          },
+          {
+            "Version": "2.1.338-alpha"
+          },
+          {
+            "Version": "2.1.339-alpha"
+          },
+          {
+            "Version": "2.1.340-alpha"
+          },
+          {
+            "Version": "2.1.341-alpha"
+          },
+          {
+            "Version": "2.1.342-alpha"
+          },
+          {
+            "Version": "2.1.343-alpha"
+          },
+          {
+            "Version": "2.1.344-alpha"
+          },
+          {
+            "Version": "2.1.347-alpha"
+          },
+          {
+            "Version": "2.1.351-alpha"
+          },
+          {
+            "Version": "2.1.352-alpha"
+          },
+          {
+            "Version": "2.1.353-alpha"
+          },
+          {
+            "Version": "2.1.354-alpha"
+          },
+          {
+            "Version": "2.1.355-alpha"
+          },
+          {
+            "Version": "2.1.356-alpha"
+          },
+          {
+            "Version": "2.1.357-alpha"
+          },
+          {
+            "Version": "2.1.358-alpha"
+          },
+          {
+            "Version": "2.1.359-alpha"
+          },
+          {
+            "Version": "2.1.360-alpha"
+          },
+          {
+            "Version": "2.1.361-alpha"
+          },
+          {
+            "Version": "2.1.362-alpha"
+          },
+          {
+            "Version": "2.1.363-alpha"
+          },
+          {
+            "Version": "2.1.364-alpha"
+          },
+          {
+            "Version": "2.1.365-alpha"
+          },
+          {
+            "Version": "2.1.366-alpha"
+          },
+          {
+            "Version": "2.1.367-alpha"
+          },
+          {
+            "Version": "2.1.368-alpha"
+          },
+          {
+            "Version": "2.1.369-alpha"
+          },
+          {
+            "Version": "2.1.371-alpha"
+          },
+          {
+            "Version": "2.1.372-alpha"
+          },
+          {
+            "Version": "2.1.373-alpha"
+          },
+          {
+            "Version": "2.1.374-alpha"
+          },
+          {
+            "Version": "2.1.375-alpha"
+          },
+          {
+            "Version": "2.1.376-alpha"
+          },
+          {
+            "Version": "2.1.378-alpha"
+          },
+          {
+            "Version": "2.1.379-alpha"
+          },
+          {
+            "Version": "2.1.380-alpha"
+          },
+          {
+            "Version": "2.1.381-alpha"
+          },
+          {
+            "Version": "2.1.382-alpha"
+          },
+          {
+            "Version": "2.1.383-alpha"
+          },
+          {
+            "Version": "2.1.384-alpha"
+          },
+          {
+            "Version": "2.1.385-alpha"
+          },
+          {
+            "Version": "2.1.386-alpha"
+          },
+          {
+            "Version": "2.1.387-alpha"
+          },
+          {
+            "Version": "2.1.388-alpha"
+          },
+          {
+            "Version": "2.1.389-alpha"
+          },
+          {
+            "Version": "2.1.390-alpha"
+          },
+          {
+            "Version": "2.1.391-alpha"
+          },
+          {
+            "Version": "2.1.392-alpha"
+          },
+          {
+            "Version": "2.1.393-alpha"
+          },
+          {
+            "Version": "2.1.394-alpha"
+          },
+          {
+            "Version": "2.1.395-alpha"
+          },
+          {
+            "Version": "2.1.396-alpha"
+          },
+          {
+            "Version": "2.1.397-alpha"
+          },
+          {
+            "Version": "2.1.398-alpha"
+          },
+          {
+            "Version": "2.1.399-alpha"
+          },
+          {
+            "Version": "2.1.400-alpha"
+          },
+          {
+            "Version": "2.1.401-alpha"
+          },
+          {
+            "Version": "2.1.402-alpha"
+          },
+          {
+            "Version": "2.1.403-alpha"
+          },
+          {
+            "Version": "2.1.404-alpha"
+          },
+          {
+            "Version": "2.1.405-alpha"
+          },
+          {
+            "Version": "2.1.406-alpha"
+          },
+          {
+            "Version": "2.1.407-alpha"
+          },
+          {
+            "Version": "2.1.408-alpha"
+          },
+          {
+            "Version": "2.1.409-alpha"
+          },
+          {
+            "Version": "2.1.410-alpha"
+          },
+          {
+            "Version": "2.1.411-alpha"
+          },
+          {
+            "Version": "2.1.412-alpha"
+          },
+          {
+            "Version": "2.1.413-alpha"
+          },
+          {
+            "Version": "2.1.414-alpha"
+          },
+          {
+            "Version": "2.1.415-alpha"
+          },
+          {
+            "Version": "2.1.416-alpha"
+          },
+          {
+            "Version": "2.1.417-alpha"
+          },
+          {
+            "Version": "2.1.418-alpha"
+          },
+          {
+            "Version": "2.1.419-alpha"
+          },
+          {
+            "Version": "2.1.420-alpha"
+          },
+          {
+            "Version": "2.1.421-alpha"
+          },
+          {
+            "Version": "2.1.422-alpha"
+          },
+          {
+            "Version": "2.1.423-alpha"
+          },
+          {
+            "Version": "2.1.424-alpha"
+          },
+          {
+            "Version": "2.1.426-alpha"
+          },
+          {
+            "Version": "2.1.427-alpha"
+          },
+          {
+            "Version": "2.1.428-alpha"
+          },
+          {
+            "Version": "2.1.429-alpha"
+          },
+          {
+            "Version": "2.1.430-alpha"
+          },
+          {
+            "Version": "2.1.431-alpha"
+          },
+          {
+            "Version": "2.1.432-alpha"
+          },
+          {
+            "Version": "2.1.434-alpha"
+          },
+          {
+            "Version": "2.1.435-alpha"
+          },
+          {
+            "Version": "2.1.436-alpha"
+          },
+          {
+            "Version": "2.1.437-alpha"
+          },
+          {
+            "Version": "2.1.438-alpha"
+          },
+          {
+            "Version": "2.1.439-alpha"
+          },
+          {
+            "Version": "2.1.440-alpha"
+          },
+          {
+            "Version": "2.1.441-alpha"
+          },
+          {
+            "Version": "2.1.442-alpha"
+          },
+          {
+            "Version": "2.1.443-alpha"
+          },
+          {
+            "Version": "2.1.445-alpha"
+          },
+          {
+            "Version": "2.1.449-alpha"
+          },
+          {
+            "Version": "2.1.461-alpha"
+          },
+          {
+            "Version": "2.1.465-alpha"
+          },
+          {
+            "Version": "2.1.468-alpha"
+          },
+          {
+            "Version": "2.1.469-alpha"
+          },
+          {
+            "Version": "2.1.470-alpha"
+          },
+          {
+            "Version": "2.1.471-alpha"
+          },
+          {
+            "Version": "2.1.472-alpha"
+          },
+          {
+            "Version": "2.1.473-alpha"
+          },
+          {
+            "Version": "2.1.474-alpha"
+          },
+          {
+            "Version": "2.1.475-alpha"
+          },
+          {
+            "Version": "2.1.476-alpha"
+          },
+          {
+            "Version": "2.1.478-alpha"
+          },
+          {
+            "Version": "2.1.479-alpha"
+          },
+          {
+            "Version": "2.1.480-alpha"
+          },
+          {
+            "Version": "2.1.481-alpha"
+          },
+          {
+            "Version": "2.1.482-alpha"
+          },
+          {
+            "Version": "2.1.483-alpha"
+          },
+          {
+            "Version": "2.1.485-alpha"
+          },
+          {
+            "Version": "2.1.486-alpha"
+          },
+          {
+            "Version": "2.1.487-alpha"
+          },
+          {
+            "Version": "2.1.488-alpha"
+          },
+          {
+            "Version": "2.1.489-alpha"
+          },
+          {
+            "Version": "2.1.490-alpha"
+          },
+          {
+            "Version": "2.1.491-alpha"
+          },
+          {
+            "Version": "2.1.492-alpha"
+          },
+          {
+            "Version": "2.1.493-alpha"
+          },
+          {
+            "Version": "2.1.494-alpha"
+          },
+          {
+            "Version": "2.1.495-alpha"
+          },
+          {
+            "Version": "2.1.496-alpha"
+          },
+          {
+            "Version": "2.1.497-alpha"
+          },
+          {
+            "Version": "2.1.498-alpha"
+          },
+          {
+            "Version": "2.1.499-alpha"
+          },
+          {
+            "Version": "2.1.500-alpha"
+          },
+          {
+            "Version": "2.1.502-alpha"
+          },
+          {
+            "Version": "2.1.503-alpha"
+          },
+          {
+            "Version": "2.1.504-alpha"
+          },
+          {
+            "Version": "2.1.505-alpha"
+          },
+          {
+            "Version": "2.1.507-alpha"
+          },
+          {
+            "Version": "2.1.509-alpha"
+          },
+          {
+            "Version": "2.1.520-alpha"
+          },
+          {
+            "Version": "2.1.521-alpha"
+          },
+          {
+            "Version": "2.1.522-alpha"
+          },
+          {
+            "Version": "2.1.524-alpha"
+          },
+          {
+            "Version": "2.1.526-alpha"
+          },
+          {
+            "Version": "2.1.527-alpha"
+          },
+          {
+            "Version": "2.1.528-alpha"
+          },
+          {
+            "Version": "2.1.530-alpha"
+          },
+          {
+            "Version": "2.1.531-alpha"
+          },
+          {
+            "Version": "2.1.533-alpha"
+          },
+          {
+            "Version": "2.1.534-alpha"
+          },
+          {
+            "Version": "2.1.535-alpha"
+          },
+          {
+            "Version": "2.1.536-alpha"
+          },
+          {
+            "Version": "2.1.537-alpha"
+          },
+          {
+            "Version": "2.1.538-alpha"
+          },
+          {
+            "Version": "2.1.539-alpha"
+          },
+          {
+            "Version": "2.1.540-alpha"
+          },
+          {
+            "Version": "2.1.542-alpha"
+          },
+          {
+            "Version": "2.1.543-alpha"
+          },
+          {
+            "Version": "2.1.544-alpha"
+          },
+          {
+            "Version": "2.1.545-alpha"
+          },
+          {
+            "Version": "2.1.546-alpha"
+          },
+          {
+            "Version": "2.1.547-alpha"
+          },
+          {
+            "Version": "2.1.548-alpha"
+          },
+          {
+            "Version": "2.1.549-alpha"
+          },
+          {
+            "Version": "2.1.550-alpha"
+          },
+          {
+            "Version": "2.1.551-alpha"
+          },
+          {
+            "Version": "2.1.552-alpha"
+          },
+          {
+            "Version": "2.1.553-alpha"
+          },
+          {
+            "Version": "2.1.554-alpha"
+          },
+          {
+            "Version": "2.1.555-alpha"
+          },
+          {
+            "Version": "2.1.556-alpha"
+          },
+          {
+            "Version": "2.1.557-alpha"
+          },
+          {
+            "Version": "2.1.560-alpha"
+          },
+          {
+            "Version": "2.1.561-alpha"
+          },
+          {
+            "Version": "2.1.562-alpha"
+          },
+          {
+            "Version": "2.1.563-alpha"
+          },
+          {
+            "Version": "2.1.564-alpha"
+          },
+          {
+            "Version": "2.1.566-alpha"
+          },
+          {
+            "Version": "2.1.567-alpha"
+          },
+          {
+            "Version": "2.1.568-alpha"
+          },
+          {
+            "Version": "2.1.569-alpha"
+          },
+          {
+            "Version": "2.1.570-alpha"
+          },
+          {
+            "Version": "2.1.571-alpha"
+          },
+          {
+            "Version": "2.1.572-alpha"
+          },
+          {
+            "Version": "2.1.573-alpha"
+          },
+          {
+            "Version": "2.1.574-alpha"
+          },
+          {
+            "Version": "2.1.575-alpha"
+          },
+          {
+            "Version": "2.1.576-alpha"
+          },
+          {
+            "Version": "2.1.577-alpha"
+          },
+          {
+            "Version": "2.1.578-alpha"
+          },
+          {
+            "Version": "2.1.580-alpha"
+          },
+          {
+            "Version": "2.1.581-alpha"
+          },
+          {
+            "Version": "2.1.583-alpha"
+          },
+          {
+            "Version": "2.1.584-alpha"
+          },
+          {
+            "Version": "2.1.585-alpha"
+          },
+          {
+            "Version": "2.1.586-alpha"
+          },
+          {
+            "Version": "2.1.587-alpha"
+          },
+          {
+            "Version": "2.1.588-alpha"
+          },
+          {
+            "Version": "2.1.589-alpha"
+          },
+          {
+            "Version": "2.1.591-alpha"
+          },
+          {
+            "Version": "2.1.592-alpha"
+          },
+          {
+            "Version": "2.1.593-alpha"
+          },
+          {
+            "Version": "2.1.594-alpha"
+          },
+          {
+            "Version": "2.1.595-alpha"
+          },
+          {
+            "Version": "2.1.596-alpha"
+          },
+          {
+            "Version": "2.1.597-alpha"
+          },
+          {
+            "Version": "2.1.598-alpha"
+          },
+          {
+            "Version": "2.1.600-alpha"
+          },
+          {
+            "Version": "2.1.601-alpha"
+          },
+          {
+            "Version": "2.1.602-alpha"
+          },
+          {
+            "Version": "2.1.603-alpha"
+          },
+          {
+            "Version": "2.1.604-alpha"
+          },
+          {
+            "Version": "2.1.605-alpha"
+          },
+          {
+            "Version": "2.1.607-alpha"
+          },
+          {
+            "Version": "2.1.609-alpha"
+          },
+          {
+            "Version": "2.1.611-alpha"
+          },
+          {
+            "Version": "2.1.612-alpha"
+          },
+          {
+            "Version": "2.1.614-alpha"
+          },
+          {
+            "Version": "2.1.616-alpha"
+          },
+          {
+            "Version": "2.1.617-alpha"
+          },
+          {
+            "Version": "2.1.618-alpha"
+          },
+          {
+            "Version": "2.1.620-alpha"
+          },
+          {
+            "Version": "2.1.621-alpha"
+          },
+          {
+            "Version": "2.1.622-alpha"
+          },
+          {
+            "Version": "2.1.623-alpha"
+          },
+          {
+            "Version": "2.1.624-alpha"
+          },
+          {
+            "Version": "2.1.625-alpha"
+          },
+          {
+            "Version": "2.1.626-alpha"
+          },
+          {
+            "Version": "2.1.629-alpha"
+          },
+          {
+            "Version": "2.1.630-alpha"
+          },
+          {
+            "Version": "2.1.631-alpha"
+          },
+          {
+            "Version": "2.1.632-alpha"
+          },
+          {
+            "Version": "2.1.633-alpha"
+          },
+          {
+            "Version": "2.1.634-alpha"
+          },
+          {
+            "Version": "2.1.635-alpha"
+          },
+          {
+            "Version": "2.1.636-alpha"
+          },
+          {
+            "Version": "2.1.637-alpha"
+          },
+          {
+            "Version": "2.1.638-alpha"
+          },
+          {
+            "Version": "2.1.639-alpha"
+          },
+          {
+            "Version": "2.1.640-alpha"
+          },
+          {
+            "Version": "2.1.641-alpha"
+          },
+          {
+            "Version": "2.1.642-alpha"
+          },
+          {
+            "Version": "2.1.643-alpha"
+          },
+          {
+            "Version": "2.1.645-alpha"
+          },
+          {
+            "Version": "2.1.646-alpha"
+          },
+          {
+            "Version": "2.1.647-alpha"
+          },
+          {
+            "Version": "2.1.648-alpha"
+          },
+          {
+            "Version": "2.1.649-alpha"
+          },
+          {
+            "Version": "2.1.651-alpha"
+          },
+          {
+            "Version": "2.1.652-alpha"
+          },
+          {
+            "Version": "2.1.653-alpha"
+          },
+          {
+            "Version": "2.1.654-alpha"
+          },
+          {
+            "Version": "2.1.655-alpha"
+          },
+          {
+            "Version": "2.1.656-alpha"
+          },
+          {
+            "Version": "2.1.657-alpha"
+          },
+          {
+            "Version": "2.1.658-alpha"
+          },
+          {
+            "Version": "2.1.659-alpha"
+          },
+          {
+            "Version": "2.1.660-alpha"
+          },
+          {
+            "Version": "2.1.661-alpha"
+          },
+          {
+            "Version": "2.1.662-alpha"
+          },
+          {
+            "Version": "2.1.663-alpha"
+          },
+          {
+            "Version": "2.1.664-alpha"
+          },
+          {
+            "Version": "2.1.665-alpha"
+          },
+          {
+            "Version": "2.1.666-alpha"
+          },
+          {
+            "Version": "2.1.667-alpha"
+          },
+          {
+            "Version": "2.1.668-alpha"
+          },
+          {
+            "Version": "2.1.671-alpha"
+          },
+          {
+            "Version": "2.1.672-alpha"
+          },
+          {
+            "Version": "2.1.673-alpha"
+          },
+          {
+            "Version": "2.1.674-alpha"
+          },
+          {
+            "Version": "2.1.675-alpha"
+          },
+          {
+            "Version": "2.1.676-alpha"
+          },
+          {
+            "Version": "2.1.677-alpha"
+          },
+          {
+            "Version": "2.1.678-alpha"
+          },
+          {
+            "Version": "2.1.679-alpha"
+          },
+          {
+            "Version": "2.1.680-alpha"
+          },
+          {
+            "Version": "2.1.681-alpha"
+          },
+          {
+            "Version": "2.1.682-alpha"
+          },
+          {
+            "Version": "2.1.683-alpha"
+          },
+          {
+            "Version": "2.1.685-alpha"
+          },
+          {
+            "Version": "2.1.686-alpha"
+          },
+          {
+            "Version": "2.1.687-alpha"
+          },
+          {
+            "Version": "2.1.688-alpha"
+          },
+          {
+            "Version": "2.1.711-alpha"
+          },
+          {
+            "Version": "2.1.713-alpha"
+          },
+          {
+            "Version": "2.1.714-alpha"
+          },
+          {
+            "Version": "2.1.718-alpha"
+          },
+          {
+            "Version": "2.1.724-alpha"
+          },
+          {
+            "Version": "2.1.726-alpha"
+          },
+          {
+            "Version": "2.1.727-alpha"
+          },
+          {
+            "Version": "2.1.728-alpha"
+          },
+          {
+            "Version": "2.1.729-alpha"
+          },
+          {
+            "Version": "2.1.730-alpha"
+          },
+          {
+            "Version": "2.1.731-alpha"
+          },
+          {
+            "Version": "2.1.732-alpha"
+          },
+          {
+            "Version": "2.1.733-alpha"
+          },
+          {
+            "Version": "2.1.735-alpha"
+          },
+          {
+            "Version": "2.1.737-alpha"
+          },
+          {
+            "Version": "2.1.738-alpha"
+          },
+          {
+            "Version": "2.1.739-alpha"
+          },
+          {
+            "Version": "2.1.740-alpha"
+          },
+          {
+            "Version": "2.1.742-alpha"
+          },
+          {
+            "Version": "2.1.743-alpha"
+          },
+          {
+            "Version": "2.1.744-alpha"
+          },
+          {
+            "Version": "2.1.745-alpha"
+          },
+          {
+            "Version": "2.1.746-alpha"
+          },
+          {
+            "Version": "2.1.747-alpha"
+          },
+          {
+            "Version": "2.1.748-alpha"
+          },
+          {
+            "Version": "2.1.750-alpha"
+          },
+          {
+            "Version": "2.1.756-alpha"
+          },
+          {
+            "Version": "2.1.758-alpha"
+          },
+          {
+            "Version": "2.1.765-alpha"
+          },
+          {
+            "Version": "2.1.766-alpha"
+          },
+          {
+            "Version": "2.1.767-alpha"
+          },
+          {
+            "Version": "2.1.768-alpha"
+          },
+          {
+            "Version": "2.1.770-alpha"
+          },
+          {
+            "Version": "2.1.771-alpha"
+          },
+          {
+            "Version": "2.1.772-alpha"
+          },
+          {
+            "Version": "2.1.773-alpha"
+          },
+          {
+            "Version": "2.1.774-alpha"
+          },
+          {
+            "Version": "2.1.775-alpha"
+          },
+          {
+            "Version": "2.1.778-alpha"
+          },
+          {
+            "Version": "2.1.779-alpha"
+          },
+          {
+            "Version": "2.1.781-alpha"
+          },
+          {
+            "Version": "2.2.0.0"
+          },
+          {
+            "Version": "2.2.1.0"
+          },
+          {
+            "Version": "2.2.2.0"
+          },
+          {
+            "Version": "2.2.4.0"
+          },
+          {
+            "Version": "2.2.6.0"
+          },
+          {
+            "Version": "2.2.7.0"
+          },
+          {
+            "Version": "2.2.8.0"
+          },
+          {
+            "Version": "2.2.9.0"
+          },
+          {
+            "Version": "2.2.10.0"
+          },
+          {
+            "Version": "2.2.11.0"
+          },
+          {
+            "Version": "2.2.12.0"
+          },
+          {
+            "Version": "2.2.13.0"
+          },
+          {
+            "Version": "2.2.14.0"
+          },
+          {
+            "Version": "2.2.18.0"
+          },
+          {
+            "Version": "2.2.19.0"
+          },
+          {
+            "Version": "2.2.20.0"
+          },
+          {
+            "Version": "2.2.21.0"
+          },
+          {
+            "Version": "2.2.22.0"
+          },
+          {
+            "Version": "2.2.23.0"
+          },
+          {
+            "Version": "2.3.1-alpha"
+          },
+          {
+            "Version": "2.3.2-alpha"
+          },
+          {
+            "Version": "2.3.5-alpha"
+          },
+          {
+            "Version": "2.3.8-alpha"
+          },
+          {
+            "Version": "2.3.10-alpha"
+          },
+          {
+            "Version": "2.3.11-alpha"
+          },
+          {
+            "Version": "2.3.14-alpha"
+          },
+          {
+            "Version": "2.3.15-alpha"
+          },
+          {
+            "Version": "2.3.16-alpha"
+          },
+          {
+            "Version": "2.3.17-alpha"
+          },
+          {
+            "Version": "2.3.18-alpha"
+          },
+          {
+            "Version": "2.3.19-alpha"
+          },
+          {
+            "Version": "2.3.20-alpha"
+          },
+          {
+            "Version": "2.3.21-alpha"
+          },
+          {
+            "Version": "2.3.22-alpha"
+          },
+          {
+            "Version": "2.3.23-alpha"
+          },
+          {
+            "Version": "2.3.24-alpha"
+          },
+          {
+            "Version": "2.3.26-alpha"
+          },
+          {
+            "Version": "2.3.28-alpha"
+          },
+          {
+            "Version": "2.3.30-alpha"
+          },
+          {
+            "Version": "2.3.31-alpha"
+          },
+          {
+            "Version": "2.3.32-alpha"
+          },
+          {
+            "Version": "2.3.33-alpha"
+          },
+          {
+            "Version": "2.3.34-alpha"
+          },
+          {
+            "Version": "2.3.36-alpha"
+          },
+          {
+            "Version": "2.3.37-alpha"
+          },
+          {
+            "Version": "2.3.38-alpha"
+          },
+          {
+            "Version": "2.3.39-alpha"
+          },
+          {
+            "Version": "2.3.41-alpha"
+          },
+          {
+            "Version": "2.3.43-alpha"
+          },
+          {
+            "Version": "2.3.49-alpha"
+          },
+          {
+            "Version": "2.3.50-alpha"
+          },
+          {
+            "Version": "2.3.51-alpha"
+          },
+          {
+            "Version": "2.3.54-alpha"
+          },
+          {
+            "Version": "2.3.55-alpha"
+          },
+          {
+            "Version": "2.3.57-alpha"
+          },
+          {
+            "Version": "2.3.58-alpha"
+          },
+          {
+            "Version": "2.3.59-alpha"
+          },
+          {
+            "Version": "2.3.60-alpha"
+          },
+          {
+            "Version": "2.3.61-alpha"
+          },
+          {
+            "Version": "2.3.62-alpha"
+          },
+          {
+            "Version": "2.3.63-alpha"
+          },
+          {
+            "Version": "2.3.64-alpha"
+          },
+          {
+            "Version": "2.3.65-alpha"
+          },
+          {
+            "Version": "2.3.66-alpha"
+          },
+          {
+            "Version": "2.3.67-alpha"
+          },
+          {
+            "Version": "2.3.68-alpha"
+          },
+          {
+            "Version": "2.3.69-alpha"
+          },
+          {
+            "Version": "2.3.70-alpha"
+          },
+          {
+            "Version": "2.3.71-alpha"
+          },
+          {
+            "Version": "2.3.72-alpha"
+          },
+          {
+            "Version": "2.3.73-alpha"
+          },
+          {
+            "Version": "2.3.74-alpha"
+          },
+          {
+            "Version": "2.3.75-alpha"
+          },
+          {
+            "Version": "2.3.76-alpha"
+          },
+          {
+            "Version": "2.3.77-alpha"
+          },
+          {
+            "Version": "2.3.78-alpha"
+          },
+          {
+            "Version": "2.3.79-alpha"
+          },
+          {
+            "Version": "2.3.80-alpha"
+          },
+          {
+            "Version": "2.3.81-alpha"
+          },
+          {
+            "Version": "2.3.82-alpha"
+          },
+          {
+            "Version": "2.3.83-alpha"
+          },
+          {
+            "Version": "2.3.84-alpha"
+          },
+          {
+            "Version": "2.3.85-alpha"
+          },
+          {
+            "Version": "2.3.86-alpha"
+          },
+          {
+            "Version": "2.3.87-alpha"
+          },
+          {
+            "Version": "2.3.88-alpha"
+          },
+          {
+            "Version": "2.4.0.0"
+          },
+          {
+            "Version": "2.4.1.0"
+          },
+          {
+            "Version": "2.4.2.0"
+          },
+          {
+            "Version": "2.4.3.0"
+          },
+          {
+            "Version": "2.4.4.0"
+          },
+          {
+            "Version": "2.4.5.0"
+          },
+          {
+            "Version": "2.4.6.0"
+          },
+          {
+            "Version": "2.4.7.0"
+          },
+          {
+            "Version": "2.4.8.0"
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.4-alpha"
+          },
+          {
+            "Version": "2.5.5-alpha"
+          },
+          {
+            "Version": "2.5.7-alpha"
+          },
+          {
+            "Version": "2.5.8-alpha"
+          },
+          {
+            "Version": "2.5.9-alpha"
+          },
+          {
+            "Version": "2.5.10-alpha"
+          },
+          {
+            "Version": "2.5.11-alpha"
+          },
+          {
+            "Version": "2.5.12-alpha"
+          },
+          {
+            "Version": "2.5.17-alpha"
+          },
+          {
+            "Version": "2.5.18-alpha"
+          },
+          {
+            "Version": "2.5.19-alpha"
+          },
+          {
+            "Version": "2.5.20-alpha"
+          },
+          {
+            "Version": "2.5.21-alpha"
+          },
+          {
+            "Version": "2.5.22-alpha"
+          },
+          {
+            "Version": "2.5.25-alpha"
+          },
+          {
+            "Version": "2.5.31-alpha"
+          },
+          {
+            "Version": "2.5.32-alpha"
+          },
+          {
+            "Version": "2.5.33-alpha"
+          },
+          {
+            "Version": "2.5.34-alpha"
+          },
+          {
+            "Version": "2.5.35-alpha"
+          },
+          {
+            "Version": "2.5.39-alpha"
+          },
+          {
+            "Version": "2.5.40-alpha"
+          },
+          {
+            "Version": "2.5.41-alpha"
+          },
+          {
+            "Version": "2.5.42-alpha"
+          },
+          {
+            "Version": "2.5.43-alpha"
+          },
+          {
+            "Version": "2.5.44-alpha"
+          },
+          {
+            "Version": "2.5.45-alpha"
+          },
+          {
+            "Version": "2.5.46-alpha"
+          },
+          {
+            "Version": "2.5.47-alpha"
+          },
+          {
+            "Version": "2.5.48-alpha"
+          },
+          {
+            "Version": "2.5.49-alpha"
+          },
+          {
+            "Version": "2.5.54-alpha"
+          },
+          {
+            "Version": "2.5.55-alpha"
+          },
+          {
+            "Version": "2.5.56-alpha"
+          },
+          {
+            "Version": "2.5.57-alpha"
+          },
+          {
+            "Version": "2.5.58-alpha"
+          },
+          {
+            "Version": "2.5.59-alpha"
+          },
+          {
+            "Version": "2.5.60-alpha"
+          },
+          {
+            "Version": "2.5.61-alpha"
+          },
+          {
+            "Version": "2.5.62-alpha"
+          },
+          {
+            "Version": "2.5.63-alpha"
+          },
+          {
+            "Version": "2.5.64-alpha"
+          },
+          {
+            "Version": "2.5.65-alpha"
+          },
+          {
+            "Version": "2.5.66-alpha"
+          },
+          {
+            "Version": "2.5.67-alpha"
+          },
+          {
+            "Version": "2.5.68-alpha"
+          },
+          {
+            "Version": "2.5.69-alpha"
+          },
+          {
+            "Version": "2.5.70-alpha"
+          },
+          {
+            "Version": "2.5.71-alpha"
+          },
+          {
+            "Version": "2.5.72-alpha"
+          },
+          {
+            "Version": "2.5.73-alpha"
+          },
+          {
+            "Version": "2.5.74-alpha"
+          },
+          {
+            "Version": "2.5.75-alpha"
+          },
+          {
+            "Version": "2.6.0.0"
+          },
+          {
+            "Version": "2.6.1.0"
+          },
+          {
+            "Version": "2.6.3.0"
+          },
+          {
+            "Version": "2.6.5.0"
+          },
+          {
+            "Version": "2.6.7.0"
+          },
+          {
+            "Version": "2.6.9.0"
+          },
+          {
+            "Version": "2.6.12.0"
+          },
+          {
+            "Version": "2.6.14.0"
+          },
+          {
+            "Version": "2.6.15.0"
+          },
+          {
+            "Version": "2.6.16.0"
+          },
+          {
+            "Version": "2.6.17.0"
+          },
+          {
+            "Version": "2.7.0-alpha10"
+          },
+          {
+            "Version": "2.7.0-alpha11"
+          },
+          {
+            "Version": "2.7.0-alpha13"
+          },
+          {
+            "Version": "2.7.0-alpha14"
+          },
+          {
+            "Version": "2.7.0-alpha15"
+          },
+          {
+            "Version": "2.7.0-alpha7"
+          },
+          {
+            "Version": "2.7.0-alpha8"
+          },
+          {
+            "Version": "2.7.0-alpha9"
+          },
+          {
+            "Version": "2.7.0.16-alpha"
+          },
+          {
+            "Version": "2.7.0.17-alpha"
+          },
+          {
+            "Version": "2.7.0.18-alpha"
+          },
+          {
+            "Version": "2.7.0.19-alpha"
+          },
+          {
+            "Version": "2.7.0.20-alpha"
+          },
+          {
+            "Version": "2.7.0.21-alpha"
+          },
+          {
+            "Version": "2.7.0.23-alpha"
+          },
+          {
+            "Version": "2.7.0.24-alpha"
+          },
+          {
+            "Version": "2.7.0.25-alpha"
+          },
+          {
+            "Version": "2.7.0.26-alpha"
+          },
+          {
+            "Version": "2.7.0.27-alpha"
+          },
+          {
+            "Version": "2.7.0.28-alpha"
+          },
+          {
+            "Version": "2.7.0.29-alpha"
+          },
+          {
+            "Version": "2.7.0.30-alpha"
+          },
+          {
+            "Version": "2.7.0.32-alpha"
+          },
+          {
+            "Version": "2.7.0.34-alpha"
+          },
+          {
+            "Version": "2.7.0.35-alpha"
+          },
+          {
+            "Version": "2.7.0.36-alpha"
+          },
+          {
+            "Version": "2.7.0.37-alpha"
+          },
+          {
+            "Version": "2.7.0.38-alpha"
+          },
+          {
+            "Version": "2.7.0.39-alpha"
+          },
+          {
+            "Version": "2.7.0.42-alpha"
+          },
+          {
+            "Version": "2.7.0.43-alpha"
+          },
+          {
+            "Version": "2.7.0.44-alpha"
+          },
+          {
+            "Version": "2.7.0.45-alpha"
+          },
+          {
+            "Version": "2.7.0.47-alpha"
+          },
+          {
+            "Version": "2.7.0.50-alpha"
+          },
+          {
+            "Version": "2.7.0.59-alpha"
+          },
+          {
+            "Version": "2.7.0.60-alpha"
+          },
+          {
+            "Version": "2.7.0.61-alpha"
+          },
+          {
+            "Version": "2.7.0.62-alpha"
+          },
+          {
+            "Version": "2.7.0.63-alpha"
+          },
+          {
+            "Version": "2.7.0.64-alpha"
+          },
+          {
+            "Version": "2.7.0.65-alpha"
+          },
+          {
+            "Version": "2.7.0.66-alpha"
+          },
+          {
+            "Version": "2.7.0.72-alpha"
+          },
+          {
+            "Version": "2.7.0.84-alpha"
+          },
+          {
+            "Version": "2.7.0.85-alpha"
+          },
+          {
+            "Version": "2.7.0.86-alpha"
+          },
+          {
+            "Version": "2.7.0.87-alpha"
+          },
+          {
+            "Version": "2.7.0.88-alpha"
+          },
+          {
+            "Version": "2.7.0.90-alpha"
+          },
+          {
+            "Version": "2.7.0.91-alpha"
+          },
+          {
+            "Version": "2.7.0.92-alpha"
+          },
+          {
+            "Version": "2.7.1-alpha"
+          },
+          {
+            "Version": "2.8.0.0"
+          },
+          {
+            "Version": "2.8.1.0"
+          },
+          {
+            "Version": "2.8.2.0"
+          },
+          {
+            "Version": "2.8.3.0"
+          },
+          {
+            "Version": "2.8.5.0"
+          },
+          {
+            "Version": "2.8.6.0"
+          },
+          {
+            "Version": "2.8.7.0"
+          },
+          {
+            "Version": "2.8.8.0"
+          },
+          {
+            "Version": "2.8.9.0"
+          },
+          {
+            "Version": "2.8.10.0"
+          },
+          {
+            "Version": "2.8.11.0"
+          },
+          {
+            "Version": "2.8.12.0"
+          },
+          {
+            "Version": "2.8.17.0"
+          },
+          {
+            "Version": "2.9.0.0-alpha"
+          },
+          {
+            "Version": "2.9.0.1-alpha"
+          },
+          {
+            "Version": "2.9.0.3-alpha"
+          },
+          {
+            "Version": "2.9.11-alpha"
+          },
+          {
+            "Version": "2.9.12-alpha"
+          },
+          {
+            "Version": "2.9.14-alpha"
+          },
+          {
+            "Version": "2.9.15-alpha"
+          },
+          {
+            "Version": "2.9.17-alpha"
+          },
+          {
+            "Version": "2.9.19-alpha"
+          },
+          {
+            "Version": "2.9.20-alpha"
+          },
+          {
+            "Version": "2.9.21-alpha"
+          },
+          {
+            "Version": "2.9.22-alpha"
+          },
+          {
+            "Version": "2.9.23-alpha"
+          },
+          {
+            "Version": "2.9.24-alpha"
+          },
+          {
+            "Version": "2.9.26-alpha"
+          },
+          {
+            "Version": "2.9.27-alpha"
+          },
+          {
+            "Version": "2.9.28-alpha"
+          },
+          {
+            "Version": "2.9.29-alpha"
+          },
+          {
+            "Version": "2.9.30-alpha"
+          },
+          {
+            "Version": "2.9.31-alpha"
+          },
+          {
+            "Version": "2.9.32-alpha"
+          },
+          {
+            "Version": "2.9.33-alpha"
+          },
+          {
+            "Version": "2.9.34-alpha"
+          },
+          {
+            "Version": "2.9.35-alpha"
+          },
+          {
+            "Version": "2.9.36-alpha"
+          },
+          {
+            "Version": "2.9.37-alpha"
+          },
+          {
+            "Version": "2.9.41-alpha"
+          },
+          {
+            "Version": "2.9.42-alpha"
+          },
+          {
+            "Version": "2.9.44-alpha"
+          },
+          {
+            "Version": "2.9.45-alpha"
+          },
+          {
+            "Version": "2.9.46-alpha"
+          },
+          {
+            "Version": "2.9.47-alpha"
+          },
+          {
+            "Version": "2.10.0.0"
+          },
+          {
+            "Version": "2.10.1.0"
+          },
+          {
+            "Version": "2.10.2.0"
+          },
+          {
+            "Version": "2.10.3.0"
+          },
+          {
+            "Version": "2.10.4.0"
+          },
+          {
+            "Version": "2.10.5.0"
+          },
+          {
+            "Version": "2.10.6.0"
+          },
+          {
+            "Version": "2.10.7.0"
+          },
+          {
+            "Version": "2.10.8.0"
+          },
+          {
+            "Version": "2.10.9.0"
+          },
+          {
+            "Version": "2.10.10.0"
+          },
+          {
+            "Version": "2.10.11.0"
+          },
+          {
+            "Version": "2.10.12.0"
+          },
+          {
+            "Version": "2.10.13.0"
+          },
+          {
+            "Version": "2.10.14.0"
+          },
+          {
+            "Version": "2.10.15.0"
+          },
+          {
+            "Version": "2.10.16.0"
+          },
+          {
+            "Version": "2.10.17.0"
+          },
+          {
+            "Version": "2.10.18.0"
+          },
+          {
+            "Version": "2.10.19.0"
+          },
+          {
+            "Version": "2.10.20.0"
+          },
+          {
+            "Version": "2.10.23.0"
+          },
+          {
+            "Version": "2.10.24.0"
+          },
+          {
+            "Version": "2.10.25.0"
+          },
+          {
+            "Version": "2.11.0-alpha"
+          },
+          {
+            "Version": "2.11.1-alpha"
+          },
+          {
+            "Version": "2.11.2-alpha"
+          },
+          {
+            "Version": "2.11.3-alpha"
+          },
+          {
+            "Version": "2.11.4-alpha"
+          },
+          {
+            "Version": "2.11.5-alpha"
+          },
+          {
+            "Version": "2.11.6-alpha"
+          },
+          {
+            "Version": "2.11.8-alpha"
+          },
+          {
+            "Version": "2.11.9-alpha"
+          },
+          {
+            "Version": "2.11.10-alpha"
+          },
+          {
+            "Version": "2.11.11-alpha"
+          },
+          {
+            "Version": "2.11.12-alpha"
+          },
+          {
+            "Version": "2.11.13-alpha"
+          },
+          {
+            "Version": "2.11.14-alpha"
+          },
+          {
+            "Version": "2.11.15-alpha"
+          },
+          {
+            "Version": "2.11.16-alpha"
+          },
+          {
+            "Version": "2.11.17-alpha"
+          },
+          {
+            "Version": "2.11.18-alpha"
+          },
+          {
+            "Version": "2.11.19-alpha"
+          },
+          {
+            "Version": "2.11.20-alpha"
+          },
+          {
+            "Version": "2.11.21-alpha"
+          },
+          {
+            "Version": "2.11.22-alpha"
+          },
+          {
+            "Version": "2.11.25-alpha"
+          },
+          {
+            "Version": "2.11.27-alpha"
+          },
+          {
+            "Version": "2.11.28-alpha"
+          },
+          {
+            "Version": "2.11.29-alpha"
+          },
+          {
+            "Version": "2.11.30-alpha"
+          },
+          {
+            "Version": "2.11.31-alpha"
+          },
+          {
+            "Version": "2.11.32-alpha"
+          },
+          {
+            "Version": "2.11.33-alpha"
+          },
+          {
+            "Version": "2.11.40-alpha"
+          },
+          {
+            "Version": "2.11.41-alpha"
+          },
+          {
+            "Version": "2.11.50-alpha"
+          },
+          {
+            "Version": "2.11.51-alpha"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.2"
+          },
+          {
+            "Version": "2.13.0-alpha1"
+          },
+          {
+            "Version": "2.13.0-alpha2"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.12"
+          },
+          {
+            "Version": "2.14.13"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.15.7"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "2.16.3"
+          },
+          {
+            "Version": "2.17.0"
+          },
+          {
+            "Version": "2.17.1"
+          },
+          {
+            "Version": "2.17.2"
+          },
+          {
+            "Version": "2.17.3-alpha1"
+          },
+          {
+            "Version": "2.17.3-alpha2"
+          },
+          {
+            "Version": "2.17.3"
+          },
+          {
+            "Version": "2.17.4"
+          },
+          {
+            "Version": "2.17.5"
+          },
+          {
+            "Version": "2.17.6"
+          },
+          {
+            "Version": "2.17.7"
+          },
+          {
+            "Version": "2.17.8"
+          },
+          {
+            "Version": "2.17.9"
+          },
+          {
+            "Version": "2.18.0-alpha1"
+          },
+          {
+            "Version": "2.18.0-alpha2"
+          },
+          {
+            "Version": "2.18.0-alpha3"
+          },
+          {
+            "Version": "2.18.0"
+          },
+          {
+            "Version": "2.18.1"
+          },
+          {
+            "Version": "2.18.2"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha10"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "3.2.5"
+          },
+          {
+            "Version": "3.2.6"
+          },
+          {
+            "Version": "3.2.7"
+          },
+          {
+            "Version": "3.2.8"
+          },
+          {
+            "Version": "3.2.9"
+          },
+          {
+            "Version": "3.2.10"
+          },
+          {
+            "Version": "3.2.11"
+          },
+          {
+            "Version": "3.2.12"
+          },
+          {
+            "Version": "3.2.13"
+          },
+          {
+            "Version": "3.2.14"
+          },
+          {
+            "Version": "3.2.15"
+          },
+          {
+            "Version": "3.2.16"
+          },
+          {
+            "Version": "3.2.17"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "3.5.9"
+          },
+          {
+            "Version": "3.5.10"
+          },
+          {
+            "Version": "3.5.11"
+          },
+          {
+            "Version": "3.5.12"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.7.8"
+          },
+          {
+            "Version": "3.7.9"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.8.3"
+          },
+          {
+            "Version": "3.8.4"
+          },
+          {
+            "Version": "3.8.5"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "3.9.4"
+          },
+          {
+            "Version": "3.9.5"
+          },
+          {
+            "Version": "3.9.6"
+          },
+          {
+            "Version": "3.9.7"
+          },
+          {
+            "Version": "3.9.8"
+          },
+          {
+            "Version": "3.9.9"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.11.2"
+          },
+          {
+            "Version": "3.11.3"
+          },
+          {
+            "Version": "3.11.4"
+          },
+          {
+            "Version": "3.12.2"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.13.2"
+          },
+          {
+            "Version": "3.13.3"
+          },
+          {
+            "Version": "3.13.4"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.14.1"
+          },
+          {
+            "Version": "3.14.2"
+          },
+          {
+            "Version": "3.14.3"
+          },
+          {
+            "Version": "3.14.4"
+          },
+          {
+            "Version": "3.14.5"
+          },
+          {
+            "Version": "3.14.6"
+          },
+          {
+            "Version": "3.14.7"
+          },
+          {
+            "Version": "3.14.8"
+          },
+          {
+            "Version": "3.14.9"
+          },
+          {
+            "Version": "3.14.10"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.17.1"
+          },
+          {
+            "Version": "3.17.2"
+          },
+          {
+            "Version": "3.17.3"
+          },
+          {
+            "Version": "3.17.4"
+          },
+          {
+            "Version": "3.17.5"
+          },
+          {
+            "Version": "3.17.6"
+          },
+          {
+            "Version": "3.17.7"
+          },
+          {
+            "Version": "3.17.8"
+          },
+          {
+            "Version": "3.17.9"
+          },
+          {
+            "Version": "3.17.11"
+          },
+          {
+            "Version": "3.17.12"
+          },
+          {
+            "Version": "3.17.13"
+          },
+          {
+            "Version": "3.17.14"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.19.3"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.25.1"
+          },
+          {
+            "Version": "3.25.2"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.26.1"
+          },
+          {
+            "Version": "3.26.3"
+          },
+          {
+            "Version": "3.26.4"
+          },
+          {
+            "Version": "3.26.5"
+          },
+          {
+            "Version": "3.26.6"
+          },
+          {
+            "Version": "3.26.7"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.27.1"
+          },
+          {
+            "Version": "3.27.2"
+          },
+          {
+            "Version": "3.27.3"
+          },
+          {
+            "Version": "3.27.4"
+          },
+          {
+            "Version": "3.27.5"
+          },
+          {
+            "Version": "3.27.6"
+          },
+          {
+            "Version": "3.27.7"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.28.1"
+          },
+          {
+            "Version": "3.28.2"
+          },
+          {
+            "Version": "3.28.3"
+          },
+          {
+            "Version": "3.28.4"
+          },
+          {
+            "Version": "3.28.5"
+          },
+          {
+            "Version": "3.28.6"
+          },
+          {
+            "Version": "3.28.7"
+          },
+          {
+            "Version": "3.28.8"
+          },
+          {
+            "Version": "3.29.1"
+          },
+          {
+            "Version": "3.29.2"
+          },
+          {
+            "Version": "3.29.3"
+          },
+          {
+            "Version": "3.29.4"
+          },
+          {
+            "Version": "3.29.5"
+          },
+          {
+            "Version": "3.29.6"
+          },
+          {
+            "Version": "3.29.7"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.31.4"
+          },
+          {
+            "Version": "3.32.4"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.34.3"
+          },
+          {
+            "Version": "3.34.4"
+          },
+          {
+            "Version": "3.34.5"
+          },
+          {
+            "Version": "3.34.6"
+          },
+          {
+            "Version": "3.34.7"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.35.2"
+          },
+          {
+            "Version": "3.35.3"
+          },
+          {
+            "Version": "3.35.4"
+          },
+          {
+            "Version": "3.35.5"
+          },
+          {
+            "Version": "3.36.0"
+          },
+          {
+            "Version": "3.37.0"
+          },
+          {
+            "Version": "3.37.1"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-alpha002"
+          },
+          {
+            "Version": "4.0.0-alpha003"
+          },
+          {
+            "Version": "4.0.0-alpha004"
+          },
+          {
+            "Version": "4.0.0-alpha005"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3"
+          },
+          {
+            "Version": "4.1.4"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1-alpha001"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "4.3.2"
+          },
+          {
+            "Version": "4.3.3"
+          },
+          {
+            "Version": "4.3.4"
+          },
+          {
+            "Version": "4.3.7"
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.4.1"
+          },
+          {
+            "Version": "4.4.2"
+          },
+          {
+            "Version": "4.4.3"
+          },
+          {
+            "Version": "4.4.4"
+          },
+          {
+            "Version": "4.4.5"
+          },
+          {
+            "Version": "4.4.6"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.6.0-alpha001"
+          },
+          {
+            "Version": "4.6.0-alpha002"
+          },
+          {
+            "Version": "4.6.0"
+          },
+          {
+            "Version": "4.6.1"
+          },
+          {
+            "Version": "4.6.2"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.6.4"
+          },
+          {
+            "Version": "4.7.0-alpha001"
+          },
+          {
+            "Version": "4.7.0-alpha002"
+          },
+          {
+            "Version": "4.7.0"
+          },
+          {
+            "Version": "4.7.1"
+          },
+          {
+            "Version": "4.7.2"
+          },
+          {
+            "Version": "4.7.3"
+          },
+          {
+            "Version": "4.8.0"
+          },
+          {
+            "Version": "4.9.0"
+          },
+          {
+            "Version": "4.9.1"
+          },
+          {
+            "Version": "4.9.2"
+          },
+          {
+            "Version": "4.9.3"
+          },
+          {
+            "Version": "4.9.5"
+          },
+          {
+            "Version": "4.9.6"
+          },
+          {
+            "Version": "4.9.7"
+          },
+          {
+            "Version": "4.9.8"
+          },
+          {
+            "Version": "4.10.0"
+          },
+          {
+            "Version": "4.10.1"
+          },
+          {
+            "Version": "4.10.3"
+          },
+          {
+            "Version": "4.10.4"
+          },
+          {
+            "Version": "4.10.5"
+          },
+          {
+            "Version": "4.11.0"
+          },
+          {
+            "Version": "4.11.1"
+          },
+          {
+            "Version": "4.11.2"
+          },
+          {
+            "Version": "4.11.3"
+          },
+          {
+            "Version": "4.12.0"
+          },
+          {
+            "Version": "4.12.2"
+          },
+          {
+            "Version": "4.13.0"
+          },
+          {
+            "Version": "4.13.1"
+          },
+          {
+            "Version": "4.14.0"
+          },
+          {
+            "Version": "4.14.1"
+          },
+          {
+            "Version": "4.14.2"
+          },
+          {
+            "Version": "4.14.3"
+          },
+          {
+            "Version": "4.14.4"
+          },
+          {
+            "Version": "4.14.5"
+          },
+          {
+            "Version": "4.14.7"
+          },
+          {
+            "Version": "4.14.8"
+          },
+          {
+            "Version": "4.14.9"
+          },
+          {
+            "Version": "4.15.0"
+          },
+          {
+            "Version": "4.15.1"
+          },
+          {
+            "Version": "4.15.2"
+          },
+          {
+            "Version": "4.16.0-alpha001"
+          },
+          {
+            "Version": "4.16.0"
+          },
+          {
+            "Version": "4.16.1"
+          },
+          {
+            "Version": "4.17.0-alpha001"
+          },
+          {
+            "Version": "4.17.0-alpha002"
+          },
+          {
+            "Version": "4.17.0-alpha003"
+          },
+          {
+            "Version": "4.17.0-alpha004"
+          },
+          {
+            "Version": "4.17.0-alpha005"
+          },
+          {
+            "Version": "4.17.0-alpha007"
+          },
+          {
+            "Version": "4.17.0"
+          },
+          {
+            "Version": "4.17.1"
+          },
+          {
+            "Version": "4.18.0"
+          },
+          {
+            "Version": "4.19.0"
+          },
+          {
+            "Version": "4.20.0"
+          },
+          {
+            "Version": "4.21.0"
+          },
+          {
+            "Version": "4.21.1"
+          },
+          {
+            "Version": "4.21.2"
+          },
+          {
+            "Version": "4.21.3"
+          },
+          {
+            "Version": "4.21.4"
+          },
+          {
+            "Version": "4.22.0"
+          },
+          {
+            "Version": "4.22.1"
+          },
+          {
+            "Version": "4.22.2"
+          },
+          {
+            "Version": "4.22.3"
+          },
+          {
+            "Version": "4.22.4"
+          },
+          {
+            "Version": "4.22.5"
+          },
+          {
+            "Version": "4.22.6"
+          },
+          {
+            "Version": "4.22.7"
+          },
+          {
+            "Version": "4.22.8"
+          },
+          {
+            "Version": "4.22.9"
+          },
+          {
+            "Version": "4.23.0"
+          },
+          {
+            "Version": "4.23.1"
+          },
+          {
+            "Version": "4.23.2"
+          },
+          {
+            "Version": "4.23.3"
+          },
+          {
+            "Version": "4.23.4"
+          },
+          {
+            "Version": "4.23.5"
+          },
+          {
+            "Version": "4.23.6"
+          },
+          {
+            "Version": "4.24.0"
+          },
+          {
+            "Version": "4.24.1"
+          },
+          {
+            "Version": "4.24.2"
+          },
+          {
+            "Version": "4.24.3"
+          },
+          {
+            "Version": "4.25.0"
+          },
+          {
+            "Version": "4.25.1"
+          },
+          {
+            "Version": "4.25.2"
+          },
+          {
+            "Version": "4.25.3"
+          },
+          {
+            "Version": "4.25.4"
+          },
+          {
+            "Version": "4.25.5"
+          },
+          {
+            "Version": "4.26.0"
+          },
+          {
+            "Version": "4.27.0"
+          },
+          {
+            "Version": "4.28.0"
+          },
+          {
+            "Version": "4.29.0"
+          },
+          {
+            "Version": "4.29.1"
+          },
+          {
+            "Version": "4.29.2"
+          },
+          {
+            "Version": "4.30.0"
+          },
+          {
+            "Version": "4.30.1"
+          },
+          {
+            "Version": "4.30.2"
+          },
+          {
+            "Version": "4.31.0"
+          },
+          {
+            "Version": "4.31.1"
+          },
+          {
+            "Version": "4.32.0"
+          },
+          {
+            "Version": "4.33.0"
+          },
+          {
+            "Version": "4.33.1"
+          },
+          {
+            "Version": "4.33.2"
+          },
+          {
+            "Version": "4.33.3"
+          },
+          {
+            "Version": "4.33.4"
+          },
+          {
+            "Version": "4.34.0"
+          },
+          {
+            "Version": "4.34.1"
+          },
+          {
+            "Version": "4.34.2"
+          },
+          {
+            "Version": "4.34.3"
+          },
+          {
+            "Version": "4.34.4"
+          },
+          {
+            "Version": "4.34.5"
+          },
+          {
+            "Version": "4.35.0"
+          },
+          {
+            "Version": "4.35.1"
+          },
+          {
+            "Version": "4.36.0"
+          },
+          {
+            "Version": "4.37.0"
+          },
+          {
+            "Version": "4.37.1"
+          },
+          {
+            "Version": "4.37.2"
+          },
+          {
+            "Version": "4.38.0"
+          },
+          {
+            "Version": "4.38.1"
+          },
+          {
+            "Version": "4.38.2"
+          },
+          {
+            "Version": "4.38.3"
+          },
+          {
+            "Version": "4.39.0"
+          },
+          {
+            "Version": "4.39.1"
+          },
+          {
+            "Version": "4.40.0"
+          },
+          {
+            "Version": "4.40.1"
+          },
+          {
+            "Version": "4.40.2"
+          },
+          {
+            "Version": "4.41.0"
+          },
+          {
+            "Version": "4.41.1"
+          },
+          {
+            "Version": "4.41.2"
+          },
+          {
+            "Version": "4.41.3"
+          },
+          {
+            "Version": "4.41.4"
+          },
+          {
+            "Version": "4.41.5"
+          },
+          {
+            "Version": "4.41.6"
+          },
+          {
+            "Version": "4.41.7"
+          },
+          {
+            "Version": "4.41.8"
+          },
+          {
+            "Version": "4.42.0"
+          },
+          {
+            "Version": "4.43.0"
+          },
+          {
+            "Version": "4.44.0"
+          },
+          {
+            "Version": "4.44.1"
+          },
+          {
+            "Version": "4.44.2"
+          },
+          {
+            "Version": "4.44.3"
+          },
+          {
+            "Version": "4.44.4"
+          },
+          {
+            "Version": "4.45.0"
+          },
+          {
+            "Version": "4.45.1"
+          },
+          {
+            "Version": "4.45.2"
+          },
+          {
+            "Version": "4.45.3"
+          },
+          {
+            "Version": "4.46.0"
+          },
+          {
+            "Version": "4.46.1"
+          },
+          {
+            "Version": "4.47.0"
+          },
+          {
+            "Version": "4.47.1"
+          },
+          {
+            "Version": "4.47.2"
+          },
+          {
+            "Version": "4.47.4"
+          },
+          {
+            "Version": "4.48.0"
+          },
+          {
+            "Version": "4.49.0"
+          },
+          {
+            "Version": "4.49.1"
+          },
+          {
+            "Version": "4.50.0"
+          },
+          {
+            "Version": "4.50.1"
+          },
+          {
+            "Version": "4.51.1"
+          },
+          {
+            "Version": "4.52.0"
+          },
+          {
+            "Version": "4.53.0"
+          },
+          {
+            "Version": "4.54.0-alpha001"
+          },
+          {
+            "Version": "4.54.0"
+          },
+          {
+            "Version": "4.55.0"
+          },
+          {
+            "Version": "4.55.1"
+          },
+          {
+            "Version": "4.56.0"
+          },
+          {
+            "Version": "4.57.0"
+          },
+          {
+            "Version": "4.57.1"
+          },
+          {
+            "Version": "4.57.2"
+          },
+          {
+            "Version": "4.57.3"
+          },
+          {
+            "Version": "4.57.4"
+          },
+          {
+            "Version": "4.58.2"
+          },
+          {
+            "Version": "4.58.3"
+          },
+          {
+            "Version": "4.58.4"
+          },
+          {
+            "Version": "4.58.5"
+          },
+          {
+            "Version": "4.58.6"
+          },
+          {
+            "Version": "4.59.0-alpha001"
+          },
+          {
+            "Version": "4.59.0-alpha002"
+          },
+          {
+            "Version": "4.59.0"
+          },
+          {
+            "Version": "4.59.1"
+          },
+          {
+            "Version": "4.59.3"
+          },
+          {
+            "Version": "4.60.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/4.60.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001190-transitive-deps/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001190-transitive-deps/cache/paket-graph.cache
@@ -1,0 +1,315 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:18.0393036+02:00",
+        "PackageName": "xunit.extensibility.core",
+        "Versions": [
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "xunit.extensibility.core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/xunit.extensibility.core/2.1.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit.abstractions",
+                  "VersionRequirement": "2.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:18.5963078+02:00",
+        "PackageName": "xunit.extensibility.execution",
+        "Versions": [
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "xunit.extensibility.execution",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/xunit.extensibility.execution/2.1.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "xunit.abstractions",
+                  "VersionRequirement": ">= 2.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "xunit.extensibility.core",
+                  "VersionRequirement": "2.1",
+                  "FrameworkRestrictions": "dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, wpav8.1, >= net45"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:17.6963045+02:00",
+        "PackageName": "xunit.assert",
+        "Versions": [
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "xunit.assert",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/xunit.assert/2.1.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:17.5818075+02:00",
+        "PackageName": "xunit.abstractions",
+        "Versions": [
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "xunit.abstractions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/xunit.abstractions/2.0.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:17.4678055+02:00",
+        "PackageName": "xunit",
+        "Versions": [
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "xunit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/xunit/2.1.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit.assert",
+                  "VersionRequirement": "2.1"
+                },
+                {
+                  "PackageName": "xunit.core",
+                  "VersionRequirement": "2.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:17.8163036+02:00",
+        "PackageName": "xunit.core",
+        "Versions": [
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "xunit.core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/xunit.core/2.1.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/xunit/xunit/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "xunit.abstractions",
+                  "VersionRequirement": ">= 2.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "xunit.extensibility.core",
+                  "VersionRequirement": "2.1",
+                  "FrameworkRestrictions": "dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, wpav8.1, portable-net45+win80+wp80+wpa81, >= net45"
+                },
+                {
+                  "PackageName": "xunit.extensibility.execution",
+                  "VersionRequirement": "2.1",
+                  "FrameworkRestrictions": "dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.0, wpav8.1, portable-net45+win80+wp80+wpa81, >= net45"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001195-broken-appconfig/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001195-broken-appconfig/cache/paket-graph.cache
@@ -1,0 +1,914 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:34",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "3.0.0.3001",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.0.0.3001",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:33",
+        "PackageName": "Albedo",
+        "Versions": [
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "Albedo",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Albedo/1.0.2",
+              "LicenseUrl": "https://raw2.github.com/ploeh/Albedo/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:34",
+        "PackageName": "AutoFixture.Idioms",
+        "Versions": [
+          {
+            "Version": "3.35.1",
+            "PackageDetails": {
+              "Name": "AutoFixture.Idioms",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture.Idioms/3.35.1",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Albedo",
+                  "VersionRequirement": ">= 1.0.1"
+                },
+                {
+                  "PackageName": "autofixture",
+                  "VersionRequirement": ">= 3.35.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:34",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "3.3.3",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Core/3.3.3",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:34",
+        "PackageName": "Castle.Windsor.Extensions",
+        "Versions": [
+          {
+            "Version": "2.1.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor.Extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor.Extensions/2.1.1",
+              "LicenseUrl": "http://www.gnu.org/licenses/lgpl-2.1.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.0.0.3001",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.0.0.3001",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:32.2961687+02:00",
+        "PackageName": "xunit.extensions",
+        "Versions": [
+          {
+            "Version": "1.7.0.1540"
+          },
+          {
+            "Version": "1.8.0.1545"
+          },
+          {
+            "Version": "1.8.0.1549",
+            "PackageDetails": {
+              "Name": "xunit.extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit.extensions/1.8.0.1549",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit",
+                  "VersionRequirement": ">= 1.8.0.1549"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.9.0.1566"
+          },
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.9.2",
+            "PackageDetails": {
+              "Name": "xunit.extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit.extensions/1.9.2",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit",
+                  "VersionRequirement": "1.9.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-alpha-build1611"
+          },
+          {
+            "Version": "2.0.0-rc4-build2924"
+          },
+          {
+            "Version": "2.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:35",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "2.0.3",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.3",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:36",
+        "PackageName": "Newtonsoft.Json.Schema",
+        "Versions": [
+          {
+            "Version": "1.0.11",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json.Schema",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json.Schema/1.0.11",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:36",
+        "PackageName": "xunit",
+        "Versions": [
+          {
+            "Version": "1.9.2",
+            "PackageDetails": {
+              "Name": "xunit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit/1.9.2",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:34",
+        "PackageName": "AutoFixture.Xunit",
+        "Versions": [
+          {
+            "Version": "3.36.9",
+            "PackageDetails": {
+              "Name": "AutoFixture.Xunit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture.Xunit/3.36.9",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "autofixture",
+                  "VersionRequirement": ">= 3.36.9"
+                },
+                {
+                  "PackageName": "xunit.extensions",
+                  "VersionRequirement": ">= 1.8.0.1549 < 2.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:31.297172+02:00",
+        "PackageName": "autofixture",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.2.44"
+          },
+          {
+            "Version": "2.2.45"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.11.1"
+          },
+          {
+            "Version": "2.11.2"
+          },
+          {
+            "Version": "2.11.3"
+          },
+          {
+            "Version": "2.11.4"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.0.9"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.6.2"
+          },
+          {
+            "Version": "3.6.3"
+          },
+          {
+            "Version": "3.6.4"
+          },
+          {
+            "Version": "3.6.5"
+          },
+          {
+            "Version": "3.6.6"
+          },
+          {
+            "Version": "3.6.7"
+          },
+          {
+            "Version": "3.6.8"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.12.0"
+          },
+          {
+            "Version": "3.12.1"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.15.1"
+          },
+          {
+            "Version": "3.16.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.16.3"
+          },
+          {
+            "Version": "3.16.4"
+          },
+          {
+            "Version": "3.16.5"
+          },
+          {
+            "Version": "3.16.6"
+          },
+          {
+            "Version": "3.16.7"
+          },
+          {
+            "Version": "3.16.8"
+          },
+          {
+            "Version": "3.16.9"
+          },
+          {
+            "Version": "3.16.10"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.18.3"
+          },
+          {
+            "Version": "3.18.4"
+          },
+          {
+            "Version": "3.18.5"
+          },
+          {
+            "Version": "3.18.6"
+          },
+          {
+            "Version": "3.18.7"
+          },
+          {
+            "Version": "3.18.8"
+          },
+          {
+            "Version": "3.18.9"
+          },
+          {
+            "Version": "3.18.10"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.20.2"
+          },
+          {
+            "Version": "3.20.3"
+          },
+          {
+            "Version": "3.20.4"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.21.1"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.23.1"
+          },
+          {
+            "Version": "3.23.2"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.24.1"
+          },
+          {
+            "Version": "3.24.2"
+          },
+          {
+            "Version": "3.24.3"
+          },
+          {
+            "Version": "3.24.4"
+          },
+          {
+            "Version": "3.24.5"
+          },
+          {
+            "Version": "3.24.6"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.29.0"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.30.4"
+          },
+          {
+            "Version": "3.30.5"
+          },
+          {
+            "Version": "3.30.6"
+          },
+          {
+            "Version": "3.30.7"
+          },
+          {
+            "Version": "3.30.8"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.32.0"
+          },
+          {
+            "Version": "3.32.2"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.36.0"
+          },
+          {
+            "Version": "3.36.1"
+          },
+          {
+            "Version": "3.36.2"
+          },
+          {
+            "Version": "3.36.3"
+          },
+          {
+            "Version": "3.36.4"
+          },
+          {
+            "Version": "3.36.5"
+          },
+          {
+            "Version": "3.36.6"
+          },
+          {
+            "Version": "3.36.7"
+          },
+          {
+            "Version": "3.36.8"
+          },
+          {
+            "Version": "3.36.9",
+            "PackageDetails": {
+              "Name": "AutoFixture",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture/3.36.9",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.36.10"
+          },
+          {
+            "Version": "3.36.11"
+          },
+          {
+            "Version": "3.36.12"
+          },
+          {
+            "Version": "3.37.0"
+          },
+          {
+            "Version": "3.37.1"
+          },
+          {
+            "Version": "3.37.2"
+          },
+          {
+            "Version": "3.37.3"
+          },
+          {
+            "Version": "3.38.0"
+          },
+          {
+            "Version": "3.38.1"
+          },
+          {
+            "Version": "3.39.0"
+          },
+          {
+            "Version": "3.40.0"
+          },
+          {
+            "Version": "3.40.1"
+          },
+          {
+            "Version": "3.41.0"
+          },
+          {
+            "Version": "3.41.1"
+          },
+          {
+            "Version": "3.42.0"
+          },
+          {
+            "Version": "3.43.0"
+          },
+          {
+            "Version": "3.43.1"
+          },
+          {
+            "Version": "3.43.2"
+          },
+          {
+            "Version": "3.43.3"
+          },
+          {
+            "Version": "3.43.4"
+          },
+          {
+            "Version": "3.44.0"
+          },
+          {
+            "Version": "3.44.1"
+          },
+          {
+            "Version": "3.45.0"
+          },
+          {
+            "Version": "3.45.1"
+          },
+          {
+            "Version": "3.45.2"
+          },
+          {
+            "Version": "3.45.3"
+          },
+          {
+            "Version": "3.46.0"
+          },
+          {
+            "Version": "3.47.0"
+          },
+          {
+            "Version": "3.47.1"
+          },
+          {
+            "Version": "3.47.2"
+          },
+          {
+            "Version": "3.47.3"
+          },
+          {
+            "Version": "3.47.4"
+          },
+          {
+            "Version": "3.47.5"
+          },
+          {
+            "Version": "3.47.6"
+          },
+          {
+            "Version": "3.47.7"
+          },
+          {
+            "Version": "3.47.8"
+          },
+          {
+            "Version": "3.48.0"
+          },
+          {
+            "Version": "3.49.0"
+          },
+          {
+            "Version": "3.49.1"
+          },
+          {
+            "Version": "3.50.0"
+          },
+          {
+            "Version": "3.50.1"
+          },
+          {
+            "Version": "3.50.2",
+            "PackageDetails": {
+              "Name": "AutoFixture",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture/3.50.2",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:35",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001197-too-strict-frameworks/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001197-too-strict-frameworks/cache/paket-graph.cache
@@ -1,0 +1,1500 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:47.5886402+02:00",
+        "PackageName": "NEST",
+        "Versions": [
+          {
+            "Version": "0.9.0.2"
+          },
+          {
+            "Version": "0.9.1.0"
+          },
+          {
+            "Version": "0.9.2.0"
+          },
+          {
+            "Version": "0.9.3.0"
+          },
+          {
+            "Version": "0.9.4.0"
+          },
+          {
+            "Version": "0.9.5.0"
+          },
+          {
+            "Version": "0.9.6.0"
+          },
+          {
+            "Version": "0.9.7.0"
+          },
+          {
+            "Version": "0.9.8.0"
+          },
+          {
+            "Version": "0.9.9.0"
+          },
+          {
+            "Version": "0.9.10.0"
+          },
+          {
+            "Version": "0.9.11.0"
+          },
+          {
+            "Version": "0.9.12.0"
+          },
+          {
+            "Version": "0.9.13.0"
+          },
+          {
+            "Version": "0.9.14.0"
+          },
+          {
+            "Version": "0.9.15.0"
+          },
+          {
+            "Version": "0.9.16.0"
+          },
+          {
+            "Version": "0.9.17.0"
+          },
+          {
+            "Version": "0.9.18.0"
+          },
+          {
+            "Version": "0.9.19.0"
+          },
+          {
+            "Version": "0.9.20.0"
+          },
+          {
+            "Version": "0.9.21.0"
+          },
+          {
+            "Version": "0.9.22.0"
+          },
+          {
+            "Version": "0.9.23.0"
+          },
+          {
+            "Version": "0.9.24.0"
+          },
+          {
+            "Version": "0.10.0.0"
+          },
+          {
+            "Version": "0.10.1.0"
+          },
+          {
+            "Version": "0.11.0.0"
+          },
+          {
+            "Version": "0.11.1.0"
+          },
+          {
+            "Version": "0.11.2.0"
+          },
+          {
+            "Version": "0.11.3.0"
+          },
+          {
+            "Version": "0.11.4.0"
+          },
+          {
+            "Version": "0.11.5.0"
+          },
+          {
+            "Version": "0.11.7.0"
+          },
+          {
+            "Version": "0.12.0.0"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.7.1"
+          },
+          {
+            "Version": "1.7.2"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.2"
+          },
+          {
+            "Version": "1.8.3"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.9.2"
+          },
+          {
+            "Version": "2.0.0-alpha1"
+          },
+          {
+            "Version": "2.0.0-alpha2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.3"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "5.0.0-alpha1"
+          },
+          {
+            "Version": "5.0.0-alpha2"
+          },
+          {
+            "Version": "5.0.0-alpha3"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0-rc2"
+          },
+          {
+            "Version": "5.0.0-rc3"
+          },
+          {
+            "Version": "5.0.0-rc4"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.3.0"
+          },
+          {
+            "Version": "5.3.1",
+            "PackageDetails": {
+              "Name": "NEST",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NEST/5.3.1",
+              "LicenseUrl": "https://github.com/elastic/elasticsearch-net/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Elasticsearch.Net",
+                  "VersionRequirement": ">= 5.3.1 < 6.0",
+                  "FrameworkRestrictions": "net45, >= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 10.0 < 11.0",
+                  "FrameworkRestrictions": "net45, >= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:45.7356632+02:00",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.3",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7"
+          },
+          {
+            "Version": "2.0.8",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.8",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.StackTrace",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Watcher",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:46.8101381+02:00",
+        "PackageName": "log4net.ElasticSearch",
+        "Versions": [
+          {
+            "Version": "0.2.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.2.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.19.16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.3.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.3.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.9.16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.3.1",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.3.1",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.9.16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.4.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.4.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.9.16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.5.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.5.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.9.16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.6.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.6.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.9.16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.7.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.7.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.10.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.8.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.8.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.10.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.9.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.9.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.10"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.10.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.9.1",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.9.1",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.10"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.10.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.9.2",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.9.2",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.10"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.10.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.9.3",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.9.3",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.11.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.9.4",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.9.4",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.11.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.9.5",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.9.5",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.11.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.10.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.10.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.11.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.11.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/0.11.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 1.2.11"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.11.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.0-alpha"
+          },
+          {
+            "Version": "1.0.0-beta"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0-beta3"
+          },
+          {
+            "Version": "1.0.0-beta4"
+          },
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/1.0.0",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 2.0.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.12",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/1.1",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 2.0.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "NEST",
+                  "VersionRequirement": ">= 0.12",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.2-beta"
+          },
+          {
+            "Version": "1.2.0-beta2"
+          },
+          {
+            "Version": "1.2.0-beta3"
+          },
+          {
+            "Version": "1.2.0-beta4"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.3.0-alpha"
+          },
+          {
+            "Version": "1.3.0-alpha1"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.3"
+          },
+          {
+            "Version": "2.3.4",
+            "PackageDetails": {
+              "Name": "log4net.ElasticSearch",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net.ElasticSearch/2.3.4",
+              "LicenseUrl": "https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 2.0.3",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:48.0901373+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:45.2826362+02:00",
+        "PackageName": "Elasticsearch.Net",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.7.1"
+          },
+          {
+            "Version": "1.7.2"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.2"
+          },
+          {
+            "Version": "1.8.3"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.9.2"
+          },
+          {
+            "Version": "2.0.0-alpha1"
+          },
+          {
+            "Version": "2.0.0-alpha2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.3"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "5.0.0-alpha1"
+          },
+          {
+            "Version": "5.0.0-alpha2"
+          },
+          {
+            "Version": "5.0.0-alpha3"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-rc1"
+          },
+          {
+            "Version": "5.0.0-rc2"
+          },
+          {
+            "Version": "5.0.0-rc3"
+          },
+          {
+            "Version": "5.0.0-rc4"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.3.0"
+          },
+          {
+            "Version": "5.3.1",
+            "PackageDetails": {
+              "Name": "Elasticsearch.Net",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Elasticsearch.Net/5.3.1",
+              "LicenseUrl": "https://github.com/elastic/elasticsearch-net/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001213-framework-propagation/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001213-framework-propagation/cache/paket-graph.cache
@@ -1,0 +1,520 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:50.8931403+02:00",
+        "PackageName": "Nancy",
+        "Versions": [
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.5.0"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.7.1"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.8.1"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.14.1"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.15.1"
+          },
+          {
+            "Version": "0.15.2"
+          },
+          {
+            "Version": "0.15.3"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.16.1"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.17.1"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.22.1"
+          },
+          {
+            "Version": "0.22.2"
+          },
+          {
+            "Version": "0.23.0"
+          },
+          {
+            "Version": "0.23.1"
+          },
+          {
+            "Version": "0.23.2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1"
+          },
+          {
+            "Version": "1.2.0",
+            "PackageDetails": {
+              "Name": "Nancy",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Nancy/1.2.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3",
+            "PackageDetails": {
+              "Name": "Nancy",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy/1.4.3",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-barneyrubble"
+          },
+          {
+            "Version": "2.0.0-clienteastwood"
+          },
+          {
+            "Version": "2.0.0-clinteastwood"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:51.1681385+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/3.5.8",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:50.9566393+02:00",
+        "PackageName": "Nancy.Serialization.JsonNet",
+        "Versions": [
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.14.1"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.15.1"
+          },
+          {
+            "Version": "0.15.2"
+          },
+          {
+            "Version": "0.15.3"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.16.1"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.17.1"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.22.1"
+          },
+          {
+            "Version": "0.22.2"
+          },
+          {
+            "Version": "0.23.0"
+          },
+          {
+            "Version": "0.23.1"
+          },
+          {
+            "Version": "0.23.2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1"
+          },
+          {
+            "Version": "1.2.0",
+            "PackageDetails": {
+              "Name": "Nancy.Serialization.JsonNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Nancy.Serialization.JsonNet/1.2.0",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Serialization.JsonNet/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 1.2"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1",
+            "PackageDetails": {
+              "Name": "Nancy.Serialization.JsonNet",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Nancy.Serialization.JsonNet/1.4.1",
+              "LicenseUrl": "https://github.com/NancyFx/Nancy.Serialization.JsonNet/blob/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Nancy",
+                  "VersionRequirement": ">= 1.4.1"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-barneyrubble"
+          },
+          {
+            "Version": "2.0.0-clienteastwood"
+          },
+          {
+            "Version": "2.0.0-clinteastwood"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001215-framework-propagation-no-restriction/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001215-framework-propagation-no-restriction/cache/paket-graph.cache
@@ -1,0 +1,865 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:56.58514+02:00",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.3",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.4",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net/2.0.4",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.0.5",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.5",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/log4net/2.0.6",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.StackTrace",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Watcher",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.0.7",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.7",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.StackTrace",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Watcher",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.0.8",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.8",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.StackTrace",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Watcher",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:23:55.853654+02:00",
+        "PackageName": "Microsoft.Bcl.Async",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.12-beta"
+          },
+          {
+            "Version": "1.0.14-rc"
+          },
+          {
+            "Version": "1.0.16",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.16",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=296434",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.0.19"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.165",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.165",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.0.19"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.166-beta"
+          },
+          {
+            "Version": "1.0.166",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.166",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.0.19",
+                  "FrameworkRestrictions": ">= net10"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.7",
+                  "FrameworkRestrictions": "wpav8.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.168",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.168",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:00.4011409+02:00",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.14",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:00.2661431+02:00",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.8",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:32",
+        "PackageName": "Owin",
+        "Versions": [
+          {
+            "Version": "0.5"
+          },
+          {
+            "Version": "0.7"
+          },
+          {
+            "Version": "0.11"
+          },
+          {
+            "Version": "0.12"
+          },
+          {
+            "Version": "0.14"
+          },
+          {
+            "Version": "1.0",
+            "PackageDetails": {
+              "Name": "Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Owin/1.0",
+              "LicenseUrl": "https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:00.8486416+02:00",
+        "PackageName": "Microsoft.Owin",
+        "Versions": [
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Owin/2.1.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Owin/3.0.0",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.1",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Owin/3.0.1",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:32",
+        "PackageName": "OwinMiddlewares.Log4net",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "OwinMiddlewares.Log4net",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/OwinMiddlewares.Log4net/1.0.0",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ">= 2.0.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 2.1",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001217-convert-simple-project/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001217-convert-simple-project/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:33.2442464+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001218-binding-redirect/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001218-binding-redirect/cache/paket-graph.cache
@@ -1,0 +1,291 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:56",
+        "PackageName": "Castle.Windsor",
+        "Versions": [
+          {
+            "Version": "3.0.0.3001",
+            "PackageDetails": {
+              "Name": "Castle.Windsor",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor/3.0.0.3001",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:56",
+        "PackageName": "Albedo",
+        "Versions": [
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "Albedo",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Albedo/1.0.2",
+              "LicenseUrl": "https://raw2.github.com/ploeh/Albedo/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:56",
+        "PackageName": "AutoFixture.Idioms",
+        "Versions": [
+          {
+            "Version": "3.35.1",
+            "PackageDetails": {
+              "Name": "AutoFixture.Idioms",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture.Idioms/3.35.1",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Albedo",
+                  "VersionRequirement": ">= 1.0.1"
+                },
+                {
+                  "PackageName": "autofixture",
+                  "VersionRequirement": ">= 3.35.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:56",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "3.3.3",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Core/3.3.3",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:57",
+        "PackageName": "Castle.Windsor.Extensions",
+        "Versions": [
+          {
+            "Version": "2.1.1",
+            "PackageDetails": {
+              "Name": "Castle.Windsor.Extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Castle.Windsor.Extensions/2.1.1",
+              "LicenseUrl": "http://www.gnu.org/licenses/lgpl-2.1.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Castle.Core",
+                  "VersionRequirement": ">= 3.0.0.3001",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Castle.Windsor",
+                  "VersionRequirement": ">= 3.0.0.3001",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:22:37.0136692+02:00",
+        "PackageName": "xunit.extensions",
+        "Versions": [
+          {
+            "Version": "1.7.0.1540"
+          },
+          {
+            "Version": "1.8.0.1545"
+          },
+          {
+            "Version": "1.8.0.1549",
+            "PackageDetails": {
+              "Name": "xunit.extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit.extensions/1.8.0.1549",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit",
+                  "VersionRequirement": ">= 1.8.0.1549"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.9.0.1566"
+          },
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.9.2",
+            "PackageDetails": {
+              "Name": "xunit.extensions",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit.extensions/1.9.2",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "xunit",
+                  "VersionRequirement": "1.9.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-alpha-build1611"
+          },
+          {
+            "Version": "2.0.0-rc4-build2924"
+          },
+          {
+            "Version": "2.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:57",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "2.0.3",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.3",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:58",
+        "PackageName": "Newtonsoft.Json.Schema",
+        "Versions": [
+          {
+            "Version": "1.0.11",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json.Schema",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json.Schema/1.0.11",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:58",
+        "PackageName": "xunit",
+        "Versions": [
+          {
+            "Version": "1.9.2",
+            "PackageDetails": {
+              "Name": "xunit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/xunit/1.9.2",
+              "LicenseUrl": "http://xunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:56",
+        "PackageName": "AutoFixture.Xunit",
+        "Versions": [
+          {
+            "Version": "3.36.9",
+            "PackageDetails": {
+              "Name": "AutoFixture.Xunit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture.Xunit/3.36.9",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "autofixture",
+                  "VersionRequirement": ">= 3.36.9"
+                },
+                {
+                  "PackageName": "xunit.extensions",
+                  "VersionRequirement": ">= 1.8.0.1549 < 2.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:56",
+        "PackageName": "AutoFixture",
+        "Versions": [
+          {
+            "Version": "3.36.9",
+            "PackageDetails": {
+              "Name": "AutoFixture",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/AutoFixture/3.36.9",
+              "LicenseUrl": "https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:34:57",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001219-props-files/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001219-props-files/cache/paket-graph.cache
@@ -1,0 +1,60 @@
+{
+  "nuget_repo": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:45.695888+02:00",
+        "PackageName": "Dapper",
+        "Versions": [
+          {
+            "Version": "1.40"
+          },
+          {
+            "Version": "1.42.0",
+            "PackageDetails": {
+              "Name": "Dapper",
+              "DownloadLink": "Dapper",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:45.7829036+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "NUnit",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:45.7193887+02:00",
+        "PackageName": "MultiTarget",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "MultiTarget",
+              "DownloadLink": "MultiTarget",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001225-convert-simple-project-non-matching-restrictions/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001225-convert-simple-project-non-matching-restrictions/cache/paket-graph.cache
@@ -1,0 +1,40 @@
+{
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:40.4027962+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:40.0802436+02:00",
+        "PackageName": "Castle.Core",
+        "Versions": [
+          {
+            "Version": "3.3.3",
+            "PackageDetails": {
+              "Name": "Castle.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Castle.Core/3.3.3",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001232-sql-lite/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001232-sql-lite/cache/paket-graph.cache
@@ -1,0 +1,559 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:05.8101415+02:00",
+        "PackageName": "System.Data.SQLite.Core",
+        "Versions": [
+          {
+            "Version": "1.0.91.0"
+          },
+          {
+            "Version": "1.0.91.3"
+          },
+          {
+            "Version": "1.0.92.0"
+          },
+          {
+            "Version": "1.0.93.0"
+          },
+          {
+            "Version": "1.0.94.0"
+          },
+          {
+            "Version": "1.0.95.0"
+          },
+          {
+            "Version": "1.0.96.0"
+          },
+          {
+            "Version": "1.0.97.0"
+          },
+          {
+            "Version": "1.0.98.0"
+          },
+          {
+            "Version": "1.0.98.1",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.98.1",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.99.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.99.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.100.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.100.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.101.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.101.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.102.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.102.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.103",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.103",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.104.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.104.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.105.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Core/1.0.105.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:07.4699185+02:00",
+        "PackageName": "System.Data.SQLite.EF6",
+        "Versions": [
+          {
+            "Version": "1.0.91.0"
+          },
+          {
+            "Version": "1.0.91.3"
+          },
+          {
+            "Version": "1.0.92.0"
+          },
+          {
+            "Version": "1.0.93.0"
+          },
+          {
+            "Version": "1.0.94.0"
+          },
+          {
+            "Version": "1.0.95.0"
+          },
+          {
+            "Version": "1.0.96.0"
+          },
+          {
+            "Version": "1.0.97.0"
+          },
+          {
+            "Version": "1.0.98.0"
+          },
+          {
+            "Version": "1.0.98.1",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.98.1",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.99.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.99.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.100.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.100.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.101.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.101.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.102.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.102.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.103",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.103",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.104.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.104.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.105.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.EF6",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.EF6/1.0.105.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "EntityFramework",
+                  "VersionRequirement": ">= 6.0",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:12.5796209+02:00",
+        "PackageName": "EntityFramework",
+        "Versions": [
+          {
+            "Version": "4.1.10311.0"
+          },
+          {
+            "Version": "4.1.10331.0"
+          },
+          {
+            "Version": "4.1.10715.0"
+          },
+          {
+            "Version": "4.2.0.0"
+          },
+          {
+            "Version": "4.3.0-beta1"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-rc"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "6.0.0-alpha1"
+          },
+          {
+            "Version": "6.0.0-alpha2"
+          },
+          {
+            "Version": "6.0.0-alpha3"
+          },
+          {
+            "Version": "6.0.0-beta1"
+          },
+          {
+            "Version": "6.0.0-rc1"
+          },
+          {
+            "Version": "6.0.0",
+            "PackageDetails": {
+              "Name": "EntityFramework",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/EntityFramework/6.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320539",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2-beta1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.1.0-alpha1"
+          },
+          {
+            "Version": "6.1.0-beta1"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "6.1.1-beta1"
+          },
+          {
+            "Version": "6.1.1"
+          },
+          {
+            "Version": "6.1.2-beta1"
+          },
+          {
+            "Version": "6.1.2-beta2"
+          },
+          {
+            "Version": "6.1.2"
+          },
+          {
+            "Version": "6.1.3-beta1"
+          },
+          {
+            "Version": "6.1.3-beta1-40122"
+          },
+          {
+            "Version": "6.1.3",
+            "PackageDetails": {
+              "Name": "EntityFramework",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/EntityFramework/6.1.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320539",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "7.0.0-beta1"
+          },
+          {
+            "Version": "7.0.0-beta2"
+          },
+          {
+            "Version": "7.0.0-beta3"
+          },
+          {
+            "Version": "7.0.0-beta4"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:24:08.9764174+02:00",
+        "PackageName": "System.Data.SQLite.Linq",
+        "Versions": [
+          {
+            "Version": "1.0.91.0"
+          },
+          {
+            "Version": "1.0.91.3"
+          },
+          {
+            "Version": "1.0.92.0"
+          },
+          {
+            "Version": "1.0.93.0"
+          },
+          {
+            "Version": "1.0.94.0"
+          },
+          {
+            "Version": "1.0.94.1"
+          },
+          {
+            "Version": "1.0.95.0"
+          },
+          {
+            "Version": "1.0.96.0"
+          },
+          {
+            "Version": "1.0.97.0"
+          },
+          {
+            "Version": "1.0.98.0"
+          },
+          {
+            "Version": "1.0.98.1",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.98.1",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.99.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.99.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.100.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.100.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.101.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.101.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.102.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.102.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.103",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.103",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.104.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.104.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.105.0",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite.Linq/1.0.105.0",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:36",
+        "PackageName": "System.Data.SQLite",
+        "Versions": [
+          {
+            "Version": "1.0.98.1",
+            "PackageDetails": {
+              "Name": "System.Data.SQLite",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.SQLite/1.0.98.1",
+              "LicenseUrl": "https://www.sqlite.org/copyright.html",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Data.SQLite.Core",
+                  "VersionRequirement": ">= 1.0.98.1",
+                  "FrameworkRestrictions": "net20, net40, net45, net451, >= net46"
+                },
+                {
+                  "PackageName": "System.Data.SQLite.EF6",
+                  "VersionRequirement": ">= 1.0.98.1",
+                  "FrameworkRestrictions": "net40, net45, net451, >= net46"
+                },
+                {
+                  "PackageName": "System.Data.SQLite.Linq",
+                  "VersionRequirement": ">= 1.0.98.1",
+                  "FrameworkRestrictions": "net20, net40, net45, net451, >= net46"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001247-lockfile-error/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001247-lockfile-error/cache/paket-graph.cache
@@ -1,0 +1,18492 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:46.354766+02:00",
+        "PackageName": "FSharp.Data",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "FSharp.Data",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Data/1.0.0",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Data/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10"
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-alpha2"
+          },
+          {
+            "Version": "2.0.0-alpha3"
+          },
+          {
+            "Version": "2.0.0-alpha4"
+          },
+          {
+            "Version": "2.0.0-alpha5"
+          },
+          {
+            "Version": "2.0.0-alpha6"
+          },
+          {
+            "Version": "2.0.0-alpha7"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-beta3"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7"
+          },
+          {
+            "Version": "2.0.8"
+          },
+          {
+            "Version": "2.0.9"
+          },
+          {
+            "Version": "2.0.10"
+          },
+          {
+            "Version": "2.0.11"
+          },
+          {
+            "Version": "2.0.12"
+          },
+          {
+            "Version": "2.0.13"
+          },
+          {
+            "Version": "2.0.14"
+          },
+          {
+            "Version": "2.0.15"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.0-beta2"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1-beta1"
+          },
+          {
+            "Version": "2.3.1-beta2"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:42",
+        "PackageName": "NUnit.Extension.TeamCityEventListener",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:47",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:43",
+        "PackageName": "System.Runtime.Loader",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:44.7557664+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Core/4.0.0",
+              "LicenseUrl": "",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "4.0.0.1",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.0.0.1",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:41",
+        "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:55",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:27.8291305+02:00",
+        "PackageName": "Rx-Main",
+        "Versions": [
+          {
+            "Version": "1.0.2856"
+          },
+          {
+            "Version": "1.0.10605"
+          },
+          {
+            "Version": "1.0.10621"
+          },
+          {
+            "Version": "1.0.11221"
+          },
+          {
+            "Version": "1.0.11226"
+          },
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:58",
+        "PackageName": "System.Reactive.Linq",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:54",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:57",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:00.0207704+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/3.5.8",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:46",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:57.6157755+02:00",
+        "PackageName": "ILRepack",
+        "Versions": [
+          {
+            "Version": "1.17.0",
+            "PackageDetails": {
+              "Name": "ILRepack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ILRepack/1.17",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.18.0"
+          },
+          {
+            "Version": "1.19.0"
+          },
+          {
+            "Version": "1.20.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.21.2"
+          },
+          {
+            "Version": "1.21.3"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.22.2"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7"
+          },
+          {
+            "Version": "2.0.8"
+          },
+          {
+            "Version": "2.0.9"
+          },
+          {
+            "Version": "2.0.10"
+          },
+          {
+            "Version": "2.0.11"
+          },
+          {
+            "Version": "2.0.12"
+          },
+          {
+            "Version": "2.0.13"
+          },
+          {
+            "Version": "2.1.0-beta1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:44",
+        "PackageName": "System.Reactive.WindowsRuntime",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:39",
+        "PackageName": "NUnit.Extension.NUnitV2Driver",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:47",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:13.192773+02:00",
+        "PackageName": "SnmpSharpNet",
+        "Versions": [
+          {
+            "Version": "0.9.2",
+            "PackageDetails": {
+              "Name": "SnmpSharpNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SnmpSharpNet/0.9.2",
+              "LicenseUrl": "http://opensource.org/licenses/lgpl-3.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.9.3"
+          },
+          {
+            "Version": "0.9.4"
+          },
+          {
+            "Version": "0.9.5"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:51",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:44.0102838+02:00",
+        "PackageName": "FSharp.Control.Reactive",
+        "Versions": [
+          {
+            "Version": "2.3.1",
+            "PackageDetails": {
+              "Name": "FSharp.Control.Reactive",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Control.Reactive/2.3.1",
+              "LicenseUrl": "https://github.com/fsprojects/FSharp.Control.Reactive/raw/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Experimental",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.5"
+          },
+          {
+            "Version": "2.3.6"
+          },
+          {
+            "Version": "2.3.7"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:41",
+        "PackageName": "NUnit.Extension.VSProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:59",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:04.4702704+02:00",
+        "PackageName": "NUnit.Runners",
+        "Versions": [
+          {
+            "Version": "2.6.0.12051",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.0.12051",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:58",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:01.8987712+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.5.7.10213",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/2.5.7.10213",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.5.9.10348"
+          },
+          {
+            "Version": "2.5.10.11092"
+          },
+          {
+            "Version": "2.6.0.12051"
+          },
+          {
+            "Version": "2.6.0.12054"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "3.0.0-alpha"
+          },
+          {
+            "Version": "3.0.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-alpha-3"
+          },
+          {
+            "Version": "3.0.0-alpha-4"
+          },
+          {
+            "Version": "3.0.0-alpha-5"
+          },
+          {
+            "Version": "3.0.0-beta-1"
+          },
+          {
+            "Version": "3.0.0-beta-2"
+          },
+          {
+            "Version": "3.0.0-beta-3"
+          },
+          {
+            "Version": "3.0.0-beta-4"
+          },
+          {
+            "Version": "3.0.0-beta-5"
+          },
+          {
+            "Version": "3.0.0-rc"
+          },
+          {
+            "Version": "3.0.0-rc-2"
+          },
+          {
+            "Version": "3.0.0-rc-3"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:24.8866304+02:00",
+        "PackageName": "Rx-Core",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:52.7237671+02:00",
+        "PackageName": "FSharp.Formatting.CommandTool",
+        "Versions": [
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting.CommandTool",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Formatting.CommandTool/2.4.0",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2"
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:26.1981331+02:00",
+        "PackageName": "Rx-Linq",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:37",
+        "PackageName": "FsLexYacc.Runtime",
+        "Versions": [
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "7.0.0"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "7.0.2"
+          },
+          {
+            "Version": "7.0.3"
+          },
+          {
+            "Version": "7.0.4"
+          },
+          {
+            "Version": "7.0.5"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:38",
+        "PackageName": "NUnit.ConsoleRunner",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:53",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:52",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505"
+          },
+          {
+            "Version": "2.0.20710"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:51",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:38",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:01",
+        "PackageName": "System.Runtime.InteropServices.WindowsRuntime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:48",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:01",
+        "PackageName": "System.Reactive.Interfaces",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:55.9752782+02:00",
+        "PackageName": "FsUnit",
+        "Versions": [
+          {
+            "Version": "0.9.0",
+            "PackageDetails": {
+              "Name": "FsUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FsUnit/0.9.0",
+              "LicenseUrl": "http://fsunit.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit",
+                  "VersionRequirement": ">= 2.5.7.10213"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.1.1"
+          },
+          {
+            "Version": "1.0.0.3"
+          },
+          {
+            "Version": "1.0.0.4"
+          },
+          {
+            "Version": "1.0.0.5"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.0.1"
+          },
+          {
+            "Version": "1.1.0.2"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.0.1"
+          },
+          {
+            "Version": "1.3.1-beta"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0-beta"
+          },
+          {
+            "Version": "1.4.0-beta3"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.4.0-alpha-1"
+          },
+          {
+            "Version": "2.4.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:59",
+        "PackageName": "System.Reactive.Core",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:26.8796308+02:00",
+        "PackageName": "Rx-Providers",
+        "Versions": [
+          {
+            "Version": "1.0.10605"
+          },
+          {
+            "Version": "1.0.10621"
+          },
+          {
+            "Version": "1.0.11221"
+          },
+          {
+            "Version": "1.0.11226"
+          },
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:49",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:50",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:23.5215863+02:00",
+        "PackageName": "Rx-Experimental",
+        "Versions": [
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:40",
+        "PackageName": "NUnit.Extension.NUnitProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:46",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:52",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:25.5581298+02:00",
+        "PackageName": "Rx-Interfaces",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:54",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:50",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:42",
+        "PackageName": "System.Reactive",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:28.4721307+02:00",
+        "PackageName": "Rx-PlatformServices",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:45",
+        "PackageName": "System.Reactive.Windows.Threading",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:54.9127821+02:00",
+        "PackageName": "FsLexYacc",
+        "Versions": [
+          {
+            "Version": "6.0.0",
+            "PackageDetails": {
+              "Name": "FsLexYacc",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FsLexYacc/6.0.0",
+              "LicenseUrl": "http://github.com/fsprojects/FsLexYacc/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "7.0.0"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "7.0.2"
+          },
+          {
+            "Version": "7.0.3"
+          },
+          {
+            "Version": "7.0.4"
+          },
+          {
+            "Version": "7.0.5"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:19:42.4926345+02:00",
+        "PackageName": "FAKE",
+        "Versions": [
+          {
+            "Version": "1.46.1"
+          },
+          {
+            "Version": "1.46.2"
+          },
+          {
+            "Version": "1.48.0"
+          },
+          {
+            "Version": "1.50.0"
+          },
+          {
+            "Version": "1.50.1"
+          },
+          {
+            "Version": "1.50.2"
+          },
+          {
+            "Version": "1.50.3"
+          },
+          {
+            "Version": "1.50.4"
+          },
+          {
+            "Version": "1.52.0"
+          },
+          {
+            "Version": "1.52.1"
+          },
+          {
+            "Version": "1.52.5"
+          },
+          {
+            "Version": "1.52.6"
+          },
+          {
+            "Version": "1.54.0"
+          },
+          {
+            "Version": "1.54.1"
+          },
+          {
+            "Version": "1.54.2"
+          },
+          {
+            "Version": "1.54.3"
+          },
+          {
+            "Version": "1.56.0"
+          },
+          {
+            "Version": "1.56.2"
+          },
+          {
+            "Version": "1.56.3"
+          },
+          {
+            "Version": "1.56.4"
+          },
+          {
+            "Version": "1.56.5"
+          },
+          {
+            "Version": "1.56.6"
+          },
+          {
+            "Version": "1.56.7"
+          },
+          {
+            "Version": "1.56.9"
+          },
+          {
+            "Version": "1.56.10"
+          },
+          {
+            "Version": "1.56.12"
+          },
+          {
+            "Version": "1.58.0"
+          },
+          {
+            "Version": "1.58.2"
+          },
+          {
+            "Version": "1.58.3"
+          },
+          {
+            "Version": "1.58.5"
+          },
+          {
+            "Version": "1.58.6"
+          },
+          {
+            "Version": "1.58.7"
+          },
+          {
+            "Version": "1.58.8"
+          },
+          {
+            "Version": "1.58.9"
+          },
+          {
+            "Version": "1.58.10"
+          },
+          {
+            "Version": "1.58.11"
+          },
+          {
+            "Version": "1.58.14"
+          },
+          {
+            "Version": "1.60.0"
+          },
+          {
+            "Version": "1.62.0"
+          },
+          {
+            "Version": "1.62.1"
+          },
+          {
+            "Version": "1.62.2"
+          },
+          {
+            "Version": "1.62.4"
+          },
+          {
+            "Version": "1.62.5"
+          },
+          {
+            "Version": "1.64.0"
+          },
+          {
+            "Version": "1.64.1"
+          },
+          {
+            "Version": "1.64.2"
+          },
+          {
+            "Version": "1.64.3"
+          },
+          {
+            "Version": "1.64.4"
+          },
+          {
+            "Version": "1.64.5"
+          },
+          {
+            "Version": "1.64.6"
+          },
+          {
+            "Version": "1.64.7"
+          },
+          {
+            "Version": "1.64.8"
+          },
+          {
+            "Version": "1.64.9"
+          },
+          {
+            "Version": "1.64.10"
+          },
+          {
+            "Version": "1.64.11"
+          },
+          {
+            "Version": "1.64.14"
+          },
+          {
+            "Version": "1.64.15"
+          },
+          {
+            "Version": "1.64.16"
+          },
+          {
+            "Version": "1.64.17"
+          },
+          {
+            "Version": "1.64.18"
+          },
+          {
+            "Version": "1.64.19"
+          },
+          {
+            "Version": "1.66.0"
+          },
+          {
+            "Version": "1.66.1"
+          },
+          {
+            "Version": "1.66.2"
+          },
+          {
+            "Version": "1.68.1"
+          },
+          {
+            "Version": "1.68.5"
+          },
+          {
+            "Version": "1.68.6"
+          },
+          {
+            "Version": "1.70.0"
+          },
+          {
+            "Version": "1.70.1"
+          },
+          {
+            "Version": "1.70.2"
+          },
+          {
+            "Version": "1.70.3"
+          },
+          {
+            "Version": "1.70.6"
+          },
+          {
+            "Version": "1.70.8"
+          },
+          {
+            "Version": "1.70.9"
+          },
+          {
+            "Version": "1.70.10"
+          },
+          {
+            "Version": "1.70.11"
+          },
+          {
+            "Version": "1.70.13"
+          },
+          {
+            "Version": "1.70.16"
+          },
+          {
+            "Version": "1.70.17"
+          },
+          {
+            "Version": "1.70.18"
+          },
+          {
+            "Version": "1.70.20"
+          },
+          {
+            "Version": "1.70.21"
+          },
+          {
+            "Version": "1.70.22"
+          },
+          {
+            "Version": "1.70.24"
+          },
+          {
+            "Version": "1.70.25"
+          },
+          {
+            "Version": "1.70.29"
+          },
+          {
+            "Version": "1.70.32"
+          },
+          {
+            "Version": "1.72.33"
+          },
+          {
+            "Version": "1.74.0"
+          },
+          {
+            "Version": "1.74.1"
+          },
+          {
+            "Version": "1.74.2"
+          },
+          {
+            "Version": "1.74.4"
+          },
+          {
+            "Version": "1.74.6"
+          },
+          {
+            "Version": "1.74.8"
+          },
+          {
+            "Version": "1.74.9"
+          },
+          {
+            "Version": "1.74.10"
+          },
+          {
+            "Version": "1.74.13"
+          },
+          {
+            "Version": "1.74.14"
+          },
+          {
+            "Version": "1.74.15"
+          },
+          {
+            "Version": "1.74.16"
+          },
+          {
+            "Version": "1.74.17"
+          },
+          {
+            "Version": "1.74.18"
+          },
+          {
+            "Version": "1.74.19"
+          },
+          {
+            "Version": "1.74.20"
+          },
+          {
+            "Version": "1.74.21"
+          },
+          {
+            "Version": "1.74.22"
+          },
+          {
+            "Version": "1.74.24"
+          },
+          {
+            "Version": "1.74.25"
+          },
+          {
+            "Version": "1.74.26"
+          },
+          {
+            "Version": "1.74.27"
+          },
+          {
+            "Version": "1.74.28"
+          },
+          {
+            "Version": "1.74.29"
+          },
+          {
+            "Version": "1.74.30"
+          },
+          {
+            "Version": "1.74.31"
+          },
+          {
+            "Version": "1.74.32"
+          },
+          {
+            "Version": "1.74.33"
+          },
+          {
+            "Version": "1.74.34"
+          },
+          {
+            "Version": "1.74.35"
+          },
+          {
+            "Version": "1.74.39"
+          },
+          {
+            "Version": "1.74.40"
+          },
+          {
+            "Version": "1.74.41"
+          },
+          {
+            "Version": "1.74.42"
+          },
+          {
+            "Version": "1.74.43"
+          },
+          {
+            "Version": "1.74.44"
+          },
+          {
+            "Version": "1.74.48"
+          },
+          {
+            "Version": "1.74.49"
+          },
+          {
+            "Version": "1.74.50"
+          },
+          {
+            "Version": "1.74.51"
+          },
+          {
+            "Version": "1.74.55"
+          },
+          {
+            "Version": "1.74.56"
+          },
+          {
+            "Version": "1.74.57"
+          },
+          {
+            "Version": "1.74.60"
+          },
+          {
+            "Version": "1.74.61"
+          },
+          {
+            "Version": "1.74.62"
+          },
+          {
+            "Version": "1.74.63"
+          },
+          {
+            "Version": "1.74.65"
+          },
+          {
+            "Version": "1.74.74"
+          },
+          {
+            "Version": "1.74.75"
+          },
+          {
+            "Version": "1.74.77"
+          },
+          {
+            "Version": "1.74.78"
+          },
+          {
+            "Version": "1.74.79"
+          },
+          {
+            "Version": "1.74.81"
+          },
+          {
+            "Version": "1.74.82"
+          },
+          {
+            "Version": "1.74.84"
+          },
+          {
+            "Version": "1.74.85"
+          },
+          {
+            "Version": "1.74.86"
+          },
+          {
+            "Version": "1.74.87"
+          },
+          {
+            "Version": "1.74.88"
+          },
+          {
+            "Version": "1.74.92"
+          },
+          {
+            "Version": "1.74.98"
+          },
+          {
+            "Version": "1.74.99"
+          },
+          {
+            "Version": "1.74.100"
+          },
+          {
+            "Version": "1.74.101"
+          },
+          {
+            "Version": "1.74.102"
+          },
+          {
+            "Version": "1.74.103"
+          },
+          {
+            "Version": "1.74.104"
+          },
+          {
+            "Version": "1.74.105"
+          },
+          {
+            "Version": "1.74.106"
+          },
+          {
+            "Version": "1.74.107"
+          },
+          {
+            "Version": "1.74.108"
+          },
+          {
+            "Version": "1.74.109"
+          },
+          {
+            "Version": "1.74.110"
+          },
+          {
+            "Version": "1.74.111"
+          },
+          {
+            "Version": "1.74.113"
+          },
+          {
+            "Version": "1.74.114"
+          },
+          {
+            "Version": "1.74.118"
+          },
+          {
+            "Version": "1.74.119"
+          },
+          {
+            "Version": "1.74.121"
+          },
+          {
+            "Version": "1.74.123"
+          },
+          {
+            "Version": "1.74.124"
+          },
+          {
+            "Version": "1.74.125"
+          },
+          {
+            "Version": "1.74.126"
+          },
+          {
+            "Version": "1.74.127"
+          },
+          {
+            "Version": "1.74.128"
+          },
+          {
+            "Version": "1.74.129"
+          },
+          {
+            "Version": "1.74.130"
+          },
+          {
+            "Version": "1.74.131"
+          },
+          {
+            "Version": "1.74.132"
+          },
+          {
+            "Version": "1.74.133"
+          },
+          {
+            "Version": "1.74.134"
+          },
+          {
+            "Version": "1.74.135"
+          },
+          {
+            "Version": "1.74.136"
+          },
+          {
+            "Version": "1.74.137"
+          },
+          {
+            "Version": "1.74.139"
+          },
+          {
+            "Version": "1.74.140"
+          },
+          {
+            "Version": "1.74.141"
+          },
+          {
+            "Version": "1.74.142"
+          },
+          {
+            "Version": "1.74.143"
+          },
+          {
+            "Version": "1.74.144"
+          },
+          {
+            "Version": "1.74.145"
+          },
+          {
+            "Version": "1.74.146"
+          },
+          {
+            "Version": "1.74.147"
+          },
+          {
+            "Version": "1.74.148"
+          },
+          {
+            "Version": "1.74.149"
+          },
+          {
+            "Version": "1.74.150"
+          },
+          {
+            "Version": "1.74.152"
+          },
+          {
+            "Version": "1.74.153"
+          },
+          {
+            "Version": "1.74.154"
+          },
+          {
+            "Version": "1.74.155"
+          },
+          {
+            "Version": "1.74.156"
+          },
+          {
+            "Version": "1.74.160"
+          },
+          {
+            "Version": "1.74.161"
+          },
+          {
+            "Version": "1.74.162"
+          },
+          {
+            "Version": "1.74.163"
+          },
+          {
+            "Version": "1.74.164"
+          },
+          {
+            "Version": "1.74.166"
+          },
+          {
+            "Version": "1.74.167"
+          },
+          {
+            "Version": "1.74.172"
+          },
+          {
+            "Version": "1.74.173"
+          },
+          {
+            "Version": "1.74.174"
+          },
+          {
+            "Version": "1.74.175"
+          },
+          {
+            "Version": "1.74.176"
+          },
+          {
+            "Version": "1.74.180"
+          },
+          {
+            "Version": "1.74.181"
+          },
+          {
+            "Version": "1.74.183"
+          },
+          {
+            "Version": "1.74.184"
+          },
+          {
+            "Version": "1.74.185"
+          },
+          {
+            "Version": "1.74.186"
+          },
+          {
+            "Version": "1.74.187"
+          },
+          {
+            "Version": "1.74.188"
+          },
+          {
+            "Version": "1.74.189"
+          },
+          {
+            "Version": "1.74.190"
+          },
+          {
+            "Version": "1.74.192"
+          },
+          {
+            "Version": "1.74.193"
+          },
+          {
+            "Version": "1.74.195"
+          },
+          {
+            "Version": "1.74.196"
+          },
+          {
+            "Version": "1.74.197"
+          },
+          {
+            "Version": "1.74.198"
+          },
+          {
+            "Version": "1.74.199"
+          },
+          {
+            "Version": "1.74.200"
+          },
+          {
+            "Version": "1.74.205"
+          },
+          {
+            "Version": "1.74.206"
+          },
+          {
+            "Version": "1.74.207"
+          },
+          {
+            "Version": "1.74.208"
+          },
+          {
+            "Version": "1.74.209"
+          },
+          {
+            "Version": "1.74.210"
+          },
+          {
+            "Version": "1.74.211"
+          },
+          {
+            "Version": "1.74.212"
+          },
+          {
+            "Version": "1.74.213"
+          },
+          {
+            "Version": "1.74.214"
+          },
+          {
+            "Version": "1.74.215"
+          },
+          {
+            "Version": "1.74.216"
+          },
+          {
+            "Version": "1.74.217"
+          },
+          {
+            "Version": "1.74.218"
+          },
+          {
+            "Version": "1.74.219"
+          },
+          {
+            "Version": "1.74.220"
+          },
+          {
+            "Version": "1.74.221"
+          },
+          {
+            "Version": "1.74.222"
+          },
+          {
+            "Version": "1.74.223"
+          },
+          {
+            "Version": "1.74.224"
+          },
+          {
+            "Version": "1.74.225"
+          },
+          {
+            "Version": "1.74.231"
+          },
+          {
+            "Version": "1.74.237"
+          },
+          {
+            "Version": "1.74.238"
+          },
+          {
+            "Version": "1.74.239"
+          },
+          {
+            "Version": "1.74.241"
+          },
+          {
+            "Version": "1.74.243"
+          },
+          {
+            "Version": "1.74.244"
+          },
+          {
+            "Version": "1.74.245"
+          },
+          {
+            "Version": "1.74.246"
+          },
+          {
+            "Version": "1.74.247"
+          },
+          {
+            "Version": "1.74.248"
+          },
+          {
+            "Version": "1.74.249"
+          },
+          {
+            "Version": "1.74.250"
+          },
+          {
+            "Version": "1.74.251"
+          },
+          {
+            "Version": "1.74.252"
+          },
+          {
+            "Version": "1.74.253"
+          },
+          {
+            "Version": "1.74.254"
+          },
+          {
+            "Version": "1.74.255"
+          },
+          {
+            "Version": "1.74.256"
+          },
+          {
+            "Version": "1.74.257"
+          },
+          {
+            "Version": "1.74.262"
+          },
+          {
+            "Version": "1.74.263"
+          },
+          {
+            "Version": "1.74.264"
+          },
+          {
+            "Version": "1.74.265"
+          },
+          {
+            "Version": "1.74.266"
+          },
+          {
+            "Version": "1.74.267"
+          },
+          {
+            "Version": "1.74.268"
+          },
+          {
+            "Version": "1.74.269"
+          },
+          {
+            "Version": "1.74.270"
+          },
+          {
+            "Version": "1.74.271"
+          },
+          {
+            "Version": "1.74.272"
+          },
+          {
+            "Version": "1.74.273"
+          },
+          {
+            "Version": "1.74.275"
+          },
+          {
+            "Version": "1.74.277"
+          },
+          {
+            "Version": "1.74.278"
+          },
+          {
+            "Version": "1.74.279"
+          },
+          {
+            "Version": "1.74.280"
+          },
+          {
+            "Version": "1.74.282"
+          },
+          {
+            "Version": "1.74.283"
+          },
+          {
+            "Version": "1.74.284"
+          },
+          {
+            "Version": "1.74.285"
+          },
+          {
+            "Version": "1.74.286"
+          },
+          {
+            "Version": "1.74.287"
+          },
+          {
+            "Version": "1.74.290"
+          },
+          {
+            "Version": "2.0.1-alpha2"
+          },
+          {
+            "Version": "2.0.1-alpha3"
+          },
+          {
+            "Version": "2.0.1-alpha4"
+          },
+          {
+            "Version": "2.0.48-alpha"
+          },
+          {
+            "Version": "2.0.55-alpha"
+          },
+          {
+            "Version": "2.0.60-alpha"
+          },
+          {
+            "Version": "2.0.61-alpha"
+          },
+          {
+            "Version": "2.0.62-alpha"
+          },
+          {
+            "Version": "2.0.64-alpha"
+          },
+          {
+            "Version": "2.0.65-alpha"
+          },
+          {
+            "Version": "2.0.66-alpha"
+          },
+          {
+            "Version": "2.0.68-alpha"
+          },
+          {
+            "Version": "2.0.69-alpha"
+          },
+          {
+            "Version": "2.0.70-alpha"
+          },
+          {
+            "Version": "2.0.73-alpha"
+          },
+          {
+            "Version": "2.0.74-alpha"
+          },
+          {
+            "Version": "2.0.75-alpha"
+          },
+          {
+            "Version": "2.0.76-alpha"
+          },
+          {
+            "Version": "2.0.77-alpha"
+          },
+          {
+            "Version": "2.0.78-alpha"
+          },
+          {
+            "Version": "2.0.79-alpha"
+          },
+          {
+            "Version": "2.0.80-alpha"
+          },
+          {
+            "Version": "2.0.81-alpha"
+          },
+          {
+            "Version": "2.0.83-alpha"
+          },
+          {
+            "Version": "2.0.84-alpha"
+          },
+          {
+            "Version": "2.0.85-alpha"
+          },
+          {
+            "Version": "2.0.86-alpha"
+          },
+          {
+            "Version": "2.0.87-alpha"
+          },
+          {
+            "Version": "2.0.90-alpha"
+          },
+          {
+            "Version": "2.0.91-alpha"
+          },
+          {
+            "Version": "2.0.94-alpha"
+          },
+          {
+            "Version": "2.0.95-alpha"
+          },
+          {
+            "Version": "2.0.96-alpha"
+          },
+          {
+            "Version": "2.0.97-alpha"
+          },
+          {
+            "Version": "2.0.98-alpha"
+          },
+          {
+            "Version": "2.0.99-alpha"
+          },
+          {
+            "Version": "2.1.0-alpha10"
+          },
+          {
+            "Version": "2.1.0-alpha13"
+          },
+          {
+            "Version": "2.1.0-alpha15"
+          },
+          {
+            "Version": "2.1.0-alpha16"
+          },
+          {
+            "Version": "2.1.0-alpha17"
+          },
+          {
+            "Version": "2.1.0-alpha18"
+          },
+          {
+            "Version": "2.1.0-alpha20"
+          },
+          {
+            "Version": "2.1.0-alpha22"
+          },
+          {
+            "Version": "2.1.0-alpha23"
+          },
+          {
+            "Version": "2.1.0-alpha24"
+          },
+          {
+            "Version": "2.1.0-alpha5"
+          },
+          {
+            "Version": "2.1.0-alpha6"
+          },
+          {
+            "Version": "2.1.0-alpha7"
+          },
+          {
+            "Version": "2.1.1-alpha"
+          },
+          {
+            "Version": "2.1.27-alpha"
+          },
+          {
+            "Version": "2.1.28-alpha"
+          },
+          {
+            "Version": "2.1.29-alpha"
+          },
+          {
+            "Version": "2.1.30-alpha"
+          },
+          {
+            "Version": "2.1.33-alpha"
+          },
+          {
+            "Version": "2.1.35-alpha"
+          },
+          {
+            "Version": "2.1.37-alpha"
+          },
+          {
+            "Version": "2.1.39-alpha"
+          },
+          {
+            "Version": "2.1.41-alpha"
+          },
+          {
+            "Version": "2.1.42-alpha"
+          },
+          {
+            "Version": "2.1.43-alpha"
+          },
+          {
+            "Version": "2.1.46-alpha"
+          },
+          {
+            "Version": "2.1.47-alpha"
+          },
+          {
+            "Version": "2.1.48-alpha"
+          },
+          {
+            "Version": "2.1.50-alpha"
+          },
+          {
+            "Version": "2.1.51-alpha"
+          },
+          {
+            "Version": "2.1.53-alpha"
+          },
+          {
+            "Version": "2.1.58-alpha"
+          },
+          {
+            "Version": "2.1.68-alpha"
+          },
+          {
+            "Version": "2.1.71-alpha"
+          },
+          {
+            "Version": "2.1.72-alpha"
+          },
+          {
+            "Version": "2.1.75-alpha"
+          },
+          {
+            "Version": "2.1.81-alpha"
+          },
+          {
+            "Version": "2.1.83-alpha"
+          },
+          {
+            "Version": "2.1.84-alpha"
+          },
+          {
+            "Version": "2.1.85-alpha"
+          },
+          {
+            "Version": "2.1.86-alpha"
+          },
+          {
+            "Version": "2.1.91-alpha"
+          },
+          {
+            "Version": "2.1.95-alpha"
+          },
+          {
+            "Version": "2.1.97-alpha"
+          },
+          {
+            "Version": "2.1.111-alpha"
+          },
+          {
+            "Version": "2.1.113-alpha"
+          },
+          {
+            "Version": "2.1.118-alpha"
+          },
+          {
+            "Version": "2.1.119-alpha"
+          },
+          {
+            "Version": "2.1.121-alpha"
+          },
+          {
+            "Version": "2.1.123-alpha"
+          },
+          {
+            "Version": "2.1.124-alpha"
+          },
+          {
+            "Version": "2.1.126-alpha"
+          },
+          {
+            "Version": "2.1.128-alpha"
+          },
+          {
+            "Version": "2.1.129-alpha"
+          },
+          {
+            "Version": "2.1.132-alpha"
+          },
+          {
+            "Version": "2.1.133-alpha"
+          },
+          {
+            "Version": "2.1.134-alpha"
+          },
+          {
+            "Version": "2.1.137-alpha"
+          },
+          {
+            "Version": "2.1.138-alpha"
+          },
+          {
+            "Version": "2.1.141-alpha"
+          },
+          {
+            "Version": "2.1.142-alpha"
+          },
+          {
+            "Version": "2.1.144-alpha"
+          },
+          {
+            "Version": "2.1.145-alpha"
+          },
+          {
+            "Version": "2.1.147-alpha"
+          },
+          {
+            "Version": "2.1.148-alpha"
+          },
+          {
+            "Version": "2.1.149-alpha"
+          },
+          {
+            "Version": "2.1.150-alpha"
+          },
+          {
+            "Version": "2.1.151-alpha"
+          },
+          {
+            "Version": "2.1.152-alpha"
+          },
+          {
+            "Version": "2.1.154-alpha"
+          },
+          {
+            "Version": "2.1.155-alpha"
+          },
+          {
+            "Version": "2.1.156-alpha"
+          },
+          {
+            "Version": "2.1.158-alpha"
+          },
+          {
+            "Version": "2.1.159-alpha"
+          },
+          {
+            "Version": "2.1.160-alpha"
+          },
+          {
+            "Version": "2.1.161-alpha"
+          },
+          {
+            "Version": "2.1.162-alpha"
+          },
+          {
+            "Version": "2.1.164-alpha"
+          },
+          {
+            "Version": "2.1.166-alpha"
+          },
+          {
+            "Version": "2.1.167-alpha"
+          },
+          {
+            "Version": "2.1.168-alpha"
+          },
+          {
+            "Version": "2.1.170-alpha"
+          },
+          {
+            "Version": "2.1.171-alpha"
+          },
+          {
+            "Version": "2.1.172-alpha"
+          },
+          {
+            "Version": "2.1.173-alpha"
+          },
+          {
+            "Version": "2.1.174-alpha"
+          },
+          {
+            "Version": "2.1.175-alpha"
+          },
+          {
+            "Version": "2.1.176-alpha"
+          },
+          {
+            "Version": "2.1.178-alpha"
+          },
+          {
+            "Version": "2.1.179-alpha"
+          },
+          {
+            "Version": "2.1.180-alpha"
+          },
+          {
+            "Version": "2.1.182-alpha"
+          },
+          {
+            "Version": "2.1.183-alpha"
+          },
+          {
+            "Version": "2.1.184-alpha"
+          },
+          {
+            "Version": "2.1.185-alpha"
+          },
+          {
+            "Version": "2.1.186-alpha"
+          },
+          {
+            "Version": "2.1.187-alpha"
+          },
+          {
+            "Version": "2.1.192-alpha"
+          },
+          {
+            "Version": "2.1.194-alpha"
+          },
+          {
+            "Version": "2.1.196-alpha"
+          },
+          {
+            "Version": "2.1.199-alpha"
+          },
+          {
+            "Version": "2.1.200-alpha"
+          },
+          {
+            "Version": "2.1.201-alpha"
+          },
+          {
+            "Version": "2.1.204-alpha"
+          },
+          {
+            "Version": "2.1.205-alpha"
+          },
+          {
+            "Version": "2.1.207-alpha"
+          },
+          {
+            "Version": "2.1.208-alpha"
+          },
+          {
+            "Version": "2.1.209-alpha"
+          },
+          {
+            "Version": "2.1.210-alpha"
+          },
+          {
+            "Version": "2.1.211-alpha"
+          },
+          {
+            "Version": "2.1.212-alpha"
+          },
+          {
+            "Version": "2.1.213-alpha"
+          },
+          {
+            "Version": "2.1.215-alpha"
+          },
+          {
+            "Version": "2.1.216-alpha"
+          },
+          {
+            "Version": "2.1.217-alpha"
+          },
+          {
+            "Version": "2.1.218-alpha"
+          },
+          {
+            "Version": "2.1.219-alpha"
+          },
+          {
+            "Version": "2.1.220-alpha"
+          },
+          {
+            "Version": "2.1.222-alpha"
+          },
+          {
+            "Version": "2.1.223-alpha"
+          },
+          {
+            "Version": "2.1.225-alpha"
+          },
+          {
+            "Version": "2.1.226-alpha"
+          },
+          {
+            "Version": "2.1.227-alpha"
+          },
+          {
+            "Version": "2.1.228-alpha"
+          },
+          {
+            "Version": "2.1.230-alpha"
+          },
+          {
+            "Version": "2.1.234-alpha"
+          },
+          {
+            "Version": "2.1.235-alpha"
+          },
+          {
+            "Version": "2.1.236-alpha"
+          },
+          {
+            "Version": "2.1.237-alpha"
+          },
+          {
+            "Version": "2.1.239-alpha"
+          },
+          {
+            "Version": "2.1.240-alpha"
+          },
+          {
+            "Version": "2.1.241-alpha"
+          },
+          {
+            "Version": "2.1.242-alpha"
+          },
+          {
+            "Version": "2.1.243-alpha"
+          },
+          {
+            "Version": "2.1.245-alpha"
+          },
+          {
+            "Version": "2.1.246-alpha"
+          },
+          {
+            "Version": "2.1.247-alpha"
+          },
+          {
+            "Version": "2.1.248-alpha"
+          },
+          {
+            "Version": "2.1.249-alpha"
+          },
+          {
+            "Version": "2.1.251-alpha"
+          },
+          {
+            "Version": "2.1.253-alpha"
+          },
+          {
+            "Version": "2.1.255-alpha"
+          },
+          {
+            "Version": "2.1.256-alpha"
+          },
+          {
+            "Version": "2.1.264-alpha"
+          },
+          {
+            "Version": "2.1.271-alpha"
+          },
+          {
+            "Version": "2.1.272-alpha"
+          },
+          {
+            "Version": "2.1.273-alpha"
+          },
+          {
+            "Version": "2.1.274-alpha"
+          },
+          {
+            "Version": "2.1.275-alpha"
+          },
+          {
+            "Version": "2.1.276-alpha"
+          },
+          {
+            "Version": "2.1.277-alpha"
+          },
+          {
+            "Version": "2.1.279-alpha"
+          },
+          {
+            "Version": "2.1.280-alpha"
+          },
+          {
+            "Version": "2.1.288-alpha"
+          },
+          {
+            "Version": "2.1.289-alpha"
+          },
+          {
+            "Version": "2.1.290-alpha"
+          },
+          {
+            "Version": "2.1.291-alpha"
+          },
+          {
+            "Version": "2.1.292-alpha"
+          },
+          {
+            "Version": "2.1.293-alpha"
+          },
+          {
+            "Version": "2.1.294-alpha"
+          },
+          {
+            "Version": "2.1.295-alpha"
+          },
+          {
+            "Version": "2.1.297-alpha"
+          },
+          {
+            "Version": "2.1.298-alpha"
+          },
+          {
+            "Version": "2.1.299-alpha"
+          },
+          {
+            "Version": "2.1.300-alpha"
+          },
+          {
+            "Version": "2.1.301-alpha"
+          },
+          {
+            "Version": "2.1.302-alpha"
+          },
+          {
+            "Version": "2.1.303-alpha"
+          },
+          {
+            "Version": "2.1.304-alpha"
+          },
+          {
+            "Version": "2.1.305-alpha"
+          },
+          {
+            "Version": "2.1.306-alpha"
+          },
+          {
+            "Version": "2.1.307-alpha"
+          },
+          {
+            "Version": "2.1.308-alpha"
+          },
+          {
+            "Version": "2.1.309-alpha"
+          },
+          {
+            "Version": "2.1.313-alpha"
+          },
+          {
+            "Version": "2.1.314-alpha"
+          },
+          {
+            "Version": "2.1.316-alpha"
+          },
+          {
+            "Version": "2.1.318-alpha"
+          },
+          {
+            "Version": "2.1.319-alpha"
+          },
+          {
+            "Version": "2.1.320-alpha"
+          },
+          {
+            "Version": "2.1.321-alpha"
+          },
+          {
+            "Version": "2.1.322-alpha"
+          },
+          {
+            "Version": "2.1.323-alpha"
+          },
+          {
+            "Version": "2.1.324-alpha"
+          },
+          {
+            "Version": "2.1.325-alpha"
+          },
+          {
+            "Version": "2.1.326-alpha"
+          },
+          {
+            "Version": "2.1.327-alpha"
+          },
+          {
+            "Version": "2.1.328-alpha"
+          },
+          {
+            "Version": "2.1.330-alpha"
+          },
+          {
+            "Version": "2.1.332-alpha"
+          },
+          {
+            "Version": "2.1.334-alpha"
+          },
+          {
+            "Version": "2.1.336-alpha"
+          },
+          {
+            "Version": "2.1.337-alpha"
+          },
+          {
+            "Version": "2.1.338-alpha"
+          },
+          {
+            "Version": "2.1.339-alpha"
+          },
+          {
+            "Version": "2.1.340-alpha"
+          },
+          {
+            "Version": "2.1.341-alpha"
+          },
+          {
+            "Version": "2.1.342-alpha"
+          },
+          {
+            "Version": "2.1.343-alpha"
+          },
+          {
+            "Version": "2.1.344-alpha"
+          },
+          {
+            "Version": "2.1.347-alpha"
+          },
+          {
+            "Version": "2.1.351-alpha"
+          },
+          {
+            "Version": "2.1.352-alpha"
+          },
+          {
+            "Version": "2.1.353-alpha"
+          },
+          {
+            "Version": "2.1.354-alpha"
+          },
+          {
+            "Version": "2.1.355-alpha"
+          },
+          {
+            "Version": "2.1.356-alpha"
+          },
+          {
+            "Version": "2.1.357-alpha"
+          },
+          {
+            "Version": "2.1.358-alpha"
+          },
+          {
+            "Version": "2.1.359-alpha"
+          },
+          {
+            "Version": "2.1.360-alpha"
+          },
+          {
+            "Version": "2.1.361-alpha"
+          },
+          {
+            "Version": "2.1.362-alpha"
+          },
+          {
+            "Version": "2.1.363-alpha"
+          },
+          {
+            "Version": "2.1.364-alpha"
+          },
+          {
+            "Version": "2.1.365-alpha"
+          },
+          {
+            "Version": "2.1.366-alpha"
+          },
+          {
+            "Version": "2.1.367-alpha"
+          },
+          {
+            "Version": "2.1.368-alpha"
+          },
+          {
+            "Version": "2.1.369-alpha"
+          },
+          {
+            "Version": "2.1.371-alpha"
+          },
+          {
+            "Version": "2.1.372-alpha"
+          },
+          {
+            "Version": "2.1.373-alpha"
+          },
+          {
+            "Version": "2.1.374-alpha"
+          },
+          {
+            "Version": "2.1.375-alpha"
+          },
+          {
+            "Version": "2.1.376-alpha"
+          },
+          {
+            "Version": "2.1.378-alpha"
+          },
+          {
+            "Version": "2.1.379-alpha"
+          },
+          {
+            "Version": "2.1.380-alpha"
+          },
+          {
+            "Version": "2.1.381-alpha"
+          },
+          {
+            "Version": "2.1.382-alpha"
+          },
+          {
+            "Version": "2.1.383-alpha"
+          },
+          {
+            "Version": "2.1.384-alpha"
+          },
+          {
+            "Version": "2.1.385-alpha"
+          },
+          {
+            "Version": "2.1.386-alpha"
+          },
+          {
+            "Version": "2.1.387-alpha"
+          },
+          {
+            "Version": "2.1.388-alpha"
+          },
+          {
+            "Version": "2.1.389-alpha"
+          },
+          {
+            "Version": "2.1.390-alpha"
+          },
+          {
+            "Version": "2.1.391-alpha"
+          },
+          {
+            "Version": "2.1.392-alpha"
+          },
+          {
+            "Version": "2.1.393-alpha"
+          },
+          {
+            "Version": "2.1.394-alpha"
+          },
+          {
+            "Version": "2.1.395-alpha"
+          },
+          {
+            "Version": "2.1.396-alpha"
+          },
+          {
+            "Version": "2.1.397-alpha"
+          },
+          {
+            "Version": "2.1.398-alpha"
+          },
+          {
+            "Version": "2.1.399-alpha"
+          },
+          {
+            "Version": "2.1.400-alpha"
+          },
+          {
+            "Version": "2.1.401-alpha"
+          },
+          {
+            "Version": "2.1.402-alpha"
+          },
+          {
+            "Version": "2.1.403-alpha"
+          },
+          {
+            "Version": "2.1.404-alpha"
+          },
+          {
+            "Version": "2.1.405-alpha"
+          },
+          {
+            "Version": "2.1.406-alpha"
+          },
+          {
+            "Version": "2.1.407-alpha"
+          },
+          {
+            "Version": "2.1.408-alpha"
+          },
+          {
+            "Version": "2.1.409-alpha"
+          },
+          {
+            "Version": "2.1.410-alpha"
+          },
+          {
+            "Version": "2.1.411-alpha"
+          },
+          {
+            "Version": "2.1.412-alpha"
+          },
+          {
+            "Version": "2.1.413-alpha"
+          },
+          {
+            "Version": "2.1.414-alpha"
+          },
+          {
+            "Version": "2.1.415-alpha"
+          },
+          {
+            "Version": "2.1.416-alpha"
+          },
+          {
+            "Version": "2.1.417-alpha"
+          },
+          {
+            "Version": "2.1.418-alpha"
+          },
+          {
+            "Version": "2.1.419-alpha"
+          },
+          {
+            "Version": "2.1.420-alpha"
+          },
+          {
+            "Version": "2.1.421-alpha"
+          },
+          {
+            "Version": "2.1.422-alpha"
+          },
+          {
+            "Version": "2.1.423-alpha"
+          },
+          {
+            "Version": "2.1.424-alpha"
+          },
+          {
+            "Version": "2.1.426-alpha"
+          },
+          {
+            "Version": "2.1.427-alpha"
+          },
+          {
+            "Version": "2.1.428-alpha"
+          },
+          {
+            "Version": "2.1.429-alpha"
+          },
+          {
+            "Version": "2.1.430-alpha"
+          },
+          {
+            "Version": "2.1.431-alpha"
+          },
+          {
+            "Version": "2.1.432-alpha"
+          },
+          {
+            "Version": "2.1.434-alpha"
+          },
+          {
+            "Version": "2.1.435-alpha"
+          },
+          {
+            "Version": "2.1.436-alpha"
+          },
+          {
+            "Version": "2.1.437-alpha"
+          },
+          {
+            "Version": "2.1.438-alpha"
+          },
+          {
+            "Version": "2.1.439-alpha"
+          },
+          {
+            "Version": "2.1.440-alpha"
+          },
+          {
+            "Version": "2.1.441-alpha"
+          },
+          {
+            "Version": "2.1.442-alpha"
+          },
+          {
+            "Version": "2.1.443-alpha"
+          },
+          {
+            "Version": "2.1.445-alpha"
+          },
+          {
+            "Version": "2.1.449-alpha"
+          },
+          {
+            "Version": "2.1.461-alpha"
+          },
+          {
+            "Version": "2.1.465-alpha"
+          },
+          {
+            "Version": "2.1.468-alpha"
+          },
+          {
+            "Version": "2.1.469-alpha"
+          },
+          {
+            "Version": "2.1.470-alpha"
+          },
+          {
+            "Version": "2.1.471-alpha"
+          },
+          {
+            "Version": "2.1.472-alpha"
+          },
+          {
+            "Version": "2.1.473-alpha"
+          },
+          {
+            "Version": "2.1.474-alpha"
+          },
+          {
+            "Version": "2.1.475-alpha"
+          },
+          {
+            "Version": "2.1.476-alpha"
+          },
+          {
+            "Version": "2.1.478-alpha"
+          },
+          {
+            "Version": "2.1.479-alpha"
+          },
+          {
+            "Version": "2.1.480-alpha"
+          },
+          {
+            "Version": "2.1.481-alpha"
+          },
+          {
+            "Version": "2.1.482-alpha"
+          },
+          {
+            "Version": "2.1.483-alpha"
+          },
+          {
+            "Version": "2.1.485-alpha"
+          },
+          {
+            "Version": "2.1.486-alpha"
+          },
+          {
+            "Version": "2.1.487-alpha"
+          },
+          {
+            "Version": "2.1.488-alpha"
+          },
+          {
+            "Version": "2.1.489-alpha"
+          },
+          {
+            "Version": "2.1.490-alpha"
+          },
+          {
+            "Version": "2.1.491-alpha"
+          },
+          {
+            "Version": "2.1.492-alpha"
+          },
+          {
+            "Version": "2.1.493-alpha"
+          },
+          {
+            "Version": "2.1.494-alpha"
+          },
+          {
+            "Version": "2.1.495-alpha"
+          },
+          {
+            "Version": "2.1.496-alpha"
+          },
+          {
+            "Version": "2.1.497-alpha"
+          },
+          {
+            "Version": "2.1.498-alpha"
+          },
+          {
+            "Version": "2.1.499-alpha"
+          },
+          {
+            "Version": "2.1.500-alpha"
+          },
+          {
+            "Version": "2.1.502-alpha"
+          },
+          {
+            "Version": "2.1.503-alpha"
+          },
+          {
+            "Version": "2.1.504-alpha"
+          },
+          {
+            "Version": "2.1.505-alpha"
+          },
+          {
+            "Version": "2.1.507-alpha"
+          },
+          {
+            "Version": "2.1.509-alpha"
+          },
+          {
+            "Version": "2.1.520-alpha"
+          },
+          {
+            "Version": "2.1.521-alpha"
+          },
+          {
+            "Version": "2.1.522-alpha"
+          },
+          {
+            "Version": "2.1.524-alpha"
+          },
+          {
+            "Version": "2.1.526-alpha"
+          },
+          {
+            "Version": "2.1.527-alpha"
+          },
+          {
+            "Version": "2.1.528-alpha"
+          },
+          {
+            "Version": "2.1.530-alpha"
+          },
+          {
+            "Version": "2.1.531-alpha"
+          },
+          {
+            "Version": "2.1.533-alpha"
+          },
+          {
+            "Version": "2.1.534-alpha"
+          },
+          {
+            "Version": "2.1.535-alpha"
+          },
+          {
+            "Version": "2.1.536-alpha"
+          },
+          {
+            "Version": "2.1.537-alpha"
+          },
+          {
+            "Version": "2.1.538-alpha"
+          },
+          {
+            "Version": "2.1.539-alpha"
+          },
+          {
+            "Version": "2.1.540-alpha"
+          },
+          {
+            "Version": "2.1.542-alpha"
+          },
+          {
+            "Version": "2.1.543-alpha"
+          },
+          {
+            "Version": "2.1.544-alpha"
+          },
+          {
+            "Version": "2.1.545-alpha"
+          },
+          {
+            "Version": "2.1.546-alpha"
+          },
+          {
+            "Version": "2.1.547-alpha"
+          },
+          {
+            "Version": "2.1.548-alpha"
+          },
+          {
+            "Version": "2.1.549-alpha"
+          },
+          {
+            "Version": "2.1.550-alpha"
+          },
+          {
+            "Version": "2.1.551-alpha"
+          },
+          {
+            "Version": "2.1.552-alpha"
+          },
+          {
+            "Version": "2.1.553-alpha"
+          },
+          {
+            "Version": "2.1.554-alpha"
+          },
+          {
+            "Version": "2.1.555-alpha"
+          },
+          {
+            "Version": "2.1.556-alpha"
+          },
+          {
+            "Version": "2.1.557-alpha"
+          },
+          {
+            "Version": "2.1.560-alpha"
+          },
+          {
+            "Version": "2.1.561-alpha"
+          },
+          {
+            "Version": "2.1.562-alpha"
+          },
+          {
+            "Version": "2.1.563-alpha"
+          },
+          {
+            "Version": "2.1.564-alpha"
+          },
+          {
+            "Version": "2.1.566-alpha"
+          },
+          {
+            "Version": "2.1.567-alpha"
+          },
+          {
+            "Version": "2.1.568-alpha"
+          },
+          {
+            "Version": "2.1.569-alpha"
+          },
+          {
+            "Version": "2.1.570-alpha"
+          },
+          {
+            "Version": "2.1.571-alpha"
+          },
+          {
+            "Version": "2.1.572-alpha"
+          },
+          {
+            "Version": "2.1.573-alpha"
+          },
+          {
+            "Version": "2.1.574-alpha"
+          },
+          {
+            "Version": "2.1.575-alpha"
+          },
+          {
+            "Version": "2.1.576-alpha"
+          },
+          {
+            "Version": "2.1.577-alpha"
+          },
+          {
+            "Version": "2.1.578-alpha"
+          },
+          {
+            "Version": "2.1.580-alpha"
+          },
+          {
+            "Version": "2.1.581-alpha"
+          },
+          {
+            "Version": "2.1.583-alpha"
+          },
+          {
+            "Version": "2.1.584-alpha"
+          },
+          {
+            "Version": "2.1.585-alpha"
+          },
+          {
+            "Version": "2.1.586-alpha"
+          },
+          {
+            "Version": "2.1.587-alpha"
+          },
+          {
+            "Version": "2.1.588-alpha"
+          },
+          {
+            "Version": "2.1.589-alpha"
+          },
+          {
+            "Version": "2.1.591-alpha"
+          },
+          {
+            "Version": "2.1.592-alpha"
+          },
+          {
+            "Version": "2.1.593-alpha"
+          },
+          {
+            "Version": "2.1.594-alpha"
+          },
+          {
+            "Version": "2.1.595-alpha"
+          },
+          {
+            "Version": "2.1.596-alpha"
+          },
+          {
+            "Version": "2.1.597-alpha"
+          },
+          {
+            "Version": "2.1.598-alpha"
+          },
+          {
+            "Version": "2.1.600-alpha"
+          },
+          {
+            "Version": "2.1.601-alpha"
+          },
+          {
+            "Version": "2.1.602-alpha"
+          },
+          {
+            "Version": "2.1.603-alpha"
+          },
+          {
+            "Version": "2.1.604-alpha"
+          },
+          {
+            "Version": "2.1.605-alpha"
+          },
+          {
+            "Version": "2.1.607-alpha"
+          },
+          {
+            "Version": "2.1.609-alpha"
+          },
+          {
+            "Version": "2.1.611-alpha"
+          },
+          {
+            "Version": "2.1.612-alpha"
+          },
+          {
+            "Version": "2.1.614-alpha"
+          },
+          {
+            "Version": "2.1.616-alpha"
+          },
+          {
+            "Version": "2.1.617-alpha"
+          },
+          {
+            "Version": "2.1.618-alpha"
+          },
+          {
+            "Version": "2.1.620-alpha"
+          },
+          {
+            "Version": "2.1.621-alpha"
+          },
+          {
+            "Version": "2.1.622-alpha"
+          },
+          {
+            "Version": "2.1.623-alpha"
+          },
+          {
+            "Version": "2.1.624-alpha"
+          },
+          {
+            "Version": "2.1.625-alpha"
+          },
+          {
+            "Version": "2.1.626-alpha"
+          },
+          {
+            "Version": "2.1.629-alpha"
+          },
+          {
+            "Version": "2.1.630-alpha"
+          },
+          {
+            "Version": "2.1.631-alpha"
+          },
+          {
+            "Version": "2.1.632-alpha"
+          },
+          {
+            "Version": "2.1.633-alpha"
+          },
+          {
+            "Version": "2.1.634-alpha"
+          },
+          {
+            "Version": "2.1.635-alpha"
+          },
+          {
+            "Version": "2.1.636-alpha"
+          },
+          {
+            "Version": "2.1.637-alpha"
+          },
+          {
+            "Version": "2.1.638-alpha"
+          },
+          {
+            "Version": "2.1.639-alpha"
+          },
+          {
+            "Version": "2.1.640-alpha"
+          },
+          {
+            "Version": "2.1.641-alpha"
+          },
+          {
+            "Version": "2.1.642-alpha"
+          },
+          {
+            "Version": "2.1.643-alpha"
+          },
+          {
+            "Version": "2.1.645-alpha"
+          },
+          {
+            "Version": "2.1.646-alpha"
+          },
+          {
+            "Version": "2.1.647-alpha"
+          },
+          {
+            "Version": "2.1.648-alpha"
+          },
+          {
+            "Version": "2.1.649-alpha"
+          },
+          {
+            "Version": "2.1.651-alpha"
+          },
+          {
+            "Version": "2.1.652-alpha"
+          },
+          {
+            "Version": "2.1.653-alpha"
+          },
+          {
+            "Version": "2.1.654-alpha"
+          },
+          {
+            "Version": "2.1.655-alpha"
+          },
+          {
+            "Version": "2.1.656-alpha"
+          },
+          {
+            "Version": "2.1.657-alpha"
+          },
+          {
+            "Version": "2.1.658-alpha"
+          },
+          {
+            "Version": "2.1.659-alpha"
+          },
+          {
+            "Version": "2.1.660-alpha"
+          },
+          {
+            "Version": "2.1.661-alpha"
+          },
+          {
+            "Version": "2.1.662-alpha"
+          },
+          {
+            "Version": "2.1.663-alpha"
+          },
+          {
+            "Version": "2.1.664-alpha"
+          },
+          {
+            "Version": "2.1.665-alpha"
+          },
+          {
+            "Version": "2.1.666-alpha"
+          },
+          {
+            "Version": "2.1.667-alpha"
+          },
+          {
+            "Version": "2.1.668-alpha"
+          },
+          {
+            "Version": "2.1.671-alpha"
+          },
+          {
+            "Version": "2.1.672-alpha"
+          },
+          {
+            "Version": "2.1.673-alpha"
+          },
+          {
+            "Version": "2.1.674-alpha"
+          },
+          {
+            "Version": "2.1.675-alpha"
+          },
+          {
+            "Version": "2.1.676-alpha"
+          },
+          {
+            "Version": "2.1.677-alpha"
+          },
+          {
+            "Version": "2.1.678-alpha"
+          },
+          {
+            "Version": "2.1.679-alpha"
+          },
+          {
+            "Version": "2.1.680-alpha"
+          },
+          {
+            "Version": "2.1.681-alpha"
+          },
+          {
+            "Version": "2.1.682-alpha"
+          },
+          {
+            "Version": "2.1.683-alpha"
+          },
+          {
+            "Version": "2.1.685-alpha"
+          },
+          {
+            "Version": "2.1.686-alpha"
+          },
+          {
+            "Version": "2.1.687-alpha"
+          },
+          {
+            "Version": "2.1.688-alpha"
+          },
+          {
+            "Version": "2.1.711-alpha"
+          },
+          {
+            "Version": "2.1.713-alpha"
+          },
+          {
+            "Version": "2.1.714-alpha"
+          },
+          {
+            "Version": "2.1.718-alpha"
+          },
+          {
+            "Version": "2.1.724-alpha"
+          },
+          {
+            "Version": "2.1.726-alpha"
+          },
+          {
+            "Version": "2.1.727-alpha"
+          },
+          {
+            "Version": "2.1.728-alpha"
+          },
+          {
+            "Version": "2.1.729-alpha"
+          },
+          {
+            "Version": "2.1.730-alpha"
+          },
+          {
+            "Version": "2.1.731-alpha"
+          },
+          {
+            "Version": "2.1.732-alpha"
+          },
+          {
+            "Version": "2.1.733-alpha"
+          },
+          {
+            "Version": "2.1.735-alpha"
+          },
+          {
+            "Version": "2.1.737-alpha"
+          },
+          {
+            "Version": "2.1.738-alpha"
+          },
+          {
+            "Version": "2.1.739-alpha"
+          },
+          {
+            "Version": "2.1.740-alpha"
+          },
+          {
+            "Version": "2.1.742-alpha"
+          },
+          {
+            "Version": "2.1.743-alpha"
+          },
+          {
+            "Version": "2.1.744-alpha"
+          },
+          {
+            "Version": "2.1.745-alpha"
+          },
+          {
+            "Version": "2.1.746-alpha"
+          },
+          {
+            "Version": "2.1.747-alpha"
+          },
+          {
+            "Version": "2.1.748-alpha"
+          },
+          {
+            "Version": "2.1.750-alpha"
+          },
+          {
+            "Version": "2.1.756-alpha"
+          },
+          {
+            "Version": "2.1.758-alpha"
+          },
+          {
+            "Version": "2.1.765-alpha"
+          },
+          {
+            "Version": "2.1.766-alpha"
+          },
+          {
+            "Version": "2.1.767-alpha"
+          },
+          {
+            "Version": "2.1.768-alpha"
+          },
+          {
+            "Version": "2.1.770-alpha"
+          },
+          {
+            "Version": "2.1.771-alpha"
+          },
+          {
+            "Version": "2.1.772-alpha"
+          },
+          {
+            "Version": "2.1.773-alpha"
+          },
+          {
+            "Version": "2.1.774-alpha"
+          },
+          {
+            "Version": "2.1.775-alpha"
+          },
+          {
+            "Version": "2.1.778-alpha"
+          },
+          {
+            "Version": "2.1.779-alpha"
+          },
+          {
+            "Version": "2.1.781-alpha"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.6"
+          },
+          {
+            "Version": "2.2.7"
+          },
+          {
+            "Version": "2.2.8"
+          },
+          {
+            "Version": "2.2.9"
+          },
+          {
+            "Version": "2.2.10"
+          },
+          {
+            "Version": "2.2.11"
+          },
+          {
+            "Version": "2.2.12"
+          },
+          {
+            "Version": "2.2.13"
+          },
+          {
+            "Version": "2.2.14"
+          },
+          {
+            "Version": "2.2.18"
+          },
+          {
+            "Version": "2.2.19"
+          },
+          {
+            "Version": "2.2.20"
+          },
+          {
+            "Version": "2.2.21"
+          },
+          {
+            "Version": "2.2.22"
+          },
+          {
+            "Version": "2.2.23"
+          },
+          {
+            "Version": "2.3.1-alpha"
+          },
+          {
+            "Version": "2.3.2-alpha"
+          },
+          {
+            "Version": "2.3.5-alpha"
+          },
+          {
+            "Version": "2.3.8-alpha"
+          },
+          {
+            "Version": "2.3.10-alpha"
+          },
+          {
+            "Version": "2.3.11-alpha"
+          },
+          {
+            "Version": "2.3.14-alpha"
+          },
+          {
+            "Version": "2.3.15-alpha"
+          },
+          {
+            "Version": "2.3.16-alpha"
+          },
+          {
+            "Version": "2.3.17-alpha"
+          },
+          {
+            "Version": "2.3.18-alpha"
+          },
+          {
+            "Version": "2.3.19-alpha"
+          },
+          {
+            "Version": "2.3.20-alpha"
+          },
+          {
+            "Version": "2.3.21-alpha"
+          },
+          {
+            "Version": "2.3.22-alpha"
+          },
+          {
+            "Version": "2.3.23-alpha"
+          },
+          {
+            "Version": "2.3.24-alpha"
+          },
+          {
+            "Version": "2.3.26-alpha"
+          },
+          {
+            "Version": "2.3.28-alpha"
+          },
+          {
+            "Version": "2.3.30-alpha"
+          },
+          {
+            "Version": "2.3.31-alpha"
+          },
+          {
+            "Version": "2.3.32-alpha"
+          },
+          {
+            "Version": "2.3.33-alpha"
+          },
+          {
+            "Version": "2.3.34-alpha"
+          },
+          {
+            "Version": "2.3.36-alpha"
+          },
+          {
+            "Version": "2.3.37-alpha"
+          },
+          {
+            "Version": "2.3.38-alpha"
+          },
+          {
+            "Version": "2.3.39-alpha"
+          },
+          {
+            "Version": "2.3.41-alpha"
+          },
+          {
+            "Version": "2.3.43-alpha"
+          },
+          {
+            "Version": "2.3.49-alpha"
+          },
+          {
+            "Version": "2.3.50-alpha"
+          },
+          {
+            "Version": "2.3.51-alpha"
+          },
+          {
+            "Version": "2.3.54-alpha"
+          },
+          {
+            "Version": "2.3.55-alpha"
+          },
+          {
+            "Version": "2.3.57-alpha"
+          },
+          {
+            "Version": "2.3.58-alpha"
+          },
+          {
+            "Version": "2.3.59-alpha"
+          },
+          {
+            "Version": "2.3.60-alpha"
+          },
+          {
+            "Version": "2.3.61-alpha"
+          },
+          {
+            "Version": "2.3.62-alpha"
+          },
+          {
+            "Version": "2.3.63-alpha"
+          },
+          {
+            "Version": "2.3.64-alpha"
+          },
+          {
+            "Version": "2.3.65-alpha"
+          },
+          {
+            "Version": "2.3.66-alpha"
+          },
+          {
+            "Version": "2.3.67-alpha"
+          },
+          {
+            "Version": "2.3.68-alpha"
+          },
+          {
+            "Version": "2.3.69-alpha"
+          },
+          {
+            "Version": "2.3.70-alpha"
+          },
+          {
+            "Version": "2.3.71-alpha"
+          },
+          {
+            "Version": "2.3.72-alpha"
+          },
+          {
+            "Version": "2.3.73-alpha"
+          },
+          {
+            "Version": "2.3.74-alpha"
+          },
+          {
+            "Version": "2.3.75-alpha"
+          },
+          {
+            "Version": "2.3.76-alpha"
+          },
+          {
+            "Version": "2.3.77-alpha"
+          },
+          {
+            "Version": "2.3.78-alpha"
+          },
+          {
+            "Version": "2.3.79-alpha"
+          },
+          {
+            "Version": "2.3.80-alpha"
+          },
+          {
+            "Version": "2.3.81-alpha"
+          },
+          {
+            "Version": "2.3.82-alpha"
+          },
+          {
+            "Version": "2.3.83-alpha"
+          },
+          {
+            "Version": "2.3.84-alpha"
+          },
+          {
+            "Version": "2.3.85-alpha"
+          },
+          {
+            "Version": "2.3.86-alpha"
+          },
+          {
+            "Version": "2.3.87-alpha"
+          },
+          {
+            "Version": "2.3.88-alpha"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.4-alpha"
+          },
+          {
+            "Version": "2.5.5-alpha"
+          },
+          {
+            "Version": "2.5.7-alpha"
+          },
+          {
+            "Version": "2.5.8-alpha"
+          },
+          {
+            "Version": "2.5.9-alpha"
+          },
+          {
+            "Version": "2.5.10-alpha"
+          },
+          {
+            "Version": "2.5.11-alpha"
+          },
+          {
+            "Version": "2.5.12-alpha"
+          },
+          {
+            "Version": "2.5.17-alpha"
+          },
+          {
+            "Version": "2.5.18-alpha"
+          },
+          {
+            "Version": "2.5.19-alpha"
+          },
+          {
+            "Version": "2.5.20-alpha"
+          },
+          {
+            "Version": "2.5.21-alpha"
+          },
+          {
+            "Version": "2.5.22-alpha"
+          },
+          {
+            "Version": "2.5.25-alpha"
+          },
+          {
+            "Version": "2.5.31-alpha"
+          },
+          {
+            "Version": "2.5.32-alpha"
+          },
+          {
+            "Version": "2.5.33-alpha"
+          },
+          {
+            "Version": "2.5.34-alpha"
+          },
+          {
+            "Version": "2.5.35-alpha"
+          },
+          {
+            "Version": "2.5.39-alpha"
+          },
+          {
+            "Version": "2.5.40-alpha"
+          },
+          {
+            "Version": "2.5.41-alpha"
+          },
+          {
+            "Version": "2.5.42-alpha"
+          },
+          {
+            "Version": "2.5.43-alpha"
+          },
+          {
+            "Version": "2.5.44-alpha"
+          },
+          {
+            "Version": "2.5.45-alpha"
+          },
+          {
+            "Version": "2.5.46-alpha"
+          },
+          {
+            "Version": "2.5.47-alpha"
+          },
+          {
+            "Version": "2.5.48-alpha"
+          },
+          {
+            "Version": "2.5.49-alpha"
+          },
+          {
+            "Version": "2.5.54-alpha"
+          },
+          {
+            "Version": "2.5.55-alpha"
+          },
+          {
+            "Version": "2.5.56-alpha"
+          },
+          {
+            "Version": "2.5.57-alpha"
+          },
+          {
+            "Version": "2.5.58-alpha"
+          },
+          {
+            "Version": "2.5.59-alpha"
+          },
+          {
+            "Version": "2.5.60-alpha"
+          },
+          {
+            "Version": "2.5.61-alpha"
+          },
+          {
+            "Version": "2.5.62-alpha"
+          },
+          {
+            "Version": "2.5.63-alpha"
+          },
+          {
+            "Version": "2.5.64-alpha"
+          },
+          {
+            "Version": "2.5.65-alpha"
+          },
+          {
+            "Version": "2.5.66-alpha"
+          },
+          {
+            "Version": "2.5.67-alpha"
+          },
+          {
+            "Version": "2.5.68-alpha"
+          },
+          {
+            "Version": "2.5.69-alpha"
+          },
+          {
+            "Version": "2.5.70-alpha"
+          },
+          {
+            "Version": "2.5.71-alpha"
+          },
+          {
+            "Version": "2.5.72-alpha"
+          },
+          {
+            "Version": "2.5.73-alpha"
+          },
+          {
+            "Version": "2.5.74-alpha"
+          },
+          {
+            "Version": "2.5.75-alpha"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.5"
+          },
+          {
+            "Version": "2.6.7"
+          },
+          {
+            "Version": "2.6.9"
+          },
+          {
+            "Version": "2.6.12"
+          },
+          {
+            "Version": "2.6.14"
+          },
+          {
+            "Version": "2.6.15"
+          },
+          {
+            "Version": "2.6.16"
+          },
+          {
+            "Version": "2.6.17"
+          },
+          {
+            "Version": "2.7.0-alpha10"
+          },
+          {
+            "Version": "2.7.0-alpha11"
+          },
+          {
+            "Version": "2.7.0-alpha13"
+          },
+          {
+            "Version": "2.7.0-alpha14"
+          },
+          {
+            "Version": "2.7.0-alpha15"
+          },
+          {
+            "Version": "2.7.0-alpha7"
+          },
+          {
+            "Version": "2.7.0-alpha8"
+          },
+          {
+            "Version": "2.7.0-alpha9"
+          },
+          {
+            "Version": "2.7.0.16-alpha"
+          },
+          {
+            "Version": "2.7.0.17-alpha"
+          },
+          {
+            "Version": "2.7.0.18-alpha"
+          },
+          {
+            "Version": "2.7.0.19-alpha"
+          },
+          {
+            "Version": "2.7.0.20-alpha"
+          },
+          {
+            "Version": "2.7.0.21-alpha"
+          },
+          {
+            "Version": "2.7.0.23-alpha"
+          },
+          {
+            "Version": "2.7.0.24-alpha"
+          },
+          {
+            "Version": "2.7.0.25-alpha"
+          },
+          {
+            "Version": "2.7.0.26-alpha"
+          },
+          {
+            "Version": "2.7.0.27-alpha"
+          },
+          {
+            "Version": "2.7.0.28-alpha"
+          },
+          {
+            "Version": "2.7.0.29-alpha"
+          },
+          {
+            "Version": "2.7.0.30-alpha"
+          },
+          {
+            "Version": "2.7.0.32-alpha"
+          },
+          {
+            "Version": "2.7.0.34-alpha"
+          },
+          {
+            "Version": "2.7.0.35-alpha"
+          },
+          {
+            "Version": "2.7.0.36-alpha"
+          },
+          {
+            "Version": "2.7.0.37-alpha"
+          },
+          {
+            "Version": "2.7.0.38-alpha"
+          },
+          {
+            "Version": "2.7.0.39-alpha"
+          },
+          {
+            "Version": "2.7.0.42-alpha"
+          },
+          {
+            "Version": "2.7.0.43-alpha"
+          },
+          {
+            "Version": "2.7.0.44-alpha"
+          },
+          {
+            "Version": "2.7.0.45-alpha"
+          },
+          {
+            "Version": "2.7.0.47-alpha"
+          },
+          {
+            "Version": "2.7.0.50-alpha"
+          },
+          {
+            "Version": "2.7.0.59-alpha"
+          },
+          {
+            "Version": "2.7.0.60-alpha"
+          },
+          {
+            "Version": "2.7.0.61-alpha"
+          },
+          {
+            "Version": "2.7.0.62-alpha"
+          },
+          {
+            "Version": "2.7.0.63-alpha"
+          },
+          {
+            "Version": "2.7.0.64-alpha"
+          },
+          {
+            "Version": "2.7.0.65-alpha"
+          },
+          {
+            "Version": "2.7.0.66-alpha"
+          },
+          {
+            "Version": "2.7.0.72-alpha"
+          },
+          {
+            "Version": "2.7.0.84-alpha"
+          },
+          {
+            "Version": "2.7.0.85-alpha"
+          },
+          {
+            "Version": "2.7.0.86-alpha"
+          },
+          {
+            "Version": "2.7.0.87-alpha"
+          },
+          {
+            "Version": "2.7.0.88-alpha"
+          },
+          {
+            "Version": "2.7.0.90-alpha"
+          },
+          {
+            "Version": "2.7.0.91-alpha"
+          },
+          {
+            "Version": "2.7.0.92-alpha"
+          },
+          {
+            "Version": "2.7.1-alpha"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.8.1"
+          },
+          {
+            "Version": "2.8.2"
+          },
+          {
+            "Version": "2.8.3"
+          },
+          {
+            "Version": "2.8.5"
+          },
+          {
+            "Version": "2.8.6"
+          },
+          {
+            "Version": "2.8.7"
+          },
+          {
+            "Version": "2.8.8"
+          },
+          {
+            "Version": "2.8.9"
+          },
+          {
+            "Version": "2.8.10"
+          },
+          {
+            "Version": "2.8.11"
+          },
+          {
+            "Version": "2.8.12"
+          },
+          {
+            "Version": "2.8.17"
+          },
+          {
+            "Version": "2.9.0-alpha"
+          },
+          {
+            "Version": "2.9.0.1-alpha"
+          },
+          {
+            "Version": "2.9.0.3-alpha"
+          },
+          {
+            "Version": "2.9.11-alpha"
+          },
+          {
+            "Version": "2.9.12-alpha"
+          },
+          {
+            "Version": "2.9.14-alpha"
+          },
+          {
+            "Version": "2.9.15-alpha"
+          },
+          {
+            "Version": "2.9.17-alpha"
+          },
+          {
+            "Version": "2.9.19-alpha"
+          },
+          {
+            "Version": "2.9.20-alpha"
+          },
+          {
+            "Version": "2.9.21-alpha"
+          },
+          {
+            "Version": "2.9.22-alpha"
+          },
+          {
+            "Version": "2.9.23-alpha"
+          },
+          {
+            "Version": "2.9.24-alpha"
+          },
+          {
+            "Version": "2.9.26-alpha"
+          },
+          {
+            "Version": "2.9.27-alpha"
+          },
+          {
+            "Version": "2.9.28-alpha"
+          },
+          {
+            "Version": "2.9.29-alpha"
+          },
+          {
+            "Version": "2.9.30-alpha"
+          },
+          {
+            "Version": "2.9.31-alpha"
+          },
+          {
+            "Version": "2.9.32-alpha"
+          },
+          {
+            "Version": "2.9.33-alpha"
+          },
+          {
+            "Version": "2.9.34-alpha"
+          },
+          {
+            "Version": "2.9.35-alpha"
+          },
+          {
+            "Version": "2.9.36-alpha"
+          },
+          {
+            "Version": "2.9.37-alpha"
+          },
+          {
+            "Version": "2.9.41-alpha"
+          },
+          {
+            "Version": "2.9.42-alpha"
+          },
+          {
+            "Version": "2.9.44-alpha"
+          },
+          {
+            "Version": "2.9.45-alpha"
+          },
+          {
+            "Version": "2.9.46-alpha"
+          },
+          {
+            "Version": "2.9.47-alpha"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.10.4"
+          },
+          {
+            "Version": "2.10.5"
+          },
+          {
+            "Version": "2.10.6"
+          },
+          {
+            "Version": "2.10.7"
+          },
+          {
+            "Version": "2.10.8"
+          },
+          {
+            "Version": "2.10.9"
+          },
+          {
+            "Version": "2.10.10"
+          },
+          {
+            "Version": "2.10.11"
+          },
+          {
+            "Version": "2.10.12"
+          },
+          {
+            "Version": "2.10.13"
+          },
+          {
+            "Version": "2.10.14"
+          },
+          {
+            "Version": "2.10.15"
+          },
+          {
+            "Version": "2.10.16"
+          },
+          {
+            "Version": "2.10.17"
+          },
+          {
+            "Version": "2.10.18"
+          },
+          {
+            "Version": "2.10.19"
+          },
+          {
+            "Version": "2.10.20"
+          },
+          {
+            "Version": "2.10.23"
+          },
+          {
+            "Version": "2.10.24"
+          },
+          {
+            "Version": "2.10.25"
+          },
+          {
+            "Version": "2.11.0-alpha"
+          },
+          {
+            "Version": "2.11.1-alpha"
+          },
+          {
+            "Version": "2.11.2-alpha"
+          },
+          {
+            "Version": "2.11.3-alpha"
+          },
+          {
+            "Version": "2.11.4-alpha"
+          },
+          {
+            "Version": "2.11.5-alpha"
+          },
+          {
+            "Version": "2.11.6-alpha"
+          },
+          {
+            "Version": "2.11.8-alpha"
+          },
+          {
+            "Version": "2.11.9-alpha"
+          },
+          {
+            "Version": "2.11.10-alpha"
+          },
+          {
+            "Version": "2.11.11-alpha"
+          },
+          {
+            "Version": "2.11.12-alpha"
+          },
+          {
+            "Version": "2.11.13-alpha"
+          },
+          {
+            "Version": "2.11.14-alpha"
+          },
+          {
+            "Version": "2.11.15-alpha"
+          },
+          {
+            "Version": "2.11.16-alpha"
+          },
+          {
+            "Version": "2.11.17-alpha"
+          },
+          {
+            "Version": "2.11.18-alpha"
+          },
+          {
+            "Version": "2.11.19-alpha"
+          },
+          {
+            "Version": "2.11.20-alpha"
+          },
+          {
+            "Version": "2.11.21-alpha"
+          },
+          {
+            "Version": "2.11.22-alpha"
+          },
+          {
+            "Version": "2.11.25-alpha"
+          },
+          {
+            "Version": "2.11.27-alpha"
+          },
+          {
+            "Version": "2.11.28-alpha"
+          },
+          {
+            "Version": "2.11.29-alpha"
+          },
+          {
+            "Version": "2.11.30-alpha"
+          },
+          {
+            "Version": "2.11.31-alpha"
+          },
+          {
+            "Version": "2.11.32-alpha"
+          },
+          {
+            "Version": "2.11.33-alpha"
+          },
+          {
+            "Version": "2.11.40-alpha"
+          },
+          {
+            "Version": "2.11.41-alpha"
+          },
+          {
+            "Version": "2.11.50-alpha"
+          },
+          {
+            "Version": "2.11.51-alpha"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.2"
+          },
+          {
+            "Version": "2.13.0-alpha1"
+          },
+          {
+            "Version": "2.13.0-alpha2"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.12"
+          },
+          {
+            "Version": "2.14.13"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.15.7"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "2.16.3"
+          },
+          {
+            "Version": "2.17.0"
+          },
+          {
+            "Version": "2.17.1"
+          },
+          {
+            "Version": "2.17.2"
+          },
+          {
+            "Version": "2.17.3-alpha1"
+          },
+          {
+            "Version": "2.17.3-alpha2"
+          },
+          {
+            "Version": "2.17.3"
+          },
+          {
+            "Version": "2.17.4"
+          },
+          {
+            "Version": "2.17.5"
+          },
+          {
+            "Version": "2.17.6"
+          },
+          {
+            "Version": "2.17.7"
+          },
+          {
+            "Version": "2.17.8"
+          },
+          {
+            "Version": "2.17.9"
+          },
+          {
+            "Version": "2.18.0-alpha1"
+          },
+          {
+            "Version": "2.18.0-alpha2"
+          },
+          {
+            "Version": "2.18.0-alpha3"
+          },
+          {
+            "Version": "2.18.0"
+          },
+          {
+            "Version": "2.18.1"
+          },
+          {
+            "Version": "2.18.2"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha10"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "3.2.5"
+          },
+          {
+            "Version": "3.2.6"
+          },
+          {
+            "Version": "3.2.7"
+          },
+          {
+            "Version": "3.2.8"
+          },
+          {
+            "Version": "3.2.9"
+          },
+          {
+            "Version": "3.2.10"
+          },
+          {
+            "Version": "3.2.11"
+          },
+          {
+            "Version": "3.2.12"
+          },
+          {
+            "Version": "3.2.13"
+          },
+          {
+            "Version": "3.2.14"
+          },
+          {
+            "Version": "3.2.15"
+          },
+          {
+            "Version": "3.2.16"
+          },
+          {
+            "Version": "3.2.17"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "3.5.9"
+          },
+          {
+            "Version": "3.5.10"
+          },
+          {
+            "Version": "3.5.11"
+          },
+          {
+            "Version": "3.5.12"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.7.8"
+          },
+          {
+            "Version": "3.7.9"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.8.3"
+          },
+          {
+            "Version": "3.8.4"
+          },
+          {
+            "Version": "3.8.5"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "3.9.4"
+          },
+          {
+            "Version": "3.9.5"
+          },
+          {
+            "Version": "3.9.6"
+          },
+          {
+            "Version": "3.9.7"
+          },
+          {
+            "Version": "3.9.8"
+          },
+          {
+            "Version": "3.9.9"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.11.2"
+          },
+          {
+            "Version": "3.11.3"
+          },
+          {
+            "Version": "3.11.4"
+          },
+          {
+            "Version": "3.12.2"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.13.2"
+          },
+          {
+            "Version": "3.13.3"
+          },
+          {
+            "Version": "3.13.4"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.14.1"
+          },
+          {
+            "Version": "3.14.2"
+          },
+          {
+            "Version": "3.14.3"
+          },
+          {
+            "Version": "3.14.4"
+          },
+          {
+            "Version": "3.14.5"
+          },
+          {
+            "Version": "3.14.6"
+          },
+          {
+            "Version": "3.14.7"
+          },
+          {
+            "Version": "3.14.8"
+          },
+          {
+            "Version": "3.14.9"
+          },
+          {
+            "Version": "3.14.10"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.17.1"
+          },
+          {
+            "Version": "3.17.2"
+          },
+          {
+            "Version": "3.17.3"
+          },
+          {
+            "Version": "3.17.4"
+          },
+          {
+            "Version": "3.17.5"
+          },
+          {
+            "Version": "3.17.6"
+          },
+          {
+            "Version": "3.17.7"
+          },
+          {
+            "Version": "3.17.8"
+          },
+          {
+            "Version": "3.17.9"
+          },
+          {
+            "Version": "3.17.11"
+          },
+          {
+            "Version": "3.17.12"
+          },
+          {
+            "Version": "3.17.13"
+          },
+          {
+            "Version": "3.17.14"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.19.3"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.25.1"
+          },
+          {
+            "Version": "3.25.2"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.26.1"
+          },
+          {
+            "Version": "3.26.3"
+          },
+          {
+            "Version": "3.26.4"
+          },
+          {
+            "Version": "3.26.5"
+          },
+          {
+            "Version": "3.26.6"
+          },
+          {
+            "Version": "3.26.7"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.27.1"
+          },
+          {
+            "Version": "3.27.2"
+          },
+          {
+            "Version": "3.27.3"
+          },
+          {
+            "Version": "3.27.4"
+          },
+          {
+            "Version": "3.27.5"
+          },
+          {
+            "Version": "3.27.6"
+          },
+          {
+            "Version": "3.27.7"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.28.1"
+          },
+          {
+            "Version": "3.28.2"
+          },
+          {
+            "Version": "3.28.3"
+          },
+          {
+            "Version": "3.28.4"
+          },
+          {
+            "Version": "3.28.5"
+          },
+          {
+            "Version": "3.28.6"
+          },
+          {
+            "Version": "3.28.7"
+          },
+          {
+            "Version": "3.28.8"
+          },
+          {
+            "Version": "3.29.1"
+          },
+          {
+            "Version": "3.29.2"
+          },
+          {
+            "Version": "3.29.3"
+          },
+          {
+            "Version": "3.29.4"
+          },
+          {
+            "Version": "3.29.5"
+          },
+          {
+            "Version": "3.29.6"
+          },
+          {
+            "Version": "3.29.7"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.31.4"
+          },
+          {
+            "Version": "3.32.4"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.34.3"
+          },
+          {
+            "Version": "3.34.4"
+          },
+          {
+            "Version": "3.34.5"
+          },
+          {
+            "Version": "3.34.6"
+          },
+          {
+            "Version": "3.34.7"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.35.2"
+          },
+          {
+            "Version": "3.35.3"
+          },
+          {
+            "Version": "3.35.4"
+          },
+          {
+            "Version": "3.35.5"
+          },
+          {
+            "Version": "3.36.0"
+          },
+          {
+            "Version": "3.37.0"
+          },
+          {
+            "Version": "3.37.1"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-alpha002"
+          },
+          {
+            "Version": "4.0.0-alpha003"
+          },
+          {
+            "Version": "4.0.0-alpha004"
+          },
+          {
+            "Version": "4.0.0-alpha005"
+          },
+          {
+            "Version": "4.0.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FAKE/4.0.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3"
+          },
+          {
+            "Version": "4.1.4"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1-alpha001"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "4.3.2"
+          },
+          {
+            "Version": "4.3.3"
+          },
+          {
+            "Version": "4.3.4"
+          },
+          {
+            "Version": "4.3.7"
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.4.1"
+          },
+          {
+            "Version": "4.4.2"
+          },
+          {
+            "Version": "4.4.3"
+          },
+          {
+            "Version": "4.4.4"
+          },
+          {
+            "Version": "4.4.5"
+          },
+          {
+            "Version": "4.4.6"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.6.0-alpha001"
+          },
+          {
+            "Version": "4.6.0-alpha002"
+          },
+          {
+            "Version": "4.6.0"
+          },
+          {
+            "Version": "4.6.1"
+          },
+          {
+            "Version": "4.6.2"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.6.4"
+          },
+          {
+            "Version": "4.7.0-alpha001"
+          },
+          {
+            "Version": "4.7.0-alpha002"
+          },
+          {
+            "Version": "4.7.0"
+          },
+          {
+            "Version": "4.7.1"
+          },
+          {
+            "Version": "4.7.2"
+          },
+          {
+            "Version": "4.7.3"
+          },
+          {
+            "Version": "4.8.0"
+          },
+          {
+            "Version": "4.9.0"
+          },
+          {
+            "Version": "4.9.1"
+          },
+          {
+            "Version": "4.9.2"
+          },
+          {
+            "Version": "4.9.3"
+          },
+          {
+            "Version": "4.9.5"
+          },
+          {
+            "Version": "4.9.6"
+          },
+          {
+            "Version": "4.9.7"
+          },
+          {
+            "Version": "4.9.8"
+          },
+          {
+            "Version": "4.10.0"
+          },
+          {
+            "Version": "4.10.1"
+          },
+          {
+            "Version": "4.10.3"
+          },
+          {
+            "Version": "4.10.4"
+          },
+          {
+            "Version": "4.10.5"
+          },
+          {
+            "Version": "4.11.0"
+          },
+          {
+            "Version": "4.11.1"
+          },
+          {
+            "Version": "4.11.2"
+          },
+          {
+            "Version": "4.11.3"
+          },
+          {
+            "Version": "4.12.0"
+          },
+          {
+            "Version": "4.12.2"
+          },
+          {
+            "Version": "4.13.0"
+          },
+          {
+            "Version": "4.13.1"
+          },
+          {
+            "Version": "4.14.0"
+          },
+          {
+            "Version": "4.14.1"
+          },
+          {
+            "Version": "4.14.2"
+          },
+          {
+            "Version": "4.14.3"
+          },
+          {
+            "Version": "4.14.4"
+          },
+          {
+            "Version": "4.14.5"
+          },
+          {
+            "Version": "4.14.7"
+          },
+          {
+            "Version": "4.14.8"
+          },
+          {
+            "Version": "4.14.9"
+          },
+          {
+            "Version": "4.15.0"
+          },
+          {
+            "Version": "4.15.1"
+          },
+          {
+            "Version": "4.15.2"
+          },
+          {
+            "Version": "4.16.0-alpha001"
+          },
+          {
+            "Version": "4.16.0"
+          },
+          {
+            "Version": "4.16.1"
+          },
+          {
+            "Version": "4.17.0-alpha001"
+          },
+          {
+            "Version": "4.17.0-alpha002"
+          },
+          {
+            "Version": "4.17.0-alpha003"
+          },
+          {
+            "Version": "4.17.0-alpha004"
+          },
+          {
+            "Version": "4.17.0-alpha005"
+          },
+          {
+            "Version": "4.17.0-alpha007"
+          },
+          {
+            "Version": "4.17.0"
+          },
+          {
+            "Version": "4.17.1"
+          },
+          {
+            "Version": "4.18.0"
+          },
+          {
+            "Version": "4.19.0"
+          },
+          {
+            "Version": "4.20.0"
+          },
+          {
+            "Version": "4.21.0"
+          },
+          {
+            "Version": "4.21.1"
+          },
+          {
+            "Version": "4.21.2"
+          },
+          {
+            "Version": "4.21.3"
+          },
+          {
+            "Version": "4.21.4"
+          },
+          {
+            "Version": "4.22.0"
+          },
+          {
+            "Version": "4.22.1"
+          },
+          {
+            "Version": "4.22.2"
+          },
+          {
+            "Version": "4.22.3"
+          },
+          {
+            "Version": "4.22.4"
+          },
+          {
+            "Version": "4.22.5"
+          },
+          {
+            "Version": "4.22.6"
+          },
+          {
+            "Version": "4.22.7"
+          },
+          {
+            "Version": "4.22.8"
+          },
+          {
+            "Version": "4.22.9"
+          },
+          {
+            "Version": "4.23.0"
+          },
+          {
+            "Version": "4.23.1"
+          },
+          {
+            "Version": "4.23.2"
+          },
+          {
+            "Version": "4.23.3"
+          },
+          {
+            "Version": "4.23.4"
+          },
+          {
+            "Version": "4.23.5"
+          },
+          {
+            "Version": "4.23.6"
+          },
+          {
+            "Version": "4.24.0"
+          },
+          {
+            "Version": "4.24.1"
+          },
+          {
+            "Version": "4.24.2"
+          },
+          {
+            "Version": "4.24.3"
+          },
+          {
+            "Version": "4.25.0"
+          },
+          {
+            "Version": "4.25.1"
+          },
+          {
+            "Version": "4.25.2"
+          },
+          {
+            "Version": "4.25.3"
+          },
+          {
+            "Version": "4.25.4"
+          },
+          {
+            "Version": "4.25.5"
+          },
+          {
+            "Version": "4.26.0"
+          },
+          {
+            "Version": "4.27.0"
+          },
+          {
+            "Version": "4.28.0"
+          },
+          {
+            "Version": "4.29.0"
+          },
+          {
+            "Version": "4.29.1"
+          },
+          {
+            "Version": "4.29.2"
+          },
+          {
+            "Version": "4.30.0"
+          },
+          {
+            "Version": "4.30.1"
+          },
+          {
+            "Version": "4.30.2"
+          },
+          {
+            "Version": "4.31.0"
+          },
+          {
+            "Version": "4.31.1"
+          },
+          {
+            "Version": "4.32.0"
+          },
+          {
+            "Version": "4.33.0"
+          },
+          {
+            "Version": "4.33.1"
+          },
+          {
+            "Version": "4.33.2"
+          },
+          {
+            "Version": "4.33.3"
+          },
+          {
+            "Version": "4.33.4"
+          },
+          {
+            "Version": "4.34.0"
+          },
+          {
+            "Version": "4.34.1"
+          },
+          {
+            "Version": "4.34.2"
+          },
+          {
+            "Version": "4.34.3"
+          },
+          {
+            "Version": "4.34.4"
+          },
+          {
+            "Version": "4.34.5"
+          },
+          {
+            "Version": "4.35.0"
+          },
+          {
+            "Version": "4.35.1"
+          },
+          {
+            "Version": "4.36.0"
+          },
+          {
+            "Version": "4.37.0"
+          },
+          {
+            "Version": "4.37.1"
+          },
+          {
+            "Version": "4.37.2"
+          },
+          {
+            "Version": "4.38.0"
+          },
+          {
+            "Version": "4.38.1"
+          },
+          {
+            "Version": "4.38.2"
+          },
+          {
+            "Version": "4.38.3"
+          },
+          {
+            "Version": "4.39.0"
+          },
+          {
+            "Version": "4.39.1"
+          },
+          {
+            "Version": "4.40.0"
+          },
+          {
+            "Version": "4.40.1"
+          },
+          {
+            "Version": "4.40.2"
+          },
+          {
+            "Version": "4.41.0"
+          },
+          {
+            "Version": "4.41.1"
+          },
+          {
+            "Version": "4.41.2"
+          },
+          {
+            "Version": "4.41.3"
+          },
+          {
+            "Version": "4.41.4"
+          },
+          {
+            "Version": "4.41.5"
+          },
+          {
+            "Version": "4.41.6"
+          },
+          {
+            "Version": "4.41.7"
+          },
+          {
+            "Version": "4.41.8"
+          },
+          {
+            "Version": "4.42.0"
+          },
+          {
+            "Version": "4.43.0"
+          },
+          {
+            "Version": "4.44.0"
+          },
+          {
+            "Version": "4.44.1"
+          },
+          {
+            "Version": "4.44.2"
+          },
+          {
+            "Version": "4.44.3"
+          },
+          {
+            "Version": "4.44.4"
+          },
+          {
+            "Version": "4.45.0"
+          },
+          {
+            "Version": "4.45.1"
+          },
+          {
+            "Version": "4.45.2"
+          },
+          {
+            "Version": "4.45.3"
+          },
+          {
+            "Version": "4.46.0"
+          },
+          {
+            "Version": "4.46.1"
+          },
+          {
+            "Version": "4.47.0"
+          },
+          {
+            "Version": "4.47.1"
+          },
+          {
+            "Version": "4.47.2"
+          },
+          {
+            "Version": "4.47.4"
+          },
+          {
+            "Version": "4.48.0"
+          },
+          {
+            "Version": "4.49.0"
+          },
+          {
+            "Version": "4.49.1"
+          },
+          {
+            "Version": "4.50.0"
+          },
+          {
+            "Version": "4.50.1"
+          },
+          {
+            "Version": "4.51.1"
+          },
+          {
+            "Version": "4.52.0"
+          },
+          {
+            "Version": "4.53.0"
+          },
+          {
+            "Version": "4.54.0-alpha001"
+          },
+          {
+            "Version": "4.54.0"
+          },
+          {
+            "Version": "4.55.0"
+          },
+          {
+            "Version": "4.55.1"
+          },
+          {
+            "Version": "4.56.0"
+          },
+          {
+            "Version": "4.57.0"
+          },
+          {
+            "Version": "4.57.1"
+          },
+          {
+            "Version": "4.57.2"
+          },
+          {
+            "Version": "4.57.3"
+          },
+          {
+            "Version": "4.57.4"
+          },
+          {
+            "Version": "4.58.2"
+          },
+          {
+            "Version": "4.58.3"
+          },
+          {
+            "Version": "4.58.4"
+          },
+          {
+            "Version": "4.58.5"
+          },
+          {
+            "Version": "4.58.6"
+          },
+          {
+            "Version": "4.59.0-alpha001"
+          },
+          {
+            "Version": "4.59.0-alpha002"
+          },
+          {
+            "Version": "4.59.0"
+          },
+          {
+            "Version": "4.59.1"
+          },
+          {
+            "Version": "4.59.3"
+          },
+          {
+            "Version": "4.60.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:55",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:56",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:44",
+        "PackageName": "System.Reactive.PlatformServices",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:48",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:56",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          }
+        ]
+      }
+    ]
+  },
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:16",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:04.9512716+02:00",
+        "PackageName": "Rx-Core",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Core/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:15",
+        "PackageName": "SnmpSharpNet",
+        "Versions": [
+          {
+            "Version": "0.9.2"
+          },
+          {
+            "Version": "0.9.3"
+          },
+          {
+            "Version": "0.9.4"
+          },
+          {
+            "Version": "0.9.5",
+            "PackageDetails": {
+              "Name": "SnmpSharpNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SnmpSharpNet/0.9.5",
+              "LicenseUrl": "http://opensource.org/licenses/lgpl-3.0.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:21",
+        "PackageName": "System.Reactive.Windows.Threading",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "System.Reactive.Windows.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reactive.Windows.Threading/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reactive.Core",
+                  "VersionRequirement": ">= 3.1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:11.979273+02:00",
+        "PackageName": "Rx-Providers",
+        "Versions": [
+          {
+            "Version": "1.0.10605"
+          },
+          {
+            "Version": "1.0.10621"
+          },
+          {
+            "Version": "1.0.11221"
+          },
+          {
+            "Version": "1.0.11226"
+          },
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Providers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Providers/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit.Extension.NUnitProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitProjectLoader",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitProjectLoader/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:24",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:26",
+        "PackageName": "System.Runtime.InteropServices.WindowsRuntime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.WindowsRuntime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.WindowsRuntime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:07.6187739+02:00",
+        "PackageName": "Rx-Interfaces",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Interfaces",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Interfaces/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:08",
+        "PackageName": "FAKE",
+        "Versions": [
+          {
+            "Version": "1.46.1"
+          },
+          {
+            "Version": "1.46.2"
+          },
+          {
+            "Version": "1.48.0"
+          },
+          {
+            "Version": "1.50.0"
+          },
+          {
+            "Version": "1.50.1"
+          },
+          {
+            "Version": "1.50.2"
+          },
+          {
+            "Version": "1.50.3"
+          },
+          {
+            "Version": "1.50.4"
+          },
+          {
+            "Version": "1.52.0"
+          },
+          {
+            "Version": "1.52.1"
+          },
+          {
+            "Version": "1.52.5"
+          },
+          {
+            "Version": "1.52.6"
+          },
+          {
+            "Version": "1.54.0"
+          },
+          {
+            "Version": "1.54.1"
+          },
+          {
+            "Version": "1.54.2"
+          },
+          {
+            "Version": "1.54.3"
+          },
+          {
+            "Version": "1.56.0"
+          },
+          {
+            "Version": "1.56.2"
+          },
+          {
+            "Version": "1.56.3"
+          },
+          {
+            "Version": "1.56.4"
+          },
+          {
+            "Version": "1.56.5"
+          },
+          {
+            "Version": "1.56.6"
+          },
+          {
+            "Version": "1.56.7"
+          },
+          {
+            "Version": "1.56.9"
+          },
+          {
+            "Version": "1.56.10"
+          },
+          {
+            "Version": "1.56.12"
+          },
+          {
+            "Version": "1.58.0"
+          },
+          {
+            "Version": "1.58.2"
+          },
+          {
+            "Version": "1.58.3"
+          },
+          {
+            "Version": "1.58.5"
+          },
+          {
+            "Version": "1.58.6"
+          },
+          {
+            "Version": "1.58.7"
+          },
+          {
+            "Version": "1.58.8"
+          },
+          {
+            "Version": "1.58.9"
+          },
+          {
+            "Version": "1.58.10"
+          },
+          {
+            "Version": "1.58.11"
+          },
+          {
+            "Version": "1.58.14"
+          },
+          {
+            "Version": "1.60.0"
+          },
+          {
+            "Version": "1.62.0"
+          },
+          {
+            "Version": "1.62.1"
+          },
+          {
+            "Version": "1.62.2"
+          },
+          {
+            "Version": "1.62.4"
+          },
+          {
+            "Version": "1.62.5"
+          },
+          {
+            "Version": "1.64.0"
+          },
+          {
+            "Version": "1.64.1"
+          },
+          {
+            "Version": "1.64.2"
+          },
+          {
+            "Version": "1.64.3"
+          },
+          {
+            "Version": "1.64.4"
+          },
+          {
+            "Version": "1.64.5"
+          },
+          {
+            "Version": "1.64.6"
+          },
+          {
+            "Version": "1.64.7"
+          },
+          {
+            "Version": "1.64.8"
+          },
+          {
+            "Version": "1.64.9"
+          },
+          {
+            "Version": "1.64.10"
+          },
+          {
+            "Version": "1.64.11"
+          },
+          {
+            "Version": "1.64.14"
+          },
+          {
+            "Version": "1.64.15"
+          },
+          {
+            "Version": "1.64.16"
+          },
+          {
+            "Version": "1.64.17"
+          },
+          {
+            "Version": "1.64.18"
+          },
+          {
+            "Version": "1.64.19"
+          },
+          {
+            "Version": "1.66.0"
+          },
+          {
+            "Version": "1.66.1"
+          },
+          {
+            "Version": "1.66.2"
+          },
+          {
+            "Version": "1.68.1"
+          },
+          {
+            "Version": "1.68.5"
+          },
+          {
+            "Version": "1.68.6"
+          },
+          {
+            "Version": "1.70.0"
+          },
+          {
+            "Version": "1.70.1"
+          },
+          {
+            "Version": "1.70.2"
+          },
+          {
+            "Version": "1.70.3"
+          },
+          {
+            "Version": "1.70.6"
+          },
+          {
+            "Version": "1.70.8"
+          },
+          {
+            "Version": "1.70.9"
+          },
+          {
+            "Version": "1.70.10"
+          },
+          {
+            "Version": "1.70.11"
+          },
+          {
+            "Version": "1.70.13"
+          },
+          {
+            "Version": "1.70.16"
+          },
+          {
+            "Version": "1.70.17"
+          },
+          {
+            "Version": "1.70.18"
+          },
+          {
+            "Version": "1.70.20"
+          },
+          {
+            "Version": "1.70.21"
+          },
+          {
+            "Version": "1.70.22"
+          },
+          {
+            "Version": "1.70.24"
+          },
+          {
+            "Version": "1.70.25"
+          },
+          {
+            "Version": "1.70.29"
+          },
+          {
+            "Version": "1.70.32"
+          },
+          {
+            "Version": "1.72.33"
+          },
+          {
+            "Version": "1.74.0"
+          },
+          {
+            "Version": "1.74.1"
+          },
+          {
+            "Version": "1.74.2"
+          },
+          {
+            "Version": "1.74.4"
+          },
+          {
+            "Version": "1.74.6"
+          },
+          {
+            "Version": "1.74.8"
+          },
+          {
+            "Version": "1.74.9"
+          },
+          {
+            "Version": "1.74.10"
+          },
+          {
+            "Version": "1.74.13"
+          },
+          {
+            "Version": "1.74.14"
+          },
+          {
+            "Version": "1.74.15"
+          },
+          {
+            "Version": "1.74.16"
+          },
+          {
+            "Version": "1.74.17"
+          },
+          {
+            "Version": "1.74.18"
+          },
+          {
+            "Version": "1.74.19"
+          },
+          {
+            "Version": "1.74.20"
+          },
+          {
+            "Version": "1.74.21"
+          },
+          {
+            "Version": "1.74.22"
+          },
+          {
+            "Version": "1.74.24"
+          },
+          {
+            "Version": "1.74.25"
+          },
+          {
+            "Version": "1.74.26"
+          },
+          {
+            "Version": "1.74.27"
+          },
+          {
+            "Version": "1.74.28"
+          },
+          {
+            "Version": "1.74.29"
+          },
+          {
+            "Version": "1.74.30"
+          },
+          {
+            "Version": "1.74.31"
+          },
+          {
+            "Version": "1.74.32"
+          },
+          {
+            "Version": "1.74.33"
+          },
+          {
+            "Version": "1.74.34"
+          },
+          {
+            "Version": "1.74.35"
+          },
+          {
+            "Version": "1.74.39"
+          },
+          {
+            "Version": "1.74.40"
+          },
+          {
+            "Version": "1.74.41"
+          },
+          {
+            "Version": "1.74.42"
+          },
+          {
+            "Version": "1.74.43"
+          },
+          {
+            "Version": "1.74.44"
+          },
+          {
+            "Version": "1.74.48"
+          },
+          {
+            "Version": "1.74.49"
+          },
+          {
+            "Version": "1.74.50"
+          },
+          {
+            "Version": "1.74.51"
+          },
+          {
+            "Version": "1.74.55"
+          },
+          {
+            "Version": "1.74.56"
+          },
+          {
+            "Version": "1.74.57"
+          },
+          {
+            "Version": "1.74.60"
+          },
+          {
+            "Version": "1.74.61"
+          },
+          {
+            "Version": "1.74.62"
+          },
+          {
+            "Version": "1.74.63"
+          },
+          {
+            "Version": "1.74.65"
+          },
+          {
+            "Version": "1.74.74"
+          },
+          {
+            "Version": "1.74.75"
+          },
+          {
+            "Version": "1.74.77"
+          },
+          {
+            "Version": "1.74.78"
+          },
+          {
+            "Version": "1.74.79"
+          },
+          {
+            "Version": "1.74.81"
+          },
+          {
+            "Version": "1.74.82"
+          },
+          {
+            "Version": "1.74.84"
+          },
+          {
+            "Version": "1.74.85"
+          },
+          {
+            "Version": "1.74.86"
+          },
+          {
+            "Version": "1.74.87"
+          },
+          {
+            "Version": "1.74.88"
+          },
+          {
+            "Version": "1.74.92"
+          },
+          {
+            "Version": "1.74.98"
+          },
+          {
+            "Version": "1.74.99"
+          },
+          {
+            "Version": "1.74.100"
+          },
+          {
+            "Version": "1.74.101"
+          },
+          {
+            "Version": "1.74.102"
+          },
+          {
+            "Version": "1.74.103"
+          },
+          {
+            "Version": "1.74.104"
+          },
+          {
+            "Version": "1.74.105"
+          },
+          {
+            "Version": "1.74.106"
+          },
+          {
+            "Version": "1.74.107"
+          },
+          {
+            "Version": "1.74.108"
+          },
+          {
+            "Version": "1.74.109"
+          },
+          {
+            "Version": "1.74.110"
+          },
+          {
+            "Version": "1.74.111"
+          },
+          {
+            "Version": "1.74.113"
+          },
+          {
+            "Version": "1.74.114"
+          },
+          {
+            "Version": "1.74.118"
+          },
+          {
+            "Version": "1.74.119"
+          },
+          {
+            "Version": "1.74.121"
+          },
+          {
+            "Version": "1.74.123"
+          },
+          {
+            "Version": "1.74.124"
+          },
+          {
+            "Version": "1.74.125"
+          },
+          {
+            "Version": "1.74.126"
+          },
+          {
+            "Version": "1.74.127"
+          },
+          {
+            "Version": "1.74.128"
+          },
+          {
+            "Version": "1.74.129"
+          },
+          {
+            "Version": "1.74.130"
+          },
+          {
+            "Version": "1.74.131"
+          },
+          {
+            "Version": "1.74.132"
+          },
+          {
+            "Version": "1.74.133"
+          },
+          {
+            "Version": "1.74.134"
+          },
+          {
+            "Version": "1.74.135"
+          },
+          {
+            "Version": "1.74.136"
+          },
+          {
+            "Version": "1.74.137"
+          },
+          {
+            "Version": "1.74.139"
+          },
+          {
+            "Version": "1.74.140"
+          },
+          {
+            "Version": "1.74.141"
+          },
+          {
+            "Version": "1.74.142"
+          },
+          {
+            "Version": "1.74.143"
+          },
+          {
+            "Version": "1.74.144"
+          },
+          {
+            "Version": "1.74.145"
+          },
+          {
+            "Version": "1.74.146"
+          },
+          {
+            "Version": "1.74.147"
+          },
+          {
+            "Version": "1.74.148"
+          },
+          {
+            "Version": "1.74.149"
+          },
+          {
+            "Version": "1.74.150"
+          },
+          {
+            "Version": "1.74.152"
+          },
+          {
+            "Version": "1.74.153"
+          },
+          {
+            "Version": "1.74.154"
+          },
+          {
+            "Version": "1.74.155"
+          },
+          {
+            "Version": "1.74.156"
+          },
+          {
+            "Version": "1.74.160"
+          },
+          {
+            "Version": "1.74.161"
+          },
+          {
+            "Version": "1.74.162"
+          },
+          {
+            "Version": "1.74.163"
+          },
+          {
+            "Version": "1.74.164"
+          },
+          {
+            "Version": "1.74.166"
+          },
+          {
+            "Version": "1.74.167"
+          },
+          {
+            "Version": "1.74.172"
+          },
+          {
+            "Version": "1.74.173"
+          },
+          {
+            "Version": "1.74.174"
+          },
+          {
+            "Version": "1.74.175"
+          },
+          {
+            "Version": "1.74.176"
+          },
+          {
+            "Version": "1.74.180"
+          },
+          {
+            "Version": "1.74.181"
+          },
+          {
+            "Version": "1.74.183"
+          },
+          {
+            "Version": "1.74.184"
+          },
+          {
+            "Version": "1.74.185"
+          },
+          {
+            "Version": "1.74.186"
+          },
+          {
+            "Version": "1.74.187"
+          },
+          {
+            "Version": "1.74.188"
+          },
+          {
+            "Version": "1.74.189"
+          },
+          {
+            "Version": "1.74.190"
+          },
+          {
+            "Version": "1.74.192"
+          },
+          {
+            "Version": "1.74.193"
+          },
+          {
+            "Version": "1.74.195"
+          },
+          {
+            "Version": "1.74.196"
+          },
+          {
+            "Version": "1.74.197"
+          },
+          {
+            "Version": "1.74.198"
+          },
+          {
+            "Version": "1.74.199"
+          },
+          {
+            "Version": "1.74.200"
+          },
+          {
+            "Version": "1.74.205"
+          },
+          {
+            "Version": "1.74.206"
+          },
+          {
+            "Version": "1.74.207"
+          },
+          {
+            "Version": "1.74.208"
+          },
+          {
+            "Version": "1.74.209"
+          },
+          {
+            "Version": "1.74.210"
+          },
+          {
+            "Version": "1.74.211"
+          },
+          {
+            "Version": "1.74.212"
+          },
+          {
+            "Version": "1.74.213"
+          },
+          {
+            "Version": "1.74.214"
+          },
+          {
+            "Version": "1.74.215"
+          },
+          {
+            "Version": "1.74.216"
+          },
+          {
+            "Version": "1.74.217"
+          },
+          {
+            "Version": "1.74.218"
+          },
+          {
+            "Version": "1.74.219"
+          },
+          {
+            "Version": "1.74.220"
+          },
+          {
+            "Version": "1.74.221"
+          },
+          {
+            "Version": "1.74.222"
+          },
+          {
+            "Version": "1.74.223"
+          },
+          {
+            "Version": "1.74.224"
+          },
+          {
+            "Version": "1.74.225"
+          },
+          {
+            "Version": "1.74.231"
+          },
+          {
+            "Version": "1.74.237"
+          },
+          {
+            "Version": "1.74.238"
+          },
+          {
+            "Version": "1.74.239"
+          },
+          {
+            "Version": "1.74.241"
+          },
+          {
+            "Version": "1.74.243"
+          },
+          {
+            "Version": "1.74.244"
+          },
+          {
+            "Version": "1.74.245"
+          },
+          {
+            "Version": "1.74.246"
+          },
+          {
+            "Version": "1.74.247"
+          },
+          {
+            "Version": "1.74.248"
+          },
+          {
+            "Version": "1.74.249"
+          },
+          {
+            "Version": "1.74.250"
+          },
+          {
+            "Version": "1.74.251"
+          },
+          {
+            "Version": "1.74.252"
+          },
+          {
+            "Version": "1.74.253"
+          },
+          {
+            "Version": "1.74.254"
+          },
+          {
+            "Version": "1.74.255"
+          },
+          {
+            "Version": "1.74.256"
+          },
+          {
+            "Version": "1.74.257"
+          },
+          {
+            "Version": "1.74.262"
+          },
+          {
+            "Version": "1.74.263"
+          },
+          {
+            "Version": "1.74.264"
+          },
+          {
+            "Version": "1.74.265"
+          },
+          {
+            "Version": "1.74.266"
+          },
+          {
+            "Version": "1.74.267"
+          },
+          {
+            "Version": "1.74.268"
+          },
+          {
+            "Version": "1.74.269"
+          },
+          {
+            "Version": "1.74.270"
+          },
+          {
+            "Version": "1.74.271"
+          },
+          {
+            "Version": "1.74.272"
+          },
+          {
+            "Version": "1.74.273"
+          },
+          {
+            "Version": "1.74.275"
+          },
+          {
+            "Version": "1.74.277"
+          },
+          {
+            "Version": "1.74.278"
+          },
+          {
+            "Version": "1.74.279"
+          },
+          {
+            "Version": "1.74.280"
+          },
+          {
+            "Version": "1.74.282"
+          },
+          {
+            "Version": "1.74.283"
+          },
+          {
+            "Version": "1.74.284"
+          },
+          {
+            "Version": "1.74.285"
+          },
+          {
+            "Version": "1.74.286"
+          },
+          {
+            "Version": "1.74.287"
+          },
+          {
+            "Version": "1.74.290"
+          },
+          {
+            "Version": "2.0.1-alpha2"
+          },
+          {
+            "Version": "2.0.1-alpha3"
+          },
+          {
+            "Version": "2.0.1-alpha4"
+          },
+          {
+            "Version": "2.0.48-alpha"
+          },
+          {
+            "Version": "2.0.55-alpha"
+          },
+          {
+            "Version": "2.0.60-alpha"
+          },
+          {
+            "Version": "2.0.61-alpha"
+          },
+          {
+            "Version": "2.0.62-alpha"
+          },
+          {
+            "Version": "2.0.64-alpha"
+          },
+          {
+            "Version": "2.0.65-alpha"
+          },
+          {
+            "Version": "2.0.66-alpha"
+          },
+          {
+            "Version": "2.0.68-alpha"
+          },
+          {
+            "Version": "2.0.69-alpha"
+          },
+          {
+            "Version": "2.0.70-alpha"
+          },
+          {
+            "Version": "2.0.73-alpha"
+          },
+          {
+            "Version": "2.0.74-alpha"
+          },
+          {
+            "Version": "2.0.75-alpha"
+          },
+          {
+            "Version": "2.0.76-alpha"
+          },
+          {
+            "Version": "2.0.77-alpha"
+          },
+          {
+            "Version": "2.0.78-alpha"
+          },
+          {
+            "Version": "2.0.79-alpha"
+          },
+          {
+            "Version": "2.0.80-alpha"
+          },
+          {
+            "Version": "2.0.81-alpha"
+          },
+          {
+            "Version": "2.0.83-alpha"
+          },
+          {
+            "Version": "2.0.84-alpha"
+          },
+          {
+            "Version": "2.0.85-alpha"
+          },
+          {
+            "Version": "2.0.86-alpha"
+          },
+          {
+            "Version": "2.0.87-alpha"
+          },
+          {
+            "Version": "2.0.90-alpha"
+          },
+          {
+            "Version": "2.0.91-alpha"
+          },
+          {
+            "Version": "2.0.94-alpha"
+          },
+          {
+            "Version": "2.0.95-alpha"
+          },
+          {
+            "Version": "2.0.96-alpha"
+          },
+          {
+            "Version": "2.0.97-alpha"
+          },
+          {
+            "Version": "2.0.98-alpha"
+          },
+          {
+            "Version": "2.0.99-alpha"
+          },
+          {
+            "Version": "2.1.0-alpha10"
+          },
+          {
+            "Version": "2.1.0-alpha13"
+          },
+          {
+            "Version": "2.1.0-alpha15"
+          },
+          {
+            "Version": "2.1.0-alpha16"
+          },
+          {
+            "Version": "2.1.0-alpha17"
+          },
+          {
+            "Version": "2.1.0-alpha18"
+          },
+          {
+            "Version": "2.1.0-alpha20"
+          },
+          {
+            "Version": "2.1.0-alpha22"
+          },
+          {
+            "Version": "2.1.0-alpha23"
+          },
+          {
+            "Version": "2.1.0-alpha24"
+          },
+          {
+            "Version": "2.1.0-alpha5"
+          },
+          {
+            "Version": "2.1.0-alpha6"
+          },
+          {
+            "Version": "2.1.0-alpha7"
+          },
+          {
+            "Version": "2.1.1-alpha"
+          },
+          {
+            "Version": "2.1.27-alpha"
+          },
+          {
+            "Version": "2.1.28-alpha"
+          },
+          {
+            "Version": "2.1.29-alpha"
+          },
+          {
+            "Version": "2.1.30-alpha"
+          },
+          {
+            "Version": "2.1.33-alpha"
+          },
+          {
+            "Version": "2.1.35-alpha"
+          },
+          {
+            "Version": "2.1.37-alpha"
+          },
+          {
+            "Version": "2.1.39-alpha"
+          },
+          {
+            "Version": "2.1.41-alpha"
+          },
+          {
+            "Version": "2.1.42-alpha"
+          },
+          {
+            "Version": "2.1.43-alpha"
+          },
+          {
+            "Version": "2.1.46-alpha"
+          },
+          {
+            "Version": "2.1.47-alpha"
+          },
+          {
+            "Version": "2.1.48-alpha"
+          },
+          {
+            "Version": "2.1.50-alpha"
+          },
+          {
+            "Version": "2.1.51-alpha"
+          },
+          {
+            "Version": "2.1.53-alpha"
+          },
+          {
+            "Version": "2.1.58-alpha"
+          },
+          {
+            "Version": "2.1.68-alpha"
+          },
+          {
+            "Version": "2.1.71-alpha"
+          },
+          {
+            "Version": "2.1.72-alpha"
+          },
+          {
+            "Version": "2.1.75-alpha"
+          },
+          {
+            "Version": "2.1.81-alpha"
+          },
+          {
+            "Version": "2.1.83-alpha"
+          },
+          {
+            "Version": "2.1.84-alpha"
+          },
+          {
+            "Version": "2.1.85-alpha"
+          },
+          {
+            "Version": "2.1.86-alpha"
+          },
+          {
+            "Version": "2.1.91-alpha"
+          },
+          {
+            "Version": "2.1.95-alpha"
+          },
+          {
+            "Version": "2.1.97-alpha"
+          },
+          {
+            "Version": "2.1.111-alpha"
+          },
+          {
+            "Version": "2.1.113-alpha"
+          },
+          {
+            "Version": "2.1.118-alpha"
+          },
+          {
+            "Version": "2.1.119-alpha"
+          },
+          {
+            "Version": "2.1.121-alpha"
+          },
+          {
+            "Version": "2.1.123-alpha"
+          },
+          {
+            "Version": "2.1.124-alpha"
+          },
+          {
+            "Version": "2.1.126-alpha"
+          },
+          {
+            "Version": "2.1.128-alpha"
+          },
+          {
+            "Version": "2.1.129-alpha"
+          },
+          {
+            "Version": "2.1.132-alpha"
+          },
+          {
+            "Version": "2.1.133-alpha"
+          },
+          {
+            "Version": "2.1.134-alpha"
+          },
+          {
+            "Version": "2.1.137-alpha"
+          },
+          {
+            "Version": "2.1.138-alpha"
+          },
+          {
+            "Version": "2.1.141-alpha"
+          },
+          {
+            "Version": "2.1.142-alpha"
+          },
+          {
+            "Version": "2.1.144-alpha"
+          },
+          {
+            "Version": "2.1.145-alpha"
+          },
+          {
+            "Version": "2.1.147-alpha"
+          },
+          {
+            "Version": "2.1.148-alpha"
+          },
+          {
+            "Version": "2.1.149-alpha"
+          },
+          {
+            "Version": "2.1.150-alpha"
+          },
+          {
+            "Version": "2.1.151-alpha"
+          },
+          {
+            "Version": "2.1.152-alpha"
+          },
+          {
+            "Version": "2.1.154-alpha"
+          },
+          {
+            "Version": "2.1.155-alpha"
+          },
+          {
+            "Version": "2.1.156-alpha"
+          },
+          {
+            "Version": "2.1.158-alpha"
+          },
+          {
+            "Version": "2.1.159-alpha"
+          },
+          {
+            "Version": "2.1.160-alpha"
+          },
+          {
+            "Version": "2.1.161-alpha"
+          },
+          {
+            "Version": "2.1.162-alpha"
+          },
+          {
+            "Version": "2.1.164-alpha"
+          },
+          {
+            "Version": "2.1.166-alpha"
+          },
+          {
+            "Version": "2.1.167-alpha"
+          },
+          {
+            "Version": "2.1.168-alpha"
+          },
+          {
+            "Version": "2.1.170-alpha"
+          },
+          {
+            "Version": "2.1.171-alpha"
+          },
+          {
+            "Version": "2.1.172-alpha"
+          },
+          {
+            "Version": "2.1.173-alpha"
+          },
+          {
+            "Version": "2.1.174-alpha"
+          },
+          {
+            "Version": "2.1.175-alpha"
+          },
+          {
+            "Version": "2.1.176-alpha"
+          },
+          {
+            "Version": "2.1.178-alpha"
+          },
+          {
+            "Version": "2.1.179-alpha"
+          },
+          {
+            "Version": "2.1.180-alpha"
+          },
+          {
+            "Version": "2.1.182-alpha"
+          },
+          {
+            "Version": "2.1.183-alpha"
+          },
+          {
+            "Version": "2.1.184-alpha"
+          },
+          {
+            "Version": "2.1.185-alpha"
+          },
+          {
+            "Version": "2.1.186-alpha"
+          },
+          {
+            "Version": "2.1.187-alpha"
+          },
+          {
+            "Version": "2.1.192-alpha"
+          },
+          {
+            "Version": "2.1.194-alpha"
+          },
+          {
+            "Version": "2.1.196-alpha"
+          },
+          {
+            "Version": "2.1.199-alpha"
+          },
+          {
+            "Version": "2.1.200-alpha"
+          },
+          {
+            "Version": "2.1.201-alpha"
+          },
+          {
+            "Version": "2.1.204-alpha"
+          },
+          {
+            "Version": "2.1.205-alpha"
+          },
+          {
+            "Version": "2.1.207-alpha"
+          },
+          {
+            "Version": "2.1.208-alpha"
+          },
+          {
+            "Version": "2.1.209-alpha"
+          },
+          {
+            "Version": "2.1.210-alpha"
+          },
+          {
+            "Version": "2.1.211-alpha"
+          },
+          {
+            "Version": "2.1.212-alpha"
+          },
+          {
+            "Version": "2.1.213-alpha"
+          },
+          {
+            "Version": "2.1.215-alpha"
+          },
+          {
+            "Version": "2.1.216-alpha"
+          },
+          {
+            "Version": "2.1.217-alpha"
+          },
+          {
+            "Version": "2.1.218-alpha"
+          },
+          {
+            "Version": "2.1.219-alpha"
+          },
+          {
+            "Version": "2.1.220-alpha"
+          },
+          {
+            "Version": "2.1.222-alpha"
+          },
+          {
+            "Version": "2.1.223-alpha"
+          },
+          {
+            "Version": "2.1.225-alpha"
+          },
+          {
+            "Version": "2.1.226-alpha"
+          },
+          {
+            "Version": "2.1.227-alpha"
+          },
+          {
+            "Version": "2.1.228-alpha"
+          },
+          {
+            "Version": "2.1.230-alpha"
+          },
+          {
+            "Version": "2.1.234-alpha"
+          },
+          {
+            "Version": "2.1.235-alpha"
+          },
+          {
+            "Version": "2.1.236-alpha"
+          },
+          {
+            "Version": "2.1.237-alpha"
+          },
+          {
+            "Version": "2.1.239-alpha"
+          },
+          {
+            "Version": "2.1.240-alpha"
+          },
+          {
+            "Version": "2.1.241-alpha"
+          },
+          {
+            "Version": "2.1.242-alpha"
+          },
+          {
+            "Version": "2.1.243-alpha"
+          },
+          {
+            "Version": "2.1.245-alpha"
+          },
+          {
+            "Version": "2.1.246-alpha"
+          },
+          {
+            "Version": "2.1.247-alpha"
+          },
+          {
+            "Version": "2.1.248-alpha"
+          },
+          {
+            "Version": "2.1.249-alpha"
+          },
+          {
+            "Version": "2.1.251-alpha"
+          },
+          {
+            "Version": "2.1.253-alpha"
+          },
+          {
+            "Version": "2.1.255-alpha"
+          },
+          {
+            "Version": "2.1.256-alpha"
+          },
+          {
+            "Version": "2.1.264-alpha"
+          },
+          {
+            "Version": "2.1.271-alpha"
+          },
+          {
+            "Version": "2.1.272-alpha"
+          },
+          {
+            "Version": "2.1.273-alpha"
+          },
+          {
+            "Version": "2.1.274-alpha"
+          },
+          {
+            "Version": "2.1.275-alpha"
+          },
+          {
+            "Version": "2.1.276-alpha"
+          },
+          {
+            "Version": "2.1.277-alpha"
+          },
+          {
+            "Version": "2.1.279-alpha"
+          },
+          {
+            "Version": "2.1.280-alpha"
+          },
+          {
+            "Version": "2.1.288-alpha"
+          },
+          {
+            "Version": "2.1.289-alpha"
+          },
+          {
+            "Version": "2.1.290-alpha"
+          },
+          {
+            "Version": "2.1.291-alpha"
+          },
+          {
+            "Version": "2.1.292-alpha"
+          },
+          {
+            "Version": "2.1.293-alpha"
+          },
+          {
+            "Version": "2.1.294-alpha"
+          },
+          {
+            "Version": "2.1.295-alpha"
+          },
+          {
+            "Version": "2.1.297-alpha"
+          },
+          {
+            "Version": "2.1.298-alpha"
+          },
+          {
+            "Version": "2.1.299-alpha"
+          },
+          {
+            "Version": "2.1.300-alpha"
+          },
+          {
+            "Version": "2.1.301-alpha"
+          },
+          {
+            "Version": "2.1.302-alpha"
+          },
+          {
+            "Version": "2.1.303-alpha"
+          },
+          {
+            "Version": "2.1.304-alpha"
+          },
+          {
+            "Version": "2.1.305-alpha"
+          },
+          {
+            "Version": "2.1.306-alpha"
+          },
+          {
+            "Version": "2.1.307-alpha"
+          },
+          {
+            "Version": "2.1.308-alpha"
+          },
+          {
+            "Version": "2.1.309-alpha"
+          },
+          {
+            "Version": "2.1.313-alpha"
+          },
+          {
+            "Version": "2.1.314-alpha"
+          },
+          {
+            "Version": "2.1.316-alpha"
+          },
+          {
+            "Version": "2.1.318-alpha"
+          },
+          {
+            "Version": "2.1.319-alpha"
+          },
+          {
+            "Version": "2.1.320-alpha"
+          },
+          {
+            "Version": "2.1.321-alpha"
+          },
+          {
+            "Version": "2.1.322-alpha"
+          },
+          {
+            "Version": "2.1.323-alpha"
+          },
+          {
+            "Version": "2.1.324-alpha"
+          },
+          {
+            "Version": "2.1.325-alpha"
+          },
+          {
+            "Version": "2.1.326-alpha"
+          },
+          {
+            "Version": "2.1.327-alpha"
+          },
+          {
+            "Version": "2.1.328-alpha"
+          },
+          {
+            "Version": "2.1.330-alpha"
+          },
+          {
+            "Version": "2.1.332-alpha"
+          },
+          {
+            "Version": "2.1.334-alpha"
+          },
+          {
+            "Version": "2.1.336-alpha"
+          },
+          {
+            "Version": "2.1.337-alpha"
+          },
+          {
+            "Version": "2.1.338-alpha"
+          },
+          {
+            "Version": "2.1.339-alpha"
+          },
+          {
+            "Version": "2.1.340-alpha"
+          },
+          {
+            "Version": "2.1.341-alpha"
+          },
+          {
+            "Version": "2.1.342-alpha"
+          },
+          {
+            "Version": "2.1.343-alpha"
+          },
+          {
+            "Version": "2.1.344-alpha"
+          },
+          {
+            "Version": "2.1.347-alpha"
+          },
+          {
+            "Version": "2.1.351-alpha"
+          },
+          {
+            "Version": "2.1.352-alpha"
+          },
+          {
+            "Version": "2.1.353-alpha"
+          },
+          {
+            "Version": "2.1.354-alpha"
+          },
+          {
+            "Version": "2.1.355-alpha"
+          },
+          {
+            "Version": "2.1.356-alpha"
+          },
+          {
+            "Version": "2.1.357-alpha"
+          },
+          {
+            "Version": "2.1.358-alpha"
+          },
+          {
+            "Version": "2.1.359-alpha"
+          },
+          {
+            "Version": "2.1.360-alpha"
+          },
+          {
+            "Version": "2.1.361-alpha"
+          },
+          {
+            "Version": "2.1.362-alpha"
+          },
+          {
+            "Version": "2.1.363-alpha"
+          },
+          {
+            "Version": "2.1.364-alpha"
+          },
+          {
+            "Version": "2.1.365-alpha"
+          },
+          {
+            "Version": "2.1.366-alpha"
+          },
+          {
+            "Version": "2.1.367-alpha"
+          },
+          {
+            "Version": "2.1.368-alpha"
+          },
+          {
+            "Version": "2.1.369-alpha"
+          },
+          {
+            "Version": "2.1.371-alpha"
+          },
+          {
+            "Version": "2.1.372-alpha"
+          },
+          {
+            "Version": "2.1.373-alpha"
+          },
+          {
+            "Version": "2.1.374-alpha"
+          },
+          {
+            "Version": "2.1.375-alpha"
+          },
+          {
+            "Version": "2.1.376-alpha"
+          },
+          {
+            "Version": "2.1.378-alpha"
+          },
+          {
+            "Version": "2.1.379-alpha"
+          },
+          {
+            "Version": "2.1.380-alpha"
+          },
+          {
+            "Version": "2.1.381-alpha"
+          },
+          {
+            "Version": "2.1.382-alpha"
+          },
+          {
+            "Version": "2.1.383-alpha"
+          },
+          {
+            "Version": "2.1.384-alpha"
+          },
+          {
+            "Version": "2.1.385-alpha"
+          },
+          {
+            "Version": "2.1.386-alpha"
+          },
+          {
+            "Version": "2.1.387-alpha"
+          },
+          {
+            "Version": "2.1.388-alpha"
+          },
+          {
+            "Version": "2.1.389-alpha"
+          },
+          {
+            "Version": "2.1.390-alpha"
+          },
+          {
+            "Version": "2.1.391-alpha"
+          },
+          {
+            "Version": "2.1.392-alpha"
+          },
+          {
+            "Version": "2.1.393-alpha"
+          },
+          {
+            "Version": "2.1.394-alpha"
+          },
+          {
+            "Version": "2.1.395-alpha"
+          },
+          {
+            "Version": "2.1.396-alpha"
+          },
+          {
+            "Version": "2.1.397-alpha"
+          },
+          {
+            "Version": "2.1.398-alpha"
+          },
+          {
+            "Version": "2.1.399-alpha"
+          },
+          {
+            "Version": "2.1.400-alpha"
+          },
+          {
+            "Version": "2.1.401-alpha"
+          },
+          {
+            "Version": "2.1.402-alpha"
+          },
+          {
+            "Version": "2.1.403-alpha"
+          },
+          {
+            "Version": "2.1.404-alpha"
+          },
+          {
+            "Version": "2.1.405-alpha"
+          },
+          {
+            "Version": "2.1.406-alpha"
+          },
+          {
+            "Version": "2.1.407-alpha"
+          },
+          {
+            "Version": "2.1.408-alpha"
+          },
+          {
+            "Version": "2.1.409-alpha"
+          },
+          {
+            "Version": "2.1.410-alpha"
+          },
+          {
+            "Version": "2.1.411-alpha"
+          },
+          {
+            "Version": "2.1.412-alpha"
+          },
+          {
+            "Version": "2.1.413-alpha"
+          },
+          {
+            "Version": "2.1.414-alpha"
+          },
+          {
+            "Version": "2.1.415-alpha"
+          },
+          {
+            "Version": "2.1.416-alpha"
+          },
+          {
+            "Version": "2.1.417-alpha"
+          },
+          {
+            "Version": "2.1.418-alpha"
+          },
+          {
+            "Version": "2.1.419-alpha"
+          },
+          {
+            "Version": "2.1.420-alpha"
+          },
+          {
+            "Version": "2.1.421-alpha"
+          },
+          {
+            "Version": "2.1.422-alpha"
+          },
+          {
+            "Version": "2.1.423-alpha"
+          },
+          {
+            "Version": "2.1.424-alpha"
+          },
+          {
+            "Version": "2.1.426-alpha"
+          },
+          {
+            "Version": "2.1.427-alpha"
+          },
+          {
+            "Version": "2.1.428-alpha"
+          },
+          {
+            "Version": "2.1.429-alpha"
+          },
+          {
+            "Version": "2.1.430-alpha"
+          },
+          {
+            "Version": "2.1.431-alpha"
+          },
+          {
+            "Version": "2.1.432-alpha"
+          },
+          {
+            "Version": "2.1.434-alpha"
+          },
+          {
+            "Version": "2.1.435-alpha"
+          },
+          {
+            "Version": "2.1.436-alpha"
+          },
+          {
+            "Version": "2.1.437-alpha"
+          },
+          {
+            "Version": "2.1.438-alpha"
+          },
+          {
+            "Version": "2.1.439-alpha"
+          },
+          {
+            "Version": "2.1.440-alpha"
+          },
+          {
+            "Version": "2.1.441-alpha"
+          },
+          {
+            "Version": "2.1.442-alpha"
+          },
+          {
+            "Version": "2.1.443-alpha"
+          },
+          {
+            "Version": "2.1.445-alpha"
+          },
+          {
+            "Version": "2.1.449-alpha"
+          },
+          {
+            "Version": "2.1.461-alpha"
+          },
+          {
+            "Version": "2.1.465-alpha"
+          },
+          {
+            "Version": "2.1.468-alpha"
+          },
+          {
+            "Version": "2.1.469-alpha"
+          },
+          {
+            "Version": "2.1.470-alpha"
+          },
+          {
+            "Version": "2.1.471-alpha"
+          },
+          {
+            "Version": "2.1.472-alpha"
+          },
+          {
+            "Version": "2.1.473-alpha"
+          },
+          {
+            "Version": "2.1.474-alpha"
+          },
+          {
+            "Version": "2.1.475-alpha"
+          },
+          {
+            "Version": "2.1.476-alpha"
+          },
+          {
+            "Version": "2.1.478-alpha"
+          },
+          {
+            "Version": "2.1.479-alpha"
+          },
+          {
+            "Version": "2.1.480-alpha"
+          },
+          {
+            "Version": "2.1.481-alpha"
+          },
+          {
+            "Version": "2.1.482-alpha"
+          },
+          {
+            "Version": "2.1.483-alpha"
+          },
+          {
+            "Version": "2.1.485-alpha"
+          },
+          {
+            "Version": "2.1.486-alpha"
+          },
+          {
+            "Version": "2.1.487-alpha"
+          },
+          {
+            "Version": "2.1.488-alpha"
+          },
+          {
+            "Version": "2.1.489-alpha"
+          },
+          {
+            "Version": "2.1.490-alpha"
+          },
+          {
+            "Version": "2.1.491-alpha"
+          },
+          {
+            "Version": "2.1.492-alpha"
+          },
+          {
+            "Version": "2.1.493-alpha"
+          },
+          {
+            "Version": "2.1.494-alpha"
+          },
+          {
+            "Version": "2.1.495-alpha"
+          },
+          {
+            "Version": "2.1.496-alpha"
+          },
+          {
+            "Version": "2.1.497-alpha"
+          },
+          {
+            "Version": "2.1.498-alpha"
+          },
+          {
+            "Version": "2.1.499-alpha"
+          },
+          {
+            "Version": "2.1.500-alpha"
+          },
+          {
+            "Version": "2.1.502-alpha"
+          },
+          {
+            "Version": "2.1.503-alpha"
+          },
+          {
+            "Version": "2.1.504-alpha"
+          },
+          {
+            "Version": "2.1.505-alpha"
+          },
+          {
+            "Version": "2.1.507-alpha"
+          },
+          {
+            "Version": "2.1.509-alpha"
+          },
+          {
+            "Version": "2.1.520-alpha"
+          },
+          {
+            "Version": "2.1.521-alpha"
+          },
+          {
+            "Version": "2.1.522-alpha"
+          },
+          {
+            "Version": "2.1.524-alpha"
+          },
+          {
+            "Version": "2.1.526-alpha"
+          },
+          {
+            "Version": "2.1.527-alpha"
+          },
+          {
+            "Version": "2.1.528-alpha"
+          },
+          {
+            "Version": "2.1.530-alpha"
+          },
+          {
+            "Version": "2.1.531-alpha"
+          },
+          {
+            "Version": "2.1.533-alpha"
+          },
+          {
+            "Version": "2.1.534-alpha"
+          },
+          {
+            "Version": "2.1.535-alpha"
+          },
+          {
+            "Version": "2.1.536-alpha"
+          },
+          {
+            "Version": "2.1.537-alpha"
+          },
+          {
+            "Version": "2.1.538-alpha"
+          },
+          {
+            "Version": "2.1.539-alpha"
+          },
+          {
+            "Version": "2.1.540-alpha"
+          },
+          {
+            "Version": "2.1.542-alpha"
+          },
+          {
+            "Version": "2.1.543-alpha"
+          },
+          {
+            "Version": "2.1.544-alpha"
+          },
+          {
+            "Version": "2.1.545-alpha"
+          },
+          {
+            "Version": "2.1.546-alpha"
+          },
+          {
+            "Version": "2.1.547-alpha"
+          },
+          {
+            "Version": "2.1.548-alpha"
+          },
+          {
+            "Version": "2.1.549-alpha"
+          },
+          {
+            "Version": "2.1.550-alpha"
+          },
+          {
+            "Version": "2.1.551-alpha"
+          },
+          {
+            "Version": "2.1.552-alpha"
+          },
+          {
+            "Version": "2.1.553-alpha"
+          },
+          {
+            "Version": "2.1.554-alpha"
+          },
+          {
+            "Version": "2.1.555-alpha"
+          },
+          {
+            "Version": "2.1.556-alpha"
+          },
+          {
+            "Version": "2.1.557-alpha"
+          },
+          {
+            "Version": "2.1.560-alpha"
+          },
+          {
+            "Version": "2.1.561-alpha"
+          },
+          {
+            "Version": "2.1.562-alpha"
+          },
+          {
+            "Version": "2.1.563-alpha"
+          },
+          {
+            "Version": "2.1.564-alpha"
+          },
+          {
+            "Version": "2.1.566-alpha"
+          },
+          {
+            "Version": "2.1.567-alpha"
+          },
+          {
+            "Version": "2.1.568-alpha"
+          },
+          {
+            "Version": "2.1.569-alpha"
+          },
+          {
+            "Version": "2.1.570-alpha"
+          },
+          {
+            "Version": "2.1.571-alpha"
+          },
+          {
+            "Version": "2.1.572-alpha"
+          },
+          {
+            "Version": "2.1.573-alpha"
+          },
+          {
+            "Version": "2.1.574-alpha"
+          },
+          {
+            "Version": "2.1.575-alpha"
+          },
+          {
+            "Version": "2.1.576-alpha"
+          },
+          {
+            "Version": "2.1.577-alpha"
+          },
+          {
+            "Version": "2.1.578-alpha"
+          },
+          {
+            "Version": "2.1.580-alpha"
+          },
+          {
+            "Version": "2.1.581-alpha"
+          },
+          {
+            "Version": "2.1.583-alpha"
+          },
+          {
+            "Version": "2.1.584-alpha"
+          },
+          {
+            "Version": "2.1.585-alpha"
+          },
+          {
+            "Version": "2.1.586-alpha"
+          },
+          {
+            "Version": "2.1.587-alpha"
+          },
+          {
+            "Version": "2.1.588-alpha"
+          },
+          {
+            "Version": "2.1.589-alpha"
+          },
+          {
+            "Version": "2.1.591-alpha"
+          },
+          {
+            "Version": "2.1.592-alpha"
+          },
+          {
+            "Version": "2.1.593-alpha"
+          },
+          {
+            "Version": "2.1.594-alpha"
+          },
+          {
+            "Version": "2.1.595-alpha"
+          },
+          {
+            "Version": "2.1.596-alpha"
+          },
+          {
+            "Version": "2.1.597-alpha"
+          },
+          {
+            "Version": "2.1.598-alpha"
+          },
+          {
+            "Version": "2.1.600-alpha"
+          },
+          {
+            "Version": "2.1.601-alpha"
+          },
+          {
+            "Version": "2.1.602-alpha"
+          },
+          {
+            "Version": "2.1.603-alpha"
+          },
+          {
+            "Version": "2.1.604-alpha"
+          },
+          {
+            "Version": "2.1.605-alpha"
+          },
+          {
+            "Version": "2.1.607-alpha"
+          },
+          {
+            "Version": "2.1.609-alpha"
+          },
+          {
+            "Version": "2.1.611-alpha"
+          },
+          {
+            "Version": "2.1.612-alpha"
+          },
+          {
+            "Version": "2.1.614-alpha"
+          },
+          {
+            "Version": "2.1.616-alpha"
+          },
+          {
+            "Version": "2.1.617-alpha"
+          },
+          {
+            "Version": "2.1.618-alpha"
+          },
+          {
+            "Version": "2.1.620-alpha"
+          },
+          {
+            "Version": "2.1.621-alpha"
+          },
+          {
+            "Version": "2.1.622-alpha"
+          },
+          {
+            "Version": "2.1.623-alpha"
+          },
+          {
+            "Version": "2.1.624-alpha"
+          },
+          {
+            "Version": "2.1.625-alpha"
+          },
+          {
+            "Version": "2.1.626-alpha"
+          },
+          {
+            "Version": "2.1.629-alpha"
+          },
+          {
+            "Version": "2.1.630-alpha"
+          },
+          {
+            "Version": "2.1.631-alpha"
+          },
+          {
+            "Version": "2.1.632-alpha"
+          },
+          {
+            "Version": "2.1.633-alpha"
+          },
+          {
+            "Version": "2.1.634-alpha"
+          },
+          {
+            "Version": "2.1.635-alpha"
+          },
+          {
+            "Version": "2.1.636-alpha"
+          },
+          {
+            "Version": "2.1.637-alpha"
+          },
+          {
+            "Version": "2.1.638-alpha"
+          },
+          {
+            "Version": "2.1.639-alpha"
+          },
+          {
+            "Version": "2.1.640-alpha"
+          },
+          {
+            "Version": "2.1.641-alpha"
+          },
+          {
+            "Version": "2.1.642-alpha"
+          },
+          {
+            "Version": "2.1.643-alpha"
+          },
+          {
+            "Version": "2.1.645-alpha"
+          },
+          {
+            "Version": "2.1.646-alpha"
+          },
+          {
+            "Version": "2.1.647-alpha"
+          },
+          {
+            "Version": "2.1.648-alpha"
+          },
+          {
+            "Version": "2.1.649-alpha"
+          },
+          {
+            "Version": "2.1.651-alpha"
+          },
+          {
+            "Version": "2.1.652-alpha"
+          },
+          {
+            "Version": "2.1.653-alpha"
+          },
+          {
+            "Version": "2.1.654-alpha"
+          },
+          {
+            "Version": "2.1.655-alpha"
+          },
+          {
+            "Version": "2.1.656-alpha"
+          },
+          {
+            "Version": "2.1.657-alpha"
+          },
+          {
+            "Version": "2.1.658-alpha"
+          },
+          {
+            "Version": "2.1.659-alpha"
+          },
+          {
+            "Version": "2.1.660-alpha"
+          },
+          {
+            "Version": "2.1.661-alpha"
+          },
+          {
+            "Version": "2.1.662-alpha"
+          },
+          {
+            "Version": "2.1.663-alpha"
+          },
+          {
+            "Version": "2.1.664-alpha"
+          },
+          {
+            "Version": "2.1.665-alpha"
+          },
+          {
+            "Version": "2.1.666-alpha"
+          },
+          {
+            "Version": "2.1.667-alpha"
+          },
+          {
+            "Version": "2.1.668-alpha"
+          },
+          {
+            "Version": "2.1.671-alpha"
+          },
+          {
+            "Version": "2.1.672-alpha"
+          },
+          {
+            "Version": "2.1.673-alpha"
+          },
+          {
+            "Version": "2.1.674-alpha"
+          },
+          {
+            "Version": "2.1.675-alpha"
+          },
+          {
+            "Version": "2.1.676-alpha"
+          },
+          {
+            "Version": "2.1.677-alpha"
+          },
+          {
+            "Version": "2.1.678-alpha"
+          },
+          {
+            "Version": "2.1.679-alpha"
+          },
+          {
+            "Version": "2.1.680-alpha"
+          },
+          {
+            "Version": "2.1.681-alpha"
+          },
+          {
+            "Version": "2.1.682-alpha"
+          },
+          {
+            "Version": "2.1.683-alpha"
+          },
+          {
+            "Version": "2.1.685-alpha"
+          },
+          {
+            "Version": "2.1.686-alpha"
+          },
+          {
+            "Version": "2.1.687-alpha"
+          },
+          {
+            "Version": "2.1.688-alpha"
+          },
+          {
+            "Version": "2.1.711-alpha"
+          },
+          {
+            "Version": "2.1.713-alpha"
+          },
+          {
+            "Version": "2.1.714-alpha"
+          },
+          {
+            "Version": "2.1.718-alpha"
+          },
+          {
+            "Version": "2.1.724-alpha"
+          },
+          {
+            "Version": "2.1.726-alpha"
+          },
+          {
+            "Version": "2.1.727-alpha"
+          },
+          {
+            "Version": "2.1.728-alpha"
+          },
+          {
+            "Version": "2.1.729-alpha"
+          },
+          {
+            "Version": "2.1.730-alpha"
+          },
+          {
+            "Version": "2.1.731-alpha"
+          },
+          {
+            "Version": "2.1.732-alpha"
+          },
+          {
+            "Version": "2.1.733-alpha"
+          },
+          {
+            "Version": "2.1.735-alpha"
+          },
+          {
+            "Version": "2.1.737-alpha"
+          },
+          {
+            "Version": "2.1.738-alpha"
+          },
+          {
+            "Version": "2.1.739-alpha"
+          },
+          {
+            "Version": "2.1.740-alpha"
+          },
+          {
+            "Version": "2.1.742-alpha"
+          },
+          {
+            "Version": "2.1.743-alpha"
+          },
+          {
+            "Version": "2.1.744-alpha"
+          },
+          {
+            "Version": "2.1.745-alpha"
+          },
+          {
+            "Version": "2.1.746-alpha"
+          },
+          {
+            "Version": "2.1.747-alpha"
+          },
+          {
+            "Version": "2.1.748-alpha"
+          },
+          {
+            "Version": "2.1.750-alpha"
+          },
+          {
+            "Version": "2.1.756-alpha"
+          },
+          {
+            "Version": "2.1.758-alpha"
+          },
+          {
+            "Version": "2.1.765-alpha"
+          },
+          {
+            "Version": "2.1.766-alpha"
+          },
+          {
+            "Version": "2.1.767-alpha"
+          },
+          {
+            "Version": "2.1.768-alpha"
+          },
+          {
+            "Version": "2.1.770-alpha"
+          },
+          {
+            "Version": "2.1.771-alpha"
+          },
+          {
+            "Version": "2.1.772-alpha"
+          },
+          {
+            "Version": "2.1.773-alpha"
+          },
+          {
+            "Version": "2.1.774-alpha"
+          },
+          {
+            "Version": "2.1.775-alpha"
+          },
+          {
+            "Version": "2.1.778-alpha"
+          },
+          {
+            "Version": "2.1.779-alpha"
+          },
+          {
+            "Version": "2.1.781-alpha"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.6"
+          },
+          {
+            "Version": "2.2.7"
+          },
+          {
+            "Version": "2.2.8"
+          },
+          {
+            "Version": "2.2.9"
+          },
+          {
+            "Version": "2.2.10"
+          },
+          {
+            "Version": "2.2.11"
+          },
+          {
+            "Version": "2.2.12"
+          },
+          {
+            "Version": "2.2.13"
+          },
+          {
+            "Version": "2.2.14"
+          },
+          {
+            "Version": "2.2.18"
+          },
+          {
+            "Version": "2.2.19"
+          },
+          {
+            "Version": "2.2.20"
+          },
+          {
+            "Version": "2.2.21"
+          },
+          {
+            "Version": "2.2.22"
+          },
+          {
+            "Version": "2.2.23"
+          },
+          {
+            "Version": "2.3.1-alpha"
+          },
+          {
+            "Version": "2.3.2-alpha"
+          },
+          {
+            "Version": "2.3.5-alpha"
+          },
+          {
+            "Version": "2.3.8-alpha"
+          },
+          {
+            "Version": "2.3.10-alpha"
+          },
+          {
+            "Version": "2.3.11-alpha"
+          },
+          {
+            "Version": "2.3.14-alpha"
+          },
+          {
+            "Version": "2.3.15-alpha"
+          },
+          {
+            "Version": "2.3.16-alpha"
+          },
+          {
+            "Version": "2.3.17-alpha"
+          },
+          {
+            "Version": "2.3.18-alpha"
+          },
+          {
+            "Version": "2.3.19-alpha"
+          },
+          {
+            "Version": "2.3.20-alpha"
+          },
+          {
+            "Version": "2.3.21-alpha"
+          },
+          {
+            "Version": "2.3.22-alpha"
+          },
+          {
+            "Version": "2.3.23-alpha"
+          },
+          {
+            "Version": "2.3.24-alpha"
+          },
+          {
+            "Version": "2.3.26-alpha"
+          },
+          {
+            "Version": "2.3.28-alpha"
+          },
+          {
+            "Version": "2.3.30-alpha"
+          },
+          {
+            "Version": "2.3.31-alpha"
+          },
+          {
+            "Version": "2.3.32-alpha"
+          },
+          {
+            "Version": "2.3.33-alpha"
+          },
+          {
+            "Version": "2.3.34-alpha"
+          },
+          {
+            "Version": "2.3.36-alpha"
+          },
+          {
+            "Version": "2.3.37-alpha"
+          },
+          {
+            "Version": "2.3.38-alpha"
+          },
+          {
+            "Version": "2.3.39-alpha"
+          },
+          {
+            "Version": "2.3.41-alpha"
+          },
+          {
+            "Version": "2.3.43-alpha"
+          },
+          {
+            "Version": "2.3.49-alpha"
+          },
+          {
+            "Version": "2.3.50-alpha"
+          },
+          {
+            "Version": "2.3.51-alpha"
+          },
+          {
+            "Version": "2.3.54-alpha"
+          },
+          {
+            "Version": "2.3.55-alpha"
+          },
+          {
+            "Version": "2.3.57-alpha"
+          },
+          {
+            "Version": "2.3.58-alpha"
+          },
+          {
+            "Version": "2.3.59-alpha"
+          },
+          {
+            "Version": "2.3.60-alpha"
+          },
+          {
+            "Version": "2.3.61-alpha"
+          },
+          {
+            "Version": "2.3.62-alpha"
+          },
+          {
+            "Version": "2.3.63-alpha"
+          },
+          {
+            "Version": "2.3.64-alpha"
+          },
+          {
+            "Version": "2.3.65-alpha"
+          },
+          {
+            "Version": "2.3.66-alpha"
+          },
+          {
+            "Version": "2.3.67-alpha"
+          },
+          {
+            "Version": "2.3.68-alpha"
+          },
+          {
+            "Version": "2.3.69-alpha"
+          },
+          {
+            "Version": "2.3.70-alpha"
+          },
+          {
+            "Version": "2.3.71-alpha"
+          },
+          {
+            "Version": "2.3.72-alpha"
+          },
+          {
+            "Version": "2.3.73-alpha"
+          },
+          {
+            "Version": "2.3.74-alpha"
+          },
+          {
+            "Version": "2.3.75-alpha"
+          },
+          {
+            "Version": "2.3.76-alpha"
+          },
+          {
+            "Version": "2.3.77-alpha"
+          },
+          {
+            "Version": "2.3.78-alpha"
+          },
+          {
+            "Version": "2.3.79-alpha"
+          },
+          {
+            "Version": "2.3.80-alpha"
+          },
+          {
+            "Version": "2.3.81-alpha"
+          },
+          {
+            "Version": "2.3.82-alpha"
+          },
+          {
+            "Version": "2.3.83-alpha"
+          },
+          {
+            "Version": "2.3.84-alpha"
+          },
+          {
+            "Version": "2.3.85-alpha"
+          },
+          {
+            "Version": "2.3.86-alpha"
+          },
+          {
+            "Version": "2.3.87-alpha"
+          },
+          {
+            "Version": "2.3.88-alpha"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.4-alpha"
+          },
+          {
+            "Version": "2.5.5-alpha"
+          },
+          {
+            "Version": "2.5.7-alpha"
+          },
+          {
+            "Version": "2.5.8-alpha"
+          },
+          {
+            "Version": "2.5.9-alpha"
+          },
+          {
+            "Version": "2.5.10-alpha"
+          },
+          {
+            "Version": "2.5.11-alpha"
+          },
+          {
+            "Version": "2.5.12-alpha"
+          },
+          {
+            "Version": "2.5.17-alpha"
+          },
+          {
+            "Version": "2.5.18-alpha"
+          },
+          {
+            "Version": "2.5.19-alpha"
+          },
+          {
+            "Version": "2.5.20-alpha"
+          },
+          {
+            "Version": "2.5.21-alpha"
+          },
+          {
+            "Version": "2.5.22-alpha"
+          },
+          {
+            "Version": "2.5.25-alpha"
+          },
+          {
+            "Version": "2.5.31-alpha"
+          },
+          {
+            "Version": "2.5.32-alpha"
+          },
+          {
+            "Version": "2.5.33-alpha"
+          },
+          {
+            "Version": "2.5.34-alpha"
+          },
+          {
+            "Version": "2.5.35-alpha"
+          },
+          {
+            "Version": "2.5.39-alpha"
+          },
+          {
+            "Version": "2.5.40-alpha"
+          },
+          {
+            "Version": "2.5.41-alpha"
+          },
+          {
+            "Version": "2.5.42-alpha"
+          },
+          {
+            "Version": "2.5.43-alpha"
+          },
+          {
+            "Version": "2.5.44-alpha"
+          },
+          {
+            "Version": "2.5.45-alpha"
+          },
+          {
+            "Version": "2.5.46-alpha"
+          },
+          {
+            "Version": "2.5.47-alpha"
+          },
+          {
+            "Version": "2.5.48-alpha"
+          },
+          {
+            "Version": "2.5.49-alpha"
+          },
+          {
+            "Version": "2.5.54-alpha"
+          },
+          {
+            "Version": "2.5.55-alpha"
+          },
+          {
+            "Version": "2.5.56-alpha"
+          },
+          {
+            "Version": "2.5.57-alpha"
+          },
+          {
+            "Version": "2.5.58-alpha"
+          },
+          {
+            "Version": "2.5.59-alpha"
+          },
+          {
+            "Version": "2.5.60-alpha"
+          },
+          {
+            "Version": "2.5.61-alpha"
+          },
+          {
+            "Version": "2.5.62-alpha"
+          },
+          {
+            "Version": "2.5.63-alpha"
+          },
+          {
+            "Version": "2.5.64-alpha"
+          },
+          {
+            "Version": "2.5.65-alpha"
+          },
+          {
+            "Version": "2.5.66-alpha"
+          },
+          {
+            "Version": "2.5.67-alpha"
+          },
+          {
+            "Version": "2.5.68-alpha"
+          },
+          {
+            "Version": "2.5.69-alpha"
+          },
+          {
+            "Version": "2.5.70-alpha"
+          },
+          {
+            "Version": "2.5.71-alpha"
+          },
+          {
+            "Version": "2.5.72-alpha"
+          },
+          {
+            "Version": "2.5.73-alpha"
+          },
+          {
+            "Version": "2.5.74-alpha"
+          },
+          {
+            "Version": "2.5.75-alpha"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.5"
+          },
+          {
+            "Version": "2.6.7"
+          },
+          {
+            "Version": "2.6.9"
+          },
+          {
+            "Version": "2.6.12"
+          },
+          {
+            "Version": "2.6.14"
+          },
+          {
+            "Version": "2.6.15"
+          },
+          {
+            "Version": "2.6.16"
+          },
+          {
+            "Version": "2.6.17"
+          },
+          {
+            "Version": "2.7.0-alpha10"
+          },
+          {
+            "Version": "2.7.0-alpha11"
+          },
+          {
+            "Version": "2.7.0-alpha13"
+          },
+          {
+            "Version": "2.7.0-alpha14"
+          },
+          {
+            "Version": "2.7.0-alpha15"
+          },
+          {
+            "Version": "2.7.0-alpha7"
+          },
+          {
+            "Version": "2.7.0-alpha8"
+          },
+          {
+            "Version": "2.7.0-alpha9"
+          },
+          {
+            "Version": "2.7.0.16-alpha"
+          },
+          {
+            "Version": "2.7.0.17-alpha"
+          },
+          {
+            "Version": "2.7.0.18-alpha"
+          },
+          {
+            "Version": "2.7.0.19-alpha"
+          },
+          {
+            "Version": "2.7.0.20-alpha"
+          },
+          {
+            "Version": "2.7.0.21-alpha"
+          },
+          {
+            "Version": "2.7.0.23-alpha"
+          },
+          {
+            "Version": "2.7.0.24-alpha"
+          },
+          {
+            "Version": "2.7.0.25-alpha"
+          },
+          {
+            "Version": "2.7.0.26-alpha"
+          },
+          {
+            "Version": "2.7.0.27-alpha"
+          },
+          {
+            "Version": "2.7.0.28-alpha"
+          },
+          {
+            "Version": "2.7.0.29-alpha"
+          },
+          {
+            "Version": "2.7.0.30-alpha"
+          },
+          {
+            "Version": "2.7.0.32-alpha"
+          },
+          {
+            "Version": "2.7.0.34-alpha"
+          },
+          {
+            "Version": "2.7.0.35-alpha"
+          },
+          {
+            "Version": "2.7.0.36-alpha"
+          },
+          {
+            "Version": "2.7.0.37-alpha"
+          },
+          {
+            "Version": "2.7.0.38-alpha"
+          },
+          {
+            "Version": "2.7.0.39-alpha"
+          },
+          {
+            "Version": "2.7.0.42-alpha"
+          },
+          {
+            "Version": "2.7.0.43-alpha"
+          },
+          {
+            "Version": "2.7.0.44-alpha"
+          },
+          {
+            "Version": "2.7.0.45-alpha"
+          },
+          {
+            "Version": "2.7.0.47-alpha"
+          },
+          {
+            "Version": "2.7.0.50-alpha"
+          },
+          {
+            "Version": "2.7.0.59-alpha"
+          },
+          {
+            "Version": "2.7.0.60-alpha"
+          },
+          {
+            "Version": "2.7.0.61-alpha"
+          },
+          {
+            "Version": "2.7.0.62-alpha"
+          },
+          {
+            "Version": "2.7.0.63-alpha"
+          },
+          {
+            "Version": "2.7.0.64-alpha"
+          },
+          {
+            "Version": "2.7.0.65-alpha"
+          },
+          {
+            "Version": "2.7.0.66-alpha"
+          },
+          {
+            "Version": "2.7.0.72-alpha"
+          },
+          {
+            "Version": "2.7.0.84-alpha"
+          },
+          {
+            "Version": "2.7.0.85-alpha"
+          },
+          {
+            "Version": "2.7.0.86-alpha"
+          },
+          {
+            "Version": "2.7.0.87-alpha"
+          },
+          {
+            "Version": "2.7.0.88-alpha"
+          },
+          {
+            "Version": "2.7.0.90-alpha"
+          },
+          {
+            "Version": "2.7.0.91-alpha"
+          },
+          {
+            "Version": "2.7.0.92-alpha"
+          },
+          {
+            "Version": "2.7.1-alpha"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.8.1"
+          },
+          {
+            "Version": "2.8.2"
+          },
+          {
+            "Version": "2.8.3"
+          },
+          {
+            "Version": "2.8.5"
+          },
+          {
+            "Version": "2.8.6"
+          },
+          {
+            "Version": "2.8.7"
+          },
+          {
+            "Version": "2.8.8"
+          },
+          {
+            "Version": "2.8.9"
+          },
+          {
+            "Version": "2.8.10"
+          },
+          {
+            "Version": "2.8.11"
+          },
+          {
+            "Version": "2.8.12"
+          },
+          {
+            "Version": "2.8.17"
+          },
+          {
+            "Version": "2.9.0-alpha"
+          },
+          {
+            "Version": "2.9.0.1-alpha"
+          },
+          {
+            "Version": "2.9.0.3-alpha"
+          },
+          {
+            "Version": "2.9.11-alpha"
+          },
+          {
+            "Version": "2.9.12-alpha"
+          },
+          {
+            "Version": "2.9.14-alpha"
+          },
+          {
+            "Version": "2.9.15-alpha"
+          },
+          {
+            "Version": "2.9.17-alpha"
+          },
+          {
+            "Version": "2.9.19-alpha"
+          },
+          {
+            "Version": "2.9.20-alpha"
+          },
+          {
+            "Version": "2.9.21-alpha"
+          },
+          {
+            "Version": "2.9.22-alpha"
+          },
+          {
+            "Version": "2.9.23-alpha"
+          },
+          {
+            "Version": "2.9.24-alpha"
+          },
+          {
+            "Version": "2.9.26-alpha"
+          },
+          {
+            "Version": "2.9.27-alpha"
+          },
+          {
+            "Version": "2.9.28-alpha"
+          },
+          {
+            "Version": "2.9.29-alpha"
+          },
+          {
+            "Version": "2.9.30-alpha"
+          },
+          {
+            "Version": "2.9.31-alpha"
+          },
+          {
+            "Version": "2.9.32-alpha"
+          },
+          {
+            "Version": "2.9.33-alpha"
+          },
+          {
+            "Version": "2.9.34-alpha"
+          },
+          {
+            "Version": "2.9.35-alpha"
+          },
+          {
+            "Version": "2.9.36-alpha"
+          },
+          {
+            "Version": "2.9.37-alpha"
+          },
+          {
+            "Version": "2.9.41-alpha"
+          },
+          {
+            "Version": "2.9.42-alpha"
+          },
+          {
+            "Version": "2.9.44-alpha"
+          },
+          {
+            "Version": "2.9.45-alpha"
+          },
+          {
+            "Version": "2.9.46-alpha"
+          },
+          {
+            "Version": "2.9.47-alpha"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.10.4"
+          },
+          {
+            "Version": "2.10.5"
+          },
+          {
+            "Version": "2.10.6"
+          },
+          {
+            "Version": "2.10.7"
+          },
+          {
+            "Version": "2.10.8"
+          },
+          {
+            "Version": "2.10.9"
+          },
+          {
+            "Version": "2.10.10"
+          },
+          {
+            "Version": "2.10.11"
+          },
+          {
+            "Version": "2.10.12"
+          },
+          {
+            "Version": "2.10.13"
+          },
+          {
+            "Version": "2.10.14"
+          },
+          {
+            "Version": "2.10.15"
+          },
+          {
+            "Version": "2.10.16"
+          },
+          {
+            "Version": "2.10.17"
+          },
+          {
+            "Version": "2.10.18"
+          },
+          {
+            "Version": "2.10.19"
+          },
+          {
+            "Version": "2.10.20"
+          },
+          {
+            "Version": "2.10.23"
+          },
+          {
+            "Version": "2.10.24"
+          },
+          {
+            "Version": "2.10.25"
+          },
+          {
+            "Version": "2.11.0-alpha"
+          },
+          {
+            "Version": "2.11.1-alpha"
+          },
+          {
+            "Version": "2.11.2-alpha"
+          },
+          {
+            "Version": "2.11.3-alpha"
+          },
+          {
+            "Version": "2.11.4-alpha"
+          },
+          {
+            "Version": "2.11.5-alpha"
+          },
+          {
+            "Version": "2.11.6-alpha"
+          },
+          {
+            "Version": "2.11.8-alpha"
+          },
+          {
+            "Version": "2.11.9-alpha"
+          },
+          {
+            "Version": "2.11.10-alpha"
+          },
+          {
+            "Version": "2.11.11-alpha"
+          },
+          {
+            "Version": "2.11.12-alpha"
+          },
+          {
+            "Version": "2.11.13-alpha"
+          },
+          {
+            "Version": "2.11.14-alpha"
+          },
+          {
+            "Version": "2.11.15-alpha"
+          },
+          {
+            "Version": "2.11.16-alpha"
+          },
+          {
+            "Version": "2.11.17-alpha"
+          },
+          {
+            "Version": "2.11.18-alpha"
+          },
+          {
+            "Version": "2.11.19-alpha"
+          },
+          {
+            "Version": "2.11.20-alpha"
+          },
+          {
+            "Version": "2.11.21-alpha"
+          },
+          {
+            "Version": "2.11.22-alpha"
+          },
+          {
+            "Version": "2.11.25-alpha"
+          },
+          {
+            "Version": "2.11.27-alpha"
+          },
+          {
+            "Version": "2.11.28-alpha"
+          },
+          {
+            "Version": "2.11.29-alpha"
+          },
+          {
+            "Version": "2.11.30-alpha"
+          },
+          {
+            "Version": "2.11.31-alpha"
+          },
+          {
+            "Version": "2.11.32-alpha"
+          },
+          {
+            "Version": "2.11.33-alpha"
+          },
+          {
+            "Version": "2.11.40-alpha"
+          },
+          {
+            "Version": "2.11.41-alpha"
+          },
+          {
+            "Version": "2.11.50-alpha"
+          },
+          {
+            "Version": "2.11.51-alpha"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.2"
+          },
+          {
+            "Version": "2.13.0-alpha1"
+          },
+          {
+            "Version": "2.13.0-alpha2"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.12"
+          },
+          {
+            "Version": "2.14.13"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.15.7"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "2.16.3"
+          },
+          {
+            "Version": "2.17.0"
+          },
+          {
+            "Version": "2.17.1"
+          },
+          {
+            "Version": "2.17.2"
+          },
+          {
+            "Version": "2.17.3-alpha1"
+          },
+          {
+            "Version": "2.17.3-alpha2"
+          },
+          {
+            "Version": "2.17.3"
+          },
+          {
+            "Version": "2.17.4"
+          },
+          {
+            "Version": "2.17.5"
+          },
+          {
+            "Version": "2.17.6"
+          },
+          {
+            "Version": "2.17.7"
+          },
+          {
+            "Version": "2.17.8"
+          },
+          {
+            "Version": "2.17.9"
+          },
+          {
+            "Version": "2.18.0-alpha1"
+          },
+          {
+            "Version": "2.18.0-alpha2"
+          },
+          {
+            "Version": "2.18.0-alpha3"
+          },
+          {
+            "Version": "2.18.0"
+          },
+          {
+            "Version": "2.18.1"
+          },
+          {
+            "Version": "2.18.2"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha10"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "3.2.5"
+          },
+          {
+            "Version": "3.2.6"
+          },
+          {
+            "Version": "3.2.7"
+          },
+          {
+            "Version": "3.2.8"
+          },
+          {
+            "Version": "3.2.9"
+          },
+          {
+            "Version": "3.2.10"
+          },
+          {
+            "Version": "3.2.11"
+          },
+          {
+            "Version": "3.2.12"
+          },
+          {
+            "Version": "3.2.13"
+          },
+          {
+            "Version": "3.2.14"
+          },
+          {
+            "Version": "3.2.15"
+          },
+          {
+            "Version": "3.2.16"
+          },
+          {
+            "Version": "3.2.17"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "3.5.9"
+          },
+          {
+            "Version": "3.5.10"
+          },
+          {
+            "Version": "3.5.11"
+          },
+          {
+            "Version": "3.5.12"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.7.8"
+          },
+          {
+            "Version": "3.7.9"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.8.3"
+          },
+          {
+            "Version": "3.8.4"
+          },
+          {
+            "Version": "3.8.5"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "3.9.4"
+          },
+          {
+            "Version": "3.9.5"
+          },
+          {
+            "Version": "3.9.6"
+          },
+          {
+            "Version": "3.9.7"
+          },
+          {
+            "Version": "3.9.8"
+          },
+          {
+            "Version": "3.9.9"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.11.2"
+          },
+          {
+            "Version": "3.11.3"
+          },
+          {
+            "Version": "3.11.4"
+          },
+          {
+            "Version": "3.12.2"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.13.2"
+          },
+          {
+            "Version": "3.13.3"
+          },
+          {
+            "Version": "3.13.4"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.14.1"
+          },
+          {
+            "Version": "3.14.2"
+          },
+          {
+            "Version": "3.14.3"
+          },
+          {
+            "Version": "3.14.4"
+          },
+          {
+            "Version": "3.14.5"
+          },
+          {
+            "Version": "3.14.6"
+          },
+          {
+            "Version": "3.14.7"
+          },
+          {
+            "Version": "3.14.8"
+          },
+          {
+            "Version": "3.14.9"
+          },
+          {
+            "Version": "3.14.10"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.17.1"
+          },
+          {
+            "Version": "3.17.2"
+          },
+          {
+            "Version": "3.17.3"
+          },
+          {
+            "Version": "3.17.4"
+          },
+          {
+            "Version": "3.17.5"
+          },
+          {
+            "Version": "3.17.6"
+          },
+          {
+            "Version": "3.17.7"
+          },
+          {
+            "Version": "3.17.8"
+          },
+          {
+            "Version": "3.17.9"
+          },
+          {
+            "Version": "3.17.11"
+          },
+          {
+            "Version": "3.17.12"
+          },
+          {
+            "Version": "3.17.13"
+          },
+          {
+            "Version": "3.17.14"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.19.3"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.25.1"
+          },
+          {
+            "Version": "3.25.2"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.26.1"
+          },
+          {
+            "Version": "3.26.3"
+          },
+          {
+            "Version": "3.26.4"
+          },
+          {
+            "Version": "3.26.5"
+          },
+          {
+            "Version": "3.26.6"
+          },
+          {
+            "Version": "3.26.7"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.27.1"
+          },
+          {
+            "Version": "3.27.2"
+          },
+          {
+            "Version": "3.27.3"
+          },
+          {
+            "Version": "3.27.4"
+          },
+          {
+            "Version": "3.27.5"
+          },
+          {
+            "Version": "3.27.6"
+          },
+          {
+            "Version": "3.27.7"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.28.1"
+          },
+          {
+            "Version": "3.28.2"
+          },
+          {
+            "Version": "3.28.3"
+          },
+          {
+            "Version": "3.28.4"
+          },
+          {
+            "Version": "3.28.5"
+          },
+          {
+            "Version": "3.28.6"
+          },
+          {
+            "Version": "3.28.7"
+          },
+          {
+            "Version": "3.28.8"
+          },
+          {
+            "Version": "3.29.1"
+          },
+          {
+            "Version": "3.29.2"
+          },
+          {
+            "Version": "3.29.3"
+          },
+          {
+            "Version": "3.29.4"
+          },
+          {
+            "Version": "3.29.5"
+          },
+          {
+            "Version": "3.29.6"
+          },
+          {
+            "Version": "3.29.7"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.31.4"
+          },
+          {
+            "Version": "3.32.4"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.34.3"
+          },
+          {
+            "Version": "3.34.4"
+          },
+          {
+            "Version": "3.34.5"
+          },
+          {
+            "Version": "3.34.6"
+          },
+          {
+            "Version": "3.34.7"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.35.2"
+          },
+          {
+            "Version": "3.35.3"
+          },
+          {
+            "Version": "3.35.4"
+          },
+          {
+            "Version": "3.35.5"
+          },
+          {
+            "Version": "3.36.0"
+          },
+          {
+            "Version": "3.37.0"
+          },
+          {
+            "Version": "3.37.1"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-alpha002"
+          },
+          {
+            "Version": "4.0.0-alpha003"
+          },
+          {
+            "Version": "4.0.0-alpha004"
+          },
+          {
+            "Version": "4.0.0-alpha005"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3"
+          },
+          {
+            "Version": "4.1.4"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1-alpha001"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "4.3.2"
+          },
+          {
+            "Version": "4.3.3"
+          },
+          {
+            "Version": "4.3.4"
+          },
+          {
+            "Version": "4.3.7"
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.4.1"
+          },
+          {
+            "Version": "4.4.2"
+          },
+          {
+            "Version": "4.4.3"
+          },
+          {
+            "Version": "4.4.4"
+          },
+          {
+            "Version": "4.4.5"
+          },
+          {
+            "Version": "4.4.6"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.6.0-alpha001"
+          },
+          {
+            "Version": "4.6.0-alpha002"
+          },
+          {
+            "Version": "4.6.0"
+          },
+          {
+            "Version": "4.6.1"
+          },
+          {
+            "Version": "4.6.2"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.6.4"
+          },
+          {
+            "Version": "4.7.0-alpha001"
+          },
+          {
+            "Version": "4.7.0-alpha002"
+          },
+          {
+            "Version": "4.7.0"
+          },
+          {
+            "Version": "4.7.1"
+          },
+          {
+            "Version": "4.7.2"
+          },
+          {
+            "Version": "4.7.3"
+          },
+          {
+            "Version": "4.8.0"
+          },
+          {
+            "Version": "4.9.0"
+          },
+          {
+            "Version": "4.9.1"
+          },
+          {
+            "Version": "4.9.2"
+          },
+          {
+            "Version": "4.9.3"
+          },
+          {
+            "Version": "4.9.5"
+          },
+          {
+            "Version": "4.9.6"
+          },
+          {
+            "Version": "4.9.7"
+          },
+          {
+            "Version": "4.9.8"
+          },
+          {
+            "Version": "4.10.0"
+          },
+          {
+            "Version": "4.10.1"
+          },
+          {
+            "Version": "4.10.3"
+          },
+          {
+            "Version": "4.10.4"
+          },
+          {
+            "Version": "4.10.5"
+          },
+          {
+            "Version": "4.11.0"
+          },
+          {
+            "Version": "4.11.1"
+          },
+          {
+            "Version": "4.11.2"
+          },
+          {
+            "Version": "4.11.3"
+          },
+          {
+            "Version": "4.12.0"
+          },
+          {
+            "Version": "4.12.2"
+          },
+          {
+            "Version": "4.13.0"
+          },
+          {
+            "Version": "4.13.1"
+          },
+          {
+            "Version": "4.14.0"
+          },
+          {
+            "Version": "4.14.1"
+          },
+          {
+            "Version": "4.14.2"
+          },
+          {
+            "Version": "4.14.3"
+          },
+          {
+            "Version": "4.14.4"
+          },
+          {
+            "Version": "4.14.5"
+          },
+          {
+            "Version": "4.14.7"
+          },
+          {
+            "Version": "4.14.8"
+          },
+          {
+            "Version": "4.14.9"
+          },
+          {
+            "Version": "4.15.0"
+          },
+          {
+            "Version": "4.15.1"
+          },
+          {
+            "Version": "4.15.2"
+          },
+          {
+            "Version": "4.16.0-alpha001"
+          },
+          {
+            "Version": "4.16.0"
+          },
+          {
+            "Version": "4.16.1"
+          },
+          {
+            "Version": "4.17.0-alpha001"
+          },
+          {
+            "Version": "4.17.0-alpha002"
+          },
+          {
+            "Version": "4.17.0-alpha003"
+          },
+          {
+            "Version": "4.17.0-alpha004"
+          },
+          {
+            "Version": "4.17.0-alpha005"
+          },
+          {
+            "Version": "4.17.0-alpha007"
+          },
+          {
+            "Version": "4.17.0"
+          },
+          {
+            "Version": "4.17.1"
+          },
+          {
+            "Version": "4.18.0"
+          },
+          {
+            "Version": "4.19.0"
+          },
+          {
+            "Version": "4.20.0"
+          },
+          {
+            "Version": "4.21.0"
+          },
+          {
+            "Version": "4.21.1"
+          },
+          {
+            "Version": "4.21.2"
+          },
+          {
+            "Version": "4.21.3"
+          },
+          {
+            "Version": "4.21.4"
+          },
+          {
+            "Version": "4.22.0"
+          },
+          {
+            "Version": "4.22.1"
+          },
+          {
+            "Version": "4.22.2"
+          },
+          {
+            "Version": "4.22.3"
+          },
+          {
+            "Version": "4.22.4"
+          },
+          {
+            "Version": "4.22.5"
+          },
+          {
+            "Version": "4.22.6"
+          },
+          {
+            "Version": "4.22.7"
+          },
+          {
+            "Version": "4.22.8"
+          },
+          {
+            "Version": "4.22.9"
+          },
+          {
+            "Version": "4.23.0"
+          },
+          {
+            "Version": "4.23.1"
+          },
+          {
+            "Version": "4.23.2"
+          },
+          {
+            "Version": "4.23.3"
+          },
+          {
+            "Version": "4.23.4"
+          },
+          {
+            "Version": "4.23.5"
+          },
+          {
+            "Version": "4.23.6"
+          },
+          {
+            "Version": "4.24.0"
+          },
+          {
+            "Version": "4.24.1"
+          },
+          {
+            "Version": "4.24.2"
+          },
+          {
+            "Version": "4.24.3"
+          },
+          {
+            "Version": "4.25.0"
+          },
+          {
+            "Version": "4.25.1"
+          },
+          {
+            "Version": "4.25.2"
+          },
+          {
+            "Version": "4.25.3"
+          },
+          {
+            "Version": "4.25.4"
+          },
+          {
+            "Version": "4.25.5"
+          },
+          {
+            "Version": "4.26.0"
+          },
+          {
+            "Version": "4.27.0"
+          },
+          {
+            "Version": "4.28.0"
+          },
+          {
+            "Version": "4.29.0"
+          },
+          {
+            "Version": "4.29.1"
+          },
+          {
+            "Version": "4.29.2"
+          },
+          {
+            "Version": "4.30.0"
+          },
+          {
+            "Version": "4.30.1"
+          },
+          {
+            "Version": "4.30.2"
+          },
+          {
+            "Version": "4.31.0"
+          },
+          {
+            "Version": "4.31.1"
+          },
+          {
+            "Version": "4.32.0"
+          },
+          {
+            "Version": "4.33.0"
+          },
+          {
+            "Version": "4.33.1"
+          },
+          {
+            "Version": "4.33.2"
+          },
+          {
+            "Version": "4.33.3"
+          },
+          {
+            "Version": "4.33.4"
+          },
+          {
+            "Version": "4.34.0"
+          },
+          {
+            "Version": "4.34.1"
+          },
+          {
+            "Version": "4.34.2"
+          },
+          {
+            "Version": "4.34.3"
+          },
+          {
+            "Version": "4.34.4"
+          },
+          {
+            "Version": "4.34.5"
+          },
+          {
+            "Version": "4.35.0"
+          },
+          {
+            "Version": "4.35.1"
+          },
+          {
+            "Version": "4.36.0"
+          },
+          {
+            "Version": "4.37.0"
+          },
+          {
+            "Version": "4.37.1"
+          },
+          {
+            "Version": "4.37.2"
+          },
+          {
+            "Version": "4.38.0"
+          },
+          {
+            "Version": "4.38.1"
+          },
+          {
+            "Version": "4.38.2"
+          },
+          {
+            "Version": "4.38.3"
+          },
+          {
+            "Version": "4.39.0"
+          },
+          {
+            "Version": "4.39.1"
+          },
+          {
+            "Version": "4.40.0"
+          },
+          {
+            "Version": "4.40.1"
+          },
+          {
+            "Version": "4.40.2"
+          },
+          {
+            "Version": "4.41.0"
+          },
+          {
+            "Version": "4.41.1"
+          },
+          {
+            "Version": "4.41.2"
+          },
+          {
+            "Version": "4.41.3"
+          },
+          {
+            "Version": "4.41.4"
+          },
+          {
+            "Version": "4.41.5"
+          },
+          {
+            "Version": "4.41.6"
+          },
+          {
+            "Version": "4.41.7"
+          },
+          {
+            "Version": "4.41.8"
+          },
+          {
+            "Version": "4.42.0"
+          },
+          {
+            "Version": "4.43.0"
+          },
+          {
+            "Version": "4.44.0"
+          },
+          {
+            "Version": "4.44.1"
+          },
+          {
+            "Version": "4.44.2"
+          },
+          {
+            "Version": "4.44.3"
+          },
+          {
+            "Version": "4.44.4"
+          },
+          {
+            "Version": "4.45.0"
+          },
+          {
+            "Version": "4.45.1"
+          },
+          {
+            "Version": "4.45.2"
+          },
+          {
+            "Version": "4.45.3"
+          },
+          {
+            "Version": "4.46.0"
+          },
+          {
+            "Version": "4.46.1"
+          },
+          {
+            "Version": "4.47.0"
+          },
+          {
+            "Version": "4.47.1"
+          },
+          {
+            "Version": "4.47.2"
+          },
+          {
+            "Version": "4.47.4"
+          },
+          {
+            "Version": "4.48.0"
+          },
+          {
+            "Version": "4.49.0"
+          },
+          {
+            "Version": "4.49.1"
+          },
+          {
+            "Version": "4.50.0"
+          },
+          {
+            "Version": "4.50.1"
+          },
+          {
+            "Version": "4.51.1"
+          },
+          {
+            "Version": "4.52.0"
+          },
+          {
+            "Version": "4.53.0"
+          },
+          {
+            "Version": "4.54.0-alpha001"
+          },
+          {
+            "Version": "4.54.0"
+          },
+          {
+            "Version": "4.55.0"
+          },
+          {
+            "Version": "4.55.1"
+          },
+          {
+            "Version": "4.56.0"
+          },
+          {
+            "Version": "4.57.0"
+          },
+          {
+            "Version": "4.57.1"
+          },
+          {
+            "Version": "4.57.2"
+          },
+          {
+            "Version": "4.57.3"
+          },
+          {
+            "Version": "4.57.4"
+          },
+          {
+            "Version": "4.58.2"
+          },
+          {
+            "Version": "4.58.3"
+          },
+          {
+            "Version": "4.58.4"
+          },
+          {
+            "Version": "4.58.5"
+          },
+          {
+            "Version": "4.58.6"
+          },
+          {
+            "Version": "4.59.0-alpha001"
+          },
+          {
+            "Version": "4.59.0-alpha002"
+          },
+          {
+            "Version": "4.59.0"
+          },
+          {
+            "Version": "4.59.1"
+          },
+          {
+            "Version": "4.59.3"
+          },
+          {
+            "Version": "4.60.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/4.60.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:17",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:18",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:10",
+        "PackageName": "FSharp.Data",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10"
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-alpha2"
+          },
+          {
+            "Version": "2.0.0-alpha3"
+          },
+          {
+            "Version": "2.0.0-alpha4"
+          },
+          {
+            "Version": "2.0.0-alpha5"
+          },
+          {
+            "Version": "2.0.0-alpha6"
+          },
+          {
+            "Version": "2.0.0-alpha7"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-beta3"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7"
+          },
+          {
+            "Version": "2.0.8"
+          },
+          {
+            "Version": "2.0.9"
+          },
+          {
+            "Version": "2.0.10"
+          },
+          {
+            "Version": "2.0.11"
+          },
+          {
+            "Version": "2.0.12"
+          },
+          {
+            "Version": "2.0.13"
+          },
+          {
+            "Version": "2.0.14"
+          },
+          {
+            "Version": "2.0.15"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.0-beta2"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1-beta1"
+          },
+          {
+            "Version": "2.3.1-beta2"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.3",
+            "PackageDetails": {
+              "Name": "FSharp.Data",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Data/2.3.3",
+              "LicenseUrl": "http://github.com/fsharp/FSharp.Data/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Zlib.Portable",
+                  "VersionRequirement": ">= 1.11",
+                  "FrameworkRestrictions": "portable-net45+sl5+win8, portable-net45+win8, portable-net45+win8+wp8+wpa81, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:12",
+        "PackageName": "ILRepack",
+        "Versions": [
+          {
+            "Version": "1.17.0"
+          },
+          {
+            "Version": "1.18.0"
+          },
+          {
+            "Version": "1.19.0"
+          },
+          {
+            "Version": "1.20.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.21.2"
+          },
+          {
+            "Version": "1.21.3"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.22.2"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7"
+          },
+          {
+            "Version": "2.0.8"
+          },
+          {
+            "Version": "2.0.9"
+          },
+          {
+            "Version": "2.0.10"
+          },
+          {
+            "Version": "2.0.11"
+          },
+          {
+            "Version": "2.0.12"
+          },
+          {
+            "Version": "2.0.13",
+            "PackageDetails": {
+              "Name": "ILRepack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ILRepack/2.0.13",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.1.0-beta1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:11",
+        "PackageName": "FSharp.Formatting.CommandTool",
+        "Versions": [
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2"
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting.CommandTool",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting.CommandTool/2.14.4",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit.Extension.VSProjectLoader",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.VSProjectLoader",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.VSProjectLoader/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:26",
+        "PackageName": "System.Runtime.Loader",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Loader",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Loader/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:12",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit.Extension.TeamCityEventListener",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.TeamCityEventListener",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.TeamCityEventListener/1.0.2",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:12",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:28",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:13",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:27",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:20",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505"
+          },
+          {
+            "Version": "2.0.20710"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:16",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:25",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:20",
+        "PackageName": "System.Reactive.Interfaces",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "System.Reactive.Interfaces",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reactive.Interfaces/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:28",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:28",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:18",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:08.7082735+02:00",
+        "PackageName": "Rx-PlatformServices",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-PlatformServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-PlatformServices/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "Rx-PlatformServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-PlatformServices/2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:21",
+        "PackageName": "System.Reactive.PlatformServices",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "System.Reactive.PlatformServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reactive.PlatformServices/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reactive.Linq",
+                  "VersionRequirement": ">= 3.1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:20",
+        "PackageName": "System.Reactive",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "System.Reactive",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reactive/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reactive.PlatformServices",
+                  "VersionRequirement": ">= 3.1.1"
+                },
+                {
+                  "PackageName": "System.Reactive.Windows.Threading",
+                  "VersionRequirement": ">= 3.1.1",
+                  "FrameworkRestrictions": "winv4.5.1, wpav8.1, >= net45"
+                },
+                {
+                  "PackageName": "System.Reactive.WindowsRuntime",
+                  "VersionRequirement": ">= 3.1.1",
+                  "FrameworkRestrictions": "winv4.5.1, wpav8.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:08.3372741+02:00",
+        "PackageName": "Rx-Linq",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Linq/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:11",
+        "PackageName": "FsLexYacc",
+        "Versions": [
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "7.0.0"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "7.0.2"
+          },
+          {
+            "Version": "7.0.3"
+          },
+          {
+            "Version": "7.0.4"
+          },
+          {
+            "Version": "7.0.5",
+            "PackageDetails": {
+              "Name": "FsLexYacc",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FsLexYacc/7.0.5",
+              "LicenseUrl": "https://github.com/fsprojects/FsLexYacc/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FsLexYacc.Runtime",
+                  "VersionRequirement": ">= 7.0.5 < 7.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:21",
+        "PackageName": "System.Reactive.WindowsRuntime",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "System.Reactive.WindowsRuntime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reactive.WindowsRuntime/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reactive.Linq",
+                  "VersionRequirement": ">= 3.1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitV2ResultWriter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitV2ResultWriter/3.5.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:15",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:26",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:15",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:08",
+        "PackageName": "FSharp.Control.Reactive",
+        "Versions": [
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.5"
+          },
+          {
+            "Version": "2.3.6"
+          },
+          {
+            "Version": "2.3.7"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "FSharp.Control.Reactive",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Control.Reactive/3.5.0",
+              "LicenseUrl": "https://github.com/fsprojects/FSharp.Control.Reactive/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reactive",
+                  "VersionRequirement": ">= 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:20",
+        "PackageName": "System.Reactive.Core",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "System.Reactive.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reactive.Core/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netcore10, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netcore10, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netcore10, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reactive.Interfaces",
+                  "VersionRequirement": ">= 3.1.1",
+                  "FrameworkRestrictions": "netcore10, >= net45, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "netcore10"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": "netcore10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:27",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:18",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:13",
+        "PackageName": "NLog.FSharp",
+        "Versions": [
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "NLog.FSharp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NLog.FSharp/3.2.1",
+              "LicenseUrl": "https://raw.githubusercontent.com/Ravadre/NLog.FSharp/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NLog",
+                  "VersionRequirement": ">= 3.2.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:07.2737827+02:00",
+        "PackageName": "Rx-Experimental",
+        "Versions": [
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Experimental",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Experimental/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Linq",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Providers",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit.Runners",
+        "Versions": [
+          {
+            "Version": "2.6.0.12051"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit.Runners",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.Runners/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NUnit.ConsoleRunner",
+                  "VersionRequirement": ">= 3.6.1"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2Driver",
+                  "VersionRequirement": ">= 3.6"
+                },
+                {
+                  "PackageName": "NUnit.Extension.NUnitV2ResultWriter",
+                  "VersionRequirement": ">= 3.5"
+                },
+                {
+                  "PackageName": "NUnit.Extension.TeamCityEventListener",
+                  "VersionRequirement": ">= 1.0.2"
+                },
+                {
+                  "PackageName": "NUnit.Extension.VSProjectLoader",
+                  "VersionRequirement": ">= 3.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit.Extension.NUnitV2Driver",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "NUnit.Extension.NUnitV2Driver",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit.Extension.NUnitV2Driver/3.6.0",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:17",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:12",
+        "PackageName": "FsUnit",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.1.1"
+          },
+          {
+            "Version": "1.0.0.3"
+          },
+          {
+            "Version": "1.0.0.4"
+          },
+          {
+            "Version": "1.0.0.5"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.0.1"
+          },
+          {
+            "Version": "1.1.0.2"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.0.1"
+          },
+          {
+            "Version": "1.3.1-beta"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0-beta"
+          },
+          {
+            "Version": "1.4.0-beta3"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.4.0-alpha-1"
+          },
+          {
+            "Version": "2.4.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "FsUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FsUnit/3.0.0",
+              "LicenseUrl": "http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1.2.5",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "NUnit",
+                  "VersionRequirement": ">= 3.6"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:20",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:09",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:28",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:27",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:19",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:21",
+        "PackageName": "System.Reactive.Linq",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha-00362"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0-rc"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "System.Reactive.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reactive.Linq/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reactive.Core",
+                  "VersionRequirement": ">= 3.1.1",
+                  "FrameworkRestrictions": ">= net45, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.WindowsRuntime",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:24",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:13",
+        "PackageName": "NLog",
+        "Versions": [
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "NLog",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NLog/3.2.1",
+              "LicenseUrl": "http://raw.github.com/NLog/NLog/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:12",
+        "PackageName": "FsLexYacc.Runtime",
+        "Versions": [
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "7.0.0"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "7.0.2"
+          },
+          {
+            "Version": "7.0.3"
+          },
+          {
+            "Version": "7.0.4"
+          },
+          {
+            "Version": "7.0.5",
+            "PackageDetails": {
+              "Name": "FsLexYacc.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FsLexYacc.Runtime/7.0.5",
+              "LicenseUrl": "https://github.com/fsprojects/FsLexYacc/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.5.7.10213"
+          },
+          {
+            "Version": "2.5.9.10348"
+          },
+          {
+            "Version": "2.5.10.11092"
+          },
+          {
+            "Version": "2.6.0.12051"
+          },
+          {
+            "Version": "2.6.0.12054"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "3.0.0-alpha"
+          },
+          {
+            "Version": "3.0.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-alpha-3"
+          },
+          {
+            "Version": "3.0.0-alpha-4"
+          },
+          {
+            "Version": "3.0.0-alpha-5"
+          },
+          {
+            "Version": "3.0.0-beta-1"
+          },
+          {
+            "Version": "3.0.0-beta-2"
+          },
+          {
+            "Version": "3.0.0-beta-3"
+          },
+          {
+            "Version": "3.0.0-beta-4"
+          },
+          {
+            "Version": "3.0.0-beta-5"
+          },
+          {
+            "Version": "3.0.0-rc"
+          },
+          {
+            "Version": "3.0.0-rc-2"
+          },
+          {
+            "Version": "3.0.0-rc-3"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Loader",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:20:08.3992715+02:00",
+        "PackageName": "Rx-Main",
+        "Versions": [
+          {
+            "Version": "1.0.2856"
+          },
+          {
+            "Version": "1.0.10605"
+          },
+          {
+            "Version": "1.0.10621"
+          },
+          {
+            "Version": "1.0.11221"
+          },
+          {
+            "Version": "1.0.11226"
+          },
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204"
+          },
+          {
+            "Version": "2.1.30214"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Main",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Main/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Linq",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-PlatformServices",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:14",
+        "PackageName": "NUnit.ConsoleRunner",
+        "Versions": [
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "NUnit.ConsoleRunner",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit.ConsoleRunner/3.6.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001254-unlisted/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001254-unlisted/cache/paket-graph.cache
@@ -1,0 +1,7294 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:31.3105251+02:00",
+        "PackageName": "ServiceStack.Common",
+        "Versions": [
+          {
+            "Version": "3.0.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.0.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.0.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.0.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.1.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.1.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.1.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.1.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.2.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.3.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.4.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.4.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.4.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.4.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.4.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.5.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.5.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.5.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.5.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.6.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.6.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.6.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.6.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.6.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.6.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.7.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.7.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.7.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.7.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.7.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.7.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.7.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.8.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.8.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.8.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.11",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/3.9.11",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.9.14"
+          },
+          {
+            "Version": "3.9.18"
+          },
+          {
+            "Version": "3.9.21"
+          },
+          {
+            "Version": "3.9.24"
+          },
+          {
+            "Version": "3.9.25"
+          },
+          {
+            "Version": "3.9.28"
+          },
+          {
+            "Version": "3.9.32"
+          },
+          {
+            "Version": "3.9.33"
+          },
+          {
+            "Version": "3.9.34"
+          },
+          {
+            "Version": "3.9.35"
+          },
+          {
+            "Version": "3.9.37"
+          },
+          {
+            "Version": "3.9.38"
+          },
+          {
+            "Version": "3.9.40"
+          },
+          {
+            "Version": "3.9.42"
+          },
+          {
+            "Version": "3.9.43"
+          },
+          {
+            "Version": "3.9.44"
+          },
+          {
+            "Version": "3.9.45"
+          },
+          {
+            "Version": "3.9.46"
+          },
+          {
+            "Version": "3.9.47"
+          },
+          {
+            "Version": "3.9.48"
+          },
+          {
+            "Version": "3.9.49"
+          },
+          {
+            "Version": "3.9.53"
+          },
+          {
+            "Version": "3.9.54"
+          },
+          {
+            "Version": "3.9.55"
+          },
+          {
+            "Version": "3.9.56"
+          },
+          {
+            "Version": "3.9.58"
+          },
+          {
+            "Version": "3.9.59"
+          },
+          {
+            "Version": "3.9.60"
+          },
+          {
+            "Version": "3.9.61"
+          },
+          {
+            "Version": "3.9.62"
+          },
+          {
+            "Version": "3.9.63"
+          },
+          {
+            "Version": "3.9.64"
+          },
+          {
+            "Version": "3.9.66"
+          },
+          {
+            "Version": "3.9.67"
+          },
+          {
+            "Version": "3.9.68"
+          },
+          {
+            "Version": "3.9.69"
+          },
+          {
+            "Version": "3.9.70"
+          },
+          {
+            "Version": "3.9.71"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Common/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Interfaces",
+                  "VersionRequirement": ">= 4.5.8"
+                },
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ">= 4.5.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:36",
+        "PackageName": "ServiceStack.Server",
+        "Versions": [
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Server",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Server/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ">= 4.5.8"
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite",
+                  "VersionRequirement": ">= 4.5.8"
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ">= 4.5.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:30.5205264+02:00",
+        "PackageName": "ServiceStack",
+        "Versions": [
+          {
+            "Version": "2.2.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/2.2.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/2.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.92",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/2.92",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.93",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/2.93",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.95",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/2.95",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.96",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/2.96",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.0.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.5",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.0.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.6",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.0.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.0.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.0.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.1.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.1.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.1.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.6",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.1.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.1.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.4",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.5",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.6",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.2.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.1",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.4",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.5",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.6",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.3.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.4.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.1",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.4.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.4.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.4.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.4.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.1",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.4",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.5",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.5.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.6.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.6.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.6.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.5",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.6.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.6",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.6.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.6.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.6.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.1",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.4",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.7.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.8.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.5",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.8.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.8.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.8.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.0",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.1",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.2",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.3",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.4",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.5",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.6",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.7",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.9",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.10",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/3.9.10",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "ServiceStack.Redis",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.9.11"
+          },
+          {
+            "Version": "3.9.14"
+          },
+          {
+            "Version": "3.9.15"
+          },
+          {
+            "Version": "3.9.16"
+          },
+          {
+            "Version": "3.9.17"
+          },
+          {
+            "Version": "3.9.18"
+          },
+          {
+            "Version": "3.9.19"
+          },
+          {
+            "Version": "3.9.21"
+          },
+          {
+            "Version": "3.9.22"
+          },
+          {
+            "Version": "3.9.23"
+          },
+          {
+            "Version": "3.9.24"
+          },
+          {
+            "Version": "3.9.25"
+          },
+          {
+            "Version": "3.9.28"
+          },
+          {
+            "Version": "3.9.32"
+          },
+          {
+            "Version": "3.9.33"
+          },
+          {
+            "Version": "3.9.34"
+          },
+          {
+            "Version": "3.9.35"
+          },
+          {
+            "Version": "3.9.37"
+          },
+          {
+            "Version": "3.9.38"
+          },
+          {
+            "Version": "3.9.40"
+          },
+          {
+            "Version": "3.9.42"
+          },
+          {
+            "Version": "3.9.43"
+          },
+          {
+            "Version": "3.9.44"
+          },
+          {
+            "Version": "3.9.45"
+          },
+          {
+            "Version": "3.9.46"
+          },
+          {
+            "Version": "3.9.47"
+          },
+          {
+            "Version": "3.9.48"
+          },
+          {
+            "Version": "3.9.49"
+          },
+          {
+            "Version": "3.9.53"
+          },
+          {
+            "Version": "3.9.54"
+          },
+          {
+            "Version": "3.9.55"
+          },
+          {
+            "Version": "3.9.56"
+          },
+          {
+            "Version": "3.9.58"
+          },
+          {
+            "Version": "3.9.59"
+          },
+          {
+            "Version": "3.9.60"
+          },
+          {
+            "Version": "3.9.61"
+          },
+          {
+            "Version": "3.9.62"
+          },
+          {
+            "Version": "3.9.63"
+          },
+          {
+            "Version": "3.9.64"
+          },
+          {
+            "Version": "3.9.65"
+          },
+          {
+            "Version": "3.9.66"
+          },
+          {
+            "Version": "3.9.67"
+          },
+          {
+            "Version": "3.9.68"
+          },
+          {
+            "Version": "3.9.69"
+          },
+          {
+            "Version": "3.9.70"
+          },
+          {
+            "Version": "3.9.71"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Client",
+                  "VersionRequirement": ">= 4.5.8"
+                },
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ">= 4.5.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:35",
+        "PackageName": "ServiceStack.Client",
+        "Versions": [
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Client",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Client/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Interfaces",
+                  "VersionRequirement": ">= 4.5.8"
+                },
+                {
+                  "PackageName": "ServiceStack.Text",
+                  "VersionRequirement": ">= 4.5.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:37.3385269+02:00",
+        "PackageName": "WebActivator",
+        "Versions": [
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.4"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.4.4"
+          },
+          {
+            "Version": "1.5",
+            "PackageDetails": {
+              "Name": "WebActivator",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WebActivator/1.5",
+              "LicenseUrl": "http://www.opensource.org/licenses/ms-pl",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.5.1",
+            "PackageDetails": {
+              "Name": "WebActivator",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WebActivator/1.5.1",
+              "LicenseUrl": "http://www.opensource.org/licenses/ms-pl",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.5.2",
+            "PackageDetails": {
+              "Name": "WebActivator",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WebActivator/1.5.2",
+              "LicenseUrl": "http://www.opensource.org/licenses/ms-pl",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.5.3",
+            "PackageDetails": {
+              "Name": "WebActivator",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WebActivator/1.5.3",
+              "LicenseUrl": "http://www.opensource.org/licenses/ms-pl",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:34.0840281+02:00",
+        "PackageName": "ServiceStack.OrmLite.SqlServer",
+        "Versions": [
+          {
+            "Version": "2.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/2.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.0.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.0.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.0.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.0.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.1.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.1.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.1.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.1.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.1.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.3.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.3.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.4.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.4.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.4.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.4.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.4.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.5.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.5.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.5.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.6.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.6.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.6.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.6.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.6.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.7.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.7.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.7.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.7.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.7.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.8.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.8.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.8.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.8.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.8.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.14",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/3.9.14",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.9.24"
+          },
+          {
+            "Version": "3.9.25"
+          },
+          {
+            "Version": "3.9.26"
+          },
+          {
+            "Version": "3.9.28"
+          },
+          {
+            "Version": "3.9.32"
+          },
+          {
+            "Version": "3.9.33"
+          },
+          {
+            "Version": "3.9.34"
+          },
+          {
+            "Version": "3.9.35"
+          },
+          {
+            "Version": "3.9.37"
+          },
+          {
+            "Version": "3.9.38"
+          },
+          {
+            "Version": "3.9.39"
+          },
+          {
+            "Version": "3.9.40"
+          },
+          {
+            "Version": "3.9.41"
+          },
+          {
+            "Version": "3.9.42"
+          },
+          {
+            "Version": "3.9.43"
+          },
+          {
+            "Version": "3.9.44"
+          },
+          {
+            "Version": "3.9.45"
+          },
+          {
+            "Version": "3.9.47"
+          },
+          {
+            "Version": "3.9.48"
+          },
+          {
+            "Version": "3.9.49"
+          },
+          {
+            "Version": "3.9.53"
+          },
+          {
+            "Version": "3.9.54"
+          },
+          {
+            "Version": "3.9.55"
+          },
+          {
+            "Version": "3.9.56"
+          },
+          {
+            "Version": "3.9.58"
+          },
+          {
+            "Version": "3.9.59"
+          },
+          {
+            "Version": "3.9.60"
+          },
+          {
+            "Version": "3.9.61"
+          },
+          {
+            "Version": "3.9.62"
+          },
+          {
+            "Version": "3.9.63"
+          },
+          {
+            "Version": "3.9.64"
+          },
+          {
+            "Version": "3.9.66"
+          },
+          {
+            "Version": "3.9.67"
+          },
+          {
+            "Version": "3.9.68"
+          },
+          {
+            "Version": "3.9.69"
+          },
+          {
+            "Version": "3.9.70"
+          },
+          {
+            "Version": "3.9.71"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite.SqlServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite.SqlServer/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.OrmLite",
+                  "VersionRequirement": ">= 4.5.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:35",
+        "PackageName": "ServiceStack.Interfaces",
+        "Versions": [
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Interfaces",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Interfaces/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:32.7245268+02:00",
+        "PackageName": "ServiceStack.Host.AspNet",
+        "Versions": [
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.1.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.2.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.2.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.2.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.2.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.3.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.3.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.3.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.5.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.5.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.6.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.7.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.8.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.8.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.9.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.30",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/3.9.30",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.9.31"
+          },
+          {
+            "Version": "3.9.33"
+          },
+          {
+            "Version": "3.9.37"
+          },
+          {
+            "Version": "3.9.38"
+          },
+          {
+            "Version": "3.9.40"
+          },
+          {
+            "Version": "3.9.42"
+          },
+          {
+            "Version": "3.9.43"
+          },
+          {
+            "Version": "3.9.44"
+          },
+          {
+            "Version": "3.9.45"
+          },
+          {
+            "Version": "3.9.47"
+          },
+          {
+            "Version": "3.9.48"
+          },
+          {
+            "Version": "3.9.49"
+          },
+          {
+            "Version": "3.9.53"
+          },
+          {
+            "Version": "3.9.54"
+          },
+          {
+            "Version": "3.9.55"
+          },
+          {
+            "Version": "3.9.56"
+          },
+          {
+            "Version": "3.9.58"
+          },
+          {
+            "Version": "3.9.59"
+          },
+          {
+            "Version": "3.9.60"
+          },
+          {
+            "Version": "3.9.61"
+          },
+          {
+            "Version": "3.9.62"
+          },
+          {
+            "Version": "3.9.63"
+          },
+          {
+            "Version": "3.9.64"
+          },
+          {
+            "Version": "3.9.66"
+          },
+          {
+            "Version": "3.9.67"
+          },
+          {
+            "Version": "3.9.68"
+          },
+          {
+            "Version": "3.9.69"
+          },
+          {
+            "Version": "3.9.70"
+          },
+          {
+            "Version": "3.9.71"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Host.AspNet",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Host.AspNet/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.OrmLite.SqlServer",
+                  "VersionRequirement": ">= 4.5.8"
+                },
+                {
+                  "PackageName": "ServiceStack.Server",
+                  "VersionRequirement": ">= 4.5.8"
+                },
+                {
+                  "PackageName": "WebActivator",
+                  "VersionRequirement": ">= 1.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:35.7565295+02:00",
+        "PackageName": "ServiceStack.Redis",
+        "Versions": [
+          {
+            "Version": "2.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/2.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.20",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/2.20",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.28",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/2.28",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.29",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/2.29",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.0.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.0.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.0.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.0.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.0.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.1.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.1.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.2.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.2.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.3.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.3.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.4.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.4.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.5.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.5.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.5.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.5.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.5.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.6.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.7.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.7.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.7.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.7.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.7.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.7.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.8.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.8.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.8.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.8.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.9.11",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/3.9.11",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Redis/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.9.12"
+          },
+          {
+            "Version": "3.9.14"
+          },
+          {
+            "Version": "3.9.24"
+          },
+          {
+            "Version": "3.9.25"
+          },
+          {
+            "Version": "3.9.28"
+          },
+          {
+            "Version": "3.9.29"
+          },
+          {
+            "Version": "3.9.32"
+          },
+          {
+            "Version": "3.9.33"
+          },
+          {
+            "Version": "3.9.34"
+          },
+          {
+            "Version": "3.9.35"
+          },
+          {
+            "Version": "3.9.37"
+          },
+          {
+            "Version": "3.9.38"
+          },
+          {
+            "Version": "3.9.40"
+          },
+          {
+            "Version": "3.9.42"
+          },
+          {
+            "Version": "3.9.43"
+          },
+          {
+            "Version": "3.9.44"
+          },
+          {
+            "Version": "3.9.45"
+          },
+          {
+            "Version": "3.9.47"
+          },
+          {
+            "Version": "3.9.48"
+          },
+          {
+            "Version": "3.9.49"
+          },
+          {
+            "Version": "3.9.50"
+          },
+          {
+            "Version": "3.9.51"
+          },
+          {
+            "Version": "3.9.52"
+          },
+          {
+            "Version": "3.9.53"
+          },
+          {
+            "Version": "3.9.54"
+          },
+          {
+            "Version": "3.9.55"
+          },
+          {
+            "Version": "3.9.56"
+          },
+          {
+            "Version": "3.9.57"
+          },
+          {
+            "Version": "3.9.58"
+          },
+          {
+            "Version": "3.9.59"
+          },
+          {
+            "Version": "3.9.60"
+          },
+          {
+            "Version": "3.9.61"
+          },
+          {
+            "Version": "3.9.62"
+          },
+          {
+            "Version": "3.9.63"
+          },
+          {
+            "Version": "3.9.64"
+          },
+          {
+            "Version": "3.9.66"
+          },
+          {
+            "Version": "3.9.67"
+          },
+          {
+            "Version": "3.9.68"
+          },
+          {
+            "Version": "3.9.69"
+          },
+          {
+            "Version": "3.9.70"
+          },
+          {
+            "Version": "3.9.71"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Redis",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Redis/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ">= 4.5.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:35",
+        "PackageName": "ServiceStack.OrmLite",
+        "Versions": [
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.OrmLite",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.OrmLite/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "ServiceStack.Common",
+                  "VersionRequirement": ">= 4.5.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:21:36.8550261+02:00",
+        "PackageName": "ServiceStack.Text",
+        "Versions": [
+          {
+            "Version": "2.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/2.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.20",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/2.20",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.26",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/2.26",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.27",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/2.27",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.28",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/2.28",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.29",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/2.29",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.0.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.0.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.0.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.0.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.0.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.1.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.1.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.1.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.2.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.3.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.3.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.3.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.3.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.3.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.3.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.4.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.5.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.5.1",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.5.1",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.5.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.5.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.5.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.5.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.5.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.5.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.5.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.5.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.6.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.6.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.6.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.6.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.6.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.6.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.6.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.6.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.6.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.6.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.6.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.7.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.7.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.7.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.7.8",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.7.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.7.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.8.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.8.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.8.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.8.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.8.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.8.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.0",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.0",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.2",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.2",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.3",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.3",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.4",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.4",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.5",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.5",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.6",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.6",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.7",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.7",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.9",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.9",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.9.11",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/3.9.11",
+              "LicenseUrl": "https://github.com/ServiceStack/ServiceStack.Text/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.9.14"
+          },
+          {
+            "Version": "3.9.21"
+          },
+          {
+            "Version": "3.9.24"
+          },
+          {
+            "Version": "3.9.25"
+          },
+          {
+            "Version": "3.9.26"
+          },
+          {
+            "Version": "3.9.27"
+          },
+          {
+            "Version": "3.9.28"
+          },
+          {
+            "Version": "3.9.29"
+          },
+          {
+            "Version": "3.9.32"
+          },
+          {
+            "Version": "3.9.33"
+          },
+          {
+            "Version": "3.9.34"
+          },
+          {
+            "Version": "3.9.35"
+          },
+          {
+            "Version": "3.9.37"
+          },
+          {
+            "Version": "3.9.38"
+          },
+          {
+            "Version": "3.9.40"
+          },
+          {
+            "Version": "3.9.42"
+          },
+          {
+            "Version": "3.9.43"
+          },
+          {
+            "Version": "3.9.44"
+          },
+          {
+            "Version": "3.9.45"
+          },
+          {
+            "Version": "3.9.46"
+          },
+          {
+            "Version": "3.9.47"
+          },
+          {
+            "Version": "3.9.48"
+          },
+          {
+            "Version": "3.9.49"
+          },
+          {
+            "Version": "3.9.53"
+          },
+          {
+            "Version": "3.9.54"
+          },
+          {
+            "Version": "3.9.55"
+          },
+          {
+            "Version": "3.9.56"
+          },
+          {
+            "Version": "3.9.58"
+          },
+          {
+            "Version": "3.9.59"
+          },
+          {
+            "Version": "3.9.60"
+          },
+          {
+            "Version": "3.9.61"
+          },
+          {
+            "Version": "3.9.62"
+          },
+          {
+            "Version": "3.9.63"
+          },
+          {
+            "Version": "3.9.64"
+          },
+          {
+            "Version": "3.9.66"
+          },
+          {
+            "Version": "3.9.67"
+          },
+          {
+            "Version": "3.9.68"
+          },
+          {
+            "Version": "3.9.69"
+          },
+          {
+            "Version": "3.9.70"
+          },
+          {
+            "Version": "3.9.71"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.0.9"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.0.13"
+          },
+          {
+            "Version": "4.0.14"
+          },
+          {
+            "Version": "4.0.15"
+          },
+          {
+            "Version": "4.0.16"
+          },
+          {
+            "Version": "4.0.17"
+          },
+          {
+            "Version": "4.0.18"
+          },
+          {
+            "Version": "4.0.19"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21"
+          },
+          {
+            "Version": "4.0.22"
+          },
+          {
+            "Version": "4.0.23"
+          },
+          {
+            "Version": "4.0.24"
+          },
+          {
+            "Version": "4.0.30"
+          },
+          {
+            "Version": "4.0.31"
+          },
+          {
+            "Version": "4.0.32"
+          },
+          {
+            "Version": "4.0.33"
+          },
+          {
+            "Version": "4.0.34"
+          },
+          {
+            "Version": "4.0.35"
+          },
+          {
+            "Version": "4.0.36"
+          },
+          {
+            "Version": "4.0.38"
+          },
+          {
+            "Version": "4.0.40"
+          },
+          {
+            "Version": "4.0.42"
+          },
+          {
+            "Version": "4.0.44"
+          },
+          {
+            "Version": "4.0.46"
+          },
+          {
+            "Version": "4.0.48"
+          },
+          {
+            "Version": "4.0.50"
+          },
+          {
+            "Version": "4.0.52"
+          },
+          {
+            "Version": "4.0.54"
+          },
+          {
+            "Version": "4.0.56"
+          },
+          {
+            "Version": "4.0.58"
+          },
+          {
+            "Version": "4.0.60"
+          },
+          {
+            "Version": "4.0.62"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.8",
+            "PackageDetails": {
+              "Name": "ServiceStack.Text",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ServiceStack.Text/4.5.8",
+              "LicenseUrl": "https://servicestack.net/terms",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:27:34",
+        "PackageName": "Microsoft.Web.Infrastructure",
+        "Versions": [
+          {
+            "Version": "1.0.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Web.Infrastructure",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Web.Infrastructure/1.0.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=214339",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001260-csharp-wpf-project/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001260-csharp-wpf-project/cache/paket-graph.cache
@@ -1,0 +1,3402 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:51.2455426+02:00",
+        "PackageName": "MahApps.Metro",
+        "Versions": [
+          {
+            "Version": "0.1"
+          },
+          {
+            "Version": "0.2"
+          },
+          {
+            "Version": "0.3"
+          },
+          {
+            "Version": "0.3.0.1"
+          },
+          {
+            "Version": "0.4.0.17"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.0.1"
+          },
+          {
+            "Version": "0.7.0.41-ALPHA"
+          },
+          {
+            "Version": "0.7.0.42-ALPHA"
+          },
+          {
+            "Version": "0.7.0.43-ALPHA"
+          },
+          {
+            "Version": "0.7.0.44-ALPHA"
+          },
+          {
+            "Version": "0.7.0.45-ALPHA"
+          },
+          {
+            "Version": "0.7.0.46-ALPHA"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.7.2.0"
+          },
+          {
+            "Version": "0.7.9.47-ALPHA"
+          },
+          {
+            "Version": "0.7.9.48-ALPHA"
+          },
+          {
+            "Version": "0.7.9.49-ALPHA"
+          },
+          {
+            "Version": "0.7.9.50-ALPHA"
+          },
+          {
+            "Version": "0.7.9.51-ALPHA"
+          },
+          {
+            "Version": "0.7.9.52-ALPHA"
+          },
+          {
+            "Version": "0.7.9.53-ALPHA"
+          },
+          {
+            "Version": "0.7.9.54-ALPHA"
+          },
+          {
+            "Version": "0.7.9.55-ALPHA"
+          },
+          {
+            "Version": "0.7.9.56-ALPHA"
+          },
+          {
+            "Version": "0.7.9.57-ALPHA"
+          },
+          {
+            "Version": "0.7.9.58-ALPHA"
+          },
+          {
+            "Version": "0.7.9.59-ALPHA"
+          },
+          {
+            "Version": "0.7.9.60-ALPHA"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.9.8-ALPHA"
+          },
+          {
+            "Version": "0.8.9.9-ALPHA"
+          },
+          {
+            "Version": "0.8.9.10-ALPHA"
+          },
+          {
+            "Version": "0.8.9.16-ALPHA"
+          },
+          {
+            "Version": "0.8.9.17-ALPHA"
+          },
+          {
+            "Version": "0.8.9.18-ALPHA"
+          },
+          {
+            "Version": "0.8.9.19-ALPHA"
+          },
+          {
+            "Version": "0.8.9.20-ALPHA"
+          },
+          {
+            "Version": "0.8.9.21-ALPHA"
+          },
+          {
+            "Version": "0.8.9.22-ALPHA"
+          },
+          {
+            "Version": "0.8.9.23-ALPHA"
+          },
+          {
+            "Version": "0.8.9.24-ALPHA"
+          },
+          {
+            "Version": "0.8.9.25-ALPHA"
+          },
+          {
+            "Version": "0.8.9.26-ALPHA"
+          },
+          {
+            "Version": "0.8.9.27-ALPHA"
+          },
+          {
+            "Version": "0.8.9.28-ALPHA"
+          },
+          {
+            "Version": "0.8.9.29-ALPHA"
+          },
+          {
+            "Version": "0.8.9.30-ALPHA"
+          },
+          {
+            "Version": "0.8.9.32-ALPHA"
+          },
+          {
+            "Version": "0.8.9.33-ALPHA"
+          },
+          {
+            "Version": "0.8.9.34-ALPHA"
+          },
+          {
+            "Version": "0.8.9.35-ALPHA"
+          },
+          {
+            "Version": "0.8.9.36-ALPHA"
+          },
+          {
+            "Version": "0.9.0.0"
+          },
+          {
+            "Version": "0.9.9.37-ALPHA"
+          },
+          {
+            "Version": "0.9.9.40-ALPHA"
+          },
+          {
+            "Version": "0.9.9.41-ALPHA"
+          },
+          {
+            "Version": "0.9.9.42-ALPHA"
+          },
+          {
+            "Version": "0.9.9.43-ALPHA"
+          },
+          {
+            "Version": "0.9.9.44-ALPHA"
+          },
+          {
+            "Version": "0.9.9.45-ALPHA"
+          },
+          {
+            "Version": "0.9.9.46-ALPHA"
+          },
+          {
+            "Version": "0.9.9.47-ALPHA"
+          },
+          {
+            "Version": "0.9.9.48-ALPHA"
+          },
+          {
+            "Version": "0.9.9.49-ALPHA"
+          },
+          {
+            "Version": "0.9.9.50-ALPHA"
+          },
+          {
+            "Version": "0.9.9.51-ALPHA"
+          },
+          {
+            "Version": "0.9.9.52-ALPHA"
+          },
+          {
+            "Version": "0.9.9.53-ALPHA"
+          },
+          {
+            "Version": "0.9.9.54-ALPHA"
+          },
+          {
+            "Version": "0.9.9.55-ALPHA"
+          },
+          {
+            "Version": "0.10.0.0"
+          },
+          {
+            "Version": "0.10.0.1"
+          },
+          {
+            "Version": "0.10.1.1"
+          },
+          {
+            "Version": "0.10.1.6-ALPHA"
+          },
+          {
+            "Version": "0.10.1.7-ALPHA"
+          },
+          {
+            "Version": "0.10.1.8-ALPHA"
+          },
+          {
+            "Version": "0.10.1.9-ALPHA"
+          },
+          {
+            "Version": "0.10.1.10-ALPHA"
+          },
+          {
+            "Version": "0.10.1.11-ALPHA"
+          },
+          {
+            "Version": "0.10.1.12-ALPHA"
+          },
+          {
+            "Version": "0.10.1.13-ALPHA"
+          },
+          {
+            "Version": "0.10.1.14-ALPHA"
+          },
+          {
+            "Version": "0.10.1.17-ALPHA"
+          },
+          {
+            "Version": "0.10.1.20-ALPHA"
+          },
+          {
+            "Version": "0.10.1.21-ALPHA"
+          },
+          {
+            "Version": "0.10.1.22-ALPHA"
+          },
+          {
+            "Version": "0.10.1.23-ALPHA"
+          },
+          {
+            "Version": "0.10.1.24-ALPHA"
+          },
+          {
+            "Version": "0.10.1.25-ALPHA"
+          },
+          {
+            "Version": "0.10.1.26-ALPHA"
+          },
+          {
+            "Version": "0.10.1.27-ALPHA"
+          },
+          {
+            "Version": "0.10.1.28-ALPHA"
+          },
+          {
+            "Version": "0.10.1.29-ALPHA"
+          },
+          {
+            "Version": "0.10.1.30-ALPHA"
+          },
+          {
+            "Version": "0.10.1.31-ALPHA"
+          },
+          {
+            "Version": "0.10.1.32-ALPHA"
+          },
+          {
+            "Version": "0.10.1.33-ALPHA"
+          },
+          {
+            "Version": "0.10.1.34-ALPHA"
+          },
+          {
+            "Version": "0.11.0.0"
+          },
+          {
+            "Version": "0.11.0.1-ALPHA"
+          },
+          {
+            "Version": "0.11.0.2-ALPHA"
+          },
+          {
+            "Version": "0.11.0.3-ALPHA"
+          },
+          {
+            "Version": "0.11.0.4-ALPHA"
+          },
+          {
+            "Version": "0.11.0.8-ALPHA"
+          },
+          {
+            "Version": "0.11.0.9-ALPHA"
+          },
+          {
+            "Version": "0.11.0.10-ALPHA"
+          },
+          {
+            "Version": "0.11.0.12-ALPHA"
+          },
+          {
+            "Version": "0.11.0.13-ALPHA"
+          },
+          {
+            "Version": "0.11.0.14-ALPHA"
+          },
+          {
+            "Version": "0.11.0.15-ALPHA"
+          },
+          {
+            "Version": "0.11.0.16-ALPHA"
+          },
+          {
+            "Version": "0.11.0.17-ALPHA"
+          },
+          {
+            "Version": "0.11.0.18-ALPHA"
+          },
+          {
+            "Version": "0.11.0.19-ALPHA"
+          },
+          {
+            "Version": "0.11.0.20-ALPHA"
+          },
+          {
+            "Version": "0.11.0.21-ALPHA"
+          },
+          {
+            "Version": "0.11.0.22-ALPHA"
+          },
+          {
+            "Version": "0.11.0.23-ALPHA"
+          },
+          {
+            "Version": "0.11.0.24-ALPHA"
+          },
+          {
+            "Version": "0.11.0.25-ALPHA"
+          },
+          {
+            "Version": "0.11.0.26-ALPHA"
+          },
+          {
+            "Version": "0.11.0.27-ALPHA"
+          },
+          {
+            "Version": "0.11.0.28-ALPHA"
+          },
+          {
+            "Version": "0.11.0.29-ALPHA"
+          },
+          {
+            "Version": "0.11.0.30-ALPHA"
+          },
+          {
+            "Version": "0.11.0.31-ALPHA"
+          },
+          {
+            "Version": "0.11.0.32-ALPHA"
+          },
+          {
+            "Version": "0.11.0.34-ALPHA"
+          },
+          {
+            "Version": "0.11.0.35-ALPHA"
+          },
+          {
+            "Version": "0.11.0.36-ALPHA"
+          },
+          {
+            "Version": "0.11.0.37-ALPHA"
+          },
+          {
+            "Version": "0.11.0.38-ALPHA"
+          },
+          {
+            "Version": "0.11.0.39-ALPHA"
+          },
+          {
+            "Version": "0.11.0.40-ALPHA"
+          },
+          {
+            "Version": "0.11.0.41-ALPHA"
+          },
+          {
+            "Version": "0.11.0.42-ALPHA"
+          },
+          {
+            "Version": "0.11.0.43-ALPHA"
+          },
+          {
+            "Version": "0.11.0.44-ALPHA"
+          },
+          {
+            "Version": "0.11.0.45-ALPHA"
+          },
+          {
+            "Version": "0.11.0.46-ALPHA"
+          },
+          {
+            "Version": "0.11.0.47-ALPHA"
+          },
+          {
+            "Version": "0.11.0.48-ALPHA"
+          },
+          {
+            "Version": "0.11.0.49-ALPHA"
+          },
+          {
+            "Version": "0.11.0.50-ALPHA"
+          },
+          {
+            "Version": "0.11.0.51-ALPHA"
+          },
+          {
+            "Version": "0.11.0.53-ALPHA"
+          },
+          {
+            "Version": "0.11.0.54-ALPHA"
+          },
+          {
+            "Version": "0.11.0.59-ALPHA"
+          },
+          {
+            "Version": "0.11.1.1-ALPHA"
+          },
+          {
+            "Version": "0.11.1.2-ALPHA"
+          },
+          {
+            "Version": "0.11.1.3-ALPHA"
+          },
+          {
+            "Version": "0.11.1.4-ALPHA"
+          },
+          {
+            "Version": "0.11.1.5-ALPHA"
+          },
+          {
+            "Version": "0.11.1.6-ALPHA"
+          },
+          {
+            "Version": "0.11.1.7-ALPHA"
+          },
+          {
+            "Version": "0.11.1.8-ALPHA"
+          },
+          {
+            "Version": "0.11.1.9-ALPHA"
+          },
+          {
+            "Version": "0.11.1.11-ALPHA"
+          },
+          {
+            "Version": "0.11.1.12-ALPHA"
+          },
+          {
+            "Version": "0.11.1.15-ALPHA"
+          },
+          {
+            "Version": "0.11.1.16-ALPHA"
+          },
+          {
+            "Version": "0.11.1.17-ALPHA"
+          },
+          {
+            "Version": "0.11.1.18-ALPHA"
+          },
+          {
+            "Version": "0.11.1.19-ALPHA"
+          },
+          {
+            "Version": "0.11.1.20-ALPHA"
+          },
+          {
+            "Version": "0.11.1.21-ALPHA"
+          },
+          {
+            "Version": "0.11.1.22-ALPHA"
+          },
+          {
+            "Version": "0.11.1.23-ALPHA"
+          },
+          {
+            "Version": "0.11.1.24-ALPHA"
+          },
+          {
+            "Version": "0.11.1.25-ALPHA"
+          },
+          {
+            "Version": "0.11.1.26-ALPHA"
+          },
+          {
+            "Version": "0.11.1.27-ALPHA"
+          },
+          {
+            "Version": "0.11.1.28-ALPHA"
+          },
+          {
+            "Version": "0.11.1.30-ALPHA"
+          },
+          {
+            "Version": "0.11.1.31-ALPHA"
+          },
+          {
+            "Version": "0.11.1.32-ALPHA"
+          },
+          {
+            "Version": "0.11.1.33-ALPHA"
+          },
+          {
+            "Version": "0.11.2.1-ALPHA"
+          },
+          {
+            "Version": "0.11.2.2-ALPHA"
+          },
+          {
+            "Version": "0.11.2.3-ALPHA"
+          },
+          {
+            "Version": "0.11.2.4-ALPHA"
+          },
+          {
+            "Version": "0.11.2.5-ALPHA"
+          },
+          {
+            "Version": "0.11.2.6-ALPHA"
+          },
+          {
+            "Version": "0.11.2.7-ALPHA"
+          },
+          {
+            "Version": "0.11.2.9-ALPHA"
+          },
+          {
+            "Version": "0.11.2.10-ALPHA"
+          },
+          {
+            "Version": "0.11.2.11-ALPHA"
+          },
+          {
+            "Version": "0.11.2.12-ALPHA"
+          },
+          {
+            "Version": "0.11.2.13-ALPHA"
+          },
+          {
+            "Version": "0.11.2.14-ALPHA"
+          },
+          {
+            "Version": "0.11.2.15-ALPHA"
+          },
+          {
+            "Version": "0.11.2.17-ALPHA"
+          },
+          {
+            "Version": "0.11.2.18-ALPHA"
+          },
+          {
+            "Version": "0.11.2.19-ALPHA"
+          },
+          {
+            "Version": "0.11.2.20-ALPHA"
+          },
+          {
+            "Version": "0.11.2.21-ALPHA"
+          },
+          {
+            "Version": "0.11.2.22-ALPHA"
+          },
+          {
+            "Version": "0.11.2.23-ALPHA"
+          },
+          {
+            "Version": "0.11.2.24-ALPHA"
+          },
+          {
+            "Version": "0.11.3.1-ALPHA"
+          },
+          {
+            "Version": "0.12.0.0"
+          },
+          {
+            "Version": "0.12.0.1-ALPHA"
+          },
+          {
+            "Version": "0.12.0.2-ALPHA"
+          },
+          {
+            "Version": "0.12.0.3-ALPHA"
+          },
+          {
+            "Version": "0.12.0.4-ALPHA"
+          },
+          {
+            "Version": "0.12.0.5-ALPHA"
+          },
+          {
+            "Version": "0.12.0.6-ALPHA"
+          },
+          {
+            "Version": "0.12.0.7-ALPHA"
+          },
+          {
+            "Version": "0.12.0.8-ALPHA"
+          },
+          {
+            "Version": "0.12.0.9-ALPHA"
+          },
+          {
+            "Version": "0.12.0.10-ALPHA"
+          },
+          {
+            "Version": "0.12.0.11-ALPHA"
+          },
+          {
+            "Version": "0.12.0.13-ALPHA"
+          },
+          {
+            "Version": "0.12.0.14-ALPHA"
+          },
+          {
+            "Version": "0.12.0.15-ALPHA"
+          },
+          {
+            "Version": "0.12.0.16-ALPHA"
+          },
+          {
+            "Version": "0.12.0.17-ALPHA"
+          },
+          {
+            "Version": "0.12.0.18-ALPHA"
+          },
+          {
+            "Version": "0.12.0.20-ALPHA"
+          },
+          {
+            "Version": "0.12.0.21-ALPHA"
+          },
+          {
+            "Version": "0.12.0.22-ALPHA"
+          },
+          {
+            "Version": "0.12.0.23-ALPHA"
+          },
+          {
+            "Version": "0.12.1.0"
+          },
+          {
+            "Version": "0.13.0-ALPHA11"
+          },
+          {
+            "Version": "0.13.0.0"
+          },
+          {
+            "Version": "0.13.0.1-ALPHA"
+          },
+          {
+            "Version": "0.13.0.2-ALPHA"
+          },
+          {
+            "Version": "0.13.0.3-ALPHA"
+          },
+          {
+            "Version": "0.13.0.4-ALPHA"
+          },
+          {
+            "Version": "0.13.0.5-ALPHA"
+          },
+          {
+            "Version": "0.13.0.13-ALPHA"
+          },
+          {
+            "Version": "0.13.0.14-ALPHA"
+          },
+          {
+            "Version": "0.13.0.15-ALPHA"
+          },
+          {
+            "Version": "0.13.0.16-ALPHA"
+          },
+          {
+            "Version": "0.13.0.17-ALPHA"
+          },
+          {
+            "Version": "0.13.0.18-ALPHA"
+          },
+          {
+            "Version": "0.13.0.19-ALPHA"
+          },
+          {
+            "Version": "0.13.0.20-ALPHA"
+          },
+          {
+            "Version": "0.13.0.22-ALPHA"
+          },
+          {
+            "Version": "0.13.0.23-ALPHA"
+          },
+          {
+            "Version": "0.13.0.30-ALPHA"
+          },
+          {
+            "Version": "0.13.0.46-ALPHA"
+          },
+          {
+            "Version": "0.13.0.47-ALPHA"
+          },
+          {
+            "Version": "0.13.0.48-ALPHA"
+          },
+          {
+            "Version": "0.13.0.49-ALPHA"
+          },
+          {
+            "Version": "0.13.0.50-ALPHA"
+          },
+          {
+            "Version": "0.13.0.51-ALPHA"
+          },
+          {
+            "Version": "0.13.0.52-ALPHA"
+          },
+          {
+            "Version": "0.13.0.53-ALPHA"
+          },
+          {
+            "Version": "0.13.0.54-ALPHA"
+          },
+          {
+            "Version": "0.13.0.55-ALPHA"
+          },
+          {
+            "Version": "0.13.0.56-ALPHA"
+          },
+          {
+            "Version": "0.13.0.57-ALPHA"
+          },
+          {
+            "Version": "0.13.0.58-ALPHA"
+          },
+          {
+            "Version": "0.13.0.59-ALPHA"
+          },
+          {
+            "Version": "0.13.0.60-ALPHA"
+          },
+          {
+            "Version": "0.13.0.61-ALPHA"
+          },
+          {
+            "Version": "0.13.0.62-ALPHA"
+          },
+          {
+            "Version": "0.13.0.63-ALPHA"
+          },
+          {
+            "Version": "0.13.0.64-ALPHA"
+          },
+          {
+            "Version": "0.13.0.65-ALPHA"
+          },
+          {
+            "Version": "0.13.0.66-ALPHA"
+          },
+          {
+            "Version": "0.13.0.67-ALPHA"
+          },
+          {
+            "Version": "0.13.0.68-ALPHA"
+          },
+          {
+            "Version": "0.13.0.69-ALPHA"
+          },
+          {
+            "Version": "0.13.0.70-ALPHA"
+          },
+          {
+            "Version": "0.13.0.71-ALPHA"
+          },
+          {
+            "Version": "0.13.0.72-ALPHA"
+          },
+          {
+            "Version": "0.13.0.73-ALPHA"
+          },
+          {
+            "Version": "0.13.0.75-ALPHA"
+          },
+          {
+            "Version": "0.13.0.77-ALPHA"
+          },
+          {
+            "Version": "0.13.0.78-ALPHA"
+          },
+          {
+            "Version": "0.13.0.79-ALPHA"
+          },
+          {
+            "Version": "0.13.0.80-ALPHA"
+          },
+          {
+            "Version": "0.13.0.81-ALPHA"
+          },
+          {
+            "Version": "0.13.0.82-ALPHA"
+          },
+          {
+            "Version": "0.13.0.83-ALPHA"
+          },
+          {
+            "Version": "0.13.0.84-ALPHA"
+          },
+          {
+            "Version": "0.13.0.85-ALPHA"
+          },
+          {
+            "Version": "0.13.0.86-ALPHA"
+          },
+          {
+            "Version": "0.13.0.87-ALPHA"
+          },
+          {
+            "Version": "0.13.0.88-ALPHA"
+          },
+          {
+            "Version": "0.13.0.89-ALPHA"
+          },
+          {
+            "Version": "0.13.0.90-ALPHA"
+          },
+          {
+            "Version": "0.13.0.91-ALPHA"
+          },
+          {
+            "Version": "0.13.0.92-ALPHA"
+          },
+          {
+            "Version": "0.13.0.93-ALPHA"
+          },
+          {
+            "Version": "0.13.0.94-ALPHA"
+          },
+          {
+            "Version": "0.13.0.95-ALPHA"
+          },
+          {
+            "Version": "0.13.0.96-ALPHA"
+          },
+          {
+            "Version": "0.13.0.97-ALPHA"
+          },
+          {
+            "Version": "0.13.0.98-ALPHA"
+          },
+          {
+            "Version": "0.13.0.99-ALPHA"
+          },
+          {
+            "Version": "0.13.0.100-ALPHA"
+          },
+          {
+            "Version": "0.13.0.101-ALPHA"
+          },
+          {
+            "Version": "0.13.0.102-ALPHA"
+          },
+          {
+            "Version": "0.13.0.103-ALPHA"
+          },
+          {
+            "Version": "0.13.0.104-ALPHA"
+          },
+          {
+            "Version": "0.13.0.105-ALPHA"
+          },
+          {
+            "Version": "0.13.0.106-ALPHA"
+          },
+          {
+            "Version": "0.13.0.107-ALPHA"
+          },
+          {
+            "Version": "0.13.0.108-ALPHA"
+          },
+          {
+            "Version": "0.13.0.109-ALPHA"
+          },
+          {
+            "Version": "0.13.0.110-ALPHA"
+          },
+          {
+            "Version": "0.13.0.111-ALPHA"
+          },
+          {
+            "Version": "0.13.0.112-ALPHA"
+          },
+          {
+            "Version": "0.13.0.113-ALPHA"
+          },
+          {
+            "Version": "0.13.0.114-ALPHA"
+          },
+          {
+            "Version": "0.13.0.115-ALPHA"
+          },
+          {
+            "Version": "0.13.0.116-ALPHA"
+          },
+          {
+            "Version": "0.13.0.117-ALPHA"
+          },
+          {
+            "Version": "0.13.0.118-ALPHA"
+          },
+          {
+            "Version": "0.13.0.119-ALPHA"
+          },
+          {
+            "Version": "0.13.0.120-ALPHA"
+          },
+          {
+            "Version": "0.13.0.121-ALPHA"
+          },
+          {
+            "Version": "0.13.0.122-ALPHA"
+          },
+          {
+            "Version": "0.13.0.123-ALPHA"
+          },
+          {
+            "Version": "0.13.0.124-ALPHA"
+          },
+          {
+            "Version": "0.13.0.125-ALPHA"
+          },
+          {
+            "Version": "0.13.0.126-ALPHA"
+          },
+          {
+            "Version": "0.13.0.127-ALPHA"
+          },
+          {
+            "Version": "0.13.1.0"
+          },
+          {
+            "Version": "0.14.0-ALPHA10"
+          },
+          {
+            "Version": "0.14.0-ALPHA11"
+          },
+          {
+            "Version": "0.14.0-ALPHA12"
+          },
+          {
+            "Version": "0.14.0-ALPHA13"
+          },
+          {
+            "Version": "0.14.0-ALPHA14"
+          },
+          {
+            "Version": "0.14.0-ALPHA15"
+          },
+          {
+            "Version": "0.14.0-ALPHA16"
+          },
+          {
+            "Version": "0.14.0-ALPHA17"
+          },
+          {
+            "Version": "0.14.0-ALPHA18"
+          },
+          {
+            "Version": "0.14.0-ALPHA19"
+          },
+          {
+            "Version": "0.14.0-ALPHA20"
+          },
+          {
+            "Version": "0.14.0-ALPHA21"
+          },
+          {
+            "Version": "0.14.0-ALPHA22"
+          },
+          {
+            "Version": "0.14.0-ALPHA23"
+          },
+          {
+            "Version": "0.14.0-ALPHA24"
+          },
+          {
+            "Version": "0.14.0-ALPHA25"
+          },
+          {
+            "Version": "0.14.0-ALPHA26"
+          },
+          {
+            "Version": "0.14.0-ALPHA27"
+          },
+          {
+            "Version": "0.14.0-ALPHA28"
+          },
+          {
+            "Version": "0.14.0-ALPHA29"
+          },
+          {
+            "Version": "0.14.0-ALPHA30"
+          },
+          {
+            "Version": "0.14.0-ALPHA31"
+          },
+          {
+            "Version": "0.14.0-ALPHA32"
+          },
+          {
+            "Version": "0.14.0-ALPHA33"
+          },
+          {
+            "Version": "0.14.0-ALPHA34"
+          },
+          {
+            "Version": "0.14.0-ALPHA35"
+          },
+          {
+            "Version": "0.14.0-ALPHA36"
+          },
+          {
+            "Version": "0.14.0-ALPHA37"
+          },
+          {
+            "Version": "0.14.0-ALPHA38"
+          },
+          {
+            "Version": "0.14.0-ALPHA39"
+          },
+          {
+            "Version": "0.14.0-ALPHA40"
+          },
+          {
+            "Version": "0.14.0-ALPHA41"
+          },
+          {
+            "Version": "0.14.0-ALPHA42"
+          },
+          {
+            "Version": "0.14.0-ALPHA43"
+          },
+          {
+            "Version": "0.14.0-ALPHA44"
+          },
+          {
+            "Version": "0.14.0-ALPHA45"
+          },
+          {
+            "Version": "0.14.0-ALPHA46"
+          },
+          {
+            "Version": "0.14.0-ALPHA47"
+          },
+          {
+            "Version": "0.14.0-ALPHA48"
+          },
+          {
+            "Version": "0.14.0-ALPHA49"
+          },
+          {
+            "Version": "0.14.0-ALPHA50"
+          },
+          {
+            "Version": "0.14.0-ALPHA51"
+          },
+          {
+            "Version": "0.14.0-ALPHA52"
+          },
+          {
+            "Version": "0.14.0-ALPHA53"
+          },
+          {
+            "Version": "0.14.0-ALPHA54"
+          },
+          {
+            "Version": "0.14.0-ALPHA55"
+          },
+          {
+            "Version": "0.14.0-ALPHA56"
+          },
+          {
+            "Version": "0.14.0-ALPHA57"
+          },
+          {
+            "Version": "0.14.0-ALPHA58"
+          },
+          {
+            "Version": "0.14.0-ALPHA59"
+          },
+          {
+            "Version": "0.14.0-ALPHA6"
+          },
+          {
+            "Version": "0.14.0-ALPHA60"
+          },
+          {
+            "Version": "0.14.0-ALPHA61"
+          },
+          {
+            "Version": "0.14.0-ALPHA62"
+          },
+          {
+            "Version": "0.14.0-ALPHA63"
+          },
+          {
+            "Version": "0.14.0-ALPHA64"
+          },
+          {
+            "Version": "0.14.0-ALPHA65"
+          },
+          {
+            "Version": "0.14.0-ALPHA66"
+          },
+          {
+            "Version": "0.14.0-ALPHA67"
+          },
+          {
+            "Version": "0.14.0-ALPHA68"
+          },
+          {
+            "Version": "0.14.0-ALPHA69"
+          },
+          {
+            "Version": "0.14.0-ALPHA70"
+          },
+          {
+            "Version": "0.14.0-ALPHA71"
+          },
+          {
+            "Version": "0.14.0-ALPHA72"
+          },
+          {
+            "Version": "0.14.0-ALPHA73"
+          },
+          {
+            "Version": "0.14.0-ALPHA74"
+          },
+          {
+            "Version": "0.14.0-ALPHA75"
+          },
+          {
+            "Version": "0.14.0-ALPHA76"
+          },
+          {
+            "Version": "0.14.0-ALPHA77"
+          },
+          {
+            "Version": "0.14.0-ALPHA78"
+          },
+          {
+            "Version": "0.14.0-ALPHA79"
+          },
+          {
+            "Version": "0.14.0-ALPHA8"
+          },
+          {
+            "Version": "0.14.0-ALPHA80"
+          },
+          {
+            "Version": "0.14.0-ALPHA81"
+          },
+          {
+            "Version": "0.14.0-ALPHA82"
+          },
+          {
+            "Version": "0.14.0-ALPHA83"
+          },
+          {
+            "Version": "0.14.0-ALPHA84"
+          },
+          {
+            "Version": "0.14.0-ALPHA85"
+          },
+          {
+            "Version": "0.14.0-ALPHA86"
+          },
+          {
+            "Version": "0.14.0-ALPHA87"
+          },
+          {
+            "Version": "0.14.0-ALPHA88"
+          },
+          {
+            "Version": "0.14.0-ALPHA89"
+          },
+          {
+            "Version": "0.14.0-ALPHA9"
+          },
+          {
+            "Version": "0.14.0-ALPHA90"
+          },
+          {
+            "Version": "0.14.0-ALPHA91"
+          },
+          {
+            "Version": "0.14.0-ALPHA92"
+          },
+          {
+            "Version": "0.14.0-ALPHA93"
+          },
+          {
+            "Version": "0.14.0-ALPHA94"
+          },
+          {
+            "Version": "0.14.0-ALPHA95"
+          },
+          {
+            "Version": "0.14.0-ALPHA96"
+          },
+          {
+            "Version": "0.14.0-ALPHA97"
+          },
+          {
+            "Version": "0.14.0-ALPHA98"
+          },
+          {
+            "Version": "0.14.0-ALPHA99"
+          },
+          {
+            "Version": "0.14.0.0"
+          },
+          {
+            "Version": "0.14.0.1-ALPHA"
+          },
+          {
+            "Version": "0.14.0.2-ALPHA"
+          },
+          {
+            "Version": "0.15.0-ALPHA1"
+          },
+          {
+            "Version": "0.15.0-ALPHA10"
+          },
+          {
+            "Version": "0.15.0-ALPHA100"
+          },
+          {
+            "Version": "0.15.0-ALPHA101"
+          },
+          {
+            "Version": "0.15.0-ALPHA102"
+          },
+          {
+            "Version": "0.15.0-ALPHA103"
+          },
+          {
+            "Version": "0.15.0-ALPHA104"
+          },
+          {
+            "Version": "0.15.0-ALPHA105"
+          },
+          {
+            "Version": "0.15.0-ALPHA106"
+          },
+          {
+            "Version": "0.15.0-ALPHA107"
+          },
+          {
+            "Version": "0.15.0-ALPHA108"
+          },
+          {
+            "Version": "0.15.0-ALPHA109"
+          },
+          {
+            "Version": "0.15.0-ALPHA11"
+          },
+          {
+            "Version": "0.15.0-ALPHA110"
+          },
+          {
+            "Version": "0.15.0-ALPHA111"
+          },
+          {
+            "Version": "0.15.0-ALPHA112"
+          },
+          {
+            "Version": "0.15.0-ALPHA113"
+          },
+          {
+            "Version": "0.15.0-ALPHA114"
+          },
+          {
+            "Version": "0.15.0-ALPHA115"
+          },
+          {
+            "Version": "0.15.0-ALPHA12"
+          },
+          {
+            "Version": "0.15.0-ALPHA13"
+          },
+          {
+            "Version": "0.15.0-ALPHA14"
+          },
+          {
+            "Version": "0.15.0-ALPHA15"
+          },
+          {
+            "Version": "0.15.0-ALPHA16"
+          },
+          {
+            "Version": "0.15.0-ALPHA17"
+          },
+          {
+            "Version": "0.15.0-ALPHA18"
+          },
+          {
+            "Version": "0.15.0-ALPHA19"
+          },
+          {
+            "Version": "0.15.0-ALPHA2"
+          },
+          {
+            "Version": "0.15.0-ALPHA20"
+          },
+          {
+            "Version": "0.15.0-ALPHA21"
+          },
+          {
+            "Version": "0.15.0-ALPHA22"
+          },
+          {
+            "Version": "0.15.0-ALPHA23"
+          },
+          {
+            "Version": "0.15.0-ALPHA24"
+          },
+          {
+            "Version": "0.15.0-ALPHA25"
+          },
+          {
+            "Version": "0.15.0-ALPHA26"
+          },
+          {
+            "Version": "0.15.0-ALPHA27"
+          },
+          {
+            "Version": "0.15.0-ALPHA28"
+          },
+          {
+            "Version": "0.15.0-ALPHA29"
+          },
+          {
+            "Version": "0.15.0-ALPHA3"
+          },
+          {
+            "Version": "0.15.0-ALPHA30"
+          },
+          {
+            "Version": "0.15.0-ALPHA31"
+          },
+          {
+            "Version": "0.15.0-ALPHA32"
+          },
+          {
+            "Version": "0.15.0-ALPHA33"
+          },
+          {
+            "Version": "0.15.0-ALPHA34"
+          },
+          {
+            "Version": "0.15.0-ALPHA35"
+          },
+          {
+            "Version": "0.15.0-ALPHA36"
+          },
+          {
+            "Version": "0.15.0-ALPHA38"
+          },
+          {
+            "Version": "0.15.0-ALPHA39"
+          },
+          {
+            "Version": "0.15.0-ALPHA4"
+          },
+          {
+            "Version": "0.15.0-ALPHA40"
+          },
+          {
+            "Version": "0.15.0-ALPHA41"
+          },
+          {
+            "Version": "0.15.0-ALPHA42"
+          },
+          {
+            "Version": "0.15.0-ALPHA43"
+          },
+          {
+            "Version": "0.15.0-ALPHA44"
+          },
+          {
+            "Version": "0.15.0-ALPHA45"
+          },
+          {
+            "Version": "0.15.0-ALPHA46"
+          },
+          {
+            "Version": "0.15.0-ALPHA47"
+          },
+          {
+            "Version": "0.15.0-ALPHA48"
+          },
+          {
+            "Version": "0.15.0-ALPHA49"
+          },
+          {
+            "Version": "0.15.0-ALPHA5"
+          },
+          {
+            "Version": "0.15.0-ALPHA50"
+          },
+          {
+            "Version": "0.15.0-ALPHA51"
+          },
+          {
+            "Version": "0.15.0-ALPHA52"
+          },
+          {
+            "Version": "0.15.0-ALPHA53"
+          },
+          {
+            "Version": "0.15.0-ALPHA54"
+          },
+          {
+            "Version": "0.15.0-ALPHA55"
+          },
+          {
+            "Version": "0.15.0-ALPHA56"
+          },
+          {
+            "Version": "0.15.0-ALPHA57"
+          },
+          {
+            "Version": "0.15.0-ALPHA58"
+          },
+          {
+            "Version": "0.15.0-ALPHA59"
+          },
+          {
+            "Version": "0.15.0-ALPHA6"
+          },
+          {
+            "Version": "0.15.0-ALPHA60"
+          },
+          {
+            "Version": "0.15.0-ALPHA61"
+          },
+          {
+            "Version": "0.15.0-ALPHA62"
+          },
+          {
+            "Version": "0.15.0-ALPHA63"
+          },
+          {
+            "Version": "0.15.0-ALPHA64"
+          },
+          {
+            "Version": "0.15.0-ALPHA65"
+          },
+          {
+            "Version": "0.15.0-ALPHA66"
+          },
+          {
+            "Version": "0.15.0-ALPHA67"
+          },
+          {
+            "Version": "0.15.0-ALPHA68"
+          },
+          {
+            "Version": "0.15.0-ALPHA69"
+          },
+          {
+            "Version": "0.15.0-ALPHA7"
+          },
+          {
+            "Version": "0.15.0-ALPHA70"
+          },
+          {
+            "Version": "0.15.0-ALPHA71"
+          },
+          {
+            "Version": "0.15.0-ALPHA72"
+          },
+          {
+            "Version": "0.15.0-ALPHA73"
+          },
+          {
+            "Version": "0.15.0-ALPHA74"
+          },
+          {
+            "Version": "0.15.0-ALPHA75"
+          },
+          {
+            "Version": "0.15.0-ALPHA76"
+          },
+          {
+            "Version": "0.15.0-ALPHA77"
+          },
+          {
+            "Version": "0.15.0-ALPHA78"
+          },
+          {
+            "Version": "0.15.0-ALPHA79"
+          },
+          {
+            "Version": "0.15.0-ALPHA8"
+          },
+          {
+            "Version": "0.15.0-ALPHA80"
+          },
+          {
+            "Version": "0.15.0-ALPHA81"
+          },
+          {
+            "Version": "0.15.0-ALPHA82"
+          },
+          {
+            "Version": "0.15.0-ALPHA83"
+          },
+          {
+            "Version": "0.15.0-ALPHA84"
+          },
+          {
+            "Version": "0.15.0-ALPHA85"
+          },
+          {
+            "Version": "0.15.0-ALPHA86"
+          },
+          {
+            "Version": "0.15.0-ALPHA87"
+          },
+          {
+            "Version": "0.15.0-ALPHA88"
+          },
+          {
+            "Version": "0.15.0-ALPHA89"
+          },
+          {
+            "Version": "0.15.0-ALPHA9"
+          },
+          {
+            "Version": "0.15.0-ALPHA90"
+          },
+          {
+            "Version": "0.15.0-ALPHA91"
+          },
+          {
+            "Version": "0.15.0-ALPHA92"
+          },
+          {
+            "Version": "0.15.0-ALPHA93"
+          },
+          {
+            "Version": "0.15.0-ALPHA94"
+          },
+          {
+            "Version": "0.15.0-ALPHA95"
+          },
+          {
+            "Version": "0.15.0-ALPHA96"
+          },
+          {
+            "Version": "0.15.0-ALPHA97"
+          },
+          {
+            "Version": "0.15.0-ALPHA98"
+          },
+          {
+            "Version": "0.15.0-ALPHA99"
+          },
+          {
+            "Version": "0.16.0-ALPHA002"
+          },
+          {
+            "Version": "0.16.0-ALPHA1"
+          },
+          {
+            "Version": "1.0.0-ALPHA001"
+          },
+          {
+            "Version": "1.0.0-ALPHA002"
+          },
+          {
+            "Version": "1.0.0-ALPHA003"
+          },
+          {
+            "Version": "1.0.0-ALPHA004"
+          },
+          {
+            "Version": "1.0.0-ALPHA005"
+          },
+          {
+            "Version": "1.0.0-ALPHA006"
+          },
+          {
+            "Version": "1.0.0-ALPHA007"
+          },
+          {
+            "Version": "1.0.0-ALPHA008"
+          },
+          {
+            "Version": "1.0.0-ALPHA009"
+          },
+          {
+            "Version": "1.0.0-ALPHA010"
+          },
+          {
+            "Version": "1.0.0-ALPHA011"
+          },
+          {
+            "Version": "1.0.0-ALPHA012"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1-ALPHA001"
+          },
+          {
+            "Version": "1.0.1-ALPHA002"
+          },
+          {
+            "Version": "1.0.1-ALPHA003"
+          },
+          {
+            "Version": "1.0.1-ALPHA004"
+          },
+          {
+            "Version": "1.0.1-ALPHA005"
+          },
+          {
+            "Version": "1.0.1-ALPHA006"
+          },
+          {
+            "Version": "1.0.1-ALPHA007"
+          },
+          {
+            "Version": "1.0.1-ALPHA008"
+          },
+          {
+            "Version": "1.0.1-ALPHA009"
+          },
+          {
+            "Version": "1.0.1-ALPHA010"
+          },
+          {
+            "Version": "1.0.1-ALPHA011"
+          },
+          {
+            "Version": "1.0.1-ALPHA012"
+          },
+          {
+            "Version": "1.0.1-ALPHA013"
+          },
+          {
+            "Version": "1.0.1-ALPHA014"
+          },
+          {
+            "Version": "1.0.1-ALPHA015"
+          },
+          {
+            "Version": "1.0.1-ALPHA016"
+          },
+          {
+            "Version": "1.0.1-ALPHA017"
+          },
+          {
+            "Version": "1.0.1-ALPHA018"
+          },
+          {
+            "Version": "1.0.1-ALPHA019"
+          },
+          {
+            "Version": "1.0.1-ALPHA020"
+          },
+          {
+            "Version": "1.0.1-ALPHA021"
+          },
+          {
+            "Version": "1.0.1-ALPHA022"
+          },
+          {
+            "Version": "1.0.1-ALPHA023"
+          },
+          {
+            "Version": "1.0.1-ALPHA024"
+          },
+          {
+            "Version": "1.0.1-ALPHA025"
+          },
+          {
+            "Version": "1.0.1-ALPHA026"
+          },
+          {
+            "Version": "1.0.1-ALPHA027"
+          },
+          {
+            "Version": "1.0.1-ALPHA028"
+          },
+          {
+            "Version": "1.0.1-ALPHA029"
+          },
+          {
+            "Version": "1.0.1-ALPHA030"
+          },
+          {
+            "Version": "1.0.1-ALPHA031"
+          },
+          {
+            "Version": "1.0.1-ALPHA032"
+          },
+          {
+            "Version": "1.0.1-ALPHA033"
+          },
+          {
+            "Version": "1.0.1-ALPHA034"
+          },
+          {
+            "Version": "1.0.1-ALPHA035"
+          },
+          {
+            "Version": "1.0.1-ALPHA036"
+          },
+          {
+            "Version": "1.0.1-ALPHA037"
+          },
+          {
+            "Version": "1.0.1-ALPHA038"
+          },
+          {
+            "Version": "1.0.1-ALPHA039"
+          },
+          {
+            "Version": "1.0.1-ALPHA040"
+          },
+          {
+            "Version": "1.0.1-ALPHA041"
+          },
+          {
+            "Version": "1.0.1-ALPHA042"
+          },
+          {
+            "Version": "1.0.1-ALPHA043"
+          },
+          {
+            "Version": "1.0.1-ALPHA044"
+          },
+          {
+            "Version": "1.0.1-ALPHA045"
+          },
+          {
+            "Version": "1.0.1-ALPHA046"
+          },
+          {
+            "Version": "1.0.1-ALPHA047"
+          },
+          {
+            "Version": "1.0.1-ALPHA048"
+          },
+          {
+            "Version": "1.0.1-ALPHA049"
+          },
+          {
+            "Version": "1.0.1-ALPHA050"
+          },
+          {
+            "Version": "1.0.1-ALPHA051"
+          },
+          {
+            "Version": "1.0.1-ALPHA052"
+          },
+          {
+            "Version": "1.0.1-ALPHA053"
+          },
+          {
+            "Version": "1.0.1-ALPHA054"
+          },
+          {
+            "Version": "1.0.1-ALPHA055"
+          },
+          {
+            "Version": "1.0.1-ALPHA056"
+          },
+          {
+            "Version": "1.0.1-ALPHA057"
+          },
+          {
+            "Version": "1.0.1-ALPHA058"
+          },
+          {
+            "Version": "1.0.1-ALPHA059"
+          },
+          {
+            "Version": "1.0.1-ALPHA060"
+          },
+          {
+            "Version": "1.0.1-ALPHA061"
+          },
+          {
+            "Version": "1.0.1-ALPHA062"
+          },
+          {
+            "Version": "1.0.1-ALPHA063"
+          },
+          {
+            "Version": "1.0.1-ALPHA064"
+          },
+          {
+            "Version": "1.0.1-ALPHA065"
+          },
+          {
+            "Version": "1.0.1-ALPHA066"
+          },
+          {
+            "Version": "1.0.1-ALPHA067"
+          },
+          {
+            "Version": "1.0.1-ALPHA068"
+          },
+          {
+            "Version": "1.0.1-ALPHA069"
+          },
+          {
+            "Version": "1.0.1-ALPHA070"
+          },
+          {
+            "Version": "1.0.1-ALPHA071"
+          },
+          {
+            "Version": "1.0.1-ALPHA072"
+          },
+          {
+            "Version": "1.0.1-ALPHA073"
+          },
+          {
+            "Version": "1.0.1-ALPHA074"
+          },
+          {
+            "Version": "1.0.1-ALPHA075"
+          },
+          {
+            "Version": "1.0.1-ALPHA076"
+          },
+          {
+            "Version": "1.0.1-ALPHA077"
+          },
+          {
+            "Version": "1.0.1-ALPHA078"
+          },
+          {
+            "Version": "1.0.1-ALPHA079"
+          },
+          {
+            "Version": "1.0.1-ALPHA080"
+          },
+          {
+            "Version": "1.0.1-ALPHA081"
+          },
+          {
+            "Version": "1.0.1-ALPHA082"
+          },
+          {
+            "Version": "1.0.1-ALPHA083"
+          },
+          {
+            "Version": "1.0.39-ALPHA"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.1.1-ALPHA001"
+          },
+          {
+            "Version": "1.1.1-ALPHA002"
+          },
+          {
+            "Version": "1.1.1-ALPHA003"
+          },
+          {
+            "Version": "1.1.1-ALPHA004"
+          },
+          {
+            "Version": "1.1.1.0"
+          },
+          {
+            "Version": "1.1.2-ALPHA001"
+          },
+          {
+            "Version": "1.1.2-ALPHA002"
+          },
+          {
+            "Version": "1.1.2-ALPHA003"
+          },
+          {
+            "Version": "1.1.2-ALPHA004"
+          },
+          {
+            "Version": "1.1.2-ALPHA005"
+          },
+          {
+            "Version": "1.1.2-ALPHA006"
+          },
+          {
+            "Version": "1.1.2-ALPHA007"
+          },
+          {
+            "Version": "1.1.2-ALPHA008"
+          },
+          {
+            "Version": "1.1.2-ALPHA009"
+          },
+          {
+            "Version": "1.1.2-ALPHA010"
+          },
+          {
+            "Version": "1.1.2-ALPHA011"
+          },
+          {
+            "Version": "1.1.2.0"
+          },
+          {
+            "Version": "1.1.3-ALPHA001"
+          },
+          {
+            "Version": "1.1.3-ALPHA002"
+          },
+          {
+            "Version": "1.1.3-ALPHA003"
+          },
+          {
+            "Version": "1.1.3-ALPHA004"
+          },
+          {
+            "Version": "1.1.3-ALPHA005"
+          },
+          {
+            "Version": "1.1.3-ALPHA006"
+          },
+          {
+            "Version": "1.1.3-ALPHA007"
+          },
+          {
+            "Version": "1.1.3-ALPHA008"
+          },
+          {
+            "Version": "1.1.3-ALPHA009"
+          },
+          {
+            "Version": "1.1.3-ALPHA010"
+          },
+          {
+            "Version": "1.1.3-ALPHA011"
+          },
+          {
+            "Version": "1.1.3-ALPHA012"
+          },
+          {
+            "Version": "1.1.3-ALPHA013"
+          },
+          {
+            "Version": "1.1.3-ALPHA014"
+          },
+          {
+            "Version": "1.1.3-ALPHA015"
+          },
+          {
+            "Version": "1.1.3-ALPHA016"
+          },
+          {
+            "Version": "1.1.3-ALPHA017"
+          },
+          {
+            "Version": "1.1.3-ALPHA018"
+          },
+          {
+            "Version": "1.1.3-ALPHA019"
+          },
+          {
+            "Version": "1.1.3-ALPHA020"
+          },
+          {
+            "Version": "1.1.3-ALPHA021"
+          },
+          {
+            "Version": "1.1.3-ALPHA022"
+          },
+          {
+            "Version": "1.1.3-ALPHA023"
+          },
+          {
+            "Version": "1.1.3-ALPHA024"
+          },
+          {
+            "Version": "1.1.3-ALPHA025"
+          },
+          {
+            "Version": "1.1.3-ALPHA026"
+          },
+          {
+            "Version": "1.1.3-ALPHA027"
+          },
+          {
+            "Version": "1.1.3-ALPHA028"
+          },
+          {
+            "Version": "1.1.3-ALPHA047"
+          },
+          {
+            "Version": "1.1.3-ALPHA048"
+          },
+          {
+            "Version": "1.1.3-ALPHA049"
+          },
+          {
+            "Version": "1.1.3-ALPHA050"
+          },
+          {
+            "Version": "1.1.3-ALPHA051"
+          },
+          {
+            "Version": "1.1.3-ALPHA052"
+          },
+          {
+            "Version": "1.1.3-ALPHA053"
+          },
+          {
+            "Version": "1.1.3-ALPHA054"
+          },
+          {
+            "Version": "1.1.3-ALPHA055"
+          },
+          {
+            "Version": "1.1.3-ALPHA056"
+          },
+          {
+            "Version": "1.1.3-ALPHA057"
+          },
+          {
+            "Version": "1.1.3-ALPHA058"
+          },
+          {
+            "Version": "1.1.3-ALPHA059"
+          },
+          {
+            "Version": "1.1.3-ALPHA060"
+          },
+          {
+            "Version": "1.1.3-ALPHA061"
+          },
+          {
+            "Version": "1.1.3-ALPHA062"
+          },
+          {
+            "Version": "1.1.3-ALPHA063"
+          },
+          {
+            "Version": "1.1.3-ALPHA064"
+          },
+          {
+            "Version": "1.1.3-ALPHA065"
+          },
+          {
+            "Version": "1.1.3-ALPHA066"
+          },
+          {
+            "Version": "1.1.3-ALPHA067"
+          },
+          {
+            "Version": "1.1.3-ALPHA068"
+          },
+          {
+            "Version": "1.1.3-ALPHA069"
+          },
+          {
+            "Version": "1.1.3-ALPHA070"
+          },
+          {
+            "Version": "1.1.3-ALPHA071"
+          },
+          {
+            "Version": "1.1.3-ALPHA072"
+          },
+          {
+            "Version": "1.1.3-ALPHA073"
+          },
+          {
+            "Version": "1.1.3-ALPHA074"
+          },
+          {
+            "Version": "1.1.3-ALPHA075"
+          },
+          {
+            "Version": "1.1.3-ALPHA076"
+          },
+          {
+            "Version": "1.1.3-ALPHA077"
+          },
+          {
+            "Version": "1.1.3-ALPHA078"
+          },
+          {
+            "Version": "1.1.3-ALPHA079"
+          },
+          {
+            "Version": "1.1.3-ALPHA080"
+          },
+          {
+            "Version": "1.1.3-ALPHA081"
+          },
+          {
+            "Version": "1.1.3-ALPHA082"
+          },
+          {
+            "Version": "1.1.3-ALPHA083"
+          },
+          {
+            "Version": "1.1.3-ALPHA084"
+          },
+          {
+            "Version": "1.1.3-ALPHA085"
+          },
+          {
+            "Version": "1.1.3-ALPHA086"
+          },
+          {
+            "Version": "1.1.3-ALPHA087"
+          },
+          {
+            "Version": "1.1.3-ALPHA088"
+          },
+          {
+            "Version": "1.1.3-ALPHA089"
+          },
+          {
+            "Version": "1.1.3-ALPHA090"
+          },
+          {
+            "Version": "1.1.3-ALPHA091"
+          },
+          {
+            "Version": "1.1.3-ALPHA092"
+          },
+          {
+            "Version": "1.1.3-ALPHA093"
+          },
+          {
+            "Version": "1.1.3-ALPHA094"
+          },
+          {
+            "Version": "1.1.3-ALPHA095"
+          },
+          {
+            "Version": "1.1.3-ALPHA096"
+          },
+          {
+            "Version": "1.1.3-ALPHA097"
+          },
+          {
+            "Version": "1.1.3-ALPHA098"
+          },
+          {
+            "Version": "1.1.3-ALPHA099"
+          },
+          {
+            "Version": "1.1.3-ALPHA100"
+          },
+          {
+            "Version": "1.1.3-ALPHA101"
+          },
+          {
+            "Version": "1.1.3-ALPHA102"
+          },
+          {
+            "Version": "1.1.3-ALPHA103"
+          },
+          {
+            "Version": "1.1.3-ALPHA104"
+          },
+          {
+            "Version": "1.1.3-ALPHA105"
+          },
+          {
+            "Version": "1.1.3-ALPHA106"
+          },
+          {
+            "Version": "1.1.3-ALPHA107"
+          },
+          {
+            "Version": "1.1.3-ALPHA108"
+          },
+          {
+            "Version": "1.1.3-ALPHA109"
+          },
+          {
+            "Version": "1.1.3-ALPHA110"
+          },
+          {
+            "Version": "1.1.3-ALPHA111"
+          },
+          {
+            "Version": "1.1.3-ALPHA112"
+          },
+          {
+            "Version": "1.1.3-ALPHA113"
+          },
+          {
+            "Version": "1.1.3-ALPHA114"
+          },
+          {
+            "Version": "1.1.3-ALPHA115"
+          },
+          {
+            "Version": "1.1.3-ALPHA116"
+          },
+          {
+            "Version": "1.1.3-ALPHA117"
+          },
+          {
+            "Version": "1.1.3-ALPHA118"
+          },
+          {
+            "Version": "1.1.3-ALPHA119"
+          },
+          {
+            "Version": "1.1.3-ALPHA120"
+          },
+          {
+            "Version": "1.1.3-ALPHA121"
+          },
+          {
+            "Version": "1.1.3-ALPHA122"
+          },
+          {
+            "Version": "1.1.3-ALPHA123"
+          },
+          {
+            "Version": "1.1.3-ALPHA124"
+          },
+          {
+            "Version": "1.1.3-ALPHA125"
+          },
+          {
+            "Version": "1.1.3-ALPHA126"
+          },
+          {
+            "Version": "1.1.3-ALPHA127"
+          },
+          {
+            "Version": "1.1.3-ALPHA128"
+          },
+          {
+            "Version": "1.1.3-ALPHA130"
+          },
+          {
+            "Version": "1.1.3-ALPHA136"
+          },
+          {
+            "Version": "1.1.3-ALPHA138"
+          },
+          {
+            "Version": "1.1.3-ALPHA139"
+          },
+          {
+            "Version": "1.1.3-ALPHA140"
+          },
+          {
+            "Version": "1.1.3-ALPHA141"
+          },
+          {
+            "Version": "1.1.3-ALPHA142"
+          },
+          {
+            "Version": "1.1.3-ALPHA143"
+          },
+          {
+            "Version": "1.1.3-ALPHA144"
+          },
+          {
+            "Version": "1.1.3-ALPHA145"
+          },
+          {
+            "Version": "1.1.3-ALPHA146"
+          },
+          {
+            "Version": "1.1.3-ALPHA147"
+          },
+          {
+            "Version": "1.1.3-ALPHA148"
+          },
+          {
+            "Version": "1.1.3-ALPHA149"
+          },
+          {
+            "Version": "1.1.3-ALPHA150"
+          },
+          {
+            "Version": "1.1.3-ALPHA151"
+          },
+          {
+            "Version": "1.1.3-ALPHA152"
+          },
+          {
+            "Version": "1.1.3-ALPHA153"
+          },
+          {
+            "Version": "1.1.3-ALPHA154"
+          },
+          {
+            "Version": "1.1.3-ALPHA155"
+          },
+          {
+            "Version": "1.1.3-ALPHA156"
+          },
+          {
+            "Version": "1.1.3-ALPHA157"
+          },
+          {
+            "Version": "1.1.3-ALPHA158"
+          },
+          {
+            "Version": "1.1.3-ALPHA159"
+          },
+          {
+            "Version": "1.1.3-ALPHA160"
+          },
+          {
+            "Version": "1.1.3-ALPHA161"
+          },
+          {
+            "Version": "1.1.3-ALPHA162"
+          },
+          {
+            "Version": "1.1.3-ALPHA163"
+          },
+          {
+            "Version": "1.1.3-ALPHA164"
+          },
+          {
+            "Version": "1.1.3-ALPHA165"
+          },
+          {
+            "Version": "1.1.3-ALPHA166"
+          },
+          {
+            "Version": "1.1.3-ALPHA167"
+          },
+          {
+            "Version": "1.1.3-ALPHA168"
+          },
+          {
+            "Version": "1.1.3-ALPHA169"
+          },
+          {
+            "Version": "1.1.3-ALPHA170"
+          },
+          {
+            "Version": "1.1.3-ALPHA171"
+          },
+          {
+            "Version": "1.1.3-ALPHA172"
+          },
+          {
+            "Version": "1.1.3-ALPHA173"
+          },
+          {
+            "Version": "1.1.3-ALPHA174"
+          },
+          {
+            "Version": "1.1.3-ALPHA175"
+          },
+          {
+            "Version": "1.1.3-ALPHA176"
+          },
+          {
+            "Version": "1.1.3-ALPHA177"
+          },
+          {
+            "Version": "1.1.3-ALPHA178"
+          },
+          {
+            "Version": "1.1.3-ALPHA179"
+          },
+          {
+            "Version": "1.1.3-ALPHA180"
+          },
+          {
+            "Version": "1.1.3-ALPHA181"
+          },
+          {
+            "Version": "1.1.3-ALPHA182"
+          },
+          {
+            "Version": "1.1.3-ALPHA183"
+          },
+          {
+            "Version": "1.1.3-ALPHA184"
+          },
+          {
+            "Version": "1.1.3-ALPHA185"
+          },
+          {
+            "Version": "1.1.3-ALPHA186"
+          },
+          {
+            "Version": "1.1.3-ALPHA187"
+          },
+          {
+            "Version": "1.1.3-ALPHA188"
+          },
+          {
+            "Version": "1.1.3-ALPHA189"
+          },
+          {
+            "Version": "1.1.3-ALPHA190"
+          },
+          {
+            "Version": "1.1.3-ALPHA191"
+          },
+          {
+            "Version": "1.1.3-ALPHA192"
+          },
+          {
+            "Version": "1.1.3-ALPHA193"
+          },
+          {
+            "Version": "1.1.3-ALPHA194"
+          },
+          {
+            "Version": "1.1.3-ALPHA195"
+          },
+          {
+            "Version": "1.1.3-ALPHA196"
+          },
+          {
+            "Version": "1.1.3-ALPHA197"
+          },
+          {
+            "Version": "1.1.3-ALPHA198"
+          },
+          {
+            "Version": "1.1.3-ALPHA199"
+          },
+          {
+            "Version": "1.1.3-ALPHA200"
+          },
+          {
+            "Version": "1.1.3-ALPHA201"
+          },
+          {
+            "Version": "1.1.3-ALPHA202"
+          },
+          {
+            "Version": "1.1.3-ALPHA203"
+          },
+          {
+            "Version": "1.1.3-ALPHA204"
+          },
+          {
+            "Version": "1.1.3-ALPHA205"
+          },
+          {
+            "Version": "1.1.3-ALPHA210"
+          },
+          {
+            "Version": "1.1.3-ALPHA211"
+          },
+          {
+            "Version": "1.1.3-ALPHA212"
+          },
+          {
+            "Version": "1.1.3-ALPHA213"
+          },
+          {
+            "Version": "1.1.3-ALPHA214"
+          },
+          {
+            "Version": "1.1.3-ALPHA215"
+          },
+          {
+            "Version": "1.1.3-ALPHA216"
+          },
+          {
+            "Version": "1.1.3-ALPHA217"
+          },
+          {
+            "Version": "1.1.3-ALPHA220"
+          },
+          {
+            "Version": "1.1.3-ALPHA222"
+          },
+          {
+            "Version": "1.1.3-ALPHA223"
+          },
+          {
+            "Version": "1.1.3-ALPHA224"
+          },
+          {
+            "Version": "1.1.3-ALPHA225"
+          },
+          {
+            "Version": "1.1.3-ALPHA226"
+          },
+          {
+            "Version": "1.1.3-ALPHA227"
+          },
+          {
+            "Version": "1.1.3-ALPHA228"
+          },
+          {
+            "Version": "1.1.3-ALPHA229"
+          },
+          {
+            "Version": "1.1.3-ALPHA230"
+          },
+          {
+            "Version": "1.1.3-ALPHA231"
+          },
+          {
+            "Version": "1.1.3-ALPHA232"
+          },
+          {
+            "Version": "1.1.3-ALPHA233"
+          },
+          {
+            "Version": "1.1.3-ALPHA234"
+          },
+          {
+            "Version": "1.1.3-ALPHA236"
+          },
+          {
+            "Version": "1.1.3-ALPHA237"
+          },
+          {
+            "Version": "1.1.3-ALPHA238"
+          },
+          {
+            "Version": "1.1.3-ALPHA239"
+          },
+          {
+            "Version": "1.1.3-ALPHA240"
+          },
+          {
+            "Version": "1.1.3-ALPHA241"
+          },
+          {
+            "Version": "1.1.3-ALPHA242"
+          },
+          {
+            "Version": "1.1.3-ALPHA243"
+          },
+          {
+            "Version": "1.1.3-ALPHA244"
+          },
+          {
+            "Version": "1.1.3-ALPHA245"
+          },
+          {
+            "Version": "1.1.3-ALPHA247"
+          },
+          {
+            "Version": "1.1.3-ALPHA248"
+          },
+          {
+            "Version": "1.1.3-ALPHA249"
+          },
+          {
+            "Version": "1.1.3-ALPHA250"
+          },
+          {
+            "Version": "1.1.3-ALPHA251"
+          },
+          {
+            "Version": "1.1.3-ALPHA252"
+          },
+          {
+            "Version": "1.1.3-ALPHA253"
+          },
+          {
+            "Version": "1.1.3-ALPHA254"
+          },
+          {
+            "Version": "1.1.3-ALPHA256"
+          },
+          {
+            "Version": "1.1.3-ALPHA257"
+          },
+          {
+            "Version": "1.1.3-ALPHA258"
+          },
+          {
+            "Version": "1.1.3-ALPHA259"
+          },
+          {
+            "Version": "1.1.3-ALPHA260"
+          },
+          {
+            "Version": "1.1.3-ALPHA261"
+          },
+          {
+            "Version": "1.1.3-ALPHA262"
+          },
+          {
+            "Version": "1.1.3-ALPHA263"
+          },
+          {
+            "Version": "1.1.3-ALPHA264"
+          },
+          {
+            "Version": "1.1.3-ALPHA265"
+          },
+          {
+            "Version": "1.1.3-ALPHA266"
+          },
+          {
+            "Version": "1.1.3-ALPHA267"
+          },
+          {
+            "Version": "1.1.3-ALPHA268"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.2.1-ALPHA001"
+          },
+          {
+            "Version": "1.2.1-ALPHA002"
+          },
+          {
+            "Version": "1.2.1-ALPHA008"
+          },
+          {
+            "Version": "1.2.1-ALPHA009"
+          },
+          {
+            "Version": "1.2.1-ALPHA010"
+          },
+          {
+            "Version": "1.2.1.0"
+          },
+          {
+            "Version": "1.2.2-ALPHA011"
+          },
+          {
+            "Version": "1.2.2.0"
+          },
+          {
+            "Version": "1.2.3.0"
+          },
+          {
+            "Version": "1.2.4.0"
+          },
+          {
+            "Version": "1.3.0-ALPHA012"
+          },
+          {
+            "Version": "1.3.0-ALPHA015"
+          },
+          {
+            "Version": "1.3.0-ALPHA016"
+          },
+          {
+            "Version": "1.3.0-ALPHA017"
+          },
+          {
+            "Version": "1.3.0-ALPHA018"
+          },
+          {
+            "Version": "1.3.0-ALPHA020"
+          },
+          {
+            "Version": "1.3.0-ALPHA021"
+          },
+          {
+            "Version": "1.3.0-ALPHA022"
+          },
+          {
+            "Version": "1.3.0-ALPHA023"
+          },
+          {
+            "Version": "1.3.0-ALPHA024"
+          },
+          {
+            "Version": "1.3.0-ALPHA025"
+          },
+          {
+            "Version": "1.3.0-ALPHA026"
+          },
+          {
+            "Version": "1.3.0-ALPHA027"
+          },
+          {
+            "Version": "1.3.0-ALPHA028"
+          },
+          {
+            "Version": "1.3.0-ALPHA030"
+          },
+          {
+            "Version": "1.3.0-ALPHA031"
+          },
+          {
+            "Version": "1.3.0-ALPHA032"
+          },
+          {
+            "Version": "1.3.0-ALPHA033"
+          },
+          {
+            "Version": "1.3.0-ALPHA034"
+          },
+          {
+            "Version": "1.3.0-ALPHA035"
+          },
+          {
+            "Version": "1.3.0-ALPHA036"
+          },
+          {
+            "Version": "1.3.0-ALPHA037"
+          },
+          {
+            "Version": "1.3.0-ALPHA038"
+          },
+          {
+            "Version": "1.3.0-ALPHA039"
+          },
+          {
+            "Version": "1.3.0-ALPHA040"
+          },
+          {
+            "Version": "1.3.0-ALPHA041"
+          },
+          {
+            "Version": "1.3.0-ALPHA042"
+          },
+          {
+            "Version": "1.3.0-ALPHA043"
+          },
+          {
+            "Version": "1.3.0-ALPHA044"
+          },
+          {
+            "Version": "1.3.0-ALPHA045"
+          },
+          {
+            "Version": "1.3.0-ALPHA046"
+          },
+          {
+            "Version": "1.3.0-ALPHA047"
+          },
+          {
+            "Version": "1.3.0-ALPHA048"
+          },
+          {
+            "Version": "1.3.0-ALPHA049"
+          },
+          {
+            "Version": "1.3.0-ALPHA050"
+          },
+          {
+            "Version": "1.3.0-ALPHA051"
+          },
+          {
+            "Version": "1.3.0-ALPHA052"
+          },
+          {
+            "Version": "1.3.0-ALPHA053"
+          },
+          {
+            "Version": "1.3.0-ALPHA054"
+          },
+          {
+            "Version": "1.3.0-ALPHA055"
+          },
+          {
+            "Version": "1.3.0-ALPHA056"
+          },
+          {
+            "Version": "1.3.0-ALPHA057"
+          },
+          {
+            "Version": "1.3.0-ALPHA058"
+          },
+          {
+            "Version": "1.3.0-ALPHA059"
+          },
+          {
+            "Version": "1.3.0-ALPHA060"
+          },
+          {
+            "Version": "1.3.0-ALPHA061"
+          },
+          {
+            "Version": "1.3.0-ALPHA062"
+          },
+          {
+            "Version": "1.3.0-ALPHA063"
+          },
+          {
+            "Version": "1.3.0-ALPHA064"
+          },
+          {
+            "Version": "1.3.0-ALPHA065"
+          },
+          {
+            "Version": "1.3.0-ALPHA066"
+          },
+          {
+            "Version": "1.3.0-ALPHA067"
+          },
+          {
+            "Version": "1.3.0-ALPHA068"
+          },
+          {
+            "Version": "1.3.0-ALPHA069"
+          },
+          {
+            "Version": "1.3.0-ALPHA070"
+          },
+          {
+            "Version": "1.3.0-ALPHA071"
+          },
+          {
+            "Version": "1.3.0-ALPHA072"
+          },
+          {
+            "Version": "1.3.0-ALPHA073"
+          },
+          {
+            "Version": "1.3.0-ALPHA074"
+          },
+          {
+            "Version": "1.3.0-ALPHA075"
+          },
+          {
+            "Version": "1.3.0-ALPHA076"
+          },
+          {
+            "Version": "1.3.0-ALPHA077"
+          },
+          {
+            "Version": "1.3.0-ALPHA078"
+          },
+          {
+            "Version": "1.3.0-ALPHA079"
+          },
+          {
+            "Version": "1.3.0-ALPHA080"
+          },
+          {
+            "Version": "1.3.0-ALPHA081"
+          },
+          {
+            "Version": "1.3.0-ALPHA082"
+          },
+          {
+            "Version": "1.3.0-ALPHA083"
+          },
+          {
+            "Version": "1.3.0-ALPHA084"
+          },
+          {
+            "Version": "1.3.0-ALPHA085"
+          },
+          {
+            "Version": "1.3.0-ALPHA086"
+          },
+          {
+            "Version": "1.3.0-ALPHA087"
+          },
+          {
+            "Version": "1.3.0-ALPHA088"
+          },
+          {
+            "Version": "1.3.0-ALPHA089"
+          },
+          {
+            "Version": "1.3.0-ALPHA090"
+          },
+          {
+            "Version": "1.3.0-ALPHA091"
+          },
+          {
+            "Version": "1.3.0-ALPHA092"
+          },
+          {
+            "Version": "1.3.0-ALPHA093"
+          },
+          {
+            "Version": "1.3.0-ALPHA094"
+          },
+          {
+            "Version": "1.3.0-ALPHA095"
+          },
+          {
+            "Version": "1.3.0-ALPHA096"
+          },
+          {
+            "Version": "1.3.0-ALPHA097"
+          },
+          {
+            "Version": "1.3.0-ALPHA098"
+          },
+          {
+            "Version": "1.3.0-ALPHA099"
+          },
+          {
+            "Version": "1.3.0-ALPHA100"
+          },
+          {
+            "Version": "1.3.0-ALPHA101"
+          },
+          {
+            "Version": "1.3.0-ALPHA102"
+          },
+          {
+            "Version": "1.3.0-ALPHA103"
+          },
+          {
+            "Version": "1.3.0-ALPHA104"
+          },
+          {
+            "Version": "1.3.0-ALPHA105"
+          },
+          {
+            "Version": "1.3.0-ALPHA106"
+          },
+          {
+            "Version": "1.3.0-ALPHA107"
+          },
+          {
+            "Version": "1.3.0-ALPHA108"
+          },
+          {
+            "Version": "1.3.0-ALPHA109"
+          },
+          {
+            "Version": "1.3.0-ALPHA110"
+          },
+          {
+            "Version": "1.3.0-ALPHA111"
+          },
+          {
+            "Version": "1.3.0-ALPHA112"
+          },
+          {
+            "Version": "1.3.0-ALPHA121"
+          },
+          {
+            "Version": "1.3.0-ALPHA122"
+          },
+          {
+            "Version": "1.3.0-ALPHA123"
+          },
+          {
+            "Version": "1.3.0-ALPHA124"
+          },
+          {
+            "Version": "1.3.0-ALPHA125"
+          },
+          {
+            "Version": "1.3.0-ALPHA126"
+          },
+          {
+            "Version": "1.3.0-ALPHA128"
+          },
+          {
+            "Version": "1.3.0-ALPHA129"
+          },
+          {
+            "Version": "1.3.0-ALPHA130"
+          },
+          {
+            "Version": "1.3.0-ALPHA131"
+          },
+          {
+            "Version": "1.3.0-ALPHA132"
+          },
+          {
+            "Version": "1.3.0-ALPHA133"
+          },
+          {
+            "Version": "1.3.0-ALPHA134"
+          },
+          {
+            "Version": "1.3.0-ALPHA135"
+          },
+          {
+            "Version": "1.3.0-ALPHA136"
+          },
+          {
+            "Version": "1.3.0-ALPHA137"
+          },
+          {
+            "Version": "1.3.0-ALPHA138"
+          },
+          {
+            "Version": "1.3.0-ALPHA139"
+          },
+          {
+            "Version": "1.3.0-ALPHA140"
+          },
+          {
+            "Version": "1.3.0-ALPHA141"
+          },
+          {
+            "Version": "1.3.0-ALPHA142"
+          },
+          {
+            "Version": "1.3.0-ALPHA143"
+          },
+          {
+            "Version": "1.3.0-ALPHA144"
+          },
+          {
+            "Version": "1.3.0-ALPHA145"
+          },
+          {
+            "Version": "1.3.0-ALPHA146"
+          },
+          {
+            "Version": "1.3.0-ALPHA147"
+          },
+          {
+            "Version": "1.3.0-ALPHA150"
+          },
+          {
+            "Version": "1.3.0-ALPHA151"
+          },
+          {
+            "Version": "1.3.0-ALPHA152"
+          },
+          {
+            "Version": "1.3.0-ALPHA153"
+          },
+          {
+            "Version": "1.3.0-ALPHA154"
+          },
+          {
+            "Version": "1.3.0-ALPHA155"
+          },
+          {
+            "Version": "1.3.0-ALPHA157"
+          },
+          {
+            "Version": "1.3.0-ALPHA158"
+          },
+          {
+            "Version": "1.3.0-ALPHA159"
+          },
+          {
+            "Version": "1.3.0-ALPHA160"
+          },
+          {
+            "Version": "1.3.0-ALPHA161"
+          },
+          {
+            "Version": "1.3.0-ALPHA162"
+          },
+          {
+            "Version": "1.3.0-ALPHA163"
+          },
+          {
+            "Version": "1.3.0-ALPHA164"
+          },
+          {
+            "Version": "1.3.0-ALPHA165"
+          },
+          {
+            "Version": "1.3.0-ALPHA166"
+          },
+          {
+            "Version": "1.3.0-ALPHA167"
+          },
+          {
+            "Version": "1.3.0-ALPHA169"
+          },
+          {
+            "Version": "1.3.0-ALPHA170"
+          },
+          {
+            "Version": "1.3.0-ALPHA171"
+          },
+          {
+            "Version": "1.3.0-ALPHA172"
+          },
+          {
+            "Version": "1.3.0-ALPHA173"
+          },
+          {
+            "Version": "1.3.0-ALPHA174"
+          },
+          {
+            "Version": "1.3.0-ALPHA175"
+          },
+          {
+            "Version": "1.3.0-ALPHA176"
+          },
+          {
+            "Version": "1.3.0-ALPHA178"
+          },
+          {
+            "Version": "1.3.0-ALPHA179"
+          },
+          {
+            "Version": "1.3.0-ALPHA182"
+          },
+          {
+            "Version": "1.3.0-ALPHA183"
+          },
+          {
+            "Version": "1.3.0-ALPHA184"
+          },
+          {
+            "Version": "1.3.0-ALPHA185"
+          },
+          {
+            "Version": "1.3.0-ALPHA186"
+          },
+          {
+            "Version": "1.3.0-ALPHA188"
+          },
+          {
+            "Version": "1.3.0-ALPHA189"
+          },
+          {
+            "Version": "1.3.0-ALPHA190"
+          },
+          {
+            "Version": "1.3.0-ALPHA192"
+          },
+          {
+            "Version": "1.3.0-ALPHA193"
+          },
+          {
+            "Version": "1.3.0-ALPHA194"
+          },
+          {
+            "Version": "1.3.0-ALPHA195"
+          },
+          {
+            "Version": "1.3.0-ALPHA196"
+          },
+          {
+            "Version": "1.3.0-ALPHA197"
+          },
+          {
+            "Version": "1.3.0-ALPHA198"
+          },
+          {
+            "Version": "1.3.0-ALPHA199"
+          },
+          {
+            "Version": "1.3.0-ALPHA200"
+          },
+          {
+            "Version": "1.3.0-ALPHA201"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0-ALPHA001"
+          },
+          {
+            "Version": "1.4.0-ALPHA002"
+          },
+          {
+            "Version": "1.4.0-ALPHA003"
+          },
+          {
+            "Version": "1.4.0-ALPHA004"
+          },
+          {
+            "Version": "1.4.0-ALPHA005"
+          },
+          {
+            "Version": "1.4.0-ALPHA006"
+          },
+          {
+            "Version": "1.4.0-ALPHA007"
+          },
+          {
+            "Version": "1.4.0-ALPHA008"
+          },
+          {
+            "Version": "1.4.0-ALPHA009"
+          },
+          {
+            "Version": "1.4.0-ALPHA015"
+          },
+          {
+            "Version": "1.4.0-ALPHA021"
+          },
+          {
+            "Version": "1.4.0-ALPHA022"
+          },
+          {
+            "Version": "1.4.0-ALPHA023"
+          },
+          {
+            "Version": "1.4.0-ALPHA024"
+          },
+          {
+            "Version": "1.4.0-ALPHA025"
+          },
+          {
+            "Version": "1.4.0-ALPHA026"
+          },
+          {
+            "Version": "1.4.0-ALPHA028"
+          },
+          {
+            "Version": "1.4.0-ALPHA029"
+          },
+          {
+            "Version": "1.4.0-ALPHA030"
+          },
+          {
+            "Version": "1.4.0-ALPHA031"
+          },
+          {
+            "Version": "1.4.0-ALPHA032"
+          },
+          {
+            "Version": "1.4.0-ALPHA033"
+          },
+          {
+            "Version": "1.4.0-ALPHA035"
+          },
+          {
+            "Version": "1.4.0-ALPHA036"
+          },
+          {
+            "Version": "1.4.0-ALPHA037"
+          },
+          {
+            "Version": "1.4.0-ALPHA038"
+          },
+          {
+            "Version": "1.4.0-ALPHA039"
+          },
+          {
+            "Version": "1.4.0-ALPHA040"
+          },
+          {
+            "Version": "1.4.0-ALPHA041"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.5.0-alpha001"
+          },
+          {
+            "Version": "1.5.0-alpha002"
+          },
+          {
+            "Version": "1.5.0-alpha003"
+          },
+          {
+            "Version": "1.5.0-alpha004"
+          },
+          {
+            "Version": "1.5.0-alpha005"
+          },
+          {
+            "Version": "1.5.0-alpha006"
+          },
+          {
+            "Version": "1.5.0-alpha007"
+          },
+          {
+            "Version": "1.5.0-alpha008"
+          },
+          {
+            "Version": "1.5.0-alpha009"
+          },
+          {
+            "Version": "1.5.0-alpha010"
+          },
+          {
+            "Version": "1.5.0-alpha011"
+          },
+          {
+            "Version": "1.5.0-alpha012"
+          },
+          {
+            "Version": "1.5.0-alpha013"
+          },
+          {
+            "Version": "1.5.0-alpha014"
+          },
+          {
+            "Version": "1.5.0-alpha015"
+          },
+          {
+            "Version": "1.5.0-alpha016"
+          },
+          {
+            "Version": "1.5.0-alpha017"
+          },
+          {
+            "Version": "1.5.0-alpha018"
+          },
+          {
+            "Version": "1.5.0-alpha019"
+          },
+          {
+            "Version": "1.5.0-alpha020"
+          },
+          {
+            "Version": "1.5.0-alpha021"
+          },
+          {
+            "Version": "1.5.0-alpha022"
+          },
+          {
+            "Version": "1.5.0",
+            "PackageDetails": {
+              "Name": "MahApps.Metro",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MahApps.Metro/1.5.0",
+              "LicenseUrl": "https://github.com/MahApps/MahApps.Metro/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:51.3490581+02:00",
+        "PackageName": "MahApps.Metro.Resources",
+        "Versions": [
+          {
+            "Version": "0.5.0",
+            "PackageDetails": {
+              "Name": "MahApps.Metro.Resources",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MahApps.Metro.Resources/0.5.0.0",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "MahApps.Metro",
+                  "VersionRequirement": ">= 1.2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001270-force-redirects/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001270-force-redirects/cache/paket-graph.cache
@@ -1,0 +1,21592 @@
+{
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:34.9585091+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:31.4338896+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:24.2504014+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:29.0499759+02:00",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:21.840649+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:16.5120852+02:00",
+        "PackageName": "System.Dynamic.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Dynamic.Runtime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Dynamic.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:25.4429002+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:18.8530899+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:17.6890874+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:15.058527+02:00",
+        "PackageName": "System.Runtime.Serialization.Formatters",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Formatters",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Formatters/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:17.0960884+02:00",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:24.8439298+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:20.6536159+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:37.3525009+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:44.5382055+02:00",
+        "PackageName": "System.Collections.NonGeneric",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.NonGeneric",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.NonGeneric/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:15.9370862+02:00",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:27.2219763+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:13.8569537+02:00",
+        "PackageName": "System.ComponentModel.TypeConverter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.TypeConverter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.TypeConverter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, net45, >= net462, netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:32.6513957+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:42.6966538+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:42.0911553+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:12.6349525+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:38.5260795+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505"
+          },
+          {
+            "Version": "2.0.20710"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:34.394509+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:32.0523939+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:29.6209767+02:00",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:18.288087+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:43.8877907+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:47.2284416+02:00",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:36.1675283+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:45.1859426+02:00",
+        "PackageName": "System.Collections.Specialized",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Specialized",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.Specialized/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:48.4502242+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:49.0812253+02:00",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:33.2103951+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:40.2970976+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:33.8103941+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:30.2079767+02:00",
+        "PackageName": "System.ComponentModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:41.4901515+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:23.0596469+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:20.0735872+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:36.7315+02:00",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:28.4294795+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:15.718586+02:00",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:13.2524539+02:00",
+        "PackageName": "Microsoft.CSharp",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.CSharp",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.CSharp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:35.5716336+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:39.1266287+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:12.0174537+02:00",
+        "PackageName": "EnterpriseLibrary.SemanticLogging",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "1.0.1304"
+          },
+          {
+            "Version": "1.1.1403"
+          },
+          {
+            "Version": "1.1.1403.1"
+          },
+          {
+            "Version": "2.0.1406"
+          },
+          {
+            "Version": "2.0.1406.1",
+            "PackageDetails": {
+              "Name": "EnterpriseLibrary.SemanticLogging",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/EnterpriseLibrary.SemanticLogging/2.0.1406.1",
+              "LicenseUrl": "http://opensource.org/licenses/Apache-2.0",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 5.0.8"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "6.0.1302-preview"
+          },
+          {
+            "Version": "6.0.1302"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:43.2946512+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:47.8234716+02:00",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:40.8890998+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:21.2406473+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:37.9344987+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:45.7924435+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:14.4614682+02:00",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:23.6509366+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:39.7020993+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:19.4870893+02:00",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:26.0304028+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:27.8364748+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:26.6299744+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:22.4406476+02:00",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:46.5409426+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:30.7969911+02:00",
+        "PackageName": "System.ComponentModel.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:24",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:45",
+        "PackageName": "System.Threading.ThreadPool",
+        "Versions": [
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.0.10-beta-23225"
+          },
+          {
+            "Version": "4.0.10-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23516"
+          },
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.ThreadPool",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.ThreadPool/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:48",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:54",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:51",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:50",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:32",
+        "PackageName": "System.Net.WebHeaderCollection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.WebHeaderCollection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.WebHeaderCollection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:50",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:33",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:55",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:30",
+        "PackageName": "System.Linq.Queryable",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Queryable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Queryable/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:56",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:55",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:52",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:40",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:55",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:47",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:46",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:46",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:50",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:35",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:46",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:48",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:40",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:54",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:41",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:27",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:51",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:56",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:57",
+        "PackageName": "System.Threading.Overlapped",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Overlapped",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Threading.Overlapped/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:55",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:47",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:41",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:45",
+        "PackageName": "System.Threading.Thread",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Thread",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Thread/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:42",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:25",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:57",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:47",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:56",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:53",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:56",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:53",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:55",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:46",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:57",
+        "PackageName": "System.Runtime.WindowsRuntime",
+        "Versions": [
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.WindowsRuntime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.WindowsRuntime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:53",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:54",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:52",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:44",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:51",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:28",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:48",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:52",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:49",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:38",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:25",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:45",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:54",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:50",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:49",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:34",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:47",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:43",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:49",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:48",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:32",
+        "PackageName": "System.Net.Requests",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Requests",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Requests/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.WebHeaderCollection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:52",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:58",
+        "PackageName": "System.Diagnostics.Contracts",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Contracts",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Diagnostics.Contracts/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:38",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:51",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:31",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:28",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:53",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:43",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:47",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:46",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:50",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:57",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:24",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:53",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:33",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:54",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:28",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:52",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:47",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:34",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:34",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:33",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:44",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:27",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:48",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:35",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:46",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:26",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:22",
+        "PackageName": "Newtonsoft.Json.Schema",
+        "Versions": [
+          {
+            "Version": "1.0.11",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json.Schema",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json.Schema/1.0.11",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:57",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:56",
+        "PackageName": "System.Private.Uri",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Private.Uri",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Private.Uri/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:52",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:31",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:49",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:21",
+        "PackageName": "Alphafs",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.0.0.1"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2",
+            "PackageDetails": {
+              "Name": "AlphaFS",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/AlphaFS/2.1.2",
+              "LicenseUrl": "https://github.com/alphaleonis/AlphaFS/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:45",
+        "PackageName": "System.Threading.Tasks.Parallel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Parallel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Parallel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:50",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:48",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:24",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:51",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:23",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:41",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:29",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:51",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:25",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:38",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:40",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:41",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:49",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:53",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:34",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:49",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:54",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:26",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:42",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:36:26",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  },
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:42",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:09",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:44",
+        "PackageName": "System.Threading.Tasks.Parallel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Parallel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Parallel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:48",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:57",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:01",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:42",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:56",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:54",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:56",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:05",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:50",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:08",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:56",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "FsUnit",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.9.1.1"
+          },
+          {
+            "Version": "1.0.0.3"
+          },
+          {
+            "Version": "1.0.0.4"
+          },
+          {
+            "Version": "1.0.0.5"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.1.0.1"
+          },
+          {
+            "Version": "1.1.0.2"
+          },
+          {
+            "Version": "1.1.1.0"
+          },
+          {
+            "Version": "1.2.1.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.0.1"
+          },
+          {
+            "Version": "1.3.1.0-beta"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.4.0.0-beta"
+          },
+          {
+            "Version": "1.4.0.0-beta3"
+          },
+          {
+            "Version": "1.4.0.0"
+          },
+          {
+            "Version": "1.4.1.0",
+            "PackageDetails": {
+              "Name": "FsUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FsUnit/1.4.1.0",
+              "LicenseUrl": "http://github.com/fsprojects/FsUnit/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1.2.5"
+                },
+                {
+                  "PackageName": "NUnit",
+                  "VersionRequirement": "2.6.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.4.0-alpha-1"
+          },
+          {
+            "Version": "2.4.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:50",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:06",
+        "PackageName": "System.Net.WebHeaderCollection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.WebHeaderCollection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.WebHeaderCollection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:44",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:58",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:04",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:07",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:09",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:02",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:09",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:50",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:59",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:53",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:56",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:41",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:07",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:40",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:57",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:44",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:08",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:41",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:58",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:10",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:49",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:57",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.5.7.10213"
+          },
+          {
+            "Version": "2.5.9.10348"
+          },
+          {
+            "Version": "2.5.10.11092"
+          },
+          {
+            "Version": "2.6.0.12051"
+          },
+          {
+            "Version": "2.6.0.12054"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/NUnit/2.6.4",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0-alpha"
+          },
+          {
+            "Version": "3.0.0-alpha-2"
+          },
+          {
+            "Version": "3.0.0-alpha-3"
+          },
+          {
+            "Version": "3.0.0-alpha-4"
+          },
+          {
+            "Version": "3.0.0-alpha-5"
+          },
+          {
+            "Version": "3.0.0-beta-1"
+          },
+          {
+            "Version": "3.0.0-beta-2"
+          },
+          {
+            "Version": "3.0.0-beta-3"
+          },
+          {
+            "Version": "3.0.0-beta-4"
+          },
+          {
+            "Version": "3.0.0-beta-5"
+          },
+          {
+            "Version": "3.0.0-rc"
+          },
+          {
+            "Version": "3.0.0-rc-2"
+          },
+          {
+            "Version": "3.0.0-rc-3"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:08",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:44",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:01",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:56",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:53",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:44",
+        "PackageName": "System.Threading.Thread",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Thread",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Thread/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:49",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:56",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:01",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:56",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:04",
+        "PackageName": "System.Linq.Queryable",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Queryable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Queryable/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:41",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:06",
+        "PackageName": "System.Net.Requests",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Requests",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Requests/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.WebHeaderCollection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:58",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:48:03",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:55",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:50",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:43",
+        "PackageName": "System.Threading.ThreadPool",
+        "Versions": [
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.0.10-beta-23225"
+          },
+          {
+            "Version": "4.0.10-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23516"
+          },
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.ThreadPool",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.ThreadPool/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:47:59",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001270-net461/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001270-net461/cache/paket-graph.cache
@@ -1,0 +1,38 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:54.8610463+02:00",
+        "PackageName": "Alphafs",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.0.0.1"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2",
+            "PackageDetails": {
+              "Name": "AlphaFS",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/AlphaFS/2.1.2",
+              "LicenseUrl": "https://github.com/alphaleonis/AlphaFS/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001353-git-as-source/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001353-git-as-source/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "paket-files/github.com/forki/nupkgtest/source": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:23.010519+02:00",
+        "PackageName": "Argu",
+        "Versions": [
+          {
+            "Version": "1.1.3",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "Argu",
+              "LicenseUrl": "https://github.com/nessos/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001353-git-build-as-source/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001353-git-build-as-source/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "paket-files/github.com/forki/nupkgtest/source": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:39:00.3289877+02:00",
+        "PackageName": "Argu",
+        "Versions": [
+          {
+            "Version": "1.1.3",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "Argu",
+              "LicenseUrl": "https://github.com/nessos/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001380-git-semvertag-as-source/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001380-git-semvertag-as-source/cache/paket-graph.cache
@@ -1,0 +1,34 @@
+{
+  "paket-files/github.com/forki/nupkgtest/source": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:25:25.5270971+02:00",
+        "PackageName": "Argu",
+        "Versions": [
+          {
+            "Version": "1.1.3",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "Argu",
+              "LicenseUrl": "https://github.com/nessos/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "Argu",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001380-git-tag-as-source/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001380-git-tag-as-source/cache/paket-graph.cache
@@ -1,0 +1,34 @@
+{
+  "paket-files/github.com/forki/nupkgtest/source": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:25:19.593093+02:00",
+        "PackageName": "Argu",
+        "Versions": [
+          {
+            "Version": "1.1.3",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "Argu",
+              "LicenseUrl": "https://github.com/nessos/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "Argu",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001387-nugetv3/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001387-nugetv3/cache/paket-graph.cache
@@ -1,0 +1,153 @@
+{
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:58:35.0207216+02:00",
+        "PackageName": "Bender",
+        "Versions": [
+          {
+            "Version": "3.0.29.0",
+            "PackageDetails": {
+              "Name": "Bender",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Bender/3.0.29.0",
+              "LicenseUrl": "https://github.com/mikeobrien/Bender/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "flexo",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:58:35.1062208+02:00",
+        "PackageName": "flexo",
+        "Versions": [
+          {
+            "Version": "1.0.0.18"
+          },
+          {
+            "Version": "1.0.0.19"
+          },
+          {
+            "Version": "1.0.0.20"
+          },
+          {
+            "Version": "1.0.0.22"
+          },
+          {
+            "Version": "1.0.0.23"
+          },
+          {
+            "Version": "1.0.0.24"
+          },
+          {
+            "Version": "1.0.0.25"
+          },
+          {
+            "Version": "1.0.0.28"
+          },
+          {
+            "Version": "1.0.0.29"
+          },
+          {
+            "Version": "1.0.0.36"
+          },
+          {
+            "Version": "1.0.0.37"
+          },
+          {
+            "Version": "1.0.0.39"
+          },
+          {
+            "Version": "1.0.0.42"
+          },
+          {
+            "Version": "1.0.0.47"
+          },
+          {
+            "Version": "1.0.0.48"
+          },
+          {
+            "Version": "1.0.0.55"
+          },
+          {
+            "Version": "1.0.0.56"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.18"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.0.20"
+          },
+          {
+            "Version": "1.0.21"
+          },
+          {
+            "Version": "1.0.22"
+          },
+          {
+            "Version": "1.0.23"
+          },
+          {
+            "Version": "1.0.24",
+            "PackageDetails": {
+              "Name": "flexo",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/flexo/1.0.24.0",
+              "LicenseUrl": "https://github.com/mikeobrien/Flexo/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001413-symbols/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001413-symbols/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "NuGetFeed": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:01.1418685+02:00",
+        "PackageName": "Composable.Core",
+        "Versions": [
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "Composable.Core",
+              "DownloadLink": "Composable.Core",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001427-content-none/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001427-content-none/cache/paket-graph.cache
@@ -1,0 +1,357 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:24.6988037+02:00",
+        "PackageName": "Costura.Fody",
+        "Versions": [
+          {
+            "Version": "0.1.0.0"
+          },
+          {
+            "Version": "0.2.0.0"
+          },
+          {
+            "Version": "0.2.1.0"
+          },
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.3.1.0"
+          },
+          {
+            "Version": "0.3.1.1"
+          },
+          {
+            "Version": "0.3.1.2"
+          },
+          {
+            "Version": "0.3.2.0"
+          },
+          {
+            "Version": "0.3.2.1"
+          },
+          {
+            "Version": "0.3.3.0"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.1.0"
+          },
+          {
+            "Version": "0.7.0.0"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.1.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.2.0"
+          },
+          {
+            "Version": "1.3.3.0",
+            "PackageDetails": {
+              "Name": "Costura.Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Costura.Fody/1.3.3.0",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Fody",
+                  "VersionRequirement": ">= 1.26.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.4.0"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-beta0014"
+          },
+          {
+            "Version": "2.0.0-beta0018"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:24.8688052+02:00",
+        "PackageName": "Fody",
+        "Versions": [
+          {
+            "Version": "1.13.0.0"
+          },
+          {
+            "Version": "1.13.1.0"
+          },
+          {
+            "Version": "1.13.2.0"
+          },
+          {
+            "Version": "1.13.3.0"
+          },
+          {
+            "Version": "1.13.6.0"
+          },
+          {
+            "Version": "1.13.6.1"
+          },
+          {
+            "Version": "1.13.7.0"
+          },
+          {
+            "Version": "1.13.8.0"
+          },
+          {
+            "Version": "1.13.11.1"
+          },
+          {
+            "Version": "1.13.12"
+          },
+          {
+            "Version": "1.14.0"
+          },
+          {
+            "Version": "1.15.0.0"
+          },
+          {
+            "Version": "1.16.0.0"
+          },
+          {
+            "Version": "1.16.2.0"
+          },
+          {
+            "Version": "1.17.0.0"
+          },
+          {
+            "Version": "1.17.4.0"
+          },
+          {
+            "Version": "1.18.0.0"
+          },
+          {
+            "Version": "1.19.0.0"
+          },
+          {
+            "Version": "1.19.1.0"
+          },
+          {
+            "Version": "1.20.0.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.23.1"
+          },
+          {
+            "Version": "1.23.2"
+          },
+          {
+            "Version": "1.24.0-beta1"
+          },
+          {
+            "Version": "1.24.0-beta2"
+          },
+          {
+            "Version": "1.24.0-beta3"
+          },
+          {
+            "Version": "1.24.0-beta4"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0-beta0001"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "1.26.1"
+          },
+          {
+            "Version": "1.26.2-beta1"
+          },
+          {
+            "Version": "1.26.2"
+          },
+          {
+            "Version": "1.26.3-beta0001"
+          },
+          {
+            "Version": "1.26.3"
+          },
+          {
+            "Version": "1.26.4"
+          },
+          {
+            "Version": "1.27.0-beta01"
+          },
+          {
+            "Version": "1.27.0"
+          },
+          {
+            "Version": "1.27.1-beta01"
+          },
+          {
+            "Version": "1.27.1-beta03"
+          },
+          {
+            "Version": "1.27.1"
+          },
+          {
+            "Version": "1.28.0"
+          },
+          {
+            "Version": "1.28.1"
+          },
+          {
+            "Version": "1.28.3"
+          },
+          {
+            "Version": "1.29.0-beta01"
+          },
+          {
+            "Version": "1.29.0"
+          },
+          {
+            "Version": "1.29.0.1"
+          },
+          {
+            "Version": "1.29.1-beta2"
+          },
+          {
+            "Version": "1.29.1-beta3"
+          },
+          {
+            "Version": "1.29.1"
+          },
+          {
+            "Version": "1.29.2"
+          },
+          {
+            "Version": "1.29.3"
+          },
+          {
+            "Version": "1.29.4"
+          },
+          {
+            "Version": "1.30.0-beta01"
+          },
+          {
+            "Version": "2.0.0-beta0001"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fody/2.0.6",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001427-content-once-remove/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001427-content-once-remove/cache/paket-graph.cache
@@ -1,0 +1,357 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:09.4737082+02:00",
+        "PackageName": "Costura.Fody",
+        "Versions": [
+          {
+            "Version": "0.1.0.0"
+          },
+          {
+            "Version": "0.2.0.0"
+          },
+          {
+            "Version": "0.2.1.0"
+          },
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.3.1.0"
+          },
+          {
+            "Version": "0.3.1.1"
+          },
+          {
+            "Version": "0.3.1.2"
+          },
+          {
+            "Version": "0.3.2.0"
+          },
+          {
+            "Version": "0.3.2.1"
+          },
+          {
+            "Version": "0.3.3.0"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.1.0"
+          },
+          {
+            "Version": "0.7.0.0"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.1.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.2.0"
+          },
+          {
+            "Version": "1.3.3.0",
+            "PackageDetails": {
+              "Name": "Costura.Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Costura.Fody/1.3.3.0",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Fody",
+                  "VersionRequirement": ">= 1.26.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.4.0"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-beta0014"
+          },
+          {
+            "Version": "2.0.0-beta0018"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:09.6432105+02:00",
+        "PackageName": "Fody",
+        "Versions": [
+          {
+            "Version": "1.13.0.0"
+          },
+          {
+            "Version": "1.13.1.0"
+          },
+          {
+            "Version": "1.13.2.0"
+          },
+          {
+            "Version": "1.13.3.0"
+          },
+          {
+            "Version": "1.13.6.0"
+          },
+          {
+            "Version": "1.13.6.1"
+          },
+          {
+            "Version": "1.13.7.0"
+          },
+          {
+            "Version": "1.13.8.0"
+          },
+          {
+            "Version": "1.13.11.1"
+          },
+          {
+            "Version": "1.13.12"
+          },
+          {
+            "Version": "1.14.0"
+          },
+          {
+            "Version": "1.15.0.0"
+          },
+          {
+            "Version": "1.16.0.0"
+          },
+          {
+            "Version": "1.16.2.0"
+          },
+          {
+            "Version": "1.17.0.0"
+          },
+          {
+            "Version": "1.17.4.0"
+          },
+          {
+            "Version": "1.18.0.0"
+          },
+          {
+            "Version": "1.19.0.0"
+          },
+          {
+            "Version": "1.19.1.0"
+          },
+          {
+            "Version": "1.20.0.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.23.1"
+          },
+          {
+            "Version": "1.23.2"
+          },
+          {
+            "Version": "1.24.0-beta1"
+          },
+          {
+            "Version": "1.24.0-beta2"
+          },
+          {
+            "Version": "1.24.0-beta3"
+          },
+          {
+            "Version": "1.24.0-beta4"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0-beta0001"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "1.26.1"
+          },
+          {
+            "Version": "1.26.2-beta1"
+          },
+          {
+            "Version": "1.26.2"
+          },
+          {
+            "Version": "1.26.3-beta0001"
+          },
+          {
+            "Version": "1.26.3"
+          },
+          {
+            "Version": "1.26.4"
+          },
+          {
+            "Version": "1.27.0-beta01"
+          },
+          {
+            "Version": "1.27.0"
+          },
+          {
+            "Version": "1.27.1-beta01"
+          },
+          {
+            "Version": "1.27.1-beta03"
+          },
+          {
+            "Version": "1.27.1"
+          },
+          {
+            "Version": "1.28.0"
+          },
+          {
+            "Version": "1.28.1"
+          },
+          {
+            "Version": "1.28.3"
+          },
+          {
+            "Version": "1.29.0-beta01"
+          },
+          {
+            "Version": "1.29.0"
+          },
+          {
+            "Version": "1.29.0.1"
+          },
+          {
+            "Version": "1.29.1-beta2"
+          },
+          {
+            "Version": "1.29.1-beta3"
+          },
+          {
+            "Version": "1.29.1"
+          },
+          {
+            "Version": "1.29.2"
+          },
+          {
+            "Version": "1.29.3"
+          },
+          {
+            "Version": "1.29.4"
+          },
+          {
+            "Version": "1.30.0-beta01"
+          },
+          {
+            "Version": "2.0.0-beta0001"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fody/2.0.6",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001427-content-once-stable/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001427-content-once-stable/cache/paket-graph.cache
@@ -1,0 +1,357 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:12.9412075+02:00",
+        "PackageName": "Costura.Fody",
+        "Versions": [
+          {
+            "Version": "0.1.0.0"
+          },
+          {
+            "Version": "0.2.0.0"
+          },
+          {
+            "Version": "0.2.1.0"
+          },
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.3.1.0"
+          },
+          {
+            "Version": "0.3.1.1"
+          },
+          {
+            "Version": "0.3.1.2"
+          },
+          {
+            "Version": "0.3.2.0"
+          },
+          {
+            "Version": "0.3.2.1"
+          },
+          {
+            "Version": "0.3.3.0"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.1.0"
+          },
+          {
+            "Version": "0.7.0.0"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.1.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.2.0"
+          },
+          {
+            "Version": "1.3.3.0",
+            "PackageDetails": {
+              "Name": "Costura.Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Costura.Fody/1.3.3.0",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Fody",
+                  "VersionRequirement": ">= 1.26.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.4.0"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-beta0014"
+          },
+          {
+            "Version": "2.0.0-beta0018"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:13.1202094+02:00",
+        "PackageName": "Fody",
+        "Versions": [
+          {
+            "Version": "1.13.0.0"
+          },
+          {
+            "Version": "1.13.1.0"
+          },
+          {
+            "Version": "1.13.2.0"
+          },
+          {
+            "Version": "1.13.3.0"
+          },
+          {
+            "Version": "1.13.6.0"
+          },
+          {
+            "Version": "1.13.6.1"
+          },
+          {
+            "Version": "1.13.7.0"
+          },
+          {
+            "Version": "1.13.8.0"
+          },
+          {
+            "Version": "1.13.11.1"
+          },
+          {
+            "Version": "1.13.12"
+          },
+          {
+            "Version": "1.14.0"
+          },
+          {
+            "Version": "1.15.0.0"
+          },
+          {
+            "Version": "1.16.0.0"
+          },
+          {
+            "Version": "1.16.2.0"
+          },
+          {
+            "Version": "1.17.0.0"
+          },
+          {
+            "Version": "1.17.4.0"
+          },
+          {
+            "Version": "1.18.0.0"
+          },
+          {
+            "Version": "1.19.0.0"
+          },
+          {
+            "Version": "1.19.1.0"
+          },
+          {
+            "Version": "1.20.0.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.23.1"
+          },
+          {
+            "Version": "1.23.2"
+          },
+          {
+            "Version": "1.24.0-beta1"
+          },
+          {
+            "Version": "1.24.0-beta2"
+          },
+          {
+            "Version": "1.24.0-beta3"
+          },
+          {
+            "Version": "1.24.0-beta4"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0-beta0001"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "1.26.1"
+          },
+          {
+            "Version": "1.26.2-beta1"
+          },
+          {
+            "Version": "1.26.2"
+          },
+          {
+            "Version": "1.26.3-beta0001"
+          },
+          {
+            "Version": "1.26.3"
+          },
+          {
+            "Version": "1.26.4"
+          },
+          {
+            "Version": "1.27.0-beta01"
+          },
+          {
+            "Version": "1.27.0"
+          },
+          {
+            "Version": "1.27.1-beta01"
+          },
+          {
+            "Version": "1.27.1-beta03"
+          },
+          {
+            "Version": "1.27.1"
+          },
+          {
+            "Version": "1.28.0"
+          },
+          {
+            "Version": "1.28.1"
+          },
+          {
+            "Version": "1.28.3"
+          },
+          {
+            "Version": "1.29.0-beta01"
+          },
+          {
+            "Version": "1.29.0"
+          },
+          {
+            "Version": "1.29.0.1"
+          },
+          {
+            "Version": "1.29.1-beta2"
+          },
+          {
+            "Version": "1.29.1-beta3"
+          },
+          {
+            "Version": "1.29.1"
+          },
+          {
+            "Version": "1.29.2"
+          },
+          {
+            "Version": "1.29.3"
+          },
+          {
+            "Version": "1.29.4"
+          },
+          {
+            "Version": "1.30.0-beta01"
+          },
+          {
+            "Version": "2.0.0-beta0001"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fody/2.0.6",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001427-content-once/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001427-content-once/cache/paket-graph.cache
@@ -1,0 +1,357 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:16.5002356+02:00",
+        "PackageName": "Costura.Fody",
+        "Versions": [
+          {
+            "Version": "0.1.0.0"
+          },
+          {
+            "Version": "0.2.0.0"
+          },
+          {
+            "Version": "0.2.1.0"
+          },
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.3.1.0"
+          },
+          {
+            "Version": "0.3.1.1"
+          },
+          {
+            "Version": "0.3.1.2"
+          },
+          {
+            "Version": "0.3.2.0"
+          },
+          {
+            "Version": "0.3.2.1"
+          },
+          {
+            "Version": "0.3.3.0"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.1.0"
+          },
+          {
+            "Version": "0.7.0.0"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.1.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.2.0"
+          },
+          {
+            "Version": "1.3.3.0",
+            "PackageDetails": {
+              "Name": "Costura.Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Costura.Fody/1.3.3.0",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Fody",
+                  "VersionRequirement": ">= 1.26.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.4.0"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-beta0014"
+          },
+          {
+            "Version": "2.0.0-beta0018"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:16.666237+02:00",
+        "PackageName": "Fody",
+        "Versions": [
+          {
+            "Version": "1.13.0.0"
+          },
+          {
+            "Version": "1.13.1.0"
+          },
+          {
+            "Version": "1.13.2.0"
+          },
+          {
+            "Version": "1.13.3.0"
+          },
+          {
+            "Version": "1.13.6.0"
+          },
+          {
+            "Version": "1.13.6.1"
+          },
+          {
+            "Version": "1.13.7.0"
+          },
+          {
+            "Version": "1.13.8.0"
+          },
+          {
+            "Version": "1.13.11.1"
+          },
+          {
+            "Version": "1.13.12"
+          },
+          {
+            "Version": "1.14.0"
+          },
+          {
+            "Version": "1.15.0.0"
+          },
+          {
+            "Version": "1.16.0.0"
+          },
+          {
+            "Version": "1.16.2.0"
+          },
+          {
+            "Version": "1.17.0.0"
+          },
+          {
+            "Version": "1.17.4.0"
+          },
+          {
+            "Version": "1.18.0.0"
+          },
+          {
+            "Version": "1.19.0.0"
+          },
+          {
+            "Version": "1.19.1.0"
+          },
+          {
+            "Version": "1.20.0.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.23.1"
+          },
+          {
+            "Version": "1.23.2"
+          },
+          {
+            "Version": "1.24.0-beta1"
+          },
+          {
+            "Version": "1.24.0-beta2"
+          },
+          {
+            "Version": "1.24.0-beta3"
+          },
+          {
+            "Version": "1.24.0-beta4"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0-beta0001"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "1.26.1"
+          },
+          {
+            "Version": "1.26.2-beta1"
+          },
+          {
+            "Version": "1.26.2"
+          },
+          {
+            "Version": "1.26.3-beta0001"
+          },
+          {
+            "Version": "1.26.3"
+          },
+          {
+            "Version": "1.26.4"
+          },
+          {
+            "Version": "1.27.0-beta01"
+          },
+          {
+            "Version": "1.27.0"
+          },
+          {
+            "Version": "1.27.1-beta01"
+          },
+          {
+            "Version": "1.27.1-beta03"
+          },
+          {
+            "Version": "1.27.1"
+          },
+          {
+            "Version": "1.28.0"
+          },
+          {
+            "Version": "1.28.1"
+          },
+          {
+            "Version": "1.28.3"
+          },
+          {
+            "Version": "1.29.0-beta01"
+          },
+          {
+            "Version": "1.29.0"
+          },
+          {
+            "Version": "1.29.0.1"
+          },
+          {
+            "Version": "1.29.1-beta2"
+          },
+          {
+            "Version": "1.29.1-beta3"
+          },
+          {
+            "Version": "1.29.1"
+          },
+          {
+            "Version": "1.29.2"
+          },
+          {
+            "Version": "1.29.3"
+          },
+          {
+            "Version": "1.29.4"
+          },
+          {
+            "Version": "1.30.0-beta01"
+          },
+          {
+            "Version": "2.0.0-beta0001"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fody/2.0.6",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001427-content-true/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001427-content-true/cache/paket-graph.cache
@@ -1,0 +1,357 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:02.2561802+02:00",
+        "PackageName": "Costura.Fody",
+        "Versions": [
+          {
+            "Version": "0.1.0.0"
+          },
+          {
+            "Version": "0.2.0.0"
+          },
+          {
+            "Version": "0.2.1.0"
+          },
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.3.1.0"
+          },
+          {
+            "Version": "0.3.1.1"
+          },
+          {
+            "Version": "0.3.1.2"
+          },
+          {
+            "Version": "0.3.2.0"
+          },
+          {
+            "Version": "0.3.2.1"
+          },
+          {
+            "Version": "0.3.3.0"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.1.0"
+          },
+          {
+            "Version": "0.7.0.0"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.1.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.2.0"
+          },
+          {
+            "Version": "1.3.3.0",
+            "PackageDetails": {
+              "Name": "Costura.Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Costura.Fody/1.3.3.0",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Fody",
+                  "VersionRequirement": ">= 1.26.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.4.0"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-beta0014"
+          },
+          {
+            "Version": "2.0.0-beta0018"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:02.5066809+02:00",
+        "PackageName": "Fody",
+        "Versions": [
+          {
+            "Version": "1.13.0.0"
+          },
+          {
+            "Version": "1.13.1.0"
+          },
+          {
+            "Version": "1.13.2.0"
+          },
+          {
+            "Version": "1.13.3.0"
+          },
+          {
+            "Version": "1.13.6.0"
+          },
+          {
+            "Version": "1.13.6.1"
+          },
+          {
+            "Version": "1.13.7.0"
+          },
+          {
+            "Version": "1.13.8.0"
+          },
+          {
+            "Version": "1.13.11.1"
+          },
+          {
+            "Version": "1.13.12"
+          },
+          {
+            "Version": "1.14.0"
+          },
+          {
+            "Version": "1.15.0.0"
+          },
+          {
+            "Version": "1.16.0.0"
+          },
+          {
+            "Version": "1.16.2.0"
+          },
+          {
+            "Version": "1.17.0.0"
+          },
+          {
+            "Version": "1.17.4.0"
+          },
+          {
+            "Version": "1.18.0.0"
+          },
+          {
+            "Version": "1.19.0.0"
+          },
+          {
+            "Version": "1.19.1.0"
+          },
+          {
+            "Version": "1.20.0.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.23.1"
+          },
+          {
+            "Version": "1.23.2"
+          },
+          {
+            "Version": "1.24.0-beta1"
+          },
+          {
+            "Version": "1.24.0-beta2"
+          },
+          {
+            "Version": "1.24.0-beta3"
+          },
+          {
+            "Version": "1.24.0-beta4"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0-beta0001"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "1.26.1"
+          },
+          {
+            "Version": "1.26.2-beta1"
+          },
+          {
+            "Version": "1.26.2"
+          },
+          {
+            "Version": "1.26.3-beta0001"
+          },
+          {
+            "Version": "1.26.3"
+          },
+          {
+            "Version": "1.26.4"
+          },
+          {
+            "Version": "1.27.0-beta01"
+          },
+          {
+            "Version": "1.27.0"
+          },
+          {
+            "Version": "1.27.1-beta01"
+          },
+          {
+            "Version": "1.27.1-beta03"
+          },
+          {
+            "Version": "1.27.1"
+          },
+          {
+            "Version": "1.28.0"
+          },
+          {
+            "Version": "1.28.1"
+          },
+          {
+            "Version": "1.28.3"
+          },
+          {
+            "Version": "1.29.0-beta01"
+          },
+          {
+            "Version": "1.29.0"
+          },
+          {
+            "Version": "1.29.0.1"
+          },
+          {
+            "Version": "1.29.1-beta2"
+          },
+          {
+            "Version": "1.29.1-beta3"
+          },
+          {
+            "Version": "1.29.1"
+          },
+          {
+            "Version": "1.29.2"
+          },
+          {
+            "Version": "1.29.3"
+          },
+          {
+            "Version": "1.29.4"
+          },
+          {
+            "Version": "1.30.0-beta01"
+          },
+          {
+            "Version": "2.0.0-beta0001"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fody/2.0.6",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001427-ref-content-once/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001427-ref-content-once/cache/paket-graph.cache
@@ -1,0 +1,357 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:21.2298009+02:00",
+        "PackageName": "Costura.Fody",
+        "Versions": [
+          {
+            "Version": "0.1.0.0"
+          },
+          {
+            "Version": "0.2.0.0"
+          },
+          {
+            "Version": "0.2.1.0"
+          },
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.3.1.0"
+          },
+          {
+            "Version": "0.3.1.1"
+          },
+          {
+            "Version": "0.3.1.2"
+          },
+          {
+            "Version": "0.3.2.0"
+          },
+          {
+            "Version": "0.3.2.1"
+          },
+          {
+            "Version": "0.3.3.0"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.1.0"
+          },
+          {
+            "Version": "0.7.0.0"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.1.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.2.0"
+          },
+          {
+            "Version": "1.3.3.0",
+            "PackageDetails": {
+              "Name": "Costura.Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Costura.Fody/1.3.3.0",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Fody",
+                  "VersionRequirement": ">= 1.26.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.4.0"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-beta0014"
+          },
+          {
+            "Version": "2.0.0-beta0018"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:21.3993043+02:00",
+        "PackageName": "Fody",
+        "Versions": [
+          {
+            "Version": "1.13.0.0"
+          },
+          {
+            "Version": "1.13.1.0"
+          },
+          {
+            "Version": "1.13.2.0"
+          },
+          {
+            "Version": "1.13.3.0"
+          },
+          {
+            "Version": "1.13.6.0"
+          },
+          {
+            "Version": "1.13.6.1"
+          },
+          {
+            "Version": "1.13.7.0"
+          },
+          {
+            "Version": "1.13.8.0"
+          },
+          {
+            "Version": "1.13.11.1"
+          },
+          {
+            "Version": "1.13.12"
+          },
+          {
+            "Version": "1.14.0"
+          },
+          {
+            "Version": "1.15.0.0"
+          },
+          {
+            "Version": "1.16.0.0"
+          },
+          {
+            "Version": "1.16.2.0"
+          },
+          {
+            "Version": "1.17.0.0"
+          },
+          {
+            "Version": "1.17.4.0"
+          },
+          {
+            "Version": "1.18.0.0"
+          },
+          {
+            "Version": "1.19.0.0"
+          },
+          {
+            "Version": "1.19.1.0"
+          },
+          {
+            "Version": "1.20.0.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.23.1"
+          },
+          {
+            "Version": "1.23.2"
+          },
+          {
+            "Version": "1.24.0-beta1"
+          },
+          {
+            "Version": "1.24.0-beta2"
+          },
+          {
+            "Version": "1.24.0-beta3"
+          },
+          {
+            "Version": "1.24.0-beta4"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0-beta0001"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "1.26.1"
+          },
+          {
+            "Version": "1.26.2-beta1"
+          },
+          {
+            "Version": "1.26.2"
+          },
+          {
+            "Version": "1.26.3-beta0001"
+          },
+          {
+            "Version": "1.26.3"
+          },
+          {
+            "Version": "1.26.4"
+          },
+          {
+            "Version": "1.27.0-beta01"
+          },
+          {
+            "Version": "1.27.0"
+          },
+          {
+            "Version": "1.27.1-beta01"
+          },
+          {
+            "Version": "1.27.1-beta03"
+          },
+          {
+            "Version": "1.27.1"
+          },
+          {
+            "Version": "1.28.0"
+          },
+          {
+            "Version": "1.28.1"
+          },
+          {
+            "Version": "1.28.3"
+          },
+          {
+            "Version": "1.29.0-beta01"
+          },
+          {
+            "Version": "1.29.0"
+          },
+          {
+            "Version": "1.29.0.1"
+          },
+          {
+            "Version": "1.29.1-beta2"
+          },
+          {
+            "Version": "1.29.1-beta3"
+          },
+          {
+            "Version": "1.29.1"
+          },
+          {
+            "Version": "1.29.2"
+          },
+          {
+            "Version": "1.29.3"
+          },
+          {
+            "Version": "1.29.4"
+          },
+          {
+            "Version": "1.30.0-beta01"
+          },
+          {
+            "Version": "2.0.0-beta0001"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fody/2.0.6",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001432-stackoverflow/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001432-stackoverflow/cache/paket-graph.cache
@@ -1,0 +1,103 @@
+{
+  "bin": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:12.4896503+02:00",
+        "PackageName": "Paket.Test.D",
+        "Versions": [
+          {
+            "Version": "1.0.0-prerelease",
+            "PackageDetails": {
+              "Name": "Paket.Test.D",
+              "DownloadLink": "Paket.Test.D",
+              "LicenseUrl": "https://github.com/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Paket.Test.B",
+                  "VersionRequirement": ">= 0.0.0-prerelease"
+                },
+                {
+                  "PackageName": "Paket.Test.C",
+                  "VersionRequirement": ">= 0.0.0-prerelease"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:12.4196528+02:00",
+        "PackageName": "Paket.Test.B",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "Paket.Test.B",
+              "DownloadLink": "Paket.Test.B",
+              "LicenseUrl": "https://github.com/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Paket.Test.A",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:12.4531507+02:00",
+        "PackageName": "Paket.Test.C",
+        "Versions": [
+          {
+            "Version": "1.0.0-prerelease",
+            "PackageDetails": {
+              "Name": "Paket.Test.C",
+              "DownloadLink": "Paket.Test.C",
+              "LicenseUrl": "https://github.com/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Paket.Test.A",
+                  "VersionRequirement": ">= 0.0.0-prerelease"
+                },
+                {
+                  "PackageName": "Paket.Test.B",
+                  "VersionRequirement": ">= 0.0.0-prerelease"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:12.3866548+02:00",
+        "PackageName": "Paket.Test.A",
+        "Versions": [
+          {
+            "Version": "1.0.0-prerelease"
+          },
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "Paket.Test.A",
+              "DownloadLink": "Paket.Test.A",
+              "LicenseUrl": "https://github.com/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.1.0-prerelease"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001440-auto-detect/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001440-auto-detect/cache/paket-graph.cache
@@ -1,0 +1,284 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:29.9258928+02:00",
+        "PackageName": "System.Net.FtpClient",
+        "Versions": [
+          {
+            "Version": "1.0.4863.16216"
+          },
+          {
+            "Version": "1.0.4863.27613"
+          },
+          {
+            "Version": "1.0.4869.21546"
+          },
+          {
+            "Version": "1.0.4877.17802"
+          },
+          {
+            "Version": "1.0.4885.16106"
+          },
+          {
+            "Version": "1.0.4895.28964"
+          },
+          {
+            "Version": "1.0.4927.24245"
+          },
+          {
+            "Version": "1.0.4951.14853"
+          },
+          {
+            "Version": "1.0.4965.13659"
+          },
+          {
+            "Version": "1.0.5025.13390"
+          },
+          {
+            "Version": "1.0.5064.19175"
+          },
+          {
+            "Version": "1.0.5120.19022"
+          },
+          {
+            "Version": "1.0.5200.21177"
+          },
+          {
+            "Version": "1.0.5268.24683"
+          },
+          {
+            "Version": "1.0.5281.14359"
+          },
+          {
+            "Version": "1.0.5821.41114"
+          },
+          {
+            "Version": "1.0.5824.34026",
+            "PackageDetails": {
+              "Name": "System.Net.FtpClient",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.FtpClient/1.0.5824.34026",
+              "LicenseUrl": "https://netftp.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:29.5373934+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001442-dont-warn/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001442-dont-warn/cache/paket-graph.cache
@@ -1,0 +1,53 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:33.1314372+02:00",
+        "PackageName": "SonarLint",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "SonarLint",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/SonarLint/2.0.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/SonarSource-VisualStudio/sonaranalyzer-csharp/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001442-warn-Rx/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001442-warn-Rx/cache/paket-graph.cache
@@ -1,0 +1,646 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:38.5650848+02:00",
+        "PackageName": "Rx-Linq",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204.0"
+          },
+          {
+            "Version": "2.1.30214.0"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Linq/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:37.8950867+02:00",
+        "PackageName": "Rx-Interfaces",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204.0"
+          },
+          {
+            "Version": "2.1.30214.0"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Interfaces",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Interfaces/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:39.0680854+02:00",
+        "PackageName": "Rx-WinRT",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.0.20814",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.0.20814"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.0.20823",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.0.20823",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.0.20823"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.0.21030",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.0.21030",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.0.21030"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.0.21103",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.0.21103",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.0.21103"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.0.21114",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.0.21114",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.0.21114"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.1.30204.0",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.1.30204.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.1.30204"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.1.30214.0",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.1.30214.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.1.30214"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.2.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.2"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.2.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.2.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.2",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.2.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.2.2"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.4",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.2.4",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.2.4"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-WinRT",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-WinRT/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Main",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:38.6160851+02:00",
+        "PackageName": "Rx-Main",
+        "Versions": [
+          {
+            "Version": "1.0.2856.0"
+          },
+          {
+            "Version": "1.0.10605"
+          },
+          {
+            "Version": "1.0.10621"
+          },
+          {
+            "Version": "1.0.11221"
+          },
+          {
+            "Version": "1.0.11226"
+          },
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204.0"
+          },
+          {
+            "Version": "2.1.30214.0"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Main",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Main/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Linq",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-PlatformServices",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:38.9300855+02:00",
+        "PackageName": "Rx-PlatformServices",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204.0"
+          },
+          {
+            "Version": "2.1.30214.0"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-PlatformServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-PlatformServices/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2.5"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3",
+            "PackageDetails": {
+              "Name": "Rx-PlatformServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-PlatformServices/2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Core",
+                  "VersionRequirement": ">= 2.2"
+                },
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:37.5705843+02:00",
+        "PackageName": "Rx-Core",
+        "Versions": [
+          {
+            "Version": "2.0.20304-beta"
+          },
+          {
+            "Version": "2.0.20612-rc"
+          },
+          {
+            "Version": "2.0.20622-rc"
+          },
+          {
+            "Version": "2.0.20814"
+          },
+          {
+            "Version": "2.0.20823"
+          },
+          {
+            "Version": "2.0.21030"
+          },
+          {
+            "Version": "2.0.21103"
+          },
+          {
+            "Version": "2.0.21114"
+          },
+          {
+            "Version": "2.1.30204.0"
+          },
+          {
+            "Version": "2.1.30214.0"
+          },
+          {
+            "Version": "2.2.0-beta"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1-beta"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5",
+            "PackageDetails": {
+              "Name": "Rx-Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Rx-Core/2.2.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Rx-Interfaces",
+                  "VersionRequirement": ">= 2.2.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001450-twiddle-wakka/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001450-twiddle-wakka/cache/paket-graph.cache
@@ -1,0 +1,10852 @@
+{
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:33.3583941+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:42.7981718+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:50.1167606+02:00",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:34.9353939+02:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:15.9168245+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:33.8491177+02:00",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:42.4316714+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.3443919+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:55.1362747+02:00",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:23.1385346+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:09.2858615+02:00",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.7678943+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:11.497821+02:00",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:29.8644086+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:39.677106+02:00",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:30.9553861+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:05.3724232+02:00",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:39.8954998+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:36.2956061+02:00",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:26.5438749+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:33.9193939+02:00",
+        "PackageName": "System.Dynamic.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Dynamic.Runtime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Dynamic.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:12.5938218+02:00",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:39.0736095+02:00",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:24.2640445+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.0033929+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:25.9790333+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:00.9112215+02:00",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:00.2664153+02:00",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:46.3382347+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:32.3398968+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:45.5227206+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:48.5487605+02:00",
+        "PackageName": "System.Runtime.Serialization.Formatters",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Formatters",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Formatters/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:32.7382187+02:00",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:59.1755043+02:00",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:40.3356124+02:00",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:32.1417221+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:28.7758265+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.2288921+02:00",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:38.5714474+02:00",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.7238921+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:24.856035+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:43.067174+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:49.9222609+02:00",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:10.9651043+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:28.2098321+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:35.6693969+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:36.7343953+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:03.1740465+02:00",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:35.5081323+02:00",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:17.5547274+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:02.5578583+02:00",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:18.7157084+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.2853918+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:30.5143919+02:00",
+        "PackageName": "System.Collections.NonGeneric",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.NonGeneric",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.NonGeneric/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:29.1503921+02:00",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:06.4963635+02:00",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:01.4563516+02:00",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:27.3883922+02:00",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:52.8077605+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:16.4622294+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:31.7948955+02:00",
+        "PackageName": "System.ComponentModel.TypeConverter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.TypeConverter",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.TypeConverter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections.Specialized",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ComponentModel.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, net45, >= net462, netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.616892+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:22.0238155+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:27.3428918+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:14.7783227+02:00",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:34.3771056+02:00",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:33.2897215+02:00",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:30.3923885+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.3983913+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:50.6692606+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:56.5587626+02:00",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:27.8958933+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1"
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:50.4067612+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:39.36995+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505"
+          },
+          {
+            "Version": "2.0.20710"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:36.8211057+02:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:37.3641077+02:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:58.6285045+02:00",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:19.2540356+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:02.0128362+02:00",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:04.2654095+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:25.4040324+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:31.9968917+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:47.6627606+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:55.6842623+02:00",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:27.1858908+02:00",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:59.727006+02:00",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:29.7193925+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:03.7199083+02:00",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:54.4307621+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:58.0370071+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:41.3896756+02:00",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:36.2528941+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:04.8164233+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:23.6635316+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:07.5948605+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:21.4755354+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:30.8143927+02:00",
+        "PackageName": "System.Collections.Specialized",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Specialized",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.Specialized/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.1148923+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:19.8005347+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:17.0062259+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.1793911+02:00",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:50.5212608+02:00",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:27.6513259+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:20.3445362+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:13.1363303+02:00",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:29.0843928+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:08.1288613+02:00",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:47.9932605+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:08.7073609+02:00",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:30.2258925+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:09.8583636+02:00",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.6733959+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:22.5847998+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:20.9080355+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:14.2258242+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:31.0873927+02:00",
+        "PackageName": "System.ComponentModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:13.6683223+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:49.5322632+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:41.1756739+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:34.4109074+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:54.1122613+02:00",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:36.4778971+02:00",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:53.9872645+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:27.9473927+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:34.9216028+02:00",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:12.0393213+02:00",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:55.9487622+02:00",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:35.6896051+02:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:27.0123926+02:00",
+        "PackageName": "Microsoft.CSharp",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.CSharp",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.CSharp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:29.3183868+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:34.6658949+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:40.1050325+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.502392+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:26.6463917+02:00",
+        "PackageName": "EnterpriseLibrary.SemanticLogging",
+        "Versions": [
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "1.0.1304"
+          },
+          {
+            "Version": "1.1.1403"
+          },
+          {
+            "Version": "1.1.1403.1"
+          },
+          {
+            "Version": "2.0.1406"
+          },
+          {
+            "Version": "2.0.1406.1",
+            "PackageDetails": {
+              "Name": "EnterpriseLibrary.SemanticLogging",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/EnterpriseLibrary.SemanticLogging/2.0.1406.1",
+              "LicenseUrl": "http://opensource.org/licenses/Apache-2.0",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 5.0.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "6.0.1302-preview"
+          },
+          {
+            "Version": "6.0.1302"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:51.2922608+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:38.4946043+02:00",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:41.6121771+02:00",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.0628926+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:48.3852602+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.4478915+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:28.5573923+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:37.5059446+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:05.9298605+02:00",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:36.9628985+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:27.0928918+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:49.0872605+02:00",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:42.1171737+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:07.0533628+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:46.4972206+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:41.8341719+02:00",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:32.716897+02:00",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:10.3978654+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:18.1505277+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:51.7327615+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:53.3477615+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:52.148761+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:40.6331729+02:00",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:27.0988293+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:31.5623987+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:32.5154083+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:15.3443232+02:00",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:57.4820041+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:30:37.9321041+02:00",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:29:31.3428929+02:00",
+        "PackageName": "System.ComponentModel.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ComponentModel.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.ComponentModel.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.ComponentModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001466-expressive/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001466-expressive/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:44.2455868+02:00",
+        "PackageName": "ExpressiveAnnotations.dll",
+        "Versions": [
+          {
+            "Version": "2.3.6",
+            "PackageDetails": {
+              "Name": "ExpressiveAnnotations.dll",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/ExpressiveAnnotations.dll/2.3.6",
+              "LicenseUrl": "https://github.com/jwaliszko/ExpressiveAnnotations/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001469-darkseid/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001469-darkseid/cache/paket-graph.cache
@@ -1,0 +1,11789 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:15.0800663+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:19.9545689+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:06.5064051+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:17.7165703+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:12.117567+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:09.4334058+02:00",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:18.2615674+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:12.8490651+02:00",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:23.4455707+02:00",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:23.6490697+02:00",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:19.0395681+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.2463588+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.7633605+02:00",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:23.0570678+02:00",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:09.9409076+02:00",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:18.0780689+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:43.1373601+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:53.3823636+02:00",
+        "PackageName": "System.Reflection.Metadata",
+        "Versions": [
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.18-beta"
+          },
+          {
+            "Version": "1.0.19-rc"
+          },
+          {
+            "Version": "1.0.21"
+          },
+          {
+            "Version": "1.0.22-beta-23019"
+          },
+          {
+            "Version": "1.0.22-beta-23109"
+          },
+          {
+            "Version": "1.0.22"
+          },
+          {
+            "Version": "1.0.23-beta-23225"
+          },
+          {
+            "Version": "1.0.23-beta-23409"
+          },
+          {
+            "Version": "1.1.0-alpha-00009"
+          },
+          {
+            "Version": "1.1.0-alpha-00012"
+          },
+          {
+            "Version": "1.1.0-alpha-00014"
+          },
+          {
+            "Version": "1.1.0-alpha-00015"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-23826"
+          },
+          {
+            "Version": "1.2.0-rc3-23811"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1-beta-23918"
+          },
+          {
+            "Version": "1.3.0-rc2-24027"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.1-beta-24227-04"
+          },
+          {
+            "Version": "1.4.1-beta-24322-03"
+          },
+          {
+            "Version": "1.4.1-beta-24430-01"
+          },
+          {
+            "Version": "1.4.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2",
+            "PackageDetails": {
+              "Name": "System.Reflection.Metadata",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Metadata/1.4.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.1.37",
+                  "FrameworkRestrictions": "portable-net45+win8"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.3.1",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, winv4.5, wpav8.1, >= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:46.3148611+02:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:42.7283603+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:21.8225691+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:01.7473666+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:14.5060653+02:00",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:12.6610651+02:00",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:07.5409093+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:57.9128643+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:11.2100317+02:00",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:51.9923629+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:43.3133606+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:05.0894039+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:20.15157+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.3073616+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:02.7133658+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.0623597+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:47.6268611+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:54.4108653+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:24.229069+02:00",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:25.2760684+02:00",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:25.471068+02:00",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.6358604+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:51.0988627+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:00.1683656+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:11.7500655+02:00",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.0303721+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:50.4333639+02:00",
+        "PackageName": "System.Net.NameResolution",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.NameResolution",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Net.NameResolution/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:05.8219045+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:37.8798595+02:00",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:00.9393659+02:00",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:22.3935672+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:21.0785685+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:15.6335685+02:00",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:49.1493623+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:16.0090648+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:59.4023664+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:18.455068+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:51.7318623+02:00",
+        "PackageName": "System.Net.Requests",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Requests",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Requests/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.WebHeaderCollection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:21.640067+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:00.3553647+02:00",
+        "PackageName": "System.Runtime.Serialization.Formatters",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Formatters",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Formatters/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:47.9683615+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:23.8335673+02:00",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:13.9640677+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:23.2665707+02:00",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:35.4803584+02:00",
+        "PackageName": "AWSSDK",
+        "Versions": [
+          {
+            "Version": "1.3.4.1"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.3.6.0"
+          },
+          {
+            "Version": "1.3.7.0"
+          },
+          {
+            "Version": "1.3.8.0"
+          },
+          {
+            "Version": "1.3.9.0"
+          },
+          {
+            "Version": "1.3.10.0"
+          },
+          {
+            "Version": "1.3.11.0"
+          },
+          {
+            "Version": "1.3.12.0"
+          },
+          {
+            "Version": "1.3.13.0"
+          },
+          {
+            "Version": "1.3.13.1"
+          },
+          {
+            "Version": "1.3.14.0"
+          },
+          {
+            "Version": "1.3.15.0"
+          },
+          {
+            "Version": "1.3.16.0"
+          },
+          {
+            "Version": "1.3.17.0"
+          },
+          {
+            "Version": "1.3.18.0"
+          },
+          {
+            "Version": "1.3.19.0"
+          },
+          {
+            "Version": "1.4.0.0"
+          },
+          {
+            "Version": "1.4.0.1"
+          },
+          {
+            "Version": "1.4.1.0"
+          },
+          {
+            "Version": "1.4.2.0"
+          },
+          {
+            "Version": "1.4.3.0"
+          },
+          {
+            "Version": "1.4.4.0"
+          },
+          {
+            "Version": "1.4.5.0"
+          },
+          {
+            "Version": "1.4.6.0"
+          },
+          {
+            "Version": "1.4.6.1"
+          },
+          {
+            "Version": "1.4.6.2"
+          },
+          {
+            "Version": "1.4.6.3"
+          },
+          {
+            "Version": "1.4.7.0"
+          },
+          {
+            "Version": "1.4.8.0"
+          },
+          {
+            "Version": "1.4.8.1"
+          },
+          {
+            "Version": "1.4.8.2"
+          },
+          {
+            "Version": "1.4.9.0"
+          },
+          {
+            "Version": "1.4.10.0"
+          },
+          {
+            "Version": "1.4.11.0"
+          },
+          {
+            "Version": "1.4.12.0"
+          },
+          {
+            "Version": "1.4.12.1"
+          },
+          {
+            "Version": "1.4.12.2"
+          },
+          {
+            "Version": "1.4.13.0"
+          },
+          {
+            "Version": "1.4.14.0"
+          },
+          {
+            "Version": "1.4.15.0"
+          },
+          {
+            "Version": "1.4.15.1"
+          },
+          {
+            "Version": "1.5.0.0"
+          },
+          {
+            "Version": "1.5.1.0"
+          },
+          {
+            "Version": "1.5.2.0"
+          },
+          {
+            "Version": "1.5.2.1"
+          },
+          {
+            "Version": "1.5.2.2"
+          },
+          {
+            "Version": "1.5.3.0"
+          },
+          {
+            "Version": "1.5.4.0"
+          },
+          {
+            "Version": "1.5.4.1"
+          },
+          {
+            "Version": "1.5.4.2"
+          },
+          {
+            "Version": "1.5.4.3"
+          },
+          {
+            "Version": "1.5.5.0"
+          },
+          {
+            "Version": "1.5.5.1"
+          },
+          {
+            "Version": "1.5.6.0"
+          },
+          {
+            "Version": "1.5.7.0"
+          },
+          {
+            "Version": "1.5.7.1"
+          },
+          {
+            "Version": "1.5.8.0"
+          },
+          {
+            "Version": "1.5.9.0"
+          },
+          {
+            "Version": "1.5.9.2"
+          },
+          {
+            "Version": "1.5.10.0"
+          },
+          {
+            "Version": "1.5.11.0"
+          },
+          {
+            "Version": "1.5.12.0"
+          },
+          {
+            "Version": "1.5.12.1"
+          },
+          {
+            "Version": "1.5.13.0"
+          },
+          {
+            "Version": "1.5.14.0"
+          },
+          {
+            "Version": "1.5.15.0"
+          },
+          {
+            "Version": "1.5.16.0"
+          },
+          {
+            "Version": "1.5.16.1"
+          },
+          {
+            "Version": "1.5.17.0"
+          },
+          {
+            "Version": "1.5.18.0"
+          },
+          {
+            "Version": "1.5.19.0"
+          },
+          {
+            "Version": "1.5.20.0"
+          },
+          {
+            "Version": "1.5.21.0"
+          },
+          {
+            "Version": "1.5.22.0"
+          },
+          {
+            "Version": "1.5.23.0"
+          },
+          {
+            "Version": "1.5.23.1"
+          },
+          {
+            "Version": "1.5.23.2"
+          },
+          {
+            "Version": "1.5.24.0"
+          },
+          {
+            "Version": "1.5.24.1"
+          },
+          {
+            "Version": "1.5.25.0"
+          },
+          {
+            "Version": "1.5.26.0"
+          },
+          {
+            "Version": "1.5.26.3"
+          },
+          {
+            "Version": "1.5.27.0"
+          },
+          {
+            "Version": "1.5.28.0"
+          },
+          {
+            "Version": "1.5.28.1"
+          },
+          {
+            "Version": "1.5.28.2"
+          },
+          {
+            "Version": "1.5.28.3"
+          },
+          {
+            "Version": "1.5.28.4"
+          },
+          {
+            "Version": "1.5.29.0"
+          },
+          {
+            "Version": "1.5.30.0"
+          },
+          {
+            "Version": "1.5.30.1"
+          },
+          {
+            "Version": "1.5.31.0"
+          },
+          {
+            "Version": "1.5.32.0"
+          },
+          {
+            "Version": "1.5.33.0"
+          },
+          {
+            "Version": "1.5.34.0"
+          },
+          {
+            "Version": "1.5.35.0"
+          },
+          {
+            "Version": "1.5.36.0"
+          },
+          {
+            "Version": "1.5.37.0"
+          },
+          {
+            "Version": "1.5.38.0"
+          },
+          {
+            "Version": "1.5.39.0"
+          },
+          {
+            "Version": "1.5.39.1"
+          },
+          {
+            "Version": "1.5.40.0"
+          },
+          {
+            "Version": "1.5.43.0"
+          },
+          {
+            "Version": "1.5.44.0"
+          },
+          {
+            "Version": "1.5.45.0"
+          },
+          {
+            "Version": "1.5.46.0"
+          },
+          {
+            "Version": "1.5.46.1"
+          },
+          {
+            "Version": "1.5.47.0"
+          },
+          {
+            "Version": "1.5.48.0"
+          },
+          {
+            "Version": "1.5.49.0"
+          },
+          {
+            "Version": "1.5.50.0"
+          },
+          {
+            "Version": "1.5.51.0"
+          },
+          {
+            "Version": "1.5.52.0"
+          },
+          {
+            "Version": "1.5.52.1"
+          },
+          {
+            "Version": "1.5.53.0"
+          },
+          {
+            "Version": "1.5.54.0"
+          },
+          {
+            "Version": "1.5.55.0"
+          },
+          {
+            "Version": "1.5.56.0"
+          },
+          {
+            "Version": "1.5.57.0"
+          },
+          {
+            "Version": "1.5.58.0"
+          },
+          {
+            "Version": "1.5.59.0"
+          },
+          {
+            "Version": "1.5.60.0"
+          },
+          {
+            "Version": "1.5.61.0"
+          },
+          {
+            "Version": "1.5.61.1"
+          },
+          {
+            "Version": "2.0.0.0-beta"
+          },
+          {
+            "Version": "2.0.0.1-beta"
+          },
+          {
+            "Version": "2.0.0.2-beta"
+          },
+          {
+            "Version": "2.0.0.3-beta"
+          },
+          {
+            "Version": "2.0.0.4-beta"
+          },
+          {
+            "Version": "2.0.0.5-beta"
+          },
+          {
+            "Version": "2.0.0.6-beta"
+          },
+          {
+            "Version": "2.0.1.0"
+          },
+          {
+            "Version": "2.0.1.1"
+          },
+          {
+            "Version": "2.0.1.2"
+          },
+          {
+            "Version": "2.0.2.0"
+          },
+          {
+            "Version": "2.0.2.2"
+          },
+          {
+            "Version": "2.0.2.3"
+          },
+          {
+            "Version": "2.0.2.4"
+          },
+          {
+            "Version": "2.0.2.5"
+          },
+          {
+            "Version": "2.0.3.0"
+          },
+          {
+            "Version": "2.0.3.1"
+          },
+          {
+            "Version": "2.0.4.0"
+          },
+          {
+            "Version": "2.0.4.1"
+          },
+          {
+            "Version": "2.0.5.0"
+          },
+          {
+            "Version": "2.0.6.0"
+          },
+          {
+            "Version": "2.0.6.1"
+          },
+          {
+            "Version": "2.0.7.0"
+          },
+          {
+            "Version": "2.0.8.0"
+          },
+          {
+            "Version": "2.0.8.2"
+          },
+          {
+            "Version": "2.0.9.0"
+          },
+          {
+            "Version": "2.0.10.0"
+          },
+          {
+            "Version": "2.0.11.0"
+          },
+          {
+            "Version": "2.0.12.0"
+          },
+          {
+            "Version": "2.0.13.0"
+          },
+          {
+            "Version": "2.0.13.1"
+          },
+          {
+            "Version": "2.0.13.2"
+          },
+          {
+            "Version": "2.0.13.3"
+          },
+          {
+            "Version": "2.0.14.0"
+          },
+          {
+            "Version": "2.0.15.0"
+          },
+          {
+            "Version": "2.0.15.1"
+          },
+          {
+            "Version": "2.1.0.0"
+          },
+          {
+            "Version": "2.1.1.0"
+          },
+          {
+            "Version": "2.1.2.0"
+          },
+          {
+            "Version": "2.1.3.0"
+          },
+          {
+            "Version": "2.1.4.0"
+          },
+          {
+            "Version": "2.1.5.0"
+          },
+          {
+            "Version": "2.1.6.0"
+          },
+          {
+            "Version": "2.1.7.0"
+          },
+          {
+            "Version": "2.1.8.0"
+          },
+          {
+            "Version": "2.1.9.0"
+          },
+          {
+            "Version": "2.1.9.1"
+          },
+          {
+            "Version": "2.1.9.2"
+          },
+          {
+            "Version": "2.2.0.0"
+          },
+          {
+            "Version": "2.2.1.0"
+          },
+          {
+            "Version": "2.2.2.0"
+          },
+          {
+            "Version": "2.2.2.1"
+          },
+          {
+            "Version": "2.2.2.2"
+          },
+          {
+            "Version": "2.2.3.0"
+          },
+          {
+            "Version": "2.2.4.0"
+          },
+          {
+            "Version": "2.3.0.0"
+          },
+          {
+            "Version": "2.3.1.0"
+          },
+          {
+            "Version": "2.3.2.0"
+          },
+          {
+            "Version": "2.3.2.1"
+          },
+          {
+            "Version": "2.3.2.2"
+          },
+          {
+            "Version": "2.3.3.0"
+          },
+          {
+            "Version": "2.3.4.0"
+          },
+          {
+            "Version": "2.3.5.0"
+          },
+          {
+            "Version": "2.3.6.0"
+          },
+          {
+            "Version": "2.3.7.0"
+          },
+          {
+            "Version": "2.3.8.0"
+          },
+          {
+            "Version": "2.3.8.1"
+          },
+          {
+            "Version": "2.3.9.0"
+          },
+          {
+            "Version": "2.3.10.0"
+          },
+          {
+            "Version": "2.3.11.0"
+          },
+          {
+            "Version": "2.3.12.0"
+          },
+          {
+            "Version": "2.3.13.0"
+          },
+          {
+            "Version": "2.3.13.1"
+          },
+          {
+            "Version": "2.3.14.0"
+          },
+          {
+            "Version": "2.3.15.0"
+          },
+          {
+            "Version": "2.3.16.0"
+          },
+          {
+            "Version": "2.3.17.0"
+          },
+          {
+            "Version": "2.3.18.0"
+          },
+          {
+            "Version": "2.3.19.0"
+          },
+          {
+            "Version": "2.3.20.0"
+          },
+          {
+            "Version": "2.3.21.0"
+          },
+          {
+            "Version": "2.3.21.1"
+          },
+          {
+            "Version": "2.3.22.0"
+          },
+          {
+            "Version": "2.3.23.0"
+          },
+          {
+            "Version": "2.3.24.0"
+          },
+          {
+            "Version": "2.3.24.1"
+          },
+          {
+            "Version": "2.3.24.3"
+          },
+          {
+            "Version": "2.3.25.0"
+          },
+          {
+            "Version": "2.3.26.0"
+          },
+          {
+            "Version": "2.3.27.0"
+          },
+          {
+            "Version": "2.3.28.0"
+          },
+          {
+            "Version": "2.3.28.1"
+          },
+          {
+            "Version": "2.3.29.0"
+          },
+          {
+            "Version": "2.3.30.0"
+          },
+          {
+            "Version": "2.3.31.0"
+          },
+          {
+            "Version": "2.3.32.0"
+          },
+          {
+            "Version": "2.3.33.0"
+          },
+          {
+            "Version": "2.3.34.0"
+          },
+          {
+            "Version": "2.3.34.1"
+          },
+          {
+            "Version": "2.3.35.0"
+          },
+          {
+            "Version": "2.3.36.0"
+          },
+          {
+            "Version": "2.3.37.0"
+          },
+          {
+            "Version": "2.3.38.0"
+          },
+          {
+            "Version": "2.3.39.0"
+          },
+          {
+            "Version": "2.3.40.0"
+          },
+          {
+            "Version": "2.3.41.0"
+          },
+          {
+            "Version": "2.3.42.0"
+          },
+          {
+            "Version": "2.3.43.0"
+          },
+          {
+            "Version": "2.3.44.0"
+          },
+          {
+            "Version": "2.3.45.0"
+          },
+          {
+            "Version": "2.3.46.0"
+          },
+          {
+            "Version": "2.3.47.0"
+          },
+          {
+            "Version": "2.3.48.0"
+          },
+          {
+            "Version": "2.3.49.0"
+          },
+          {
+            "Version": "2.3.50.0"
+          },
+          {
+            "Version": "2.3.50.1"
+          },
+          {
+            "Version": "2.3.51.0"
+          },
+          {
+            "Version": "2.3.52.0"
+          },
+          {
+            "Version": "2.3.53.0"
+          },
+          {
+            "Version": "2.3.54.0"
+          },
+          {
+            "Version": "2.3.54.2"
+          },
+          {
+            "Version": "2.3.55.0"
+          },
+          {
+            "Version": "2.3.55.2",
+            "PackageDetails": {
+              "Name": "AWSSDK",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/AWSSDK/2.3.55.2",
+              "LicenseUrl": "http://aws.amazon.com/apache2.0/",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Net.Http",
+                  "VersionRequirement": ">= 2.1.10",
+                  "FrameworkRestrictions": "wpv8.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:20.3345705+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:17.3555652+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:02.8298651+02:00",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:21.4560671+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:10.494409+02:00",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.5148588+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:07.6699054+02:00",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.3683599+02:00",
+        "PackageName": "Microsoft.Win32.Registry",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Registry",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Registry/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:03.8893659+02:00",
+        "PackageName": "System.Security.Principal",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Principal",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Principal/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:22.0175717+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:20.5180694+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.36536+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:12.4920642+02:00",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:04.6434037+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:44.4698602+02:00",
+        "PackageName": "System.Diagnostics.TraceSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.TraceSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.TraceSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.582359+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:36.8528579+02:00",
+        "PackageName": "log4net",
+        "Versions": [
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7"
+          },
+          {
+            "Version": "2.0.8",
+            "PackageDetails": {
+              "Name": "log4net",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/log4net/2.0.8",
+              "LicenseUrl": "http://logging.apache.org/log4net/license.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.NonGeneric",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.StackTrace",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Watcher",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:06.8009046+02:00",
+        "PackageName": "System.Threading.Overlapped",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Overlapped",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Threading.Overlapped/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:45.73886+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:24.0345682+02:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:02.429866+02:00",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:15.431069+02:00",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.12436+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:37.778858+02:00",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:43.9088611+02:00",
+        "PackageName": "System.Diagnostics.Process",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Process",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Process/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Registry",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:10.1344173+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:24.8680688+02:00",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:17.1780661+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:38.8343575+02:00",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:14.9040659+02:00",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:14.7060656+02:00",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:20.8820683+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:16.2050646+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:16.3765674+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:58.1178652+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:48.2023627+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:57.0258653+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:14.1400663+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:08.5864055+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:11.0330272+02:00",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:20.7075684+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:13.4130663+02:00",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:59.7733642+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:13.2275643+02:00",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:36.3203591+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/3.1.2.5",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:10.6744054+02:00",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:10.312906+02:00",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:54.1318629+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:12.3165648+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:25.0635679+02:00",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:41.4033602+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:48.5443615+02:00",
+        "PackageName": "System.IO.FileSystem.Watcher",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Watcher",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.IO.FileSystem.Watcher/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:41.9483592+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.9413603+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:15.8105673+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:11.5555692+02:00",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.6993658+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.0028608+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:13.0305665+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:07.9619056+02:00",
+        "PackageName": "System.Threading.Thread",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Thread",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Thread/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:11.388067+02:00",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:52.876863+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:02.1883668+02:00",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:13.7875684+02:00",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:09.731407+02:00",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:15.2615659+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:02.9883658+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:19.2270686+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.1913603+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:22.1950685+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:46.0083606+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:42.1978615+02:00",
+        "PackageName": "System.Collections.Immutable",
+        "Versions": [
+          {
+            "Version": "1.1.32-beta"
+          },
+          {
+            "Version": "1.1.33-beta"
+          },
+          {
+            "Version": "1.1.34-rc"
+          },
+          {
+            "Version": "1.1.36"
+          },
+          {
+            "Version": "1.1.37-beta-23019"
+          },
+          {
+            "Version": "1.1.37-beta-23109"
+          },
+          {
+            "Version": "1.1.37"
+          },
+          {
+            "Version": "1.1.38-beta-23225"
+          },
+          {
+            "Version": "1.1.38-beta-23409"
+          },
+          {
+            "Version": "1.1.38-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-24027"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1",
+            "PackageDetails": {
+              "Name": "System.Collections.Immutable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Immutable/1.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:35.5693577+02:00",
+        "PackageName": "Darkseid",
+        "Versions": [
+          {
+            "Version": "0.1.0"
+          },
+          {
+            "Version": "0.2.0"
+          },
+          {
+            "Version": "0.2.1"
+          },
+          {
+            "Version": "0.3.0",
+            "PackageDetails": {
+              "Name": "Darkseid",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Darkseid/0.3.0",
+              "LicenseUrl": "https://github.com/theburningmonk/Darkseid/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "AWSSDK",
+                  "VersionRequirement": ">= 2.3.1"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1 < 4.0"
+                },
+                {
+                  "PackageName": "log4net",
+                  "VersionRequirement": ""
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:14.3315661+02:00",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:38.7233596+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:08.2759053+02:00",
+        "PackageName": "System.Threading.ThreadPool",
+        "Versions": [
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.0.10-beta-23225"
+          },
+          {
+            "Version": "4.0.10-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23516"
+          },
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.ThreadPool",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.ThreadPool/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:03.630865+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:13.5920655+02:00",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:24.4220689+02:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:17.8915687+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:44.1528621+02:00",
+        "PackageName": "System.Diagnostics.StackTrace",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.StackTrace",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Diagnostics.StackTrace/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Metadata",
+                  "VersionRequirement": ">= 1.4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:21.2755677+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:52.2463622+02:00",
+        "PackageName": "System.Net.WebHeaderCollection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.WebHeaderCollection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.WebHeaderCollection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:45.2383616+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:04.1853666+02:00",
+        "PackageName": "System.Security.Principal.Windows",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Principal.Windows",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Principal.Windows/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Claims",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:25.6630697+02:00",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.6978596+02:00",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:53.1923662+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:22.8675715+02:00",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:10.8549059+02:00",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.8738609+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:17.5295663+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:18.6525672+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.4383597+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:50.0313617+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:38.6503591+02:00",
+        "PackageName": "Microsoft.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.1.3-beta"
+          },
+          {
+            "Version": "2.1.6-rc"
+          },
+          {
+            "Version": "2.1.10"
+          },
+          {
+            "Version": "2.2.3-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.10-rc"
+          },
+          {
+            "Version": "2.2.13"
+          },
+          {
+            "Version": "2.2.15"
+          },
+          {
+            "Version": "2.2.18"
+          },
+          {
+            "Version": "2.2.19"
+          },
+          {
+            "Version": "2.2.20"
+          },
+          {
+            "Version": "2.2.22"
+          },
+          {
+            "Version": "2.2.23-beta"
+          },
+          {
+            "Version": "2.2.27-beta"
+          },
+          {
+            "Version": "2.2.28"
+          },
+          {
+            "Version": "2.2.29",
+            "PackageDetails": {
+              "Name": "Microsoft.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Net.Http/2.2.29",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:42.5048612+02:00",
+        "PackageName": "System.Collections.NonGeneric",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.NonGeneric",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Collections.NonGeneric/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:39.8198588+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:24.6575687+02:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:11.926066+02:00",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:18.840568+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:40.7823635+02:00",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:47.0288625+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:01.1968658+02:00",
+        "PackageName": "System.Security.Claims",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Claims",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Claims/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:10:53.7598626+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001494-download/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001494-download/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "nuget_repo": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:54.448988+02:00",
+        "PackageName": "simpleinjector",
+        "Versions": [
+          {
+            "Version": "3.1.2",
+            "PackageDetails": {
+              "Name": "SimpleInjector",
+              "DownloadLink": "simpleinjector",
+              "LicenseUrl": "https://simpleinjector.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001505-conditionals/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001505-conditionals/cache/paket-graph.cache
@@ -1,0 +1,340 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:58.3801983+02:00",
+        "PackageName": "EasyNetQ",
+        "Versions": [
+          {
+            "Version": "0.53.6.419",
+            "PackageDetails": {
+              "Name": "EasyNetQ",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/EasyNetQ/0.53.6.419",
+              "LicenseUrl": "https://github.com/EasyNetQ/EasyNetQ/blob/master/licence.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10",
+                  "FrameworkRestrictions": "net10, net11, net20, net30, net35, net40, net40-full"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "net10, net11, net20, net30, net35, net40, net40-full"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.21",
+                  "FrameworkRestrictions": "net10, net11, net20, net30, net35, net40, net40-full"
+                },
+                {
+                  "PackageName": "RabbitMQ.Client",
+                  "VersionRequirement": ">= 3.5.7"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:40:58.5131991+02:00",
+        "PackageName": "RabbitMQ.Client",
+        "Versions": [
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.8.1"
+          },
+          {
+            "Version": "2.8.4"
+          },
+          {
+            "Version": "2.8.6"
+          },
+          {
+            "Version": "2.8.7"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.5"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.4"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.5"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.6.2"
+          },
+          {
+            "Version": "3.6.3"
+          },
+          {
+            "Version": "3.6.4"
+          },
+          {
+            "Version": "3.6.5"
+          },
+          {
+            "Version": "3.6.6"
+          },
+          {
+            "Version": "3.6.7"
+          },
+          {
+            "Version": "3.6.8"
+          },
+          {
+            "Version": "3.6.9"
+          },
+          {
+            "Version": "4.0.0-pre3"
+          },
+          {
+            "Version": "4.0.0-pre4"
+          },
+          {
+            "Version": "4.0.0-pre5"
+          },
+          {
+            "Version": "4.0.0-rc-1"
+          },
+          {
+            "Version": "4.0.0-rc2"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-rc1"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2-pre1"
+          },
+          {
+            "Version": "4.0.2-pre2"
+          },
+          {
+            "Version": "4.0.2-rc1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.1.0-rc1"
+          },
+          {
+            "Version": "4.1.0-rc2"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc1"
+          },
+          {
+            "Version": "4.1.1-rc2"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2-pre1"
+          },
+          {
+            "Version": "4.1.2-rc1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3-rc1"
+          },
+          {
+            "Version": "4.1.3",
+            "PackageDetails": {
+              "Name": "RabbitMQ.Client",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/RabbitMQ.Client/4.1.3",
+              "LicenseUrl": "http://www.rabbitmq.com/dotnet.html",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Security",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.0.0-pre1"
+          },
+          {
+            "Version": "5.0.0-pre2"
+          },
+          {
+            "Version": "5.0.0-pre3"
+          },
+          {
+            "Version": "5.0.0-pre4"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001510-download/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001510-download/cache/paket-graph.cache
@@ -1,0 +1,19312 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:07.1313717+02:00",
+        "PackageName": "FSharp.Data",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10"
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-alpha2"
+          },
+          {
+            "Version": "2.0.0-alpha3"
+          },
+          {
+            "Version": "2.0.0-alpha4"
+          },
+          {
+            "Version": "2.0.0-alpha5"
+          },
+          {
+            "Version": "2.0.0-alpha6"
+          },
+          {
+            "Version": "2.0.0-alpha7"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-beta3"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7"
+          },
+          {
+            "Version": "2.0.8"
+          },
+          {
+            "Version": "2.0.9"
+          },
+          {
+            "Version": "2.0.10"
+          },
+          {
+            "Version": "2.0.11"
+          },
+          {
+            "Version": "2.0.12"
+          },
+          {
+            "Version": "2.0.13"
+          },
+          {
+            "Version": "2.0.14"
+          },
+          {
+            "Version": "2.0.15"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.0-beta2"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4"
+          },
+          {
+            "Version": "2.2.5"
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1-beta1"
+          },
+          {
+            "Version": "2.3.1-beta2"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "2.3.3",
+            "PackageDetails": {
+              "Name": "FSharp.Data",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Data/2.3.3",
+              "LicenseUrl": "http://github.com/fsharp/FSharp.Data/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Zlib.Portable",
+                  "VersionRequirement": ">= 1.11",
+                  "FrameworkRestrictions": "portable-net45+sl5+win8, portable-net45+win8, portable-net45+win8+wp8+wpa81, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:15.4751618+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:42.8460176+02:00",
+        "PackageName": "System.Threading.ThreadPool",
+        "Versions": [
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.0.10-beta-23225"
+          },
+          {
+            "Version": "4.0.10-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23516"
+          },
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.ThreadPool",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.ThreadPool/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:41.8834454+02:00",
+        "PackageName": "System.Threading.Tasks.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:48.9420177+02:00",
+        "PackageName": "runtime.any.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:59.3873352+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.4656622+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                },
+                {
+                  "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:00.3868342+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:52.8237215+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:44.0065165+02:00",
+        "PackageName": "System.Xml.ReaderWriter",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.ReaderWriter",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.ReaderWriter/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:06.3888708+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:02.4843336+02:00",
+        "PackageName": "runtime.win.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:44.571516+02:00",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:54.2762232+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:52.1797206+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:50.7590202+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:26.1491656+02:00",
+        "PackageName": "System.Net.WebHeaderCollection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.WebHeaderCollection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.WebHeaderCollection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:07.5743713+02:00",
+        "PackageName": "FSharp.Formatting",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.1.0-beta"
+          },
+          {
+            "Version": "2.1.1-beta"
+          },
+          {
+            "Version": "2.1.2-beta"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.1.5"
+          },
+          {
+            "Version": "2.1.6"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4-beta"
+          },
+          {
+            "Version": "2.2.5-beta"
+          },
+          {
+            "Version": "2.2.6-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.9-beta"
+          },
+          {
+            "Version": "2.2.10-beta"
+          },
+          {
+            "Version": "2.2.11-beta"
+          },
+          {
+            "Version": "2.2.12-beta"
+          },
+          {
+            "Version": "2.3.1-beta"
+          },
+          {
+            "Version": "2.3.2-beta"
+          },
+          {
+            "Version": "2.3.3-beta"
+          },
+          {
+            "Version": "2.3.4-beta"
+          },
+          {
+            "Version": "2.3.5-beta"
+          },
+          {
+            "Version": "2.3.6-beta"
+          },
+          {
+            "Version": "2.3.7-beta"
+          },
+          {
+            "Version": "2.3.10-beta"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "2.4.3"
+          },
+          {
+            "Version": "2.4.4"
+          },
+          {
+            "Version": "2.4.5"
+          },
+          {
+            "Version": "2.4.6"
+          },
+          {
+            "Version": "2.4.7"
+          },
+          {
+            "Version": "2.4.8"
+          },
+          {
+            "Version": "2.4.9"
+          },
+          {
+            "Version": "2.4.10"
+          },
+          {
+            "Version": "2.4.11"
+          },
+          {
+            "Version": "2.4.12"
+          },
+          {
+            "Version": "2.4.13"
+          },
+          {
+            "Version": "2.4.14"
+          },
+          {
+            "Version": "2.4.15"
+          },
+          {
+            "Version": "2.4.16"
+          },
+          {
+            "Version": "2.4.17"
+          },
+          {
+            "Version": "2.4.18"
+          },
+          {
+            "Version": "2.4.19"
+          },
+          {
+            "Version": "2.4.20"
+          },
+          {
+            "Version": "2.4.21"
+          },
+          {
+            "Version": "2.4.22"
+          },
+          {
+            "Version": "2.4.23"
+          },
+          {
+            "Version": "2.4.24"
+          },
+          {
+            "Version": "2.4.25"
+          },
+          {
+            "Version": "2.4.26"
+          },
+          {
+            "Version": "2.4.27"
+          },
+          {
+            "Version": "2.4.28"
+          },
+          {
+            "Version": "2.4.29"
+          },
+          {
+            "Version": "2.4.30"
+          },
+          {
+            "Version": "2.4.31"
+          },
+          {
+            "Version": "2.4.32"
+          },
+          {
+            "Version": "2.4.33"
+          },
+          {
+            "Version": "2.4.34"
+          },
+          {
+            "Version": "2.4.35"
+          },
+          {
+            "Version": "2.4.36"
+          },
+          {
+            "Version": "2.4.37"
+          },
+          {
+            "Version": "2.4.38"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.3"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.4"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.9.0"
+          },
+          {
+            "Version": "2.9.1"
+          },
+          {
+            "Version": "2.9.2"
+          },
+          {
+            "Version": "2.9.3"
+          },
+          {
+            "Version": "2.9.4"
+          },
+          {
+            "Version": "2.9.5"
+          },
+          {
+            "Version": "2.9.6"
+          },
+          {
+            "Version": "2.9.7"
+          },
+          {
+            "Version": "2.9.8"
+          },
+          {
+            "Version": "2.9.9"
+          },
+          {
+            "Version": "2.9.10"
+          },
+          {
+            "Version": "2.10.0"
+          },
+          {
+            "Version": "2.10.1"
+          },
+          {
+            "Version": "2.10.2"
+          },
+          {
+            "Version": "2.10.3"
+          },
+          {
+            "Version": "2.11.0-alpha1"
+          },
+          {
+            "Version": "2.11.0-alpha2"
+          },
+          {
+            "Version": "2.11.0"
+          },
+          {
+            "Version": "2.11.1-alpha1"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha1"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.1"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.13.5"
+          },
+          {
+            "Version": "2.13.6"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.2"
+          },
+          {
+            "Version": "2.14.3"
+          },
+          {
+            "Version": "2.14.4",
+            "PackageDetails": {
+              "Name": "FSharp.Formatting",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Formatting/2.14.4",
+              "LicenseUrl": "http://github.com/tpetricek/FSharp.Formatting/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": "2.0.0.6"
+                },
+                {
+                  "PackageName": "FSharpVSPowerTools.Core",
+                  "VersionRequirement": ">= 2.3 < 2.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.14.5-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:51.3807374+02:00",
+        "PackageName": "runtime.aot.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:26.7166907+02:00",
+        "PackageName": "System.ObjectModel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ObjectModel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ObjectModel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:01.6418333+02:00",
+        "PackageName": "runtime.unix.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:23.2901639+02:00",
+        "PackageName": "System.Linq.Queryable",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Queryable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Queryable/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:03.7361415+02:00",
+        "PackageName": "runtime.win.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:01.8353325+02:00",
+        "PackageName": "runtime.unix.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:54.4817215+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.0056613+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:10.3726613+02:00",
+        "PackageName": "FSharp.RDF",
+        "Versions": [
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "1.0.18"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.0.20"
+          },
+          {
+            "Version": "1.0.21"
+          },
+          {
+            "Version": "1.0.22"
+          },
+          {
+            "Version": "1.0.23"
+          },
+          {
+            "Version": "1.0.25"
+          },
+          {
+            "Version": "1.0.26"
+          },
+          {
+            "Version": "1.0.27"
+          },
+          {
+            "Version": "1.0.28"
+          },
+          {
+            "Version": "1.0.29"
+          },
+          {
+            "Version": "1.0.30"
+          },
+          {
+            "Version": "1.0.32"
+          },
+          {
+            "Version": "1.0.33"
+          },
+          {
+            "Version": "1.0.34"
+          },
+          {
+            "Version": "1.0.35"
+          },
+          {
+            "Version": "1.0.38"
+          },
+          {
+            "Version": "1.0.39"
+          },
+          {
+            "Version": "1.0.40"
+          },
+          {
+            "Version": "1.0.41"
+          },
+          {
+            "Version": "1.0.42"
+          },
+          {
+            "Version": "1.0.43"
+          },
+          {
+            "Version": "1.0.44"
+          },
+          {
+            "Version": "1.0.47"
+          },
+          {
+            "Version": "1.0.48"
+          },
+          {
+            "Version": "1.0.49"
+          },
+          {
+            "Version": "1.0.50"
+          },
+          {
+            "Version": "1.0.51"
+          },
+          {
+            "Version": "1.0.52"
+          },
+          {
+            "Version": "1.0.54"
+          },
+          {
+            "Version": "1.0.55"
+          },
+          {
+            "Version": "1.0.56"
+          },
+          {
+            "Version": "1.0.57"
+          },
+          {
+            "Version": "1.0.59"
+          },
+          {
+            "Version": "1.0.60"
+          },
+          {
+            "Version": "1.0.63"
+          },
+          {
+            "Version": "1.0.64"
+          },
+          {
+            "Version": "1.0.65"
+          },
+          {
+            "Version": "1.0.66"
+          },
+          {
+            "Version": "1.0.67"
+          },
+          {
+            "Version": "1.0.68"
+          },
+          {
+            "Version": "1.0.71"
+          },
+          {
+            "Version": "1.0.72"
+          },
+          {
+            "Version": "1.0.73"
+          },
+          {
+            "Version": "1.0.74"
+          },
+          {
+            "Version": "1.0.75"
+          },
+          {
+            "Version": "1.0.77"
+          },
+          {
+            "Version": "1.0.79"
+          },
+          {
+            "Version": "1.0.80"
+          },
+          {
+            "Version": "1.0.81"
+          },
+          {
+            "Version": "1.0.82"
+          },
+          {
+            "Version": "1.0.83"
+          },
+          {
+            "Version": "1.0.84"
+          },
+          {
+            "Version": "1.0.86"
+          },
+          {
+            "Version": "1.0.87"
+          },
+          {
+            "Version": "1.0.88"
+          },
+          {
+            "Version": "1.0.89"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.92"
+          },
+          {
+            "Version": "1.1.94"
+          },
+          {
+            "Version": "1.1.95"
+          },
+          {
+            "Version": "1.1.96"
+          },
+          {
+            "Version": "1.1.97"
+          },
+          {
+            "Version": "1.1.100"
+          },
+          {
+            "Version": "1.1.101",
+            "PackageDetails": {
+              "Name": "FSharp.RDF",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.RDF/1.1.101",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:36.9241932+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:01.4343335+02:00",
+        "PackageName": "runtime.unix.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:54.9878681+02:00",
+        "PackageName": "CsQuery",
+        "Versions": [
+          {
+            "Version": "1.0.1.30111"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.2.1"
+          },
+          {
+            "Version": "1.1.2.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.3.1"
+          },
+          {
+            "Version": "1.2"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.3.0-beta1"
+          },
+          {
+            "Version": "1.3.0-beta2"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.3.3"
+          },
+          {
+            "Version": "1.3.4-beta1"
+          },
+          {
+            "Version": "1.3.4",
+            "PackageDetails": {
+              "Name": "CsQuery",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/CsQuery/1.3.4",
+              "LicenseUrl": "https://github.com/jamietre/CsQuery/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.5-beta1"
+          },
+          {
+            "Version": "1.3.5-beta2"
+          },
+          {
+            "Version": "1.3.5-beta3"
+          },
+          {
+            "Version": "1.3.5-beta5"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:47.1360186+02:00",
+        "PackageName": "runtime.any.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:46.3115173+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:44.8430166+02:00",
+        "PackageName": "System.Xml.XmlDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlDocument",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Xml.XmlDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:51.7702235+02:00",
+        "PackageName": "runtime.aot.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:46.0920179+02:00",
+        "PackageName": "runtime.any.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:56.3362247+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:29.2516925+02:00",
+        "PackageName": "System.Reflection.TypeExtensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.TypeExtensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.TypeExtensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Contracts",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net462, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:46.5175256+02:00",
+        "PackageName": "runtime.any.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:10.5236621+02:00",
+        "PackageName": "FSharpVSPowerTools.Core",
+        "Versions": [
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "FSharpVSPowerTools.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharpVSPowerTools.Core/2.3.0",
+              "LicenseUrl": "https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Compiler.Service",
+                  "VersionRequirement": ">= 2.0.0.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:53.0172217+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:57.1397374+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:54.8508665+02:00",
+        "PackageName": "Argu",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "3.0.0-alpha001"
+          },
+          {
+            "Version": "3.0.0-alpha002"
+          },
+          {
+            "Version": "3.0.0-alpha003"
+          },
+          {
+            "Version": "3.0.0-alpha004"
+          },
+          {
+            "Version": "3.0.0-alpha005"
+          },
+          {
+            "Version": "3.0.0-alpha006"
+          },
+          {
+            "Version": "3.0.0-alpha007"
+          },
+          {
+            "Version": "3.0.0-alpha008"
+          },
+          {
+            "Version": "3.0.0-alpha009"
+          },
+          {
+            "Version": "3.0.0-alpha010"
+          },
+          {
+            "Version": "3.0.0-alpha011"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          },
+          {
+            "Version": "3.0.0-beta02"
+          },
+          {
+            "Version": "3.0.0-beta03"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.7.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:49.141028+02:00",
+        "PackageName": "runtime.any.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:00.1858325+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.732662+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:34.3721931+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:37.2891939+02:00",
+        "PackageName": "System.Security.Cryptography.Cng",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Cng",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Cng/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard14, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:51.9752275+02:00",
+        "PackageName": "runtime.aot.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:19.1586625+02:00",
+        "PackageName": "System.Globalization.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:03.1138353+02:00",
+        "PackageName": "runtime.win.System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:02.2408325+02:00",
+        "PackageName": "runtime.unix.System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net462, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:45.3975258+02:00",
+        "PackageName": "System.Xml.XmlSerializer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XmlSerializer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XmlSerializer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.8816609+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:25.7166643+02:00",
+        "PackageName": "System.Net.Security",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Security",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Security",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Claims",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Principal",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:46.9150172+02:00",
+        "PackageName": "runtime.any.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:37.4837015+02:00",
+        "PackageName": "System.Security.Cryptography.Csp",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Csp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Csp/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:42.5145209+02:00",
+        "PackageName": "System.Threading.Thread",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Thread",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Thread/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:45.6740206+02:00",
+        "PackageName": "Zlib.Portable",
+        "Versions": [
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.9.1.1"
+          },
+          {
+            "Version": "1.9.1.2-alpha"
+          },
+          {
+            "Version": "1.9.1.2"
+          },
+          {
+            "Version": "1.9.2"
+          },
+          {
+            "Version": "1.10.0"
+          },
+          {
+            "Version": "1.11.0-beta1"
+          },
+          {
+            "Version": "1.11.0",
+            "PackageDetails": {
+              "Name": "Zlib.Portable",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Zlib.Portable/1.11.0",
+              "LicenseUrl": "http://en.wikipedia.org/wiki/Zlib_License",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:38.7459457+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:16.6886629+02:00",
+        "PackageName": "System.Diagnostics.DiagnosticSource",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.DiagnosticSource",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.DiagnosticSource/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.4.0-preview1-25214-03"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:11.0316623+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:47.5445174+02:00",
+        "PackageName": "runtime.any.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:02.9098327+02:00",
+        "PackageName": "runtime.win.System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:56.9362218+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:53.4382203+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:14.0026644+02:00",
+        "PackageName": "Suave.Testing",
+        "Versions": [
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.20.1"
+          },
+          {
+            "Version": "0.20.2"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.25.0"
+          },
+          {
+            "Version": "0.26.0"
+          },
+          {
+            "Version": "0.26.1"
+          },
+          {
+            "Version": "0.26.2"
+          },
+          {
+            "Version": "0.27.0"
+          },
+          {
+            "Version": "0.28.0"
+          },
+          {
+            "Version": "0.28.1"
+          },
+          {
+            "Version": "0.29.0-alpha"
+          },
+          {
+            "Version": "0.29.0-alpha2"
+          },
+          {
+            "Version": "0.29.0"
+          },
+          {
+            "Version": "0.29.1"
+          },
+          {
+            "Version": "0.30.0"
+          },
+          {
+            "Version": "0.31.0"
+          },
+          {
+            "Version": "0.31.1"
+          },
+          {
+            "Version": "0.31.2"
+          },
+          {
+            "Version": "0.32.0-owin"
+          },
+          {
+            "Version": "0.32.0-owin2"
+          },
+          {
+            "Version": "0.32.0"
+          },
+          {
+            "Version": "0.32.1"
+          },
+          {
+            "Version": "0.33.0-libuv"
+          },
+          {
+            "Version": "0.33.0-libuv1"
+          },
+          {
+            "Version": "0.33.0-libuv2"
+          },
+          {
+            "Version": "0.33.0"
+          },
+          {
+            "Version": "0.34.0-nsrefactor"
+          },
+          {
+            "Version": "0.34.0-nsrefactor1"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "2.0.0-alpha3"
+          },
+          {
+            "Version": "2.0.0-alpha4"
+          },
+          {
+            "Version": "2.0.0-alpha5"
+          },
+          {
+            "Version": "2.0.0-alpha6"
+          },
+          {
+            "Version": "2.0.0-alpha7"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0-rc2"
+          },
+          {
+            "Version": "2.0.0-rc3"
+          },
+          {
+            "Version": "2.0.0-rc4"
+          },
+          {
+            "Version": "2.0.0-rc5"
+          },
+          {
+            "Version": "2.0.0-rc6"
+          },
+          {
+            "Version": "2.0.0-rc7"
+          },
+          {
+            "Version": "2.0.0-rc8"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5-alpha"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Suave.Testing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Suave.Testing/2.1.0",
+              "LicenseUrl": "https://github.com/SuaveIO/Suave/blob/master/COPYING",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Expecto",
+                  "VersionRequirement": ">= 4.0.3"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.0.1"
+                },
+                {
+                  "PackageName": "Suave",
+                  "VersionRequirement": ">= 2.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:03.3182899+02:00",
+        "PackageName": "runtime.win.System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:56.5347215+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:02.7063329+02:00",
+        "PackageName": "runtime.win.System.Console",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:46.7185175+02:00",
+        "PackageName": "runtime.any.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:13.0496608+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:59.1888411+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:14.2931638+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.6581603+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:57.7491586+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:01.2138324+02:00",
+        "PackageName": "runtime.unix.System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.8221617+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:55.7282323+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.1416623+02:00",
+        "PackageName": "runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:41.141947+02:00",
+        "PackageName": "System.Threading",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.3301611+02:00",
+        "PackageName": "runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:11.7811631+02:00",
+        "PackageName": "Mono.Cecil",
+        "Versions": [
+          {
+            "Version": "0.9.4.0"
+          },
+          {
+            "Version": "0.9.4.1"
+          },
+          {
+            "Version": "0.9.5.0"
+          },
+          {
+            "Version": "0.9.5.1"
+          },
+          {
+            "Version": "0.9.5.2"
+          },
+          {
+            "Version": "0.9.5.3"
+          },
+          {
+            "Version": "0.9.5.4"
+          },
+          {
+            "Version": "0.9.6.0-rev1"
+          },
+          {
+            "Version": "0.9.6.0"
+          },
+          {
+            "Version": "0.9.6.1"
+          },
+          {
+            "Version": "0.9.6.2"
+          },
+          {
+            "Version": "0.9.6.3"
+          },
+          {
+            "Version": "0.9.6.4",
+            "PackageDetails": {
+              "Name": "Mono.Cecil",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Mono.Cecil/0.9.6.4",
+              "LicenseUrl": "http://opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.10.0-beta1"
+          },
+          {
+            "Version": "0.10.0-beta1-v2"
+          },
+          {
+            "Version": "0.10.0-beta2"
+          },
+          {
+            "Version": "0.10.0-beta3"
+          },
+          {
+            "Version": "0.10.0-beta4"
+          },
+          {
+            "Version": "0.10.0-beta5"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:58.354375+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:53.6457224+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:21.1281985+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:54.6892236+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:48.5390195+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:55.305223+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:10.8276642+02:00",
+        "PackageName": "Microsoft.NETCore.Targets",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Targets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Targets/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.any.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.any.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.any.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.any.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.any.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.any.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.any.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.any.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.any.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.any.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.any.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.any.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.any.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.any.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.any.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.any.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "aot": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.aot.System.Collections": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tools": {
+                    "runtime.aot.System.Diagnostics.Tools": ">= 4.3"
+                  },
+                  "System.Diagnostics.Tracing": {
+                    "runtime.aot.System.Diagnostics.Tracing": ">= 4.3"
+                  },
+                  "System.Globalization": {
+                    "runtime.aot.System.Globalization": ">= 4.3"
+                  },
+                  "System.Globalization.Calendars": {
+                    "runtime.aot.System.Globalization.Calendars": ">= 4.3"
+                  },
+                  "System.IO": {
+                    "runtime.aot.System.IO": ">= 4.3"
+                  },
+                  "System.Reflection": {
+                    "runtime.aot.System.Reflection": ">= 4.3"
+                  },
+                  "System.Reflection.Extensions": {
+                    "runtime.aot.System.Reflection.Extensions": ">= 4.3"
+                  },
+                  "System.Reflection.Primitives": {
+                    "runtime.aot.System.Reflection.Primitives": ">= 4.3"
+                  },
+                  "System.Resources.ResourceManager": {
+                    "runtime.aot.System.Resources.ResourceManager": ">= 4.3"
+                  },
+                  "System.Runtime": {
+                    "runtime.aot.System.Runtime": ">= 4.3"
+                  },
+                  "System.Runtime.Handles": {
+                    "runtime.aot.System.Runtime.Handles": ">= 4.3"
+                  },
+                  "System.Runtime.InteropServices": {
+                    "runtime.aot.System.Runtime.InteropServices": ">= 4.3"
+                  },
+                  "System.Text.Encoding": {
+                    "runtime.aot.System.Text.Encoding": ">= 4.3"
+                  },
+                  "System.Text.Encoding.Extensions": {
+                    "runtime.aot.System.Text.Encoding.Extensions": ">= 4.3"
+                  },
+                  "System.Threading.Tasks": {
+                    "runtime.aot.System.Threading.Tasks": ">= 4.3"
+                  },
+                  "System.Threading.Timer": {
+                    "runtime.aot.System.Threading.Timer": ">= 4.3"
+                  }
+                },
+                "debian.8-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.debian.8-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.debian.8-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.debian.8-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.23-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.23-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.23-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.23-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "fedora.24-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.fedora.24-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.fedora.24-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.fedora.24-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "osx.10.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.osx.10.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.osx.10.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.osx.10.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "rhel.7-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.rhel.7-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.rhel.7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.rhel.7-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [],
+                  "runtime.native.System": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System": ">= 4.3"
+                  },
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Http": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http": ">= 4.3"
+                  },
+                  "runtime.native.System.Net.Security": {
+                    "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security": ">= 4.3"
+                  }
+                },
+                "unix": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.unix.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.unix.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.unix.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.unix.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.unix.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.unix.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Private.Uri": {
+                    "runtime.unix.System.Private.Uri": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.unix.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win": {
+                  "#import": [],
+                  "Microsoft.Win32.Primitives": {
+                    "runtime.win.Microsoft.Win32.Primitives": ">= 4.3"
+                  },
+                  "System.Console": {
+                    "runtime.win.System.Console": ">= 4.3"
+                  },
+                  "System.Diagnostics.Debug": {
+                    "runtime.win.System.Diagnostics.Debug": ">= 4.3"
+                  },
+                  "System.IO.FileSystem": {
+                    "runtime.win.System.IO.FileSystem": ">= 4.3"
+                  },
+                  "System.Net.Primitives": {
+                    "runtime.win.System.Net.Primitives": ">= 4.3"
+                  },
+                  "System.Net.Sockets": {
+                    "runtime.win.System.Net.Sockets": ">= 4.3"
+                  },
+                  "System.Runtime.Extensions": {
+                    "runtime.win.System.Runtime.Extensions": ">= 4.3"
+                  }
+                },
+                "win10-arm-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-arm64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-arm64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win10-x64-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x64-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win10-x86-aot": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win10-x86-aot.runtime.native.System.IO.Compression": ">= 4.0.1"
+                  }
+                },
+                "win7": {
+                  "#import": [],
+                  "System.Private.Uri": {
+                    "runtime.win7.System.Private.Uri": ">= 4.3"
+                  }
+                },
+                "win7-x64": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x64.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win7-x86": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win7-x86.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                },
+                "win8-arm": {
+                  "#import": [],
+                  "runtime.native.System.IO.Compression": {
+                    "runtime.win8-arm.runtime.native.System.IO.Compression": ">= 4.3"
+                  }
+                }
+              },
+              "supports": {
+                "dnxcore50.app": {
+                  "dnxcore50": [
+                    "win7-x86",
+                    "win7-x64"
+                  ]
+                },
+                "net45.app": {
+                  "net45": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net451.app": {
+                  "net451": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net452.app": {
+                  "net452": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net46.app": {
+                  "net46": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net461.app": {
+                  "net461": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "net462.app": {
+                  "net462": [
+                    "",
+                    "win-x86",
+                    "win-x64"
+                  ]
+                },
+                "netcoreapp1.0.app": {
+                  "netcore10": [
+                    "win7-x86",
+                    "win7-x64",
+                    "osx.10.11-x64",
+                    "centos.7-x64",
+                    "debian.8-x64",
+                    "linuxmint.17-x64",
+                    "opensuse.13.2-x64",
+                    "rhel.7.2-x64",
+                    "ubuntu.14.04-x64",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "uwp.10.0.app": {
+                  "uap100": [
+                    "win10-x86",
+                    "win10-x86-aot",
+                    "win10-x64",
+                    "win10-x64-aot",
+                    "win10-arm",
+                    "win10-arm-aot"
+                  ]
+                },
+                "win8.app": {
+                  "winv4.5": [
+                    ""
+                  ]
+                },
+                "win81.app": {
+                  "winv4.5.1": [
+                    ""
+                  ]
+                },
+                "wp8.app": {
+                  "wpv8.0": [
+                    ""
+                  ]
+                },
+                "wp81.app": {
+                  "wpv8.1": [
+                    ""
+                  ]
+                },
+                "wpa81.app": {
+                  "wpav8.1": [
+                    ""
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:10.732161+02:00",
+        "PackageName": "Microsoft.NETCore.Platforms",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta-23019"
+          },
+          {
+            "Version": "1.0.0-beta-23109"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1-beta-23225"
+          },
+          {
+            "Version": "1.0.1-beta-23409"
+          },
+          {
+            "Version": "1.0.1-beta-23516"
+          },
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.NETCore.Platforms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.NETCore.Platforms/1.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [
+                    "base"
+                  ]
+                },
+                "aot": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "base": {
+                  "#import": []
+                },
+                "centos": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "centos-x64": {
+                  "#import": [
+                    "centos",
+                    "rhel-x64"
+                  ]
+                },
+                "centos.7": {
+                  "#import": [
+                    "centos",
+                    "rhel.7"
+                  ]
+                },
+                "centos.7-x64": {
+                  "#import": [
+                    "centos.7",
+                    "centos-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "debian": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "debian-x64": {
+                  "#import": [
+                    "debian",
+                    "linux-x64"
+                  ]
+                },
+                "debian.8": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "debian.8-x64": {
+                  "#import": [
+                    "debian.8",
+                    "debian-x64"
+                  ]
+                },
+                "fedora": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "fedora-x64": {
+                  "#import": [
+                    "fedora",
+                    "linux-x64"
+                  ]
+                },
+                "fedora.23": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.23-x64": {
+                  "#import": [
+                    "fedora.23",
+                    "fedora-x64"
+                  ]
+                },
+                "fedora.24": {
+                  "#import": [
+                    "fedora"
+                  ]
+                },
+                "fedora.24-x64": {
+                  "#import": [
+                    "fedora.24",
+                    "fedora-x64"
+                  ]
+                },
+                "linux": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "linux-x64": {
+                  "#import": [
+                    "linux",
+                    "unix-x64"
+                  ]
+                },
+                "linuxmint.17": {
+                  "#import": [
+                    "ubuntu.14.04"
+                  ]
+                },
+                "linuxmint.17-x64": {
+                  "#import": [
+                    "linuxmint.17",
+                    "ubuntu.14.04-x64"
+                  ]
+                },
+                "linuxmint.17.1": {
+                  "#import": [
+                    "linuxmint.17"
+                  ]
+                },
+                "linuxmint.17.1-x64": {
+                  "#import": [
+                    "linuxmint.17.1",
+                    "linuxmint.17-x64"
+                  ]
+                },
+                "linuxmint.17.2": {
+                  "#import": [
+                    "linuxmint.17.1"
+                  ]
+                },
+                "linuxmint.17.2-x64": {
+                  "#import": [
+                    "linuxmint.17.2",
+                    "linuxmint.17.1-x64"
+                  ]
+                },
+                "linuxmint.17.3": {
+                  "#import": [
+                    "linuxmint.17.2"
+                  ]
+                },
+                "linuxmint.17.3-x64": {
+                  "#import": [
+                    "linuxmint.17.3",
+                    "linuxmint.17.2-x64"
+                  ]
+                },
+                "linuxmint.18": {
+                  "#import": [
+                    "ubuntu.16.04"
+                  ]
+                },
+                "linuxmint.18-x64": {
+                  "#import": [
+                    "linuxmint.18",
+                    "ubuntu.16.04-x64"
+                  ]
+                },
+                "ol": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "ol-x64": {
+                  "#import": [
+                    "ol",
+                    "rhel-x64"
+                  ]
+                },
+                "ol.7": {
+                  "#import": [
+                    "ol",
+                    "rhel.7"
+                  ]
+                },
+                "ol.7-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol-x64",
+                    "rhel.7-x64"
+                  ]
+                },
+                "ol.7.0": {
+                  "#import": [
+                    "ol.7",
+                    "rhel.7.0"
+                  ]
+                },
+                "ol.7.0-x64": {
+                  "#import": [
+                    "ol.7",
+                    "ol.7-x64",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "ol.7.1": {
+                  "#import": [
+                    "ol.7.0",
+                    "rhel.7.1"
+                  ]
+                },
+                "ol.7.1-x64": {
+                  "#import": [
+                    "ol.7.0",
+                    "ol.7.0-x64",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ol.7.2": {
+                  "#import": [
+                    "ol.7.1",
+                    "rhel.7.2"
+                  ]
+                },
+                "ol.7.2-x64": {
+                  "#import": [
+                    "ol.7.1",
+                    "ol.7.1-x64",
+                    "rhel.7.2-x64"
+                  ]
+                },
+                "opensuse": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "opensuse-x64": {
+                  "#import": [
+                    "opensuse",
+                    "linux-x64"
+                  ]
+                },
+                "opensuse.13.2": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.13.2-x64": {
+                  "#import": [
+                    "opensuse.13.2",
+                    "opensuse-x64"
+                  ]
+                },
+                "opensuse.42.1": {
+                  "#import": [
+                    "opensuse"
+                  ]
+                },
+                "opensuse.42.1-x64": {
+                  "#import": [
+                    "opensuse.42.1",
+                    "opensuse-x64"
+                  ]
+                },
+                "osx": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "osx-x64": {
+                  "#import": [
+                    "osx",
+                    "unix-x64"
+                  ]
+                },
+                "osx.10.10": {
+                  "#import": [
+                    "osx"
+                  ]
+                },
+                "osx.10.10-x64": {
+                  "#import": [
+                    "osx.10.10",
+                    "osx-x64"
+                  ]
+                },
+                "osx.10.11": {
+                  "#import": [
+                    "osx.10.10"
+                  ]
+                },
+                "osx.10.11-x64": {
+                  "#import": [
+                    "osx.10.11",
+                    "osx.10.10-x64"
+                  ]
+                },
+                "osx.10.12": {
+                  "#import": [
+                    "osx.10.11"
+                  ]
+                },
+                "osx.10.12-x64": {
+                  "#import": [
+                    "osx.10.12",
+                    "osx.10.11-x64"
+                  ]
+                },
+                "rhel": {
+                  "#import": [
+                    "linux"
+                  ]
+                },
+                "rhel-x64": {
+                  "#import": [
+                    "rhel",
+                    "linux-x64"
+                  ]
+                },
+                "rhel.7": {
+                  "#import": [
+                    "rhel"
+                  ]
+                },
+                "rhel.7-x64": {
+                  "#import": [
+                    "rhel",
+                    "rhel-x64"
+                  ]
+                },
+                "rhel.7.0": {
+                  "#import": [
+                    "rhel.7"
+                  ]
+                },
+                "rhel.7.0-x64": {
+                  "#import": [
+                    "rhel.7",
+                    "rhel.7-x64"
+                  ]
+                },
+                "rhel.7.1": {
+                  "#import": [
+                    "rhel.7.0"
+                  ]
+                },
+                "rhel.7.1-x64": {
+                  "#import": [
+                    "rhel.7.0",
+                    "rhel.7.0-x64"
+                  ]
+                },
+                "rhel.7.2": {
+                  "#import": [
+                    "rhel.7.1"
+                  ]
+                },
+                "rhel.7.2-x64": {
+                  "#import": [
+                    "rhel.7.1",
+                    "rhel.7.1-x64"
+                  ]
+                },
+                "ubuntu": {
+                  "#import": [
+                    "debian"
+                  ]
+                },
+                "ubuntu-x64": {
+                  "#import": [
+                    "ubuntu",
+                    "debian-x64"
+                  ]
+                },
+                "ubuntu.14.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.04-x64": {
+                  "#import": [
+                    "ubuntu.14.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.14.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.14.10-x64": {
+                  "#import": [
+                    "ubuntu.14.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.04-x64": {
+                  "#import": [
+                    "ubuntu.15.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.15.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.15.10-x64": {
+                  "#import": [
+                    "ubuntu.15.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.04": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.04-x64": {
+                  "#import": [
+                    "ubuntu.16.04",
+                    "ubuntu-x64"
+                  ]
+                },
+                "ubuntu.16.10": {
+                  "#import": [
+                    "ubuntu"
+                  ]
+                },
+                "ubuntu.16.10-x64": {
+                  "#import": [
+                    "ubuntu.16.10",
+                    "ubuntu-x64"
+                  ]
+                },
+                "unix": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "unix-x64": {
+                  "#import": [
+                    "unix"
+                  ]
+                },
+                "win": {
+                  "#import": [
+                    "any"
+                  ]
+                },
+                "win-aot": {
+                  "#import": [
+                    "win",
+                    "aot"
+                  ]
+                },
+                "win-x64": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x64-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x64"
+                  ]
+                },
+                "win-x86": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win-x86-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win-x86"
+                  ]
+                },
+                "win10": {
+                  "#import": [
+                    "win81"
+                  ]
+                },
+                "win10-aot": {
+                  "#import": [
+                    "win10",
+                    "win81-aot"
+                  ]
+                },
+                "win10-arm": {
+                  "#import": [
+                    "win10",
+                    "win81-arm"
+                  ]
+                },
+                "win10-arm-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm",
+                    "win81-arm-aot"
+                  ]
+                },
+                "win10-arm64": {
+                  "#import": [
+                    "win10"
+                  ]
+                },
+                "win10-arm64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-arm64"
+                  ]
+                },
+                "win10-x64": {
+                  "#import": [
+                    "win10",
+                    "win81-x64"
+                  ]
+                },
+                "win10-x64-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x64",
+                    "win81-x64-aot"
+                  ]
+                },
+                "win10-x86": {
+                  "#import": [
+                    "win10",
+                    "win81-x86"
+                  ]
+                },
+                "win10-x86-aot": {
+                  "#import": [
+                    "win10-aot",
+                    "win10-x86",
+                    "win81-x86-aot"
+                  ]
+                },
+                "win7": {
+                  "#import": [
+                    "win"
+                  ]
+                },
+                "win7-aot": {
+                  "#import": [
+                    "win-aot",
+                    "win7"
+                  ]
+                },
+                "win7-x64": {
+                  "#import": [
+                    "win7",
+                    "win-x64"
+                  ]
+                },
+                "win7-x64-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x64"
+                  ]
+                },
+                "win7-x86": {
+                  "#import": [
+                    "win7",
+                    "win-x86"
+                  ]
+                },
+                "win7-x86-aot": {
+                  "#import": [
+                    "win7-aot",
+                    "win7-x86"
+                  ]
+                },
+                "win8": {
+                  "#import": [
+                    "win7"
+                  ]
+                },
+                "win8-aot": {
+                  "#import": [
+                    "win8",
+                    "win7-aot"
+                  ]
+                },
+                "win8-arm": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win8-arm-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-arm"
+                  ]
+                },
+                "win8-x64": {
+                  "#import": [
+                    "win8",
+                    "win7-x64"
+                  ]
+                },
+                "win8-x64-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x64",
+                    "win7-x64-aot"
+                  ]
+                },
+                "win8-x86": {
+                  "#import": [
+                    "win8",
+                    "win7-x86"
+                  ]
+                },
+                "win8-x86-aot": {
+                  "#import": [
+                    "win8-aot",
+                    "win8-x86",
+                    "win7-x86-aot"
+                  ]
+                },
+                "win81": {
+                  "#import": [
+                    "win8"
+                  ]
+                },
+                "win81-aot": {
+                  "#import": [
+                    "win81",
+                    "win8-aot"
+                  ]
+                },
+                "win81-arm": {
+                  "#import": [
+                    "win81",
+                    "win8-arm"
+                  ]
+                },
+                "win81-arm-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-arm",
+                    "win8-arm-aot"
+                  ]
+                },
+                "win81-x64": {
+                  "#import": [
+                    "win81",
+                    "win8-x64"
+                  ]
+                },
+                "win81-x64-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x64",
+                    "win8-x64-aot"
+                  ]
+                },
+                "win81-x86": {
+                  "#import": [
+                    "win81",
+                    "win8-x86"
+                  ]
+                },
+                "win81-x86-aot": {
+                  "#import": [
+                    "win81-aot",
+                    "win81-x86",
+                    "win8-x86-aot"
+                  ]
+                }
+              },
+              "supports": {}
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:49.5300213+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:32.029191+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:16.524162+02:00",
+        "PackageName": "System.Diagnostics.Debug",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Debug",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Debug/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:43.0595165+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.5391614+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:16.1081618+02:00",
+        "PackageName": "System.Data.Common",
+        "Versions": [
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Data.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Data.Common/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.2141594+02:00",
+        "PackageName": "runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:00.5913356+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:58.7758324+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:57.540162+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:51.5697225+02:00",
+        "PackageName": "runtime.aot.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:50.3400315+02:00",
+        "PackageName": "runtime.aot.System.IO",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:28.577691+02:00",
+        "PackageName": "System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:55.5217217+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:02.0403331+02:00",
+        "PackageName": "runtime.unix.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:36.0646923+02:00",
+        "PackageName": "System.Runtime.Serialization.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Primitives",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Runtime.Serialization.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:10.648162+02:00",
+        "PackageName": "Fuchu",
+        "Versions": [
+          {
+            "Version": "0.1.0"
+          },
+          {
+            "Version": "0.1.1"
+          },
+          {
+            "Version": "0.1.2"
+          },
+          {
+            "Version": "0.1.3"
+          },
+          {
+            "Version": "0.2.0"
+          },
+          {
+            "Version": "0.2.1"
+          },
+          {
+            "Version": "0.2.2"
+          },
+          {
+            "Version": "0.3.0"
+          },
+          {
+            "Version": "0.3.0.1"
+          },
+          {
+            "Version": "0.4.0.0"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.0.2.0"
+          },
+          {
+            "Version": "1.0.3.0",
+            "PackageDetails": {
+              "Name": "Fuchu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fuchu/1.0.3.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/mausch/Fuchu/master/license.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1.2.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:03.5216383+02:00",
+        "PackageName": "runtime.win.System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.win.System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.win.System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.NameResolution",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal.Windows",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Overlapped",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:47.3580209+02:00",
+        "PackageName": "runtime.any.System.Reflection.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Reflection.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Reflection.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:00.8103347+02:00",
+        "PackageName": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:59.583332+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:55.9422212+02:00",
+        "PackageName": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.13.2-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:40.5259472+02:00",
+        "PackageName": "System.Text.RegularExpressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.RegularExpressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.RegularExpressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:49.731518+02:00",
+        "PackageName": "runtime.aot.System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.20-rc2-24027"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:48.1295688+02:00",
+        "PackageName": "runtime.any.System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:25.3766652+02:00",
+        "PackageName": "System.Net.Requests",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Requests",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Requests/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.WebHeaderCollection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:56.1382222+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:38.9859474+02:00",
+        "PackageName": "System.Security.Principal",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Principal",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Principal/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:33.059692+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:55.1137254+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:52.3792202+02:00",
+        "PackageName": "runtime.aot.System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:24.221665+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:45.5685191+02:00",
+        "PackageName": "Unquote",
+        "Versions": [
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "Unquote",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Unquote/3.2.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:20.8931628+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:57.3512233+02:00",
+        "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.osx.10.10-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.osx.10.10-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:13.9066753+02:00",
+        "PackageName": "Suave.DotLiquid",
+        "Versions": [
+          {
+            "Version": "0.29.1"
+          },
+          {
+            "Version": "0.30.0"
+          },
+          {
+            "Version": "0.31.0"
+          },
+          {
+            "Version": "0.31.1"
+          },
+          {
+            "Version": "0.31.2"
+          },
+          {
+            "Version": "0.32.0-owin"
+          },
+          {
+            "Version": "0.32.0-owin2"
+          },
+          {
+            "Version": "0.32.0"
+          },
+          {
+            "Version": "0.32.1"
+          },
+          {
+            "Version": "0.33.0-libuv"
+          },
+          {
+            "Version": "0.33.0-libuv1"
+          },
+          {
+            "Version": "0.33.0-libuv2"
+          },
+          {
+            "Version": "0.33.0"
+          },
+          {
+            "Version": "0.34.0-nsrefactor"
+          },
+          {
+            "Version": "0.34.0-nsrefactor1"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "2.0.0-alpha3"
+          },
+          {
+            "Version": "2.0.0-alpha4"
+          },
+          {
+            "Version": "2.0.0-alpha5"
+          },
+          {
+            "Version": "2.0.0-alpha6"
+          },
+          {
+            "Version": "2.0.0-alpha7"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0-rc2"
+          },
+          {
+            "Version": "2.0.0-rc3"
+          },
+          {
+            "Version": "2.0.0-rc4"
+          },
+          {
+            "Version": "2.0.0-rc5"
+          },
+          {
+            "Version": "2.0.0-rc6"
+          },
+          {
+            "Version": "2.0.0-rc7"
+          },
+          {
+            "Version": "2.0.0-rc8"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5-alpha"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Suave.DotLiquid",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Suave.DotLiquid/2.1.0",
+              "LicenseUrl": "https://github.com/SuaveIO/Suave/blob/master/COPYING",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "DotLiquid",
+                  "VersionRequirement": ">= 2.0.55",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "DotLiquid",
+                  "VersionRequirement": ">= 2.0.64",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.0.1",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.1.2",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "Suave",
+                  "VersionRequirement": ">= 2.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "Suave",
+                  "VersionRequirement": ">= 2.1",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:39.4459453+02:00",
+        "PackageName": "System.Text.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:47.738518+02:00",
+        "PackageName": "runtime.any.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:43.1885164+02:00",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:50.9580181+02:00",
+        "PackageName": "runtime.aot.System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:39.8964455+02:00",
+        "PackageName": "System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:15.6701614+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:35.5666924+02:00",
+        "PackageName": "System.Runtime.Serialization.Json",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2-rc2-24027"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Serialization.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Serialization.Json/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Private.DataContractSerialization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:05.0683715+02:00",
+        "PackageName": "FSharp.Compiler.Service",
+        "Versions": [
+          {
+            "Version": "2.0.0.6",
+            "PackageDetails": {
+              "Name": "FSharp.Compiler.Service",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Compiler.Service/2.0.0.6",
+              "LicenseUrl": "https://github.com/fsharp/FSharp.Compiler.Service/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:58.1653204+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:11.9301624+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:59.9883326+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:11.3076603+02:00",
+        "PackageName": "Microsoft.Win32.Registry",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Registry",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Registry/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:53.8572216+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:27.7841902+02:00",
+        "PackageName": "System.Reflection.Emit",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:59.7873332+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.3906613+02:00",
+        "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Security.Cryptography.Apple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Security.Cryptography.Apple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:21.7031643+02:00",
+        "PackageName": "System.Linq",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:54.0607357+02:00",
+        "PackageName": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.23-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.23-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:47.9355176+02:00",
+        "PackageName": "runtime.any.System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Private.Uri",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard15"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.9596628+02:00",
+        "PackageName": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:55.2708691+02:00",
+        "PackageName": "Expecto",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "2.4.1"
+          },
+          {
+            "Version": "2.4.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1",
+            "PackageDetails": {
+              "Name": "Expecto",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Expecto/4.2.1",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Argu",
+                  "VersionRequirement": ">= 3.7"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.1.12"
+                },
+                {
+                  "PackageName": "Mono.Cecil",
+                  "VersionRequirement": ">= 0.9.6.4"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.0.0-beta"
+          },
+          {
+            "Version": "5.0.0-beta1"
+          },
+          {
+            "Version": "5.0.0-beta2"
+          },
+          {
+            "Version": "5.0.0-beta3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:28.0142026+02:00",
+        "PackageName": "System.Reflection.Emit.ILGeneration",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.ILGeneration",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.ILGeneration/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:26.8771892+02:00",
+        "PackageName": "System.Private.DataContractSerialization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Private.DataContractSerialization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Private.DataContractSerialization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlSerializer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:28.2396911+02:00",
+        "PackageName": "System.Reflection.Emit.Lightweight",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Emit.Lightweight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Emit.Lightweight/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.0856617+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:27.4776904+02:00",
+        "PackageName": "System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:41.7699478+02:00",
+        "PackageName": "System.Threading.Tasks",
+        "Versions": [
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-beta1"
+          },
+          {
+            "Version": "3.0.2-beta2"
+          },
+          {
+            "Version": "3.1.0-beta1"
+          },
+          {
+            "Version": "3.1.0-beta2"
+          },
+          {
+            "Version": "3.1"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:19.8511644+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:49.3425178+02:00",
+        "PackageName": "runtime.aot.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:29.5041921+02:00",
+        "PackageName": "System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:45.8930167+02:00",
+        "PackageName": "runtime.any.System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:18.8746651+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.2656615+02:00",
+        "PackageName": "runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:14.3651667+02:00",
+        "PackageName": "System.Buffers",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Buffers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Buffers/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:20.4046636+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:13.5716621+02:00",
+        "PackageName": "SourceLink.Fake",
+        "Versions": [
+          {
+            "Version": "0.3.0-a1401160010-f42a74a5"
+          },
+          {
+            "Version": "0.3.0-a1401160102-fc7f738e"
+          },
+          {
+            "Version": "0.3.0-a1401200506-1fa7c639"
+          },
+          {
+            "Version": "0.3.0-a1401210630-e51f2c0b"
+          },
+          {
+            "Version": "0.3.0-a1401210639-e51f2c0b"
+          },
+          {
+            "Version": "0.3.0-a1401221522-b7bd7f00"
+          },
+          {
+            "Version": "0.3.0-a1401221527-a1ade11c"
+          },
+          {
+            "Version": "0.3.0-a1401231502-bd67c57f"
+          },
+          {
+            "Version": "0.3.0"
+          },
+          {
+            "Version": "0.3.1"
+          },
+          {
+            "Version": "0.3.2"
+          },
+          {
+            "Version": "0.3.3"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5-a1402170509-22a0f1bd"
+          },
+          {
+            "Version": "0.3.5-a1402171459-a1cba03d"
+          },
+          {
+            "Version": "0.4.0-ci1404051901"
+          },
+          {
+            "Version": "0.4.0-ci1404252207"
+          },
+          {
+            "Version": "0.4.0-ci1404260027"
+          },
+          {
+            "Version": "0.4.0-ci1404260502"
+          },
+          {
+            "Version": "0.4.0-ci1405020136"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0-ci1411242108"
+          },
+          {
+            "Version": "0.5.0-ci1503171318"
+          },
+          {
+            "Version": "0.5.0-ci1503171444"
+          },
+          {
+            "Version": "0.5.0-ci1503212313"
+          },
+          {
+            "Version": "0.5.0"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.6.1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0",
+            "PackageDetails": {
+              "Name": "SourceLink.Fake",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/SourceLink.Fake/1.1.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:36.3381923+02:00",
+        "PackageName": "System.Security.Claims",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Claims",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/System.Security.Claims/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Principal",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:13.7876628+02:00",
+        "PackageName": "Suave",
+        "Versions": [
+          {
+            "Version": "0.0.1"
+          },
+          {
+            "Version": "0.0.2"
+          },
+          {
+            "Version": "0.0.3"
+          },
+          {
+            "Version": "0.0.4"
+          },
+          {
+            "Version": "0.0.5"
+          },
+          {
+            "Version": "0.1.78"
+          },
+          {
+            "Version": "0.2.0"
+          },
+          {
+            "Version": "0.3.0"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.5.0"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.19.0"
+          },
+          {
+            "Version": "0.19.1"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.20.1"
+          },
+          {
+            "Version": "0.20.2"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.23.0"
+          },
+          {
+            "Version": "0.24.0"
+          },
+          {
+            "Version": "0.25.0"
+          },
+          {
+            "Version": "0.26.0"
+          },
+          {
+            "Version": "0.26.1"
+          },
+          {
+            "Version": "0.26.2"
+          },
+          {
+            "Version": "0.27.0"
+          },
+          {
+            "Version": "0.28.0"
+          },
+          {
+            "Version": "0.28.1"
+          },
+          {
+            "Version": "0.29.0-alpha"
+          },
+          {
+            "Version": "0.29.0-alpha2"
+          },
+          {
+            "Version": "0.29.0"
+          },
+          {
+            "Version": "0.29.1"
+          },
+          {
+            "Version": "0.30.0"
+          },
+          {
+            "Version": "0.31.0"
+          },
+          {
+            "Version": "0.31.1"
+          },
+          {
+            "Version": "0.31.2"
+          },
+          {
+            "Version": "0.32.0-owin"
+          },
+          {
+            "Version": "0.32.0-owin2"
+          },
+          {
+            "Version": "0.32.0"
+          },
+          {
+            "Version": "0.32.1"
+          },
+          {
+            "Version": "0.33.0-libuv"
+          },
+          {
+            "Version": "0.33.0-libuv1"
+          },
+          {
+            "Version": "0.33.0-libuv2"
+          },
+          {
+            "Version": "0.33.0"
+          },
+          {
+            "Version": "0.34.0-nsrefactor"
+          },
+          {
+            "Version": "0.34.0-nsrefactor1"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "2.0.0-alpha3"
+          },
+          {
+            "Version": "2.0.0-alpha4"
+          },
+          {
+            "Version": "2.0.0-alpha5"
+          },
+          {
+            "Version": "2.0.0-alpha6"
+          },
+          {
+            "Version": "2.0.0-alpha7"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0-rc2"
+          },
+          {
+            "Version": "2.0.0-rc3"
+          },
+          {
+            "Version": "2.0.0-rc4"
+          },
+          {
+            "Version": "2.0.0-rc5"
+          },
+          {
+            "Version": "2.0.0-rc6"
+          },
+          {
+            "Version": "2.0.0-rc7"
+          },
+          {
+            "Version": "2.0.0-rc8"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5-alpha"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Suave",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Suave/2.1.0",
+              "LicenseUrl": "https://github.com/SuaveIO/Suave/blob/master/COPYING",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.0.1",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.1.2",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Data.Common",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Security",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Claims",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:54.8962212+02:00",
+        "PackageName": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.fedora.24-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/runtime.fedora.24-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:17.1936658+02:00",
+        "PackageName": "System.Diagnostics.Process",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Process",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Process/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Registry",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:48.7450169+02:00",
+        "PackageName": "runtime.any.System.Text.Encoding.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Text.Encoding.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Text.Encoding.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:11.8621623+02:00",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:25.9341647+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:01.0118464+02:00",
+        "PackageName": "runtime.unix.Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.unix.Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.unix.Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:24.8061786+02:00",
+        "PackageName": "System.Net.Primitives",
+        "Versions": [
+          {
+            "Version": "3.9.0-beta-23019"
+          },
+          {
+            "Version": "3.9.0-beta-23109"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:50.5510179+02:00",
+        "PackageName": "runtime.aot.System.Reflection",
+        "Versions": [
+          {
+            "Version": "4.0.10-rc2-24027"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Reflection",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Reflection/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:03.9108132+02:00",
+        "PackageName": "runtime.win10-arm64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:42.2770177+02:00",
+        "PackageName": "System.Threading.Tasks.Parallel",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Tasks.Parallel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Tasks.Parallel/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:34.7621916+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:20.6216664+02:00",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:51.1610183+02:00",
+        "PackageName": "runtime.aot.System.Resources.ResourceManager",
+        "Versions": [
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Resources.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Resources.ResourceManager/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:57.9572814+02:00",
+        "PackageName": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.rhel.7-x64.runtime.native.System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.rhel.7-x64.runtime.native.System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:48.334529+02:00",
+        "PackageName": "runtime.any.System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.any.System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.any.System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:14.9781628+02:00",
+        "PackageName": "System.Collections",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:11:55.1683675+02:00",
+        "PackageName": "DotLiquid",
+        "Versions": [
+          {
+            "Version": "0.0.0"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.1.1.0"
+          },
+          {
+            "Version": "1.5.0.0"
+          },
+          {
+            "Version": "1.5.4.0"
+          },
+          {
+            "Version": "1.6.0.0"
+          },
+          {
+            "Version": "1.6.1.0"
+          },
+          {
+            "Version": "1.7.0-beta1"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.8.0-beta1"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "2.0.24"
+          },
+          {
+            "Version": "2.0.26"
+          },
+          {
+            "Version": "2.0.30"
+          },
+          {
+            "Version": "2.0.55"
+          },
+          {
+            "Version": "2.0.61"
+          },
+          {
+            "Version": "2.0.63"
+          },
+          {
+            "Version": "2.0.64"
+          },
+          {
+            "Version": "2.0.80"
+          },
+          {
+            "Version": "2.0.81"
+          },
+          {
+            "Version": "2.0.84",
+            "PackageDetails": {
+              "Name": "DotLiquid",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/DotLiquid/2.0.84",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:52.575723+02:00",
+        "PackageName": "runtime.aot.System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:12.5986603+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:56.7357227+02:00",
+        "PackageName": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security",
+        "Versions": [
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.opensuse.42.1-x64.runtime.native.System.Net.Security/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:37.9166929+02:00",
+        "PackageName": "System.Security.Cryptography.OpenSsl",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.OpenSsl",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.OpenSsl/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:22.8721651+02:00",
+        "PackageName": "System.Linq.Expressions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Linq.Expressions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Linq.Expressions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.ILGeneration",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Emit.Lightweight",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:03.0593707+02:00",
+        "PackageName": "FAKE",
+        "Versions": [
+          {
+            "Version": "1.46.1.0"
+          },
+          {
+            "Version": "1.46.2.0"
+          },
+          {
+            "Version": "1.48.0.0"
+          },
+          {
+            "Version": "1.50.0.0"
+          },
+          {
+            "Version": "1.50.1.0"
+          },
+          {
+            "Version": "1.50.2.0"
+          },
+          {
+            "Version": "1.50.3.0"
+          },
+          {
+            "Version": "1.50.4.0"
+          },
+          {
+            "Version": "1.52.0.0"
+          },
+          {
+            "Version": "1.52.1.0"
+          },
+          {
+            "Version": "1.52.5.0"
+          },
+          {
+            "Version": "1.52.6.0"
+          },
+          {
+            "Version": "1.54.0.0"
+          },
+          {
+            "Version": "1.54.1.0"
+          },
+          {
+            "Version": "1.54.2.0"
+          },
+          {
+            "Version": "1.54.3.0"
+          },
+          {
+            "Version": "1.56"
+          },
+          {
+            "Version": "1.56.2"
+          },
+          {
+            "Version": "1.56.3"
+          },
+          {
+            "Version": "1.56.4"
+          },
+          {
+            "Version": "1.56.5"
+          },
+          {
+            "Version": "1.56.6"
+          },
+          {
+            "Version": "1.56.7"
+          },
+          {
+            "Version": "1.56.9"
+          },
+          {
+            "Version": "1.56.10"
+          },
+          {
+            "Version": "1.56.12"
+          },
+          {
+            "Version": "1.58"
+          },
+          {
+            "Version": "1.58.2"
+          },
+          {
+            "Version": "1.58.3"
+          },
+          {
+            "Version": "1.58.5"
+          },
+          {
+            "Version": "1.58.6"
+          },
+          {
+            "Version": "1.58.7"
+          },
+          {
+            "Version": "1.58.8"
+          },
+          {
+            "Version": "1.58.9"
+          },
+          {
+            "Version": "1.58.10"
+          },
+          {
+            "Version": "1.58.11"
+          },
+          {
+            "Version": "1.58.14"
+          },
+          {
+            "Version": "1.60"
+          },
+          {
+            "Version": "1.62"
+          },
+          {
+            "Version": "1.62.1"
+          },
+          {
+            "Version": "1.62.2"
+          },
+          {
+            "Version": "1.62.4"
+          },
+          {
+            "Version": "1.62.5"
+          },
+          {
+            "Version": "1.64"
+          },
+          {
+            "Version": "1.64.1"
+          },
+          {
+            "Version": "1.64.2"
+          },
+          {
+            "Version": "1.64.3"
+          },
+          {
+            "Version": "1.64.4"
+          },
+          {
+            "Version": "1.64.5"
+          },
+          {
+            "Version": "1.64.6"
+          },
+          {
+            "Version": "1.64.7"
+          },
+          {
+            "Version": "1.64.8"
+          },
+          {
+            "Version": "1.64.9"
+          },
+          {
+            "Version": "1.64.10"
+          },
+          {
+            "Version": "1.64.11"
+          },
+          {
+            "Version": "1.64.14"
+          },
+          {
+            "Version": "1.64.15"
+          },
+          {
+            "Version": "1.64.16.0"
+          },
+          {
+            "Version": "1.64.17.0"
+          },
+          {
+            "Version": "1.64.18.0"
+          },
+          {
+            "Version": "1.64.19.0"
+          },
+          {
+            "Version": "1.66.0.0"
+          },
+          {
+            "Version": "1.66.1.0"
+          },
+          {
+            "Version": "1.66.2.0"
+          },
+          {
+            "Version": "1.68.1.0"
+          },
+          {
+            "Version": "1.68.5.0"
+          },
+          {
+            "Version": "1.68.6.0"
+          },
+          {
+            "Version": "1.70.0.0"
+          },
+          {
+            "Version": "1.70.1.0"
+          },
+          {
+            "Version": "1.70.2.0"
+          },
+          {
+            "Version": "1.70.3.0"
+          },
+          {
+            "Version": "1.70.6.0"
+          },
+          {
+            "Version": "1.70.8.0"
+          },
+          {
+            "Version": "1.70.9.0"
+          },
+          {
+            "Version": "1.70.10.0"
+          },
+          {
+            "Version": "1.70.11.0"
+          },
+          {
+            "Version": "1.70.13.0"
+          },
+          {
+            "Version": "1.70.16.0"
+          },
+          {
+            "Version": "1.70.17.0"
+          },
+          {
+            "Version": "1.70.18.0"
+          },
+          {
+            "Version": "1.70.20.0"
+          },
+          {
+            "Version": "1.70.21.0"
+          },
+          {
+            "Version": "1.70.22.0"
+          },
+          {
+            "Version": "1.70.24.0"
+          },
+          {
+            "Version": "1.70.25.0"
+          },
+          {
+            "Version": "1.70.29.0"
+          },
+          {
+            "Version": "1.70.32.0"
+          },
+          {
+            "Version": "1.72.33.0"
+          },
+          {
+            "Version": "1.74.0.0"
+          },
+          {
+            "Version": "1.74.1.0"
+          },
+          {
+            "Version": "1.74.2.0"
+          },
+          {
+            "Version": "1.74.4.0"
+          },
+          {
+            "Version": "1.74.6.0"
+          },
+          {
+            "Version": "1.74.8.0"
+          },
+          {
+            "Version": "1.74.9.0"
+          },
+          {
+            "Version": "1.74.10.0"
+          },
+          {
+            "Version": "1.74.13.0"
+          },
+          {
+            "Version": "1.74.14.0"
+          },
+          {
+            "Version": "1.74.15.0"
+          },
+          {
+            "Version": "1.74.16.0"
+          },
+          {
+            "Version": "1.74.17.0"
+          },
+          {
+            "Version": "1.74.18.0"
+          },
+          {
+            "Version": "1.74.19.0"
+          },
+          {
+            "Version": "1.74.20.0"
+          },
+          {
+            "Version": "1.74.21.0"
+          },
+          {
+            "Version": "1.74.22.0"
+          },
+          {
+            "Version": "1.74.24.0"
+          },
+          {
+            "Version": "1.74.25.0"
+          },
+          {
+            "Version": "1.74.26.0"
+          },
+          {
+            "Version": "1.74.27.0"
+          },
+          {
+            "Version": "1.74.28.0"
+          },
+          {
+            "Version": "1.74.29.0"
+          },
+          {
+            "Version": "1.74.30.0"
+          },
+          {
+            "Version": "1.74.31.0"
+          },
+          {
+            "Version": "1.74.32.0"
+          },
+          {
+            "Version": "1.74.33.0"
+          },
+          {
+            "Version": "1.74.34.0"
+          },
+          {
+            "Version": "1.74.35.0"
+          },
+          {
+            "Version": "1.74.39.0"
+          },
+          {
+            "Version": "1.74.40.0"
+          },
+          {
+            "Version": "1.74.41.0"
+          },
+          {
+            "Version": "1.74.42.0"
+          },
+          {
+            "Version": "1.74.43.0"
+          },
+          {
+            "Version": "1.74.44.0"
+          },
+          {
+            "Version": "1.74.48.0"
+          },
+          {
+            "Version": "1.74.49.0"
+          },
+          {
+            "Version": "1.74.50.0"
+          },
+          {
+            "Version": "1.74.51.0"
+          },
+          {
+            "Version": "1.74.55.0"
+          },
+          {
+            "Version": "1.74.56.0"
+          },
+          {
+            "Version": "1.74.57.0"
+          },
+          {
+            "Version": "1.74.60.0"
+          },
+          {
+            "Version": "1.74.61.0"
+          },
+          {
+            "Version": "1.74.62.0"
+          },
+          {
+            "Version": "1.74.63.0"
+          },
+          {
+            "Version": "1.74.65.0"
+          },
+          {
+            "Version": "1.74.74.0"
+          },
+          {
+            "Version": "1.74.75.0"
+          },
+          {
+            "Version": "1.74.77.0"
+          },
+          {
+            "Version": "1.74.78.0"
+          },
+          {
+            "Version": "1.74.79.0"
+          },
+          {
+            "Version": "1.74.81.0"
+          },
+          {
+            "Version": "1.74.82.0"
+          },
+          {
+            "Version": "1.74.84.0"
+          },
+          {
+            "Version": "1.74.85.0"
+          },
+          {
+            "Version": "1.74.86.0"
+          },
+          {
+            "Version": "1.74.87.0"
+          },
+          {
+            "Version": "1.74.88.0"
+          },
+          {
+            "Version": "1.74.92.0"
+          },
+          {
+            "Version": "1.74.98.0"
+          },
+          {
+            "Version": "1.74.99.0"
+          },
+          {
+            "Version": "1.74.100.0"
+          },
+          {
+            "Version": "1.74.101.0"
+          },
+          {
+            "Version": "1.74.102.0"
+          },
+          {
+            "Version": "1.74.103.0"
+          },
+          {
+            "Version": "1.74.104.0"
+          },
+          {
+            "Version": "1.74.105.0"
+          },
+          {
+            "Version": "1.74.106.0"
+          },
+          {
+            "Version": "1.74.107.0"
+          },
+          {
+            "Version": "1.74.108.0"
+          },
+          {
+            "Version": "1.74.109.0"
+          },
+          {
+            "Version": "1.74.110.0"
+          },
+          {
+            "Version": "1.74.111.0"
+          },
+          {
+            "Version": "1.74.113.0"
+          },
+          {
+            "Version": "1.74.114.0"
+          },
+          {
+            "Version": "1.74.118.0"
+          },
+          {
+            "Version": "1.74.119.0"
+          },
+          {
+            "Version": "1.74.121.0"
+          },
+          {
+            "Version": "1.74.123.0"
+          },
+          {
+            "Version": "1.74.124.0"
+          },
+          {
+            "Version": "1.74.125.0"
+          },
+          {
+            "Version": "1.74.126.0"
+          },
+          {
+            "Version": "1.74.127.0"
+          },
+          {
+            "Version": "1.74.128.0"
+          },
+          {
+            "Version": "1.74.129.0"
+          },
+          {
+            "Version": "1.74.130.0"
+          },
+          {
+            "Version": "1.74.131.0"
+          },
+          {
+            "Version": "1.74.132.0"
+          },
+          {
+            "Version": "1.74.133.0"
+          },
+          {
+            "Version": "1.74.134.0"
+          },
+          {
+            "Version": "1.74.135.0"
+          },
+          {
+            "Version": "1.74.136.0"
+          },
+          {
+            "Version": "1.74.137.0"
+          },
+          {
+            "Version": "1.74.139.0"
+          },
+          {
+            "Version": "1.74.140.0"
+          },
+          {
+            "Version": "1.74.141.0"
+          },
+          {
+            "Version": "1.74.142.0"
+          },
+          {
+            "Version": "1.74.143.0"
+          },
+          {
+            "Version": "1.74.144.0"
+          },
+          {
+            "Version": "1.74.145.0"
+          },
+          {
+            "Version": "1.74.146.0"
+          },
+          {
+            "Version": "1.74.147.0"
+          },
+          {
+            "Version": "1.74.148.0"
+          },
+          {
+            "Version": "1.74.149.0"
+          },
+          {
+            "Version": "1.74.150.0"
+          },
+          {
+            "Version": "1.74.152.0"
+          },
+          {
+            "Version": "1.74.153.0"
+          },
+          {
+            "Version": "1.74.154.0"
+          },
+          {
+            "Version": "1.74.155.0"
+          },
+          {
+            "Version": "1.74.156.0"
+          },
+          {
+            "Version": "1.74.160.0"
+          },
+          {
+            "Version": "1.74.161.0"
+          },
+          {
+            "Version": "1.74.162.0"
+          },
+          {
+            "Version": "1.74.163.0"
+          },
+          {
+            "Version": "1.74.164.0"
+          },
+          {
+            "Version": "1.74.166.0"
+          },
+          {
+            "Version": "1.74.167.0"
+          },
+          {
+            "Version": "1.74.172.0"
+          },
+          {
+            "Version": "1.74.173.0"
+          },
+          {
+            "Version": "1.74.174.0"
+          },
+          {
+            "Version": "1.74.175.0"
+          },
+          {
+            "Version": "1.74.176.0"
+          },
+          {
+            "Version": "1.74.180.0"
+          },
+          {
+            "Version": "1.74.181.0"
+          },
+          {
+            "Version": "1.74.183.0"
+          },
+          {
+            "Version": "1.74.184.0"
+          },
+          {
+            "Version": "1.74.185.0"
+          },
+          {
+            "Version": "1.74.186.0"
+          },
+          {
+            "Version": "1.74.187.0"
+          },
+          {
+            "Version": "1.74.188.0"
+          },
+          {
+            "Version": "1.74.189.0"
+          },
+          {
+            "Version": "1.74.190.0"
+          },
+          {
+            "Version": "1.74.192.0"
+          },
+          {
+            "Version": "1.74.193.0"
+          },
+          {
+            "Version": "1.74.195.0"
+          },
+          {
+            "Version": "1.74.196.0"
+          },
+          {
+            "Version": "1.74.197.0"
+          },
+          {
+            "Version": "1.74.198.0"
+          },
+          {
+            "Version": "1.74.199.0"
+          },
+          {
+            "Version": "1.74.200.0"
+          },
+          {
+            "Version": "1.74.205.0"
+          },
+          {
+            "Version": "1.74.206.0"
+          },
+          {
+            "Version": "1.74.207.0"
+          },
+          {
+            "Version": "1.74.208.0"
+          },
+          {
+            "Version": "1.74.209.0"
+          },
+          {
+            "Version": "1.74.210.0"
+          },
+          {
+            "Version": "1.74.211.0"
+          },
+          {
+            "Version": "1.74.212.0"
+          },
+          {
+            "Version": "1.74.213.0"
+          },
+          {
+            "Version": "1.74.214.0"
+          },
+          {
+            "Version": "1.74.215.0"
+          },
+          {
+            "Version": "1.74.216.0"
+          },
+          {
+            "Version": "1.74.217.0"
+          },
+          {
+            "Version": "1.74.218.0"
+          },
+          {
+            "Version": "1.74.219.0"
+          },
+          {
+            "Version": "1.74.220.0"
+          },
+          {
+            "Version": "1.74.221.0"
+          },
+          {
+            "Version": "1.74.222.0"
+          },
+          {
+            "Version": "1.74.223.0"
+          },
+          {
+            "Version": "1.74.224.0"
+          },
+          {
+            "Version": "1.74.225.0"
+          },
+          {
+            "Version": "1.74.231.0"
+          },
+          {
+            "Version": "1.74.237.0"
+          },
+          {
+            "Version": "1.74.238.0"
+          },
+          {
+            "Version": "1.74.239.0"
+          },
+          {
+            "Version": "1.74.241.0"
+          },
+          {
+            "Version": "1.74.243.0"
+          },
+          {
+            "Version": "1.74.244.0"
+          },
+          {
+            "Version": "1.74.245.0"
+          },
+          {
+            "Version": "1.74.246.0"
+          },
+          {
+            "Version": "1.74.247.0"
+          },
+          {
+            "Version": "1.74.248.0"
+          },
+          {
+            "Version": "1.74.249.0"
+          },
+          {
+            "Version": "1.74.250.0"
+          },
+          {
+            "Version": "1.74.251.0"
+          },
+          {
+            "Version": "1.74.252.0"
+          },
+          {
+            "Version": "1.74.253.0"
+          },
+          {
+            "Version": "1.74.254.0"
+          },
+          {
+            "Version": "1.74.255.0"
+          },
+          {
+            "Version": "1.74.256.0"
+          },
+          {
+            "Version": "1.74.257.0"
+          },
+          {
+            "Version": "1.74.262.0"
+          },
+          {
+            "Version": "1.74.263.0"
+          },
+          {
+            "Version": "1.74.264.0"
+          },
+          {
+            "Version": "1.74.265.0"
+          },
+          {
+            "Version": "1.74.266.0"
+          },
+          {
+            "Version": "1.74.267.0"
+          },
+          {
+            "Version": "1.74.268.0"
+          },
+          {
+            "Version": "1.74.269.0"
+          },
+          {
+            "Version": "1.74.270.0"
+          },
+          {
+            "Version": "1.74.271.0"
+          },
+          {
+            "Version": "1.74.272.0"
+          },
+          {
+            "Version": "1.74.273.0"
+          },
+          {
+            "Version": "1.74.275.0"
+          },
+          {
+            "Version": "1.74.277.0"
+          },
+          {
+            "Version": "1.74.278.0"
+          },
+          {
+            "Version": "1.74.279.0"
+          },
+          {
+            "Version": "1.74.280.0"
+          },
+          {
+            "Version": "1.74.282.0"
+          },
+          {
+            "Version": "1.74.283.0"
+          },
+          {
+            "Version": "1.74.284.0"
+          },
+          {
+            "Version": "1.74.285.0"
+          },
+          {
+            "Version": "1.74.286.0"
+          },
+          {
+            "Version": "1.74.287.0"
+          },
+          {
+            "Version": "1.74.290.0"
+          },
+          {
+            "Version": "2.0.1-alpha2"
+          },
+          {
+            "Version": "2.0.1-alpha3"
+          },
+          {
+            "Version": "2.0.1-alpha4"
+          },
+          {
+            "Version": "2.0.48.0-alpha"
+          },
+          {
+            "Version": "2.0.55.0-alpha"
+          },
+          {
+            "Version": "2.0.60.0-alpha"
+          },
+          {
+            "Version": "2.0.61.0-alpha"
+          },
+          {
+            "Version": "2.0.62.0-alpha"
+          },
+          {
+            "Version": "2.0.64.0-alpha"
+          },
+          {
+            "Version": "2.0.65.0-alpha"
+          },
+          {
+            "Version": "2.0.66.0-alpha"
+          },
+          {
+            "Version": "2.0.68.0-alpha"
+          },
+          {
+            "Version": "2.0.69.0-alpha"
+          },
+          {
+            "Version": "2.0.70.0-alpha"
+          },
+          {
+            "Version": "2.0.73.0-alpha"
+          },
+          {
+            "Version": "2.0.74.0-alpha"
+          },
+          {
+            "Version": "2.0.75.0-alpha"
+          },
+          {
+            "Version": "2.0.76.0-alpha"
+          },
+          {
+            "Version": "2.0.77.0-alpha"
+          },
+          {
+            "Version": "2.0.78.0-alpha"
+          },
+          {
+            "Version": "2.0.79.0-alpha"
+          },
+          {
+            "Version": "2.0.80.0-alpha"
+          },
+          {
+            "Version": "2.0.81.0-alpha"
+          },
+          {
+            "Version": "2.0.83.0-alpha"
+          },
+          {
+            "Version": "2.0.84.0-alpha"
+          },
+          {
+            "Version": "2.0.85.0-alpha"
+          },
+          {
+            "Version": "2.0.86.0-alpha"
+          },
+          {
+            "Version": "2.0.87.0-alpha"
+          },
+          {
+            "Version": "2.0.90.0-alpha"
+          },
+          {
+            "Version": "2.0.91.0-alpha"
+          },
+          {
+            "Version": "2.0.94.0-alpha"
+          },
+          {
+            "Version": "2.0.95.0-alpha"
+          },
+          {
+            "Version": "2.0.96.0-alpha"
+          },
+          {
+            "Version": "2.0.97.0-alpha"
+          },
+          {
+            "Version": "2.0.98.0-alpha"
+          },
+          {
+            "Version": "2.0.99.0-alpha"
+          },
+          {
+            "Version": "2.1-alpha10"
+          },
+          {
+            "Version": "2.1-alpha13"
+          },
+          {
+            "Version": "2.1-alpha15"
+          },
+          {
+            "Version": "2.1-alpha16"
+          },
+          {
+            "Version": "2.1-alpha17"
+          },
+          {
+            "Version": "2.1-alpha18"
+          },
+          {
+            "Version": "2.1-alpha20"
+          },
+          {
+            "Version": "2.1-alpha22"
+          },
+          {
+            "Version": "2.1-alpha23"
+          },
+          {
+            "Version": "2.1-alpha24"
+          },
+          {
+            "Version": "2.1-alpha5"
+          },
+          {
+            "Version": "2.1-alpha6"
+          },
+          {
+            "Version": "2.1-alpha7"
+          },
+          {
+            "Version": "2.1.1-alpha"
+          },
+          {
+            "Version": "2.1.27-alpha"
+          },
+          {
+            "Version": "2.1.28-alpha"
+          },
+          {
+            "Version": "2.1.29-alpha"
+          },
+          {
+            "Version": "2.1.30-alpha"
+          },
+          {
+            "Version": "2.1.33-alpha"
+          },
+          {
+            "Version": "2.1.35-alpha"
+          },
+          {
+            "Version": "2.1.37-alpha"
+          },
+          {
+            "Version": "2.1.39-alpha"
+          },
+          {
+            "Version": "2.1.41-alpha"
+          },
+          {
+            "Version": "2.1.42-alpha"
+          },
+          {
+            "Version": "2.1.43-alpha"
+          },
+          {
+            "Version": "2.1.46-alpha"
+          },
+          {
+            "Version": "2.1.47-alpha"
+          },
+          {
+            "Version": "2.1.48-alpha"
+          },
+          {
+            "Version": "2.1.50-alpha"
+          },
+          {
+            "Version": "2.1.51-alpha"
+          },
+          {
+            "Version": "2.1.53-alpha"
+          },
+          {
+            "Version": "2.1.58-alpha"
+          },
+          {
+            "Version": "2.1.68-alpha"
+          },
+          {
+            "Version": "2.1.71-alpha"
+          },
+          {
+            "Version": "2.1.72-alpha"
+          },
+          {
+            "Version": "2.1.75-alpha"
+          },
+          {
+            "Version": "2.1.81-alpha"
+          },
+          {
+            "Version": "2.1.83-alpha"
+          },
+          {
+            "Version": "2.1.84-alpha"
+          },
+          {
+            "Version": "2.1.85-alpha"
+          },
+          {
+            "Version": "2.1.86-alpha"
+          },
+          {
+            "Version": "2.1.91-alpha"
+          },
+          {
+            "Version": "2.1.95-alpha"
+          },
+          {
+            "Version": "2.1.97-alpha"
+          },
+          {
+            "Version": "2.1.111-alpha"
+          },
+          {
+            "Version": "2.1.113-alpha"
+          },
+          {
+            "Version": "2.1.118-alpha"
+          },
+          {
+            "Version": "2.1.119-alpha"
+          },
+          {
+            "Version": "2.1.121-alpha"
+          },
+          {
+            "Version": "2.1.123-alpha"
+          },
+          {
+            "Version": "2.1.124-alpha"
+          },
+          {
+            "Version": "2.1.126-alpha"
+          },
+          {
+            "Version": "2.1.128-alpha"
+          },
+          {
+            "Version": "2.1.129-alpha"
+          },
+          {
+            "Version": "2.1.132-alpha"
+          },
+          {
+            "Version": "2.1.133-alpha"
+          },
+          {
+            "Version": "2.1.134-alpha"
+          },
+          {
+            "Version": "2.1.137-alpha"
+          },
+          {
+            "Version": "2.1.138-alpha"
+          },
+          {
+            "Version": "2.1.141-alpha"
+          },
+          {
+            "Version": "2.1.142-alpha"
+          },
+          {
+            "Version": "2.1.144-alpha"
+          },
+          {
+            "Version": "2.1.145-alpha"
+          },
+          {
+            "Version": "2.1.147-alpha"
+          },
+          {
+            "Version": "2.1.148-alpha"
+          },
+          {
+            "Version": "2.1.149-alpha"
+          },
+          {
+            "Version": "2.1.150-alpha"
+          },
+          {
+            "Version": "2.1.151-alpha"
+          },
+          {
+            "Version": "2.1.152-alpha"
+          },
+          {
+            "Version": "2.1.154-alpha"
+          },
+          {
+            "Version": "2.1.155-alpha"
+          },
+          {
+            "Version": "2.1.156-alpha"
+          },
+          {
+            "Version": "2.1.158-alpha"
+          },
+          {
+            "Version": "2.1.159-alpha"
+          },
+          {
+            "Version": "2.1.160-alpha"
+          },
+          {
+            "Version": "2.1.161-alpha"
+          },
+          {
+            "Version": "2.1.162-alpha"
+          },
+          {
+            "Version": "2.1.164-alpha"
+          },
+          {
+            "Version": "2.1.166-alpha"
+          },
+          {
+            "Version": "2.1.167-alpha"
+          },
+          {
+            "Version": "2.1.168-alpha"
+          },
+          {
+            "Version": "2.1.170-alpha"
+          },
+          {
+            "Version": "2.1.171-alpha"
+          },
+          {
+            "Version": "2.1.172-alpha"
+          },
+          {
+            "Version": "2.1.173-alpha"
+          },
+          {
+            "Version": "2.1.174-alpha"
+          },
+          {
+            "Version": "2.1.175-alpha"
+          },
+          {
+            "Version": "2.1.176-alpha"
+          },
+          {
+            "Version": "2.1.178-alpha"
+          },
+          {
+            "Version": "2.1.179-alpha"
+          },
+          {
+            "Version": "2.1.180-alpha"
+          },
+          {
+            "Version": "2.1.182-alpha"
+          },
+          {
+            "Version": "2.1.183-alpha"
+          },
+          {
+            "Version": "2.1.184-alpha"
+          },
+          {
+            "Version": "2.1.185-alpha"
+          },
+          {
+            "Version": "2.1.186-alpha"
+          },
+          {
+            "Version": "2.1.187-alpha"
+          },
+          {
+            "Version": "2.1.192-alpha"
+          },
+          {
+            "Version": "2.1.194-alpha"
+          },
+          {
+            "Version": "2.1.196-alpha"
+          },
+          {
+            "Version": "2.1.199-alpha"
+          },
+          {
+            "Version": "2.1.200-alpha"
+          },
+          {
+            "Version": "2.1.201-alpha"
+          },
+          {
+            "Version": "2.1.204-alpha"
+          },
+          {
+            "Version": "2.1.205-alpha"
+          },
+          {
+            "Version": "2.1.207-alpha"
+          },
+          {
+            "Version": "2.1.208-alpha"
+          },
+          {
+            "Version": "2.1.209-alpha"
+          },
+          {
+            "Version": "2.1.210-alpha"
+          },
+          {
+            "Version": "2.1.211-alpha"
+          },
+          {
+            "Version": "2.1.212-alpha"
+          },
+          {
+            "Version": "2.1.213-alpha"
+          },
+          {
+            "Version": "2.1.215-alpha"
+          },
+          {
+            "Version": "2.1.216-alpha"
+          },
+          {
+            "Version": "2.1.217-alpha"
+          },
+          {
+            "Version": "2.1.218-alpha"
+          },
+          {
+            "Version": "2.1.219-alpha"
+          },
+          {
+            "Version": "2.1.220-alpha"
+          },
+          {
+            "Version": "2.1.222-alpha"
+          },
+          {
+            "Version": "2.1.223-alpha"
+          },
+          {
+            "Version": "2.1.225-alpha"
+          },
+          {
+            "Version": "2.1.226-alpha"
+          },
+          {
+            "Version": "2.1.227-alpha"
+          },
+          {
+            "Version": "2.1.228-alpha"
+          },
+          {
+            "Version": "2.1.230-alpha"
+          },
+          {
+            "Version": "2.1.234-alpha"
+          },
+          {
+            "Version": "2.1.235-alpha"
+          },
+          {
+            "Version": "2.1.236-alpha"
+          },
+          {
+            "Version": "2.1.237-alpha"
+          },
+          {
+            "Version": "2.1.239-alpha"
+          },
+          {
+            "Version": "2.1.240-alpha"
+          },
+          {
+            "Version": "2.1.241-alpha"
+          },
+          {
+            "Version": "2.1.242-alpha"
+          },
+          {
+            "Version": "2.1.243-alpha"
+          },
+          {
+            "Version": "2.1.245-alpha"
+          },
+          {
+            "Version": "2.1.246-alpha"
+          },
+          {
+            "Version": "2.1.247-alpha"
+          },
+          {
+            "Version": "2.1.248-alpha"
+          },
+          {
+            "Version": "2.1.249-alpha"
+          },
+          {
+            "Version": "2.1.251-alpha"
+          },
+          {
+            "Version": "2.1.253-alpha"
+          },
+          {
+            "Version": "2.1.255-alpha"
+          },
+          {
+            "Version": "2.1.256-alpha"
+          },
+          {
+            "Version": "2.1.264-alpha"
+          },
+          {
+            "Version": "2.1.271-alpha"
+          },
+          {
+            "Version": "2.1.272-alpha"
+          },
+          {
+            "Version": "2.1.273-alpha"
+          },
+          {
+            "Version": "2.1.274-alpha"
+          },
+          {
+            "Version": "2.1.275-alpha"
+          },
+          {
+            "Version": "2.1.276-alpha"
+          },
+          {
+            "Version": "2.1.277-alpha"
+          },
+          {
+            "Version": "2.1.279-alpha"
+          },
+          {
+            "Version": "2.1.280-alpha"
+          },
+          {
+            "Version": "2.1.288-alpha"
+          },
+          {
+            "Version": "2.1.289-alpha"
+          },
+          {
+            "Version": "2.1.290-alpha"
+          },
+          {
+            "Version": "2.1.291-alpha"
+          },
+          {
+            "Version": "2.1.292-alpha"
+          },
+          {
+            "Version": "2.1.293-alpha"
+          },
+          {
+            "Version": "2.1.294-alpha"
+          },
+          {
+            "Version": "2.1.295-alpha"
+          },
+          {
+            "Version": "2.1.297-alpha"
+          },
+          {
+            "Version": "2.1.298-alpha"
+          },
+          {
+            "Version": "2.1.299-alpha"
+          },
+          {
+            "Version": "2.1.300-alpha"
+          },
+          {
+            "Version": "2.1.301-alpha"
+          },
+          {
+            "Version": "2.1.302-alpha"
+          },
+          {
+            "Version": "2.1.303-alpha"
+          },
+          {
+            "Version": "2.1.304-alpha"
+          },
+          {
+            "Version": "2.1.305-alpha"
+          },
+          {
+            "Version": "2.1.306-alpha"
+          },
+          {
+            "Version": "2.1.307-alpha"
+          },
+          {
+            "Version": "2.1.308-alpha"
+          },
+          {
+            "Version": "2.1.309-alpha"
+          },
+          {
+            "Version": "2.1.313-alpha"
+          },
+          {
+            "Version": "2.1.314-alpha"
+          },
+          {
+            "Version": "2.1.316-alpha"
+          },
+          {
+            "Version": "2.1.318-alpha"
+          },
+          {
+            "Version": "2.1.319-alpha"
+          },
+          {
+            "Version": "2.1.320-alpha"
+          },
+          {
+            "Version": "2.1.321-alpha"
+          },
+          {
+            "Version": "2.1.322-alpha"
+          },
+          {
+            "Version": "2.1.323-alpha"
+          },
+          {
+            "Version": "2.1.324-alpha"
+          },
+          {
+            "Version": "2.1.325-alpha"
+          },
+          {
+            "Version": "2.1.326-alpha"
+          },
+          {
+            "Version": "2.1.327-alpha"
+          },
+          {
+            "Version": "2.1.328-alpha"
+          },
+          {
+            "Version": "2.1.330-alpha"
+          },
+          {
+            "Version": "2.1.332-alpha"
+          },
+          {
+            "Version": "2.1.334-alpha"
+          },
+          {
+            "Version": "2.1.336-alpha"
+          },
+          {
+            "Version": "2.1.337-alpha"
+          },
+          {
+            "Version": "2.1.338-alpha"
+          },
+          {
+            "Version": "2.1.339-alpha"
+          },
+          {
+            "Version": "2.1.340-alpha"
+          },
+          {
+            "Version": "2.1.341-alpha"
+          },
+          {
+            "Version": "2.1.342-alpha"
+          },
+          {
+            "Version": "2.1.343-alpha"
+          },
+          {
+            "Version": "2.1.344-alpha"
+          },
+          {
+            "Version": "2.1.347-alpha"
+          },
+          {
+            "Version": "2.1.351-alpha"
+          },
+          {
+            "Version": "2.1.352-alpha"
+          },
+          {
+            "Version": "2.1.353-alpha"
+          },
+          {
+            "Version": "2.1.354-alpha"
+          },
+          {
+            "Version": "2.1.355-alpha"
+          },
+          {
+            "Version": "2.1.356-alpha"
+          },
+          {
+            "Version": "2.1.357-alpha"
+          },
+          {
+            "Version": "2.1.358-alpha"
+          },
+          {
+            "Version": "2.1.359-alpha"
+          },
+          {
+            "Version": "2.1.360-alpha"
+          },
+          {
+            "Version": "2.1.361-alpha"
+          },
+          {
+            "Version": "2.1.362-alpha"
+          },
+          {
+            "Version": "2.1.363-alpha"
+          },
+          {
+            "Version": "2.1.364-alpha"
+          },
+          {
+            "Version": "2.1.365-alpha"
+          },
+          {
+            "Version": "2.1.366-alpha"
+          },
+          {
+            "Version": "2.1.367-alpha"
+          },
+          {
+            "Version": "2.1.368-alpha"
+          },
+          {
+            "Version": "2.1.369-alpha"
+          },
+          {
+            "Version": "2.1.371-alpha"
+          },
+          {
+            "Version": "2.1.372-alpha"
+          },
+          {
+            "Version": "2.1.373-alpha"
+          },
+          {
+            "Version": "2.1.374-alpha"
+          },
+          {
+            "Version": "2.1.375-alpha"
+          },
+          {
+            "Version": "2.1.376-alpha"
+          },
+          {
+            "Version": "2.1.378-alpha"
+          },
+          {
+            "Version": "2.1.379-alpha"
+          },
+          {
+            "Version": "2.1.380-alpha"
+          },
+          {
+            "Version": "2.1.381-alpha"
+          },
+          {
+            "Version": "2.1.382-alpha"
+          },
+          {
+            "Version": "2.1.383-alpha"
+          },
+          {
+            "Version": "2.1.384-alpha"
+          },
+          {
+            "Version": "2.1.385-alpha"
+          },
+          {
+            "Version": "2.1.386-alpha"
+          },
+          {
+            "Version": "2.1.387-alpha"
+          },
+          {
+            "Version": "2.1.388-alpha"
+          },
+          {
+            "Version": "2.1.389-alpha"
+          },
+          {
+            "Version": "2.1.390-alpha"
+          },
+          {
+            "Version": "2.1.391-alpha"
+          },
+          {
+            "Version": "2.1.392-alpha"
+          },
+          {
+            "Version": "2.1.393-alpha"
+          },
+          {
+            "Version": "2.1.394-alpha"
+          },
+          {
+            "Version": "2.1.395-alpha"
+          },
+          {
+            "Version": "2.1.396-alpha"
+          },
+          {
+            "Version": "2.1.397-alpha"
+          },
+          {
+            "Version": "2.1.398-alpha"
+          },
+          {
+            "Version": "2.1.399-alpha"
+          },
+          {
+            "Version": "2.1.400-alpha"
+          },
+          {
+            "Version": "2.1.401-alpha"
+          },
+          {
+            "Version": "2.1.402-alpha"
+          },
+          {
+            "Version": "2.1.403-alpha"
+          },
+          {
+            "Version": "2.1.404-alpha"
+          },
+          {
+            "Version": "2.1.405-alpha"
+          },
+          {
+            "Version": "2.1.406-alpha"
+          },
+          {
+            "Version": "2.1.407-alpha"
+          },
+          {
+            "Version": "2.1.408-alpha"
+          },
+          {
+            "Version": "2.1.409-alpha"
+          },
+          {
+            "Version": "2.1.410-alpha"
+          },
+          {
+            "Version": "2.1.411-alpha"
+          },
+          {
+            "Version": "2.1.412-alpha"
+          },
+          {
+            "Version": "2.1.413-alpha"
+          },
+          {
+            "Version": "2.1.414-alpha"
+          },
+          {
+            "Version": "2.1.415-alpha"
+          },
+          {
+            "Version": "2.1.416-alpha"
+          },
+          {
+            "Version": "2.1.417-alpha"
+          },
+          {
+            "Version": "2.1.418-alpha"
+          },
+          {
+            "Version": "2.1.419-alpha"
+          },
+          {
+            "Version": "2.1.420-alpha"
+          },
+          {
+            "Version": "2.1.421-alpha"
+          },
+          {
+            "Version": "2.1.422-alpha"
+          },
+          {
+            "Version": "2.1.423-alpha"
+          },
+          {
+            "Version": "2.1.424-alpha"
+          },
+          {
+            "Version": "2.1.426-alpha"
+          },
+          {
+            "Version": "2.1.427-alpha"
+          },
+          {
+            "Version": "2.1.428-alpha"
+          },
+          {
+            "Version": "2.1.429-alpha"
+          },
+          {
+            "Version": "2.1.430-alpha"
+          },
+          {
+            "Version": "2.1.431-alpha"
+          },
+          {
+            "Version": "2.1.432-alpha"
+          },
+          {
+            "Version": "2.1.434-alpha"
+          },
+          {
+            "Version": "2.1.435-alpha"
+          },
+          {
+            "Version": "2.1.436-alpha"
+          },
+          {
+            "Version": "2.1.437-alpha"
+          },
+          {
+            "Version": "2.1.438-alpha"
+          },
+          {
+            "Version": "2.1.439-alpha"
+          },
+          {
+            "Version": "2.1.440-alpha"
+          },
+          {
+            "Version": "2.1.441-alpha"
+          },
+          {
+            "Version": "2.1.442-alpha"
+          },
+          {
+            "Version": "2.1.443-alpha"
+          },
+          {
+            "Version": "2.1.445-alpha"
+          },
+          {
+            "Version": "2.1.449-alpha"
+          },
+          {
+            "Version": "2.1.461-alpha"
+          },
+          {
+            "Version": "2.1.465-alpha"
+          },
+          {
+            "Version": "2.1.468-alpha"
+          },
+          {
+            "Version": "2.1.469-alpha"
+          },
+          {
+            "Version": "2.1.470-alpha"
+          },
+          {
+            "Version": "2.1.471-alpha"
+          },
+          {
+            "Version": "2.1.472-alpha"
+          },
+          {
+            "Version": "2.1.473-alpha"
+          },
+          {
+            "Version": "2.1.474-alpha"
+          },
+          {
+            "Version": "2.1.475-alpha"
+          },
+          {
+            "Version": "2.1.476-alpha"
+          },
+          {
+            "Version": "2.1.478-alpha"
+          },
+          {
+            "Version": "2.1.479-alpha"
+          },
+          {
+            "Version": "2.1.480-alpha"
+          },
+          {
+            "Version": "2.1.481-alpha"
+          },
+          {
+            "Version": "2.1.482-alpha"
+          },
+          {
+            "Version": "2.1.483-alpha"
+          },
+          {
+            "Version": "2.1.485-alpha"
+          },
+          {
+            "Version": "2.1.486-alpha"
+          },
+          {
+            "Version": "2.1.487-alpha"
+          },
+          {
+            "Version": "2.1.488-alpha"
+          },
+          {
+            "Version": "2.1.489-alpha"
+          },
+          {
+            "Version": "2.1.490-alpha"
+          },
+          {
+            "Version": "2.1.491-alpha"
+          },
+          {
+            "Version": "2.1.492-alpha"
+          },
+          {
+            "Version": "2.1.493-alpha"
+          },
+          {
+            "Version": "2.1.494-alpha"
+          },
+          {
+            "Version": "2.1.495-alpha"
+          },
+          {
+            "Version": "2.1.496-alpha"
+          },
+          {
+            "Version": "2.1.497-alpha"
+          },
+          {
+            "Version": "2.1.498-alpha"
+          },
+          {
+            "Version": "2.1.499-alpha"
+          },
+          {
+            "Version": "2.1.500-alpha"
+          },
+          {
+            "Version": "2.1.502-alpha"
+          },
+          {
+            "Version": "2.1.503-alpha"
+          },
+          {
+            "Version": "2.1.504-alpha"
+          },
+          {
+            "Version": "2.1.505-alpha"
+          },
+          {
+            "Version": "2.1.507-alpha"
+          },
+          {
+            "Version": "2.1.509-alpha"
+          },
+          {
+            "Version": "2.1.520-alpha"
+          },
+          {
+            "Version": "2.1.521-alpha"
+          },
+          {
+            "Version": "2.1.522-alpha"
+          },
+          {
+            "Version": "2.1.524-alpha"
+          },
+          {
+            "Version": "2.1.526-alpha"
+          },
+          {
+            "Version": "2.1.527-alpha"
+          },
+          {
+            "Version": "2.1.528-alpha"
+          },
+          {
+            "Version": "2.1.530-alpha"
+          },
+          {
+            "Version": "2.1.531-alpha"
+          },
+          {
+            "Version": "2.1.533-alpha"
+          },
+          {
+            "Version": "2.1.534-alpha"
+          },
+          {
+            "Version": "2.1.535-alpha"
+          },
+          {
+            "Version": "2.1.536-alpha"
+          },
+          {
+            "Version": "2.1.537-alpha"
+          },
+          {
+            "Version": "2.1.538-alpha"
+          },
+          {
+            "Version": "2.1.539-alpha"
+          },
+          {
+            "Version": "2.1.540-alpha"
+          },
+          {
+            "Version": "2.1.542-alpha"
+          },
+          {
+            "Version": "2.1.543-alpha"
+          },
+          {
+            "Version": "2.1.544-alpha"
+          },
+          {
+            "Version": "2.1.545-alpha"
+          },
+          {
+            "Version": "2.1.546-alpha"
+          },
+          {
+            "Version": "2.1.547-alpha"
+          },
+          {
+            "Version": "2.1.548-alpha"
+          },
+          {
+            "Version": "2.1.549-alpha"
+          },
+          {
+            "Version": "2.1.550-alpha"
+          },
+          {
+            "Version": "2.1.551-alpha"
+          },
+          {
+            "Version": "2.1.552-alpha"
+          },
+          {
+            "Version": "2.1.553-alpha"
+          },
+          {
+            "Version": "2.1.554-alpha"
+          },
+          {
+            "Version": "2.1.555-alpha"
+          },
+          {
+            "Version": "2.1.556-alpha"
+          },
+          {
+            "Version": "2.1.557-alpha"
+          },
+          {
+            "Version": "2.1.560-alpha"
+          },
+          {
+            "Version": "2.1.561-alpha"
+          },
+          {
+            "Version": "2.1.562-alpha"
+          },
+          {
+            "Version": "2.1.563-alpha"
+          },
+          {
+            "Version": "2.1.564-alpha"
+          },
+          {
+            "Version": "2.1.566-alpha"
+          },
+          {
+            "Version": "2.1.567-alpha"
+          },
+          {
+            "Version": "2.1.568-alpha"
+          },
+          {
+            "Version": "2.1.569-alpha"
+          },
+          {
+            "Version": "2.1.570-alpha"
+          },
+          {
+            "Version": "2.1.571-alpha"
+          },
+          {
+            "Version": "2.1.572-alpha"
+          },
+          {
+            "Version": "2.1.573-alpha"
+          },
+          {
+            "Version": "2.1.574-alpha"
+          },
+          {
+            "Version": "2.1.575-alpha"
+          },
+          {
+            "Version": "2.1.576-alpha"
+          },
+          {
+            "Version": "2.1.577-alpha"
+          },
+          {
+            "Version": "2.1.578-alpha"
+          },
+          {
+            "Version": "2.1.580-alpha"
+          },
+          {
+            "Version": "2.1.581-alpha"
+          },
+          {
+            "Version": "2.1.583-alpha"
+          },
+          {
+            "Version": "2.1.584-alpha"
+          },
+          {
+            "Version": "2.1.585-alpha"
+          },
+          {
+            "Version": "2.1.586-alpha"
+          },
+          {
+            "Version": "2.1.587-alpha"
+          },
+          {
+            "Version": "2.1.588-alpha"
+          },
+          {
+            "Version": "2.1.589-alpha"
+          },
+          {
+            "Version": "2.1.591-alpha"
+          },
+          {
+            "Version": "2.1.592-alpha"
+          },
+          {
+            "Version": "2.1.593-alpha"
+          },
+          {
+            "Version": "2.1.594-alpha"
+          },
+          {
+            "Version": "2.1.595-alpha"
+          },
+          {
+            "Version": "2.1.596-alpha"
+          },
+          {
+            "Version": "2.1.597-alpha"
+          },
+          {
+            "Version": "2.1.598-alpha"
+          },
+          {
+            "Version": "2.1.600-alpha"
+          },
+          {
+            "Version": "2.1.601-alpha"
+          },
+          {
+            "Version": "2.1.602-alpha"
+          },
+          {
+            "Version": "2.1.603-alpha"
+          },
+          {
+            "Version": "2.1.604-alpha"
+          },
+          {
+            "Version": "2.1.605-alpha"
+          },
+          {
+            "Version": "2.1.607-alpha"
+          },
+          {
+            "Version": "2.1.609-alpha"
+          },
+          {
+            "Version": "2.1.611-alpha"
+          },
+          {
+            "Version": "2.1.612-alpha"
+          },
+          {
+            "Version": "2.1.614-alpha"
+          },
+          {
+            "Version": "2.1.616-alpha"
+          },
+          {
+            "Version": "2.1.617-alpha"
+          },
+          {
+            "Version": "2.1.618-alpha"
+          },
+          {
+            "Version": "2.1.620-alpha"
+          },
+          {
+            "Version": "2.1.621-alpha"
+          },
+          {
+            "Version": "2.1.622-alpha"
+          },
+          {
+            "Version": "2.1.623-alpha"
+          },
+          {
+            "Version": "2.1.624-alpha"
+          },
+          {
+            "Version": "2.1.625-alpha"
+          },
+          {
+            "Version": "2.1.626-alpha"
+          },
+          {
+            "Version": "2.1.629-alpha"
+          },
+          {
+            "Version": "2.1.630-alpha"
+          },
+          {
+            "Version": "2.1.631-alpha"
+          },
+          {
+            "Version": "2.1.632-alpha"
+          },
+          {
+            "Version": "2.1.633-alpha"
+          },
+          {
+            "Version": "2.1.634-alpha"
+          },
+          {
+            "Version": "2.1.635-alpha"
+          },
+          {
+            "Version": "2.1.636-alpha"
+          },
+          {
+            "Version": "2.1.637-alpha"
+          },
+          {
+            "Version": "2.1.638-alpha"
+          },
+          {
+            "Version": "2.1.639-alpha"
+          },
+          {
+            "Version": "2.1.640-alpha"
+          },
+          {
+            "Version": "2.1.641-alpha"
+          },
+          {
+            "Version": "2.1.642-alpha"
+          },
+          {
+            "Version": "2.1.643-alpha"
+          },
+          {
+            "Version": "2.1.645-alpha"
+          },
+          {
+            "Version": "2.1.646-alpha"
+          },
+          {
+            "Version": "2.1.647-alpha"
+          },
+          {
+            "Version": "2.1.648-alpha"
+          },
+          {
+            "Version": "2.1.649-alpha"
+          },
+          {
+            "Version": "2.1.651-alpha"
+          },
+          {
+            "Version": "2.1.652-alpha"
+          },
+          {
+            "Version": "2.1.653-alpha"
+          },
+          {
+            "Version": "2.1.654-alpha"
+          },
+          {
+            "Version": "2.1.655-alpha"
+          },
+          {
+            "Version": "2.1.656-alpha"
+          },
+          {
+            "Version": "2.1.657-alpha"
+          },
+          {
+            "Version": "2.1.658-alpha"
+          },
+          {
+            "Version": "2.1.659-alpha"
+          },
+          {
+            "Version": "2.1.660-alpha"
+          },
+          {
+            "Version": "2.1.661-alpha"
+          },
+          {
+            "Version": "2.1.662-alpha"
+          },
+          {
+            "Version": "2.1.663-alpha"
+          },
+          {
+            "Version": "2.1.664-alpha"
+          },
+          {
+            "Version": "2.1.665-alpha"
+          },
+          {
+            "Version": "2.1.666-alpha"
+          },
+          {
+            "Version": "2.1.667-alpha"
+          },
+          {
+            "Version": "2.1.668-alpha"
+          },
+          {
+            "Version": "2.1.671-alpha"
+          },
+          {
+            "Version": "2.1.672-alpha"
+          },
+          {
+            "Version": "2.1.673-alpha"
+          },
+          {
+            "Version": "2.1.674-alpha"
+          },
+          {
+            "Version": "2.1.675-alpha"
+          },
+          {
+            "Version": "2.1.676-alpha"
+          },
+          {
+            "Version": "2.1.677-alpha"
+          },
+          {
+            "Version": "2.1.678-alpha"
+          },
+          {
+            "Version": "2.1.679-alpha"
+          },
+          {
+            "Version": "2.1.680-alpha"
+          },
+          {
+            "Version": "2.1.681-alpha"
+          },
+          {
+            "Version": "2.1.682-alpha"
+          },
+          {
+            "Version": "2.1.683-alpha"
+          },
+          {
+            "Version": "2.1.685-alpha"
+          },
+          {
+            "Version": "2.1.686-alpha"
+          },
+          {
+            "Version": "2.1.687-alpha"
+          },
+          {
+            "Version": "2.1.688-alpha"
+          },
+          {
+            "Version": "2.1.711-alpha"
+          },
+          {
+            "Version": "2.1.713-alpha"
+          },
+          {
+            "Version": "2.1.714-alpha"
+          },
+          {
+            "Version": "2.1.718-alpha"
+          },
+          {
+            "Version": "2.1.724-alpha"
+          },
+          {
+            "Version": "2.1.726-alpha"
+          },
+          {
+            "Version": "2.1.727-alpha"
+          },
+          {
+            "Version": "2.1.728-alpha"
+          },
+          {
+            "Version": "2.1.729-alpha"
+          },
+          {
+            "Version": "2.1.730-alpha"
+          },
+          {
+            "Version": "2.1.731-alpha"
+          },
+          {
+            "Version": "2.1.732-alpha"
+          },
+          {
+            "Version": "2.1.733-alpha"
+          },
+          {
+            "Version": "2.1.735-alpha"
+          },
+          {
+            "Version": "2.1.737-alpha"
+          },
+          {
+            "Version": "2.1.738-alpha"
+          },
+          {
+            "Version": "2.1.739-alpha"
+          },
+          {
+            "Version": "2.1.740-alpha"
+          },
+          {
+            "Version": "2.1.742-alpha"
+          },
+          {
+            "Version": "2.1.743-alpha"
+          },
+          {
+            "Version": "2.1.744-alpha"
+          },
+          {
+            "Version": "2.1.745-alpha"
+          },
+          {
+            "Version": "2.1.746-alpha"
+          },
+          {
+            "Version": "2.1.747-alpha"
+          },
+          {
+            "Version": "2.1.748-alpha"
+          },
+          {
+            "Version": "2.1.750-alpha"
+          },
+          {
+            "Version": "2.1.756-alpha"
+          },
+          {
+            "Version": "2.1.758-alpha"
+          },
+          {
+            "Version": "2.1.765-alpha"
+          },
+          {
+            "Version": "2.1.766-alpha"
+          },
+          {
+            "Version": "2.1.767-alpha"
+          },
+          {
+            "Version": "2.1.768-alpha"
+          },
+          {
+            "Version": "2.1.770-alpha"
+          },
+          {
+            "Version": "2.1.771-alpha"
+          },
+          {
+            "Version": "2.1.772-alpha"
+          },
+          {
+            "Version": "2.1.773-alpha"
+          },
+          {
+            "Version": "2.1.774-alpha"
+          },
+          {
+            "Version": "2.1.775-alpha"
+          },
+          {
+            "Version": "2.1.778-alpha"
+          },
+          {
+            "Version": "2.1.779-alpha"
+          },
+          {
+            "Version": "2.1.781-alpha"
+          },
+          {
+            "Version": "2.2.0.0"
+          },
+          {
+            "Version": "2.2.1.0"
+          },
+          {
+            "Version": "2.2.2.0"
+          },
+          {
+            "Version": "2.2.4.0"
+          },
+          {
+            "Version": "2.2.6.0"
+          },
+          {
+            "Version": "2.2.7.0"
+          },
+          {
+            "Version": "2.2.8.0"
+          },
+          {
+            "Version": "2.2.9.0"
+          },
+          {
+            "Version": "2.2.10.0"
+          },
+          {
+            "Version": "2.2.11.0"
+          },
+          {
+            "Version": "2.2.12.0"
+          },
+          {
+            "Version": "2.2.13.0"
+          },
+          {
+            "Version": "2.2.14.0"
+          },
+          {
+            "Version": "2.2.18.0"
+          },
+          {
+            "Version": "2.2.19.0"
+          },
+          {
+            "Version": "2.2.20.0"
+          },
+          {
+            "Version": "2.2.21.0"
+          },
+          {
+            "Version": "2.2.22.0"
+          },
+          {
+            "Version": "2.2.23.0"
+          },
+          {
+            "Version": "2.3.1-alpha"
+          },
+          {
+            "Version": "2.3.2-alpha"
+          },
+          {
+            "Version": "2.3.5-alpha"
+          },
+          {
+            "Version": "2.3.8-alpha"
+          },
+          {
+            "Version": "2.3.10-alpha"
+          },
+          {
+            "Version": "2.3.11-alpha"
+          },
+          {
+            "Version": "2.3.14-alpha"
+          },
+          {
+            "Version": "2.3.15-alpha"
+          },
+          {
+            "Version": "2.3.16-alpha"
+          },
+          {
+            "Version": "2.3.17-alpha"
+          },
+          {
+            "Version": "2.3.18-alpha"
+          },
+          {
+            "Version": "2.3.19-alpha"
+          },
+          {
+            "Version": "2.3.20-alpha"
+          },
+          {
+            "Version": "2.3.21-alpha"
+          },
+          {
+            "Version": "2.3.22-alpha"
+          },
+          {
+            "Version": "2.3.23-alpha"
+          },
+          {
+            "Version": "2.3.24-alpha"
+          },
+          {
+            "Version": "2.3.26-alpha"
+          },
+          {
+            "Version": "2.3.28-alpha"
+          },
+          {
+            "Version": "2.3.30-alpha"
+          },
+          {
+            "Version": "2.3.31-alpha"
+          },
+          {
+            "Version": "2.3.32-alpha"
+          },
+          {
+            "Version": "2.3.33-alpha"
+          },
+          {
+            "Version": "2.3.34-alpha"
+          },
+          {
+            "Version": "2.3.36-alpha"
+          },
+          {
+            "Version": "2.3.37-alpha"
+          },
+          {
+            "Version": "2.3.38-alpha"
+          },
+          {
+            "Version": "2.3.39-alpha"
+          },
+          {
+            "Version": "2.3.41-alpha"
+          },
+          {
+            "Version": "2.3.43-alpha"
+          },
+          {
+            "Version": "2.3.49-alpha"
+          },
+          {
+            "Version": "2.3.50-alpha"
+          },
+          {
+            "Version": "2.3.51-alpha"
+          },
+          {
+            "Version": "2.3.54-alpha"
+          },
+          {
+            "Version": "2.3.55-alpha"
+          },
+          {
+            "Version": "2.3.57-alpha"
+          },
+          {
+            "Version": "2.3.58-alpha"
+          },
+          {
+            "Version": "2.3.59-alpha"
+          },
+          {
+            "Version": "2.3.60-alpha"
+          },
+          {
+            "Version": "2.3.61-alpha"
+          },
+          {
+            "Version": "2.3.62-alpha"
+          },
+          {
+            "Version": "2.3.63-alpha"
+          },
+          {
+            "Version": "2.3.64-alpha"
+          },
+          {
+            "Version": "2.3.65-alpha"
+          },
+          {
+            "Version": "2.3.66-alpha"
+          },
+          {
+            "Version": "2.3.67-alpha"
+          },
+          {
+            "Version": "2.3.68-alpha"
+          },
+          {
+            "Version": "2.3.69-alpha"
+          },
+          {
+            "Version": "2.3.70-alpha"
+          },
+          {
+            "Version": "2.3.71-alpha"
+          },
+          {
+            "Version": "2.3.72-alpha"
+          },
+          {
+            "Version": "2.3.73-alpha"
+          },
+          {
+            "Version": "2.3.74-alpha"
+          },
+          {
+            "Version": "2.3.75-alpha"
+          },
+          {
+            "Version": "2.3.76-alpha"
+          },
+          {
+            "Version": "2.3.77-alpha"
+          },
+          {
+            "Version": "2.3.78-alpha"
+          },
+          {
+            "Version": "2.3.79-alpha"
+          },
+          {
+            "Version": "2.3.80-alpha"
+          },
+          {
+            "Version": "2.3.81-alpha"
+          },
+          {
+            "Version": "2.3.82-alpha"
+          },
+          {
+            "Version": "2.3.83-alpha"
+          },
+          {
+            "Version": "2.3.84-alpha"
+          },
+          {
+            "Version": "2.3.85-alpha"
+          },
+          {
+            "Version": "2.3.86-alpha"
+          },
+          {
+            "Version": "2.3.87-alpha"
+          },
+          {
+            "Version": "2.3.88-alpha"
+          },
+          {
+            "Version": "2.4.0.0"
+          },
+          {
+            "Version": "2.4.1.0"
+          },
+          {
+            "Version": "2.4.2.0"
+          },
+          {
+            "Version": "2.4.3.0"
+          },
+          {
+            "Version": "2.4.4.0"
+          },
+          {
+            "Version": "2.4.5.0"
+          },
+          {
+            "Version": "2.4.6.0"
+          },
+          {
+            "Version": "2.4.7.0"
+          },
+          {
+            "Version": "2.4.8.0"
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.4-alpha"
+          },
+          {
+            "Version": "2.5.5-alpha"
+          },
+          {
+            "Version": "2.5.7-alpha"
+          },
+          {
+            "Version": "2.5.8-alpha"
+          },
+          {
+            "Version": "2.5.9-alpha"
+          },
+          {
+            "Version": "2.5.10-alpha"
+          },
+          {
+            "Version": "2.5.11-alpha"
+          },
+          {
+            "Version": "2.5.12-alpha"
+          },
+          {
+            "Version": "2.5.17-alpha"
+          },
+          {
+            "Version": "2.5.18-alpha"
+          },
+          {
+            "Version": "2.5.19-alpha"
+          },
+          {
+            "Version": "2.5.20-alpha"
+          },
+          {
+            "Version": "2.5.21-alpha"
+          },
+          {
+            "Version": "2.5.22-alpha"
+          },
+          {
+            "Version": "2.5.25-alpha"
+          },
+          {
+            "Version": "2.5.31-alpha"
+          },
+          {
+            "Version": "2.5.32-alpha"
+          },
+          {
+            "Version": "2.5.33-alpha"
+          },
+          {
+            "Version": "2.5.34-alpha"
+          },
+          {
+            "Version": "2.5.35-alpha"
+          },
+          {
+            "Version": "2.5.39-alpha"
+          },
+          {
+            "Version": "2.5.40-alpha"
+          },
+          {
+            "Version": "2.5.41-alpha"
+          },
+          {
+            "Version": "2.5.42-alpha"
+          },
+          {
+            "Version": "2.5.43-alpha"
+          },
+          {
+            "Version": "2.5.44-alpha"
+          },
+          {
+            "Version": "2.5.45-alpha"
+          },
+          {
+            "Version": "2.5.46-alpha"
+          },
+          {
+            "Version": "2.5.47-alpha"
+          },
+          {
+            "Version": "2.5.48-alpha"
+          },
+          {
+            "Version": "2.5.49-alpha"
+          },
+          {
+            "Version": "2.5.54-alpha"
+          },
+          {
+            "Version": "2.5.55-alpha"
+          },
+          {
+            "Version": "2.5.56-alpha"
+          },
+          {
+            "Version": "2.5.57-alpha"
+          },
+          {
+            "Version": "2.5.58-alpha"
+          },
+          {
+            "Version": "2.5.59-alpha"
+          },
+          {
+            "Version": "2.5.60-alpha"
+          },
+          {
+            "Version": "2.5.61-alpha"
+          },
+          {
+            "Version": "2.5.62-alpha"
+          },
+          {
+            "Version": "2.5.63-alpha"
+          },
+          {
+            "Version": "2.5.64-alpha"
+          },
+          {
+            "Version": "2.5.65-alpha"
+          },
+          {
+            "Version": "2.5.66-alpha"
+          },
+          {
+            "Version": "2.5.67-alpha"
+          },
+          {
+            "Version": "2.5.68-alpha"
+          },
+          {
+            "Version": "2.5.69-alpha"
+          },
+          {
+            "Version": "2.5.70-alpha"
+          },
+          {
+            "Version": "2.5.71-alpha"
+          },
+          {
+            "Version": "2.5.72-alpha"
+          },
+          {
+            "Version": "2.5.73-alpha"
+          },
+          {
+            "Version": "2.5.74-alpha"
+          },
+          {
+            "Version": "2.5.75-alpha"
+          },
+          {
+            "Version": "2.6.0.0"
+          },
+          {
+            "Version": "2.6.1.0"
+          },
+          {
+            "Version": "2.6.3.0"
+          },
+          {
+            "Version": "2.6.5.0"
+          },
+          {
+            "Version": "2.6.7.0"
+          },
+          {
+            "Version": "2.6.9.0"
+          },
+          {
+            "Version": "2.6.12.0"
+          },
+          {
+            "Version": "2.6.14.0"
+          },
+          {
+            "Version": "2.6.15.0"
+          },
+          {
+            "Version": "2.6.16.0"
+          },
+          {
+            "Version": "2.6.17.0"
+          },
+          {
+            "Version": "2.7.0-alpha10"
+          },
+          {
+            "Version": "2.7.0-alpha11"
+          },
+          {
+            "Version": "2.7.0-alpha13"
+          },
+          {
+            "Version": "2.7.0-alpha14"
+          },
+          {
+            "Version": "2.7.0-alpha15"
+          },
+          {
+            "Version": "2.7.0-alpha7"
+          },
+          {
+            "Version": "2.7.0-alpha8"
+          },
+          {
+            "Version": "2.7.0-alpha9"
+          },
+          {
+            "Version": "2.7.0.16-alpha"
+          },
+          {
+            "Version": "2.7.0.17-alpha"
+          },
+          {
+            "Version": "2.7.0.18-alpha"
+          },
+          {
+            "Version": "2.7.0.19-alpha"
+          },
+          {
+            "Version": "2.7.0.20-alpha"
+          },
+          {
+            "Version": "2.7.0.21-alpha"
+          },
+          {
+            "Version": "2.7.0.23-alpha"
+          },
+          {
+            "Version": "2.7.0.24-alpha"
+          },
+          {
+            "Version": "2.7.0.25-alpha"
+          },
+          {
+            "Version": "2.7.0.26-alpha"
+          },
+          {
+            "Version": "2.7.0.27-alpha"
+          },
+          {
+            "Version": "2.7.0.28-alpha"
+          },
+          {
+            "Version": "2.7.0.29-alpha"
+          },
+          {
+            "Version": "2.7.0.30-alpha"
+          },
+          {
+            "Version": "2.7.0.32-alpha"
+          },
+          {
+            "Version": "2.7.0.34-alpha"
+          },
+          {
+            "Version": "2.7.0.35-alpha"
+          },
+          {
+            "Version": "2.7.0.36-alpha"
+          },
+          {
+            "Version": "2.7.0.37-alpha"
+          },
+          {
+            "Version": "2.7.0.38-alpha"
+          },
+          {
+            "Version": "2.7.0.39-alpha"
+          },
+          {
+            "Version": "2.7.0.42-alpha"
+          },
+          {
+            "Version": "2.7.0.43-alpha"
+          },
+          {
+            "Version": "2.7.0.44-alpha"
+          },
+          {
+            "Version": "2.7.0.45-alpha"
+          },
+          {
+            "Version": "2.7.0.47-alpha"
+          },
+          {
+            "Version": "2.7.0.50-alpha"
+          },
+          {
+            "Version": "2.7.0.59-alpha"
+          },
+          {
+            "Version": "2.7.0.60-alpha"
+          },
+          {
+            "Version": "2.7.0.61-alpha"
+          },
+          {
+            "Version": "2.7.0.62-alpha"
+          },
+          {
+            "Version": "2.7.0.63-alpha"
+          },
+          {
+            "Version": "2.7.0.64-alpha"
+          },
+          {
+            "Version": "2.7.0.65-alpha"
+          },
+          {
+            "Version": "2.7.0.66-alpha"
+          },
+          {
+            "Version": "2.7.0.72-alpha"
+          },
+          {
+            "Version": "2.7.0.84-alpha"
+          },
+          {
+            "Version": "2.7.0.85-alpha"
+          },
+          {
+            "Version": "2.7.0.86-alpha"
+          },
+          {
+            "Version": "2.7.0.87-alpha"
+          },
+          {
+            "Version": "2.7.0.88-alpha"
+          },
+          {
+            "Version": "2.7.0.90-alpha"
+          },
+          {
+            "Version": "2.7.0.91-alpha"
+          },
+          {
+            "Version": "2.7.0.92-alpha"
+          },
+          {
+            "Version": "2.7.1-alpha"
+          },
+          {
+            "Version": "2.8.0.0"
+          },
+          {
+            "Version": "2.8.1.0"
+          },
+          {
+            "Version": "2.8.2.0"
+          },
+          {
+            "Version": "2.8.3.0"
+          },
+          {
+            "Version": "2.8.5.0"
+          },
+          {
+            "Version": "2.8.6.0"
+          },
+          {
+            "Version": "2.8.7.0"
+          },
+          {
+            "Version": "2.8.8.0"
+          },
+          {
+            "Version": "2.8.9.0"
+          },
+          {
+            "Version": "2.8.10.0"
+          },
+          {
+            "Version": "2.8.11.0"
+          },
+          {
+            "Version": "2.8.12.0"
+          },
+          {
+            "Version": "2.8.17.0"
+          },
+          {
+            "Version": "2.9.0.0-alpha"
+          },
+          {
+            "Version": "2.9.0.1-alpha"
+          },
+          {
+            "Version": "2.9.0.3-alpha"
+          },
+          {
+            "Version": "2.9.11-alpha"
+          },
+          {
+            "Version": "2.9.12-alpha"
+          },
+          {
+            "Version": "2.9.14-alpha"
+          },
+          {
+            "Version": "2.9.15-alpha"
+          },
+          {
+            "Version": "2.9.17-alpha"
+          },
+          {
+            "Version": "2.9.19-alpha"
+          },
+          {
+            "Version": "2.9.20-alpha"
+          },
+          {
+            "Version": "2.9.21-alpha"
+          },
+          {
+            "Version": "2.9.22-alpha"
+          },
+          {
+            "Version": "2.9.23-alpha"
+          },
+          {
+            "Version": "2.9.24-alpha"
+          },
+          {
+            "Version": "2.9.26-alpha"
+          },
+          {
+            "Version": "2.9.27-alpha"
+          },
+          {
+            "Version": "2.9.28-alpha"
+          },
+          {
+            "Version": "2.9.29-alpha"
+          },
+          {
+            "Version": "2.9.30-alpha"
+          },
+          {
+            "Version": "2.9.31-alpha"
+          },
+          {
+            "Version": "2.9.32-alpha"
+          },
+          {
+            "Version": "2.9.33-alpha"
+          },
+          {
+            "Version": "2.9.34-alpha"
+          },
+          {
+            "Version": "2.9.35-alpha"
+          },
+          {
+            "Version": "2.9.36-alpha"
+          },
+          {
+            "Version": "2.9.37-alpha"
+          },
+          {
+            "Version": "2.9.41-alpha"
+          },
+          {
+            "Version": "2.9.42-alpha"
+          },
+          {
+            "Version": "2.9.44-alpha"
+          },
+          {
+            "Version": "2.9.45-alpha"
+          },
+          {
+            "Version": "2.9.46-alpha"
+          },
+          {
+            "Version": "2.9.47-alpha"
+          },
+          {
+            "Version": "2.10.0.0"
+          },
+          {
+            "Version": "2.10.1.0"
+          },
+          {
+            "Version": "2.10.2.0"
+          },
+          {
+            "Version": "2.10.3.0"
+          },
+          {
+            "Version": "2.10.4.0"
+          },
+          {
+            "Version": "2.10.5.0"
+          },
+          {
+            "Version": "2.10.6.0"
+          },
+          {
+            "Version": "2.10.7.0"
+          },
+          {
+            "Version": "2.10.8.0"
+          },
+          {
+            "Version": "2.10.9.0"
+          },
+          {
+            "Version": "2.10.10.0"
+          },
+          {
+            "Version": "2.10.11.0"
+          },
+          {
+            "Version": "2.10.12.0"
+          },
+          {
+            "Version": "2.10.13.0"
+          },
+          {
+            "Version": "2.10.14.0"
+          },
+          {
+            "Version": "2.10.15.0"
+          },
+          {
+            "Version": "2.10.16.0"
+          },
+          {
+            "Version": "2.10.17.0"
+          },
+          {
+            "Version": "2.10.18.0"
+          },
+          {
+            "Version": "2.10.19.0"
+          },
+          {
+            "Version": "2.10.20.0"
+          },
+          {
+            "Version": "2.10.23.0"
+          },
+          {
+            "Version": "2.10.24.0"
+          },
+          {
+            "Version": "2.10.25.0"
+          },
+          {
+            "Version": "2.11.0-alpha"
+          },
+          {
+            "Version": "2.11.1-alpha"
+          },
+          {
+            "Version": "2.11.2-alpha"
+          },
+          {
+            "Version": "2.11.3-alpha"
+          },
+          {
+            "Version": "2.11.4-alpha"
+          },
+          {
+            "Version": "2.11.5-alpha"
+          },
+          {
+            "Version": "2.11.6-alpha"
+          },
+          {
+            "Version": "2.11.8-alpha"
+          },
+          {
+            "Version": "2.11.9-alpha"
+          },
+          {
+            "Version": "2.11.10-alpha"
+          },
+          {
+            "Version": "2.11.11-alpha"
+          },
+          {
+            "Version": "2.11.12-alpha"
+          },
+          {
+            "Version": "2.11.13-alpha"
+          },
+          {
+            "Version": "2.11.14-alpha"
+          },
+          {
+            "Version": "2.11.15-alpha"
+          },
+          {
+            "Version": "2.11.16-alpha"
+          },
+          {
+            "Version": "2.11.17-alpha"
+          },
+          {
+            "Version": "2.11.18-alpha"
+          },
+          {
+            "Version": "2.11.19-alpha"
+          },
+          {
+            "Version": "2.11.20-alpha"
+          },
+          {
+            "Version": "2.11.21-alpha"
+          },
+          {
+            "Version": "2.11.22-alpha"
+          },
+          {
+            "Version": "2.11.25-alpha"
+          },
+          {
+            "Version": "2.11.27-alpha"
+          },
+          {
+            "Version": "2.11.28-alpha"
+          },
+          {
+            "Version": "2.11.29-alpha"
+          },
+          {
+            "Version": "2.11.30-alpha"
+          },
+          {
+            "Version": "2.11.31-alpha"
+          },
+          {
+            "Version": "2.11.32-alpha"
+          },
+          {
+            "Version": "2.11.33-alpha"
+          },
+          {
+            "Version": "2.11.40-alpha"
+          },
+          {
+            "Version": "2.11.41-alpha"
+          },
+          {
+            "Version": "2.11.50-alpha"
+          },
+          {
+            "Version": "2.11.51-alpha"
+          },
+          {
+            "Version": "2.12.0"
+          },
+          {
+            "Version": "2.12.1-alpha"
+          },
+          {
+            "Version": "2.12.1-alpha2"
+          },
+          {
+            "Version": "2.12.1-alpha3"
+          },
+          {
+            "Version": "2.12.2"
+          },
+          {
+            "Version": "2.13.0-alpha1"
+          },
+          {
+            "Version": "2.13.0-alpha2"
+          },
+          {
+            "Version": "2.13.0"
+          },
+          {
+            "Version": "2.13.1"
+          },
+          {
+            "Version": "2.13.2"
+          },
+          {
+            "Version": "2.13.3"
+          },
+          {
+            "Version": "2.13.4"
+          },
+          {
+            "Version": "2.14.0"
+          },
+          {
+            "Version": "2.14.1"
+          },
+          {
+            "Version": "2.14.12"
+          },
+          {
+            "Version": "2.14.13"
+          },
+          {
+            "Version": "2.15.0"
+          },
+          {
+            "Version": "2.15.1"
+          },
+          {
+            "Version": "2.15.2"
+          },
+          {
+            "Version": "2.15.3"
+          },
+          {
+            "Version": "2.15.4"
+          },
+          {
+            "Version": "2.15.5"
+          },
+          {
+            "Version": "2.15.6"
+          },
+          {
+            "Version": "2.15.7"
+          },
+          {
+            "Version": "2.16.0"
+          },
+          {
+            "Version": "2.16.1"
+          },
+          {
+            "Version": "2.16.2"
+          },
+          {
+            "Version": "2.16.3"
+          },
+          {
+            "Version": "2.17.0"
+          },
+          {
+            "Version": "2.17.1"
+          },
+          {
+            "Version": "2.17.2"
+          },
+          {
+            "Version": "2.17.3-alpha1"
+          },
+          {
+            "Version": "2.17.3-alpha2"
+          },
+          {
+            "Version": "2.17.3"
+          },
+          {
+            "Version": "2.17.4"
+          },
+          {
+            "Version": "2.17.5"
+          },
+          {
+            "Version": "2.17.6"
+          },
+          {
+            "Version": "2.17.7"
+          },
+          {
+            "Version": "2.17.8"
+          },
+          {
+            "Version": "2.17.9"
+          },
+          {
+            "Version": "2.18.0-alpha1"
+          },
+          {
+            "Version": "2.18.0-alpha2"
+          },
+          {
+            "Version": "2.18.0-alpha3"
+          },
+          {
+            "Version": "2.18.0"
+          },
+          {
+            "Version": "2.18.1"
+          },
+          {
+            "Version": "2.18.2"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-alpha10"
+          },
+          {
+            "Version": "3.0.0-alpha2"
+          },
+          {
+            "Version": "3.0.0-alpha3"
+          },
+          {
+            "Version": "3.0.0-alpha4"
+          },
+          {
+            "Version": "3.0.0-alpha5"
+          },
+          {
+            "Version": "3.0.0-alpha6"
+          },
+          {
+            "Version": "3.0.0-alpha7"
+          },
+          {
+            "Version": "3.0.0-alpha8"
+          },
+          {
+            "Version": "3.0.0-alpha9"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-beta3"
+          },
+          {
+            "Version": "3.0.0-beta4"
+          },
+          {
+            "Version": "3.0.0-beta5"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.0.4"
+          },
+          {
+            "Version": "3.0.5"
+          },
+          {
+            "Version": "3.0.6"
+          },
+          {
+            "Version": "3.0.7"
+          },
+          {
+            "Version": "3.0.8"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "3.2.3"
+          },
+          {
+            "Version": "3.2.5"
+          },
+          {
+            "Version": "3.2.6"
+          },
+          {
+            "Version": "3.2.7"
+          },
+          {
+            "Version": "3.2.8"
+          },
+          {
+            "Version": "3.2.9"
+          },
+          {
+            "Version": "3.2.10"
+          },
+          {
+            "Version": "3.2.11"
+          },
+          {
+            "Version": "3.2.12"
+          },
+          {
+            "Version": "3.2.13"
+          },
+          {
+            "Version": "3.2.14"
+          },
+          {
+            "Version": "3.2.15"
+          },
+          {
+            "Version": "3.2.16"
+          },
+          {
+            "Version": "3.2.17"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.4.0"
+          },
+          {
+            "Version": "3.4.1"
+          },
+          {
+            "Version": "3.4.2"
+          },
+          {
+            "Version": "3.4.3"
+          },
+          {
+            "Version": "3.5.0"
+          },
+          {
+            "Version": "3.5.1"
+          },
+          {
+            "Version": "3.5.2"
+          },
+          {
+            "Version": "3.5.3"
+          },
+          {
+            "Version": "3.5.4"
+          },
+          {
+            "Version": "3.5.5"
+          },
+          {
+            "Version": "3.5.6"
+          },
+          {
+            "Version": "3.5.7"
+          },
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "3.5.9"
+          },
+          {
+            "Version": "3.5.10"
+          },
+          {
+            "Version": "3.5.11"
+          },
+          {
+            "Version": "3.5.12"
+          },
+          {
+            "Version": "3.6.0"
+          },
+          {
+            "Version": "3.6.1"
+          },
+          {
+            "Version": "3.7.0"
+          },
+          {
+            "Version": "3.7.1"
+          },
+          {
+            "Version": "3.7.2"
+          },
+          {
+            "Version": "3.7.3"
+          },
+          {
+            "Version": "3.7.4"
+          },
+          {
+            "Version": "3.7.5"
+          },
+          {
+            "Version": "3.7.6"
+          },
+          {
+            "Version": "3.7.7"
+          },
+          {
+            "Version": "3.7.8"
+          },
+          {
+            "Version": "3.7.9"
+          },
+          {
+            "Version": "3.8.0"
+          },
+          {
+            "Version": "3.8.1"
+          },
+          {
+            "Version": "3.8.2"
+          },
+          {
+            "Version": "3.8.3"
+          },
+          {
+            "Version": "3.8.4"
+          },
+          {
+            "Version": "3.8.5"
+          },
+          {
+            "Version": "3.9.0"
+          },
+          {
+            "Version": "3.9.1"
+          },
+          {
+            "Version": "3.9.2"
+          },
+          {
+            "Version": "3.9.3"
+          },
+          {
+            "Version": "3.9.4"
+          },
+          {
+            "Version": "3.9.5"
+          },
+          {
+            "Version": "3.9.6"
+          },
+          {
+            "Version": "3.9.7"
+          },
+          {
+            "Version": "3.9.8"
+          },
+          {
+            "Version": "3.9.9"
+          },
+          {
+            "Version": "3.10.0"
+          },
+          {
+            "Version": "3.10.1"
+          },
+          {
+            "Version": "3.11.0"
+          },
+          {
+            "Version": "3.11.1"
+          },
+          {
+            "Version": "3.11.2"
+          },
+          {
+            "Version": "3.11.3"
+          },
+          {
+            "Version": "3.11.4"
+          },
+          {
+            "Version": "3.12.2"
+          },
+          {
+            "Version": "3.13.0"
+          },
+          {
+            "Version": "3.13.1"
+          },
+          {
+            "Version": "3.13.2"
+          },
+          {
+            "Version": "3.13.3"
+          },
+          {
+            "Version": "3.13.4"
+          },
+          {
+            "Version": "3.14.0"
+          },
+          {
+            "Version": "3.14.1"
+          },
+          {
+            "Version": "3.14.2"
+          },
+          {
+            "Version": "3.14.3"
+          },
+          {
+            "Version": "3.14.4"
+          },
+          {
+            "Version": "3.14.5"
+          },
+          {
+            "Version": "3.14.6"
+          },
+          {
+            "Version": "3.14.7"
+          },
+          {
+            "Version": "3.14.8"
+          },
+          {
+            "Version": "3.14.9"
+          },
+          {
+            "Version": "3.14.10"
+          },
+          {
+            "Version": "3.15.0"
+          },
+          {
+            "Version": "3.16.1"
+          },
+          {
+            "Version": "3.16.2"
+          },
+          {
+            "Version": "3.17.0"
+          },
+          {
+            "Version": "3.17.1"
+          },
+          {
+            "Version": "3.17.2"
+          },
+          {
+            "Version": "3.17.3"
+          },
+          {
+            "Version": "3.17.4"
+          },
+          {
+            "Version": "3.17.5"
+          },
+          {
+            "Version": "3.17.6"
+          },
+          {
+            "Version": "3.17.7"
+          },
+          {
+            "Version": "3.17.8"
+          },
+          {
+            "Version": "3.17.9"
+          },
+          {
+            "Version": "3.17.11"
+          },
+          {
+            "Version": "3.17.12"
+          },
+          {
+            "Version": "3.17.13"
+          },
+          {
+            "Version": "3.17.14"
+          },
+          {
+            "Version": "3.18.0"
+          },
+          {
+            "Version": "3.18.1"
+          },
+          {
+            "Version": "3.18.2"
+          },
+          {
+            "Version": "3.19.0"
+          },
+          {
+            "Version": "3.19.1"
+          },
+          {
+            "Version": "3.19.2"
+          },
+          {
+            "Version": "3.19.3"
+          },
+          {
+            "Version": "3.20.0"
+          },
+          {
+            "Version": "3.20.1"
+          },
+          {
+            "Version": "3.21.0"
+          },
+          {
+            "Version": "3.22.0"
+          },
+          {
+            "Version": "3.23.0"
+          },
+          {
+            "Version": "3.24.0"
+          },
+          {
+            "Version": "3.25.0"
+          },
+          {
+            "Version": "3.25.1"
+          },
+          {
+            "Version": "3.25.2"
+          },
+          {
+            "Version": "3.26.0"
+          },
+          {
+            "Version": "3.26.1"
+          },
+          {
+            "Version": "3.26.3"
+          },
+          {
+            "Version": "3.26.4"
+          },
+          {
+            "Version": "3.26.5"
+          },
+          {
+            "Version": "3.26.6"
+          },
+          {
+            "Version": "3.26.7"
+          },
+          {
+            "Version": "3.27.0"
+          },
+          {
+            "Version": "3.27.1"
+          },
+          {
+            "Version": "3.27.2"
+          },
+          {
+            "Version": "3.27.3"
+          },
+          {
+            "Version": "3.27.4"
+          },
+          {
+            "Version": "3.27.5"
+          },
+          {
+            "Version": "3.27.6"
+          },
+          {
+            "Version": "3.27.7"
+          },
+          {
+            "Version": "3.28.0"
+          },
+          {
+            "Version": "3.28.1"
+          },
+          {
+            "Version": "3.28.2"
+          },
+          {
+            "Version": "3.28.3"
+          },
+          {
+            "Version": "3.28.4"
+          },
+          {
+            "Version": "3.28.5"
+          },
+          {
+            "Version": "3.28.6"
+          },
+          {
+            "Version": "3.28.7"
+          },
+          {
+            "Version": "3.28.8"
+          },
+          {
+            "Version": "3.29.1"
+          },
+          {
+            "Version": "3.29.2"
+          },
+          {
+            "Version": "3.29.3"
+          },
+          {
+            "Version": "3.29.4"
+          },
+          {
+            "Version": "3.29.5"
+          },
+          {
+            "Version": "3.29.6"
+          },
+          {
+            "Version": "3.29.7"
+          },
+          {
+            "Version": "3.30.0"
+          },
+          {
+            "Version": "3.30.1"
+          },
+          {
+            "Version": "3.30.2"
+          },
+          {
+            "Version": "3.30.3"
+          },
+          {
+            "Version": "3.31.0"
+          },
+          {
+            "Version": "3.31.1"
+          },
+          {
+            "Version": "3.31.2"
+          },
+          {
+            "Version": "3.31.3"
+          },
+          {
+            "Version": "3.31.4"
+          },
+          {
+            "Version": "3.32.4"
+          },
+          {
+            "Version": "3.33.0"
+          },
+          {
+            "Version": "3.34.0"
+          },
+          {
+            "Version": "3.34.1"
+          },
+          {
+            "Version": "3.34.2"
+          },
+          {
+            "Version": "3.34.3"
+          },
+          {
+            "Version": "3.34.4"
+          },
+          {
+            "Version": "3.34.5"
+          },
+          {
+            "Version": "3.34.6"
+          },
+          {
+            "Version": "3.34.7"
+          },
+          {
+            "Version": "3.35.0"
+          },
+          {
+            "Version": "3.35.1"
+          },
+          {
+            "Version": "3.35.2"
+          },
+          {
+            "Version": "3.35.3"
+          },
+          {
+            "Version": "3.35.4"
+          },
+          {
+            "Version": "3.35.5"
+          },
+          {
+            "Version": "3.36.0"
+          },
+          {
+            "Version": "3.37.0"
+          },
+          {
+            "Version": "3.37.1"
+          },
+          {
+            "Version": "4.0.0-alpha001"
+          },
+          {
+            "Version": "4.0.0-alpha002"
+          },
+          {
+            "Version": "4.0.0-alpha003"
+          },
+          {
+            "Version": "4.0.0-alpha004"
+          },
+          {
+            "Version": "4.0.0-alpha005"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.3"
+          },
+          {
+            "Version": "4.1.4"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1-alpha001"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1"
+          },
+          {
+            "Version": "4.3.2"
+          },
+          {
+            "Version": "4.3.3"
+          },
+          {
+            "Version": "4.3.4"
+          },
+          {
+            "Version": "4.3.7"
+          },
+          {
+            "Version": "4.4.0"
+          },
+          {
+            "Version": "4.4.1"
+          },
+          {
+            "Version": "4.4.2"
+          },
+          {
+            "Version": "4.4.3"
+          },
+          {
+            "Version": "4.4.4"
+          },
+          {
+            "Version": "4.4.5"
+          },
+          {
+            "Version": "4.4.6"
+          },
+          {
+            "Version": "4.5.0"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.6.0-alpha001"
+          },
+          {
+            "Version": "4.6.0-alpha002"
+          },
+          {
+            "Version": "4.6.0"
+          },
+          {
+            "Version": "4.6.1"
+          },
+          {
+            "Version": "4.6.2"
+          },
+          {
+            "Version": "4.6.3"
+          },
+          {
+            "Version": "4.6.4"
+          },
+          {
+            "Version": "4.7.0-alpha001"
+          },
+          {
+            "Version": "4.7.0-alpha002"
+          },
+          {
+            "Version": "4.7.0"
+          },
+          {
+            "Version": "4.7.1"
+          },
+          {
+            "Version": "4.7.2"
+          },
+          {
+            "Version": "4.7.3"
+          },
+          {
+            "Version": "4.8.0"
+          },
+          {
+            "Version": "4.9.0"
+          },
+          {
+            "Version": "4.9.1"
+          },
+          {
+            "Version": "4.9.2"
+          },
+          {
+            "Version": "4.9.3"
+          },
+          {
+            "Version": "4.9.5"
+          },
+          {
+            "Version": "4.9.6"
+          },
+          {
+            "Version": "4.9.7"
+          },
+          {
+            "Version": "4.9.8"
+          },
+          {
+            "Version": "4.10.0"
+          },
+          {
+            "Version": "4.10.1"
+          },
+          {
+            "Version": "4.10.3"
+          },
+          {
+            "Version": "4.10.4"
+          },
+          {
+            "Version": "4.10.5"
+          },
+          {
+            "Version": "4.11.0"
+          },
+          {
+            "Version": "4.11.1"
+          },
+          {
+            "Version": "4.11.2"
+          },
+          {
+            "Version": "4.11.3"
+          },
+          {
+            "Version": "4.12.0"
+          },
+          {
+            "Version": "4.12.2"
+          },
+          {
+            "Version": "4.13.0"
+          },
+          {
+            "Version": "4.13.1"
+          },
+          {
+            "Version": "4.14.0"
+          },
+          {
+            "Version": "4.14.1"
+          },
+          {
+            "Version": "4.14.2"
+          },
+          {
+            "Version": "4.14.3"
+          },
+          {
+            "Version": "4.14.4"
+          },
+          {
+            "Version": "4.14.5"
+          },
+          {
+            "Version": "4.14.7"
+          },
+          {
+            "Version": "4.14.8"
+          },
+          {
+            "Version": "4.14.9"
+          },
+          {
+            "Version": "4.15.0"
+          },
+          {
+            "Version": "4.15.1"
+          },
+          {
+            "Version": "4.15.2"
+          },
+          {
+            "Version": "4.16.0-alpha001"
+          },
+          {
+            "Version": "4.16.0"
+          },
+          {
+            "Version": "4.16.1"
+          },
+          {
+            "Version": "4.17.0-alpha001"
+          },
+          {
+            "Version": "4.17.0-alpha002"
+          },
+          {
+            "Version": "4.17.0-alpha003"
+          },
+          {
+            "Version": "4.17.0-alpha004"
+          },
+          {
+            "Version": "4.17.0-alpha005"
+          },
+          {
+            "Version": "4.17.0-alpha007"
+          },
+          {
+            "Version": "4.17.0"
+          },
+          {
+            "Version": "4.17.1"
+          },
+          {
+            "Version": "4.18.0"
+          },
+          {
+            "Version": "4.19.0"
+          },
+          {
+            "Version": "4.20.0"
+          },
+          {
+            "Version": "4.21.0"
+          },
+          {
+            "Version": "4.21.1"
+          },
+          {
+            "Version": "4.21.2"
+          },
+          {
+            "Version": "4.21.3"
+          },
+          {
+            "Version": "4.21.4"
+          },
+          {
+            "Version": "4.22.0"
+          },
+          {
+            "Version": "4.22.1"
+          },
+          {
+            "Version": "4.22.2"
+          },
+          {
+            "Version": "4.22.3"
+          },
+          {
+            "Version": "4.22.4"
+          },
+          {
+            "Version": "4.22.5"
+          },
+          {
+            "Version": "4.22.6"
+          },
+          {
+            "Version": "4.22.7"
+          },
+          {
+            "Version": "4.22.8"
+          },
+          {
+            "Version": "4.22.9"
+          },
+          {
+            "Version": "4.23.0"
+          },
+          {
+            "Version": "4.23.1"
+          },
+          {
+            "Version": "4.23.2"
+          },
+          {
+            "Version": "4.23.3"
+          },
+          {
+            "Version": "4.23.4"
+          },
+          {
+            "Version": "4.23.5"
+          },
+          {
+            "Version": "4.23.6"
+          },
+          {
+            "Version": "4.24.0"
+          },
+          {
+            "Version": "4.24.1"
+          },
+          {
+            "Version": "4.24.2"
+          },
+          {
+            "Version": "4.24.3"
+          },
+          {
+            "Version": "4.25.0"
+          },
+          {
+            "Version": "4.25.1"
+          },
+          {
+            "Version": "4.25.2"
+          },
+          {
+            "Version": "4.25.3"
+          },
+          {
+            "Version": "4.25.4"
+          },
+          {
+            "Version": "4.25.5"
+          },
+          {
+            "Version": "4.26.0"
+          },
+          {
+            "Version": "4.27.0"
+          },
+          {
+            "Version": "4.28.0"
+          },
+          {
+            "Version": "4.29.0"
+          },
+          {
+            "Version": "4.29.1"
+          },
+          {
+            "Version": "4.29.2"
+          },
+          {
+            "Version": "4.30.0"
+          },
+          {
+            "Version": "4.30.1"
+          },
+          {
+            "Version": "4.30.2"
+          },
+          {
+            "Version": "4.31.0"
+          },
+          {
+            "Version": "4.31.1"
+          },
+          {
+            "Version": "4.32.0"
+          },
+          {
+            "Version": "4.33.0"
+          },
+          {
+            "Version": "4.33.1"
+          },
+          {
+            "Version": "4.33.2"
+          },
+          {
+            "Version": "4.33.3"
+          },
+          {
+            "Version": "4.33.4"
+          },
+          {
+            "Version": "4.34.0"
+          },
+          {
+            "Version": "4.34.1"
+          },
+          {
+            "Version": "4.34.2"
+          },
+          {
+            "Version": "4.34.3"
+          },
+          {
+            "Version": "4.34.4"
+          },
+          {
+            "Version": "4.34.5"
+          },
+          {
+            "Version": "4.35.0"
+          },
+          {
+            "Version": "4.35.1"
+          },
+          {
+            "Version": "4.36.0"
+          },
+          {
+            "Version": "4.37.0"
+          },
+          {
+            "Version": "4.37.1"
+          },
+          {
+            "Version": "4.37.2"
+          },
+          {
+            "Version": "4.38.0"
+          },
+          {
+            "Version": "4.38.1"
+          },
+          {
+            "Version": "4.38.2"
+          },
+          {
+            "Version": "4.38.3"
+          },
+          {
+            "Version": "4.39.0"
+          },
+          {
+            "Version": "4.39.1"
+          },
+          {
+            "Version": "4.40.0"
+          },
+          {
+            "Version": "4.40.1"
+          },
+          {
+            "Version": "4.40.2"
+          },
+          {
+            "Version": "4.41.0"
+          },
+          {
+            "Version": "4.41.1"
+          },
+          {
+            "Version": "4.41.2"
+          },
+          {
+            "Version": "4.41.3"
+          },
+          {
+            "Version": "4.41.4"
+          },
+          {
+            "Version": "4.41.5"
+          },
+          {
+            "Version": "4.41.6"
+          },
+          {
+            "Version": "4.41.7"
+          },
+          {
+            "Version": "4.41.8"
+          },
+          {
+            "Version": "4.42.0"
+          },
+          {
+            "Version": "4.43.0"
+          },
+          {
+            "Version": "4.44.0"
+          },
+          {
+            "Version": "4.44.1"
+          },
+          {
+            "Version": "4.44.2"
+          },
+          {
+            "Version": "4.44.3"
+          },
+          {
+            "Version": "4.44.4"
+          },
+          {
+            "Version": "4.45.0"
+          },
+          {
+            "Version": "4.45.1"
+          },
+          {
+            "Version": "4.45.2"
+          },
+          {
+            "Version": "4.45.3"
+          },
+          {
+            "Version": "4.46.0"
+          },
+          {
+            "Version": "4.46.1"
+          },
+          {
+            "Version": "4.47.0"
+          },
+          {
+            "Version": "4.47.1"
+          },
+          {
+            "Version": "4.47.2"
+          },
+          {
+            "Version": "4.47.4"
+          },
+          {
+            "Version": "4.48.0"
+          },
+          {
+            "Version": "4.49.0"
+          },
+          {
+            "Version": "4.49.1"
+          },
+          {
+            "Version": "4.50.0"
+          },
+          {
+            "Version": "4.50.1"
+          },
+          {
+            "Version": "4.51.1"
+          },
+          {
+            "Version": "4.52.0"
+          },
+          {
+            "Version": "4.53.0"
+          },
+          {
+            "Version": "4.54.0-alpha001"
+          },
+          {
+            "Version": "4.54.0"
+          },
+          {
+            "Version": "4.55.0"
+          },
+          {
+            "Version": "4.55.1"
+          },
+          {
+            "Version": "4.56.0"
+          },
+          {
+            "Version": "4.57.0"
+          },
+          {
+            "Version": "4.57.1"
+          },
+          {
+            "Version": "4.57.2"
+          },
+          {
+            "Version": "4.57.3"
+          },
+          {
+            "Version": "4.57.4"
+          },
+          {
+            "Version": "4.58.2"
+          },
+          {
+            "Version": "4.58.3"
+          },
+          {
+            "Version": "4.58.4"
+          },
+          {
+            "Version": "4.58.5"
+          },
+          {
+            "Version": "4.58.6"
+          },
+          {
+            "Version": "4.59.0-alpha001"
+          },
+          {
+            "Version": "4.59.0-alpha002"
+          },
+          {
+            "Version": "4.59.0"
+          },
+          {
+            "Version": "4.59.1"
+          },
+          {
+            "Version": "4.59.3"
+          },
+          {
+            "Version": "4.60.0",
+            "PackageDetails": {
+              "Name": "FAKE",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FAKE/4.60.0",
+              "LicenseUrl": "http://www.github.com/fsharp/Fake/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:53.2297226+02:00",
+        "PackageName": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.debian.8-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.debian.8-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:17.4131629+02:00",
+        "PackageName": "System.Diagnostics.Tools",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tools",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tools/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:32.8851902+02:00",
+        "PackageName": "System.Runtime.Extensions",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Extensions",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Extensions/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:35.1892005+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:37.7771913+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:50.1275174+02:00",
+        "PackageName": "runtime.aot.System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:58.5623321+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:28.9086901+02:00",
+        "PackageName": "System.Reflection.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Reflection.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:49.9295197+02:00",
+        "PackageName": "runtime.aot.System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.aot.System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.aot.System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:58.9923327+02:00",
+        "PackageName": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+        "Versions": [
+          {
+            "Version": "1.0.1-rc2-24027"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:18.0906635+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:38.1021926+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:12:18.5891638+02:00",
+        "PackageName": "System.Globalization",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001520-pinned-error/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001520-pinned-error/cache/paket-graph.cache
@@ -1,0 +1,971 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:12.9675214+02:00",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:11.2749466+02:00",
+        "PackageName": "Microsoft.ApplicationInsights",
+        "Versions": [
+          {
+            "Version": "1.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights/1.2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "wpv8.0, net40"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.24",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:11.9644483+02:00",
+        "PackageName": "Microsoft.ApplicationInsights.WindowsServer",
+        "Versions": [
+          {
+            "Version": "1.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.WindowsServer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.WindowsServer/1.2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "1.2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.DependencyCollector",
+                  "VersionRequirement": ">= 1.2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.PerfCounterCollector",
+                  "VersionRequirement": ">= 1.2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel",
+                  "VersionRequirement": ">= 1.2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.24",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:12.1034469+02:00",
+        "PackageName": "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel",
+        "Versions": [
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/1.2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=391182",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "1.2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.24",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-beta3"
+          },
+          {
+            "Version": "2.0.0-beta4"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=391182",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.0",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.24",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.1.0-beta1"
+          },
+          {
+            "Version": "2.1.0-beta3"
+          },
+          {
+            "Version": "2.1.0-beta4"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=391182",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.1",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.28",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0-beta2"
+          },
+          {
+            "Version": "2.2.0-beta4"
+          },
+          {
+            "Version": "2.2.0-beta6"
+          },
+          {
+            "Version": "2.2.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.2.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.2",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.28",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0-beta3"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.28",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.4.0-beta1"
+          },
+          {
+            "Version": "2.4.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:13.743021+02:00",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:11.6964463+02:00",
+        "PackageName": "Microsoft.ApplicationInsights.DependencyCollector",
+        "Versions": [
+          {
+            "Version": "0.15.0-build00179"
+          },
+          {
+            "Version": "0.16.0-build00183"
+          },
+          {
+            "Version": "0.16.1-build00418"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.DependencyCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.DependencyCollector/1.2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "1.2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.Agent.Intercept",
+                  "VersionRequirement": ">= 1.2",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-beta3"
+          },
+          {
+            "Version": "2.0.0-beta4"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.DependencyCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.DependencyCollector/2.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.0",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.Agent.Intercept",
+                  "VersionRequirement": ">= 1.2.1",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.1.0-beta1"
+          },
+          {
+            "Version": "2.1.0-beta2"
+          },
+          {
+            "Version": "2.1.0-beta3"
+          },
+          {
+            "Version": "2.1.0-beta4"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.DependencyCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.DependencyCollector/2.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.1",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.Agent.Intercept",
+                  "VersionRequirement": ">= 1.2.1",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0-beta2"
+          },
+          {
+            "Version": "2.2.0-beta4"
+          },
+          {
+            "Version": "2.2.0-beta6"
+          },
+          {
+            "Version": "2.2.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.DependencyCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.DependencyCollector/2.2.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.2",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.Agent.Intercept",
+                  "VersionRequirement": ">= 2.0.6",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0-beta3"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.DependencyCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.DependencyCollector/2.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.3",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights.Agent.Intercept",
+                  "VersionRequirement": ">= 2.0.7",
+                  "FrameworkRestrictions": ">= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.4.0-beta1"
+          },
+          {
+            "Version": "2.4.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:11.831446+02:00",
+        "PackageName": "Microsoft.ApplicationInsights.PerfCounterCollector",
+        "Versions": [
+          {
+            "Version": "0.15.0-build00179"
+          },
+          {
+            "Version": "0.16.0-build00183"
+          },
+          {
+            "Version": "0.16.1-build00418"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.PerfCounterCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.PerfCounterCollector/1.2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=391182",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": ">= 1.2.3",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "1.2.3",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.24",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-beta1"
+          },
+          {
+            "Version": "2.0.0-beta2"
+          },
+          {
+            "Version": "2.0.0-beta3"
+          },
+          {
+            "Version": "2.0.0-beta4"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.PerfCounterCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.PerfCounterCollector/2.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=391182",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": ">= 2.0",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.0",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.24",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.1.0-beta1"
+          },
+          {
+            "Version": "2.1.0-beta2"
+          },
+          {
+            "Version": "2.1.0-beta3"
+          },
+          {
+            "Version": "2.1.0-beta4"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.PerfCounterCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.PerfCounterCollector/2.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=391182",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": ">= 2.1",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.1",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.28",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.2.0-beta1"
+          },
+          {
+            "Version": "2.2.0-beta2"
+          },
+          {
+            "Version": "2.2.0-beta4"
+          },
+          {
+            "Version": "2.2.0-beta6"
+          },
+          {
+            "Version": "2.2.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.PerfCounterCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.PerfCounterCollector/2.2.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": ">= 2.2",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.2",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.28",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.3.0-beta1"
+          },
+          {
+            "Version": "2.3.0-beta2"
+          },
+          {
+            "Version": "2.3.0-beta3"
+          },
+          {
+            "Version": "2.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.PerfCounterCollector",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.PerfCounterCollector/2.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": ">= 2.3",
+                  "FrameworkRestrictions": "net40"
+                },
+                {
+                  "PackageName": "Microsoft.ApplicationInsights",
+                  "VersionRequirement": "2.3",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.28",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "2.4.0-beta1"
+          },
+          {
+            "Version": "2.4.0-beta2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:13.6560206+02:00",
+        "PackageName": "Microsoft.Bcl.Async",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.12-beta"
+          },
+          {
+            "Version": "1.0.14-rc"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.165"
+          },
+          {
+            "Version": "1.0.166-beta"
+          },
+          {
+            "Version": "1.0.166"
+          },
+          {
+            "Version": "1.0.168",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.168",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:14.0445208+02:00",
+        "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+        "Versions": [
+          {
+            "Version": "1.0.24"
+          },
+          {
+            "Version": "1.0.26"
+          },
+          {
+            "Version": "1.1.3-beta"
+          },
+          {
+            "Version": "1.1.5-beta"
+          },
+          {
+            "Version": "1.1.7-beta"
+          },
+          {
+            "Version": "1.1.8-beta"
+          },
+          {
+            "Version": "1.1.10-beta"
+          },
+          {
+            "Version": "1.1.11-beta"
+          },
+          {
+            "Version": "1.1.13-beta"
+          },
+          {
+            "Version": "1.1.14-beta"
+          },
+          {
+            "Version": "1.1.15-beta"
+          },
+          {
+            "Version": "1.1.16-beta"
+          },
+          {
+            "Version": "1.1.17-beta"
+          },
+          {
+            "Version": "1.1.20-beta"
+          },
+          {
+            "Version": "1.1.23-beta"
+          },
+          {
+            "Version": "1.1.24",
+            "PackageDetails": {
+              "Name": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Diagnostics.Tracing.EventSource.Redist/1.1.24",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.1.25",
+            "PackageDetails": {
+              "Name": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Diagnostics.Tracing.EventSource.Redist/1.1.25",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.1.26",
+            "PackageDetails": {
+              "Name": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Diagnostics.Tracing.EventSource.Redist/1.1.26",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.1.28",
+            "PackageDetails": {
+              "Name": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Diagnostics.Tracing.EventSource.Redist/1.1.28",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:11.5579465+02:00",
+        "PackageName": "Microsoft.ApplicationInsights.Agent.Intercept",
+        "Versions": [
+          {
+            "Version": "0.14.0-build08008"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6"
+          },
+          {
+            "Version": "2.0.7",
+            "PackageDetails": {
+              "Name": "Microsoft.ApplicationInsights.Agent.Intercept",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.ApplicationInsights.Agent.Intercept/2.0.7",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Diagnostics.Tracing.EventSource.Redist",
+                  "VersionRequirement": ">= 1.1.28",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001522-copy-content/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001522-copy-content/cache/paket-graph.cache
@@ -1,0 +1,357 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:02.0867957+02:00",
+        "PackageName": "Costura.Fody",
+        "Versions": [
+          {
+            "Version": "0.1.0.0"
+          },
+          {
+            "Version": "0.2.0.0"
+          },
+          {
+            "Version": "0.2.1.0"
+          },
+          {
+            "Version": "0.3.0.0"
+          },
+          {
+            "Version": "0.3.1.0"
+          },
+          {
+            "Version": "0.3.1.1"
+          },
+          {
+            "Version": "0.3.1.2"
+          },
+          {
+            "Version": "0.3.2.0"
+          },
+          {
+            "Version": "0.3.2.1"
+          },
+          {
+            "Version": "0.3.3.0"
+          },
+          {
+            "Version": "0.3.4"
+          },
+          {
+            "Version": "0.3.5"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.4.1"
+          },
+          {
+            "Version": "0.4.2"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.5.1.0"
+          },
+          {
+            "Version": "0.5.2.0"
+          },
+          {
+            "Version": "0.5.3.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "0.6.1.0"
+          },
+          {
+            "Version": "0.7.0.0"
+          },
+          {
+            "Version": "0.7.1.0"
+          },
+          {
+            "Version": "0.8.0.0"
+          },
+          {
+            "Version": "0.8.1.0"
+          },
+          {
+            "Version": "1.0.0.0"
+          },
+          {
+            "Version": "1.0.1.0"
+          },
+          {
+            "Version": "1.1.0.0"
+          },
+          {
+            "Version": "1.2.0.0"
+          },
+          {
+            "Version": "1.3.0.0"
+          },
+          {
+            "Version": "1.3.1.0"
+          },
+          {
+            "Version": "1.3.2.0"
+          },
+          {
+            "Version": "1.3.3.0",
+            "PackageDetails": {
+              "Name": "Costura.Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Costura.Fody/1.3.3.0",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Fody",
+                  "VersionRequirement": ">= 1.26.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.4.0"
+          },
+          {
+            "Version": "1.3.5.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "2.0.0-beta0014"
+          },
+          {
+            "Version": "2.0.0-beta0018"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:02.2748003+02:00",
+        "PackageName": "Fody",
+        "Versions": [
+          {
+            "Version": "1.13.0.0"
+          },
+          {
+            "Version": "1.13.1.0"
+          },
+          {
+            "Version": "1.13.2.0"
+          },
+          {
+            "Version": "1.13.3.0"
+          },
+          {
+            "Version": "1.13.6.0"
+          },
+          {
+            "Version": "1.13.6.1"
+          },
+          {
+            "Version": "1.13.7.0"
+          },
+          {
+            "Version": "1.13.8.0"
+          },
+          {
+            "Version": "1.13.11.1"
+          },
+          {
+            "Version": "1.13.12"
+          },
+          {
+            "Version": "1.14.0"
+          },
+          {
+            "Version": "1.15.0.0"
+          },
+          {
+            "Version": "1.16.0.0"
+          },
+          {
+            "Version": "1.16.2.0"
+          },
+          {
+            "Version": "1.17.0.0"
+          },
+          {
+            "Version": "1.17.4.0"
+          },
+          {
+            "Version": "1.18.0.0"
+          },
+          {
+            "Version": "1.19.0.0"
+          },
+          {
+            "Version": "1.19.1.0"
+          },
+          {
+            "Version": "1.20.0.0"
+          },
+          {
+            "Version": "1.21.0"
+          },
+          {
+            "Version": "1.21.1"
+          },
+          {
+            "Version": "1.22.0"
+          },
+          {
+            "Version": "1.22.1"
+          },
+          {
+            "Version": "1.23.0"
+          },
+          {
+            "Version": "1.23.1"
+          },
+          {
+            "Version": "1.23.2"
+          },
+          {
+            "Version": "1.24.0-beta1"
+          },
+          {
+            "Version": "1.24.0-beta2"
+          },
+          {
+            "Version": "1.24.0-beta3"
+          },
+          {
+            "Version": "1.24.0-beta4"
+          },
+          {
+            "Version": "1.24.0"
+          },
+          {
+            "Version": "1.25.0"
+          },
+          {
+            "Version": "1.26.0-beta0001"
+          },
+          {
+            "Version": "1.26.0"
+          },
+          {
+            "Version": "1.26.1"
+          },
+          {
+            "Version": "1.26.2-beta1"
+          },
+          {
+            "Version": "1.26.2"
+          },
+          {
+            "Version": "1.26.3-beta0001"
+          },
+          {
+            "Version": "1.26.3"
+          },
+          {
+            "Version": "1.26.4"
+          },
+          {
+            "Version": "1.27.0-beta01"
+          },
+          {
+            "Version": "1.27.0"
+          },
+          {
+            "Version": "1.27.1-beta01"
+          },
+          {
+            "Version": "1.27.1-beta03"
+          },
+          {
+            "Version": "1.27.1"
+          },
+          {
+            "Version": "1.28.0"
+          },
+          {
+            "Version": "1.28.1"
+          },
+          {
+            "Version": "1.28.3"
+          },
+          {
+            "Version": "1.29.0-beta01"
+          },
+          {
+            "Version": "1.29.0"
+          },
+          {
+            "Version": "1.29.0.1"
+          },
+          {
+            "Version": "1.29.1-beta2"
+          },
+          {
+            "Version": "1.29.1-beta3"
+          },
+          {
+            "Version": "1.29.1"
+          },
+          {
+            "Version": "1.29.2"
+          },
+          {
+            "Version": "1.29.3"
+          },
+          {
+            "Version": "1.29.4"
+          },
+          {
+            "Version": "1.30.0-beta01"
+          },
+          {
+            "Version": "2.0.0-beta0001"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.0.6",
+            "PackageDetails": {
+              "Name": "Fody",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Fody/2.0.6",
+              "LicenseUrl": "http://www.opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001579-unlisted/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001579-unlisted/cache/paket-graph.cache
@@ -1,0 +1,307 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:19.4970215+02:00",
+        "PackageName": "Mvvmlight",
+        "Versions": [
+          {
+            "Version": "3.0.0.29166"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.1.23.0",
+            "PackageDetails": {
+              "Name": "MvvmLight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLight/4.1.23.0",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "4.1.26.0",
+            "PackageDetails": {
+              "Name": "MvvmLight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLight/4.1.26.0",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "4.1.26.1",
+            "PackageDetails": {
+              "Name": "MvvmLight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLight/4.1.26.1",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "4.1.27.0",
+            "PackageDetails": {
+              "Name": "MvvmLight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLight/4.1.27.0",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "MvvmLightLibs",
+                  "VersionRequirement": ">= 4.1.27",
+                  "FrameworkRestrictions": "winv4.5, wpv7.1, wpv8.0, sl40, sl50, >= net35"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "4.1.27.1",
+            "PackageDetails": {
+              "Name": "MvvmLight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLight/4.1.27.1",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "MvvmLightLibs",
+                  "VersionRequirement": ">= 4.1.27",
+                  "FrameworkRestrictions": "winv4.5, wpv7.1, wpv8.0, sl40, sl50, >= net35"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "4.2.30.0",
+            "PackageDetails": {
+              "Name": "MvvmLight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLight/4.2.30.0",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "MvvmLightLibs",
+                  "VersionRequirement": ">= 4.2.30",
+                  "FrameworkRestrictions": "winv4.5, wpv7.1, wpv8.0, sl40, sl50, >= net35"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.2.32.7",
+            "PackageDetails": {
+              "Name": "MvvmLight",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLight/4.2.32.7",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "MvvmLightLibs",
+                  "VersionRequirement": ">= 4.4.32.7",
+                  "FrameworkRestrictions": "monoandroid, winv4.5, wpv7.1, wpv8.0, wpav8.1, sl40, sl50, >= net35"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "5.0.0.0"
+          },
+          {
+            "Version": "5.0.0.1"
+          },
+          {
+            "Version": "5.0.1.0"
+          },
+          {
+            "Version": "5.0.2.0"
+          },
+          {
+            "Version": "5.1.0.0"
+          },
+          {
+            "Version": "5.1.0.1"
+          },
+          {
+            "Version": "5.1.0.2"
+          },
+          {
+            "Version": "5.1.1.0"
+          },
+          {
+            "Version": "5.2.0.0"
+          },
+          {
+            "Version": "5.3.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:19.3890215+02:00",
+        "PackageName": "CommonServiceLocator",
+        "Versions": [
+          {
+            "Version": "1.0"
+          },
+          {
+            "Version": "1.2"
+          },
+          {
+            "Version": "1.3",
+            "PackageDetails": {
+              "Name": "CommonServiceLocator",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/CommonServiceLocator/1.3",
+              "LicenseUrl": "http://commonservicelocator.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:20.7480228+02:00",
+        "PackageName": "MvvmLightLibs",
+        "Versions": [
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.1.23.0"
+          },
+          {
+            "Version": "4.1.26.0"
+          },
+          {
+            "Version": "4.1.26.1"
+          },
+          {
+            "Version": "4.1.27.0"
+          },
+          {
+            "Version": "4.1.27.1"
+          },
+          {
+            "Version": "4.2.30.0"
+          },
+          {
+            "Version": "4.3.31.0"
+          },
+          {
+            "Version": "4.3.31.1"
+          },
+          {
+            "Version": "4.4.32.0"
+          },
+          {
+            "Version": "4.4.32.1"
+          },
+          {
+            "Version": "4.4.32.2"
+          },
+          {
+            "Version": "4.4.32.3"
+          },
+          {
+            "Version": "4.4.32.4"
+          },
+          {
+            "Version": "4.4.32.5"
+          },
+          {
+            "Version": "4.4.32.6"
+          },
+          {
+            "Version": "4.4.32.7"
+          },
+          {
+            "Version": "5.0.0.0"
+          },
+          {
+            "Version": "5.0.0.1"
+          },
+          {
+            "Version": "5.0.1.0"
+          },
+          {
+            "Version": "5.0.2.0"
+          },
+          {
+            "Version": "5.1.0.0"
+          },
+          {
+            "Version": "5.1.0.1"
+          },
+          {
+            "Version": "5.1.1.0"
+          },
+          {
+            "Version": "5.2.0.0"
+          },
+          {
+            "Version": "5.3.0.0",
+            "PackageDetails": {
+              "Name": "MvvmLightLibs",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MvvmLightLibs/5.3.0.0",
+              "LicenseUrl": "http://mvvmlight.codeplex.com/license",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "CommonServiceLocator",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": "net35"
+                },
+                {
+                  "PackageName": "CommonServiceLocator",
+                  "VersionRequirement": ">= 1.3",
+                  "FrameworkRestrictions": "monoandroid, xamarinios, winv4.5.1, wpv8.0, wpv8.1, wpav8.1, sl50, portable-net45+win8+wp8+wpa81, >= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.4.0-alpha"
+          }
+        ]
+      }
+    ]
+  },
+  "bin": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:20.7865225+02:00",
+        "PackageName": "Paket.Test.A",
+        "Versions": [
+          {
+            "Version": "1.0.0-prerelease",
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001585-websharper-props/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001585-websharper-props/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:10.6313001+02:00",
+        "PackageName": "WebSharper",
+        "Versions": [
+          {
+            "Version": "3.6.11.234",
+            "PackageDetails": {
+              "Name": "WebSharper",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WebSharper/3.6.11.234",
+              "LicenseUrl": "http://websharper.com/licensing",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001591-convert-denormalized/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001591-convert-denormalized/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:48.0077974+02:00",
+        "PackageName": "EntityFramework",
+        "Versions": [
+          {
+            "Version": "6.1.0",
+            "PackageDetails": {
+              "Name": "EntityFramework",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/EntityFramework/6.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320539",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001621-different-framework/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001621-different-framework/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:07.2195012+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "3.0.1",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NUnit/3.0.1",
+              "LicenseUrl": "http://nunit.org/nuget/nunit3-license.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001663-build-targets/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001663-build-targets/cache/paket-graph.cache
@@ -1,0 +1,40 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:13.8662999+02:00",
+        "PackageName": "BuildWebCompiler",
+        "Versions": [
+          {
+            "Version": "1.10.310",
+            "PackageDetails": {
+              "Name": "BuildWebCompiler",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/BuildWebCompiler/1.10.310",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:13.5593014+02:00",
+        "PackageName": "BuildBundlerMinifier",
+        "Versions": [
+          {
+            "Version": "1.8.154",
+            "PackageDetails": {
+              "Name": "BuildBundlerMinifier",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/BuildBundlerMinifier/1.8.154",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001701-keep-major/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001701-keep-major/cache/paket-graph.cache
@@ -1,0 +1,276 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:18.0413017+02:00",
+        "PackageName": "jQuery",
+        "Versions": [
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3"
+          },
+          {
+            "Version": "1.4.4"
+          },
+          {
+            "Version": "1.5"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.6"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.6.3"
+          },
+          {
+            "Version": "1.6.4"
+          },
+          {
+            "Version": "1.7"
+          },
+          {
+            "Version": "1.7.1"
+          },
+          {
+            "Version": "1.7.1.1"
+          },
+          {
+            "Version": "1.7.2"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.2"
+          },
+          {
+            "Version": "1.8.3"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "1.9.1"
+          },
+          {
+            "Version": "1.10.0"
+          },
+          {
+            "Version": "1.10.0.1"
+          },
+          {
+            "Version": "1.10.1"
+          },
+          {
+            "Version": "1.10.2"
+          },
+          {
+            "Version": "1.11.0"
+          },
+          {
+            "Version": "1.11.1"
+          },
+          {
+            "Version": "1.11.2"
+          },
+          {
+            "Version": "1.11.3"
+          },
+          {
+            "Version": "1.12.0"
+          },
+          {
+            "Version": "1.12.1"
+          },
+          {
+            "Version": "1.12.2"
+          },
+          {
+            "Version": "1.12.3"
+          },
+          {
+            "Version": "1.12.4"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.1.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.1.3"
+          },
+          {
+            "Version": "2.1.4"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.2.3"
+          },
+          {
+            "Version": "2.2.4",
+            "PackageDetails": {
+              "Name": "jQuery",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/jQuery/2.2.4",
+              "LicenseUrl": "http://jquery.org/license",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.0.1"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:17.7328019+02:00",
+        "PackageName": "bootstrap",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2"
+          },
+          {
+            "Version": "3.3.4"
+          },
+          {
+            "Version": "3.3.5"
+          },
+          {
+            "Version": "3.3.6-jQuery3"
+          },
+          {
+            "Version": "3.3.6"
+          },
+          {
+            "Version": "3.3.6.1"
+          },
+          {
+            "Version": "3.3.7",
+            "PackageDetails": {
+              "Name": "bootstrap",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/bootstrap/3.3.7",
+              "LicenseUrl": "https://github.com/twbs/bootstrap/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "jQuery",
+                  "VersionRequirement": ">= 1.9.1 < 4.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0-alpha"
+          },
+          {
+            "Version": "4.0.0-alpha2"
+          },
+          {
+            "Version": "4.0.0-alpha3"
+          },
+          {
+            "Version": "4.0.0-alpha4"
+          },
+          {
+            "Version": "4.0.0-alpha5"
+          },
+          {
+            "Version": "4.0.0-alpha6"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001703-local/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001703-local/cache/paket-graph.cache
@@ -1,0 +1,120 @@
+{
+  "my-package-source": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:23.723531+02:00",
+        "PackageName": "Microsoft.Web.Infrastructure",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Web.Infrastructure",
+              "DownloadLink": "Microsoft.Web.Infrastructure",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=214339",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:23.8665244+02:00",
+        "PackageName": "RazorEngine",
+        "Versions": [
+          {
+            "Version": "3.7.3",
+            "PackageDetails": {
+              "Name": "RazorEngine",
+              "DownloadLink": "RazorEngine",
+              "LicenseUrl": "https://github.com/Antaris/RazorEngine/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 3.0",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": "2.0.30506",
+                  "FrameworkRestrictions": "net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:23.6720229+02:00",
+        "PackageName": "Microsoft.AspNet.WebPages",
+        "Versions": [
+          {
+            "Version": "3.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.WebPages",
+              "DownloadLink": "Microsoft.AspNet.WebPages",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 3.2.3 < 3.3"
+                },
+                {
+                  "PackageName": "Microsoft.Web.Infrastructure",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:23.4740226+02:00",
+        "PackageName": "Microsoft.AspNet.Razor",
+        "Versions": [
+          {
+            "Version": "3.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Razor",
+              "DownloadLink": "Microsoft.AspNet.Razor",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:13:23.356525+02:00",
+        "PackageName": "Microsoft.AspNet.Mvc",
+        "Versions": [
+          {
+            "Version": "5.2.3",
+            "PackageDetails": {
+              "Name": "Microsoft.AspNet.Mvc",
+              "DownloadLink": "Microsoft.AspNet.Mvc",
+              "LicenseUrl": "http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.AspNet.Razor",
+                  "VersionRequirement": ">= 3.2.3 < 3.3"
+                },
+                {
+                  "PackageName": "Microsoft.AspNet.WebPages",
+                  "VersionRequirement": ">= 3.2.3 < 3.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001711-wrong-groupsource/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001711-wrong-groupsource/cache/paket-graph.cache
@@ -1,0 +1,44 @@
+{
+  "TestA": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:47.2181721+02:00",
+        "PackageName": "Test",
+        "Versions": [
+          {
+            "Version": "0.0.1",
+            "PackageDetails": {
+              "Name": "Test",
+              "DownloadLink": "Test",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  },
+  "TestB": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:47.1696711+02:00",
+        "PackageName": "Test",
+        "Versions": [
+          {
+            "Version": "0.0.1",
+            "PackageDetails": {
+              "Name": "Test",
+              "DownloadLink": "Test",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001711-wrong-source/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001711-wrong-source/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "TestA": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:45.0556698+02:00",
+        "PackageName": "Test",
+        "Versions": [
+          {
+            "Version": "0.0.1",
+            "PackageDetails": {
+              "Name": "Test",
+              "DownloadLink": "Test",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001732-lowercase-aliases/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001732-lowercase-aliases/cache/paket-graph.cache
@@ -1,0 +1,60 @@
+{
+  "nuget_repo": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:22.9673075+02:00",
+        "PackageName": "Dapper",
+        "Versions": [
+          {
+            "Version": "1.40"
+          },
+          {
+            "Version": "1.42.0",
+            "PackageDetails": {
+              "Name": "Dapper",
+              "DownloadLink": "Dapper",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:23.0523041+02:00",
+        "PackageName": "NUnit",
+        "Versions": [
+          {
+            "Version": "2.6.4",
+            "PackageDetails": {
+              "Name": "NUnit",
+              "DownloadLink": "NUnit",
+              "LicenseUrl": "http://nunit.org/nuget/license.html",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:22.9888032+02:00",
+        "PackageName": "MultiTarget",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "MultiTarget",
+              "DownloadLink": "MultiTarget",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001737-simplify-with-auto-framework/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001737-simplify-with-auto-framework/cache/paket-graph.cache
@@ -1,0 +1,191 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:42.5501703+02:00",
+        "PackageName": "Microsoft.Owin.Host.SystemWeb",
+        "Versions": [
+          {
+            "Version": "0.12-alpha2"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0-rc2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin.Host.SystemWeb",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Owin.Host.SystemWeb/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Owin",
+                  "VersionRequirement": ">= 3.1"
+                },
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:42.5906705+02:00",
+        "PackageName": "Owin",
+        "Versions": [
+          {
+            "Version": "0.5"
+          },
+          {
+            "Version": "0.7"
+          },
+          {
+            "Version": "0.11"
+          },
+          {
+            "Version": "0.12"
+          },
+          {
+            "Version": "0.14"
+          },
+          {
+            "Version": "1.0",
+            "PackageDetails": {
+              "Name": "Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Owin/1.0",
+              "LicenseUrl": "https://github.com/owin-contrib/owin-hosting/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T01:00:42.3766683+02:00",
+        "PackageName": "Microsoft.Owin",
+        "Versions": [
+          {
+            "Version": "1.1.0-beta1"
+          },
+          {
+            "Version": "1.1.0-beta2"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.1.0-rc1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "3.0.0-alpha1"
+          },
+          {
+            "Version": "3.0.0-beta1"
+          },
+          {
+            "Version": "3.0.0-rc1"
+          },
+          {
+            "Version": "3.0.0-rc2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.1.0-rc1"
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Owin",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Owin/3.1.0",
+              "LicenseUrl": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Owin",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001746-hard-legacy/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001746-hard-legacy/cache/paket-graph.cache
@@ -1,0 +1,157 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:27.9943144+02:00",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:27.9293047+02:00",
+        "PackageName": "microsoft.bcl.async",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.12-beta"
+          },
+          {
+            "Version": "1.0.14-rc"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.165"
+          },
+          {
+            "Version": "1.0.166-beta"
+          },
+          {
+            "Version": "1.0.166"
+          },
+          {
+            "Version": "1.0.168",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.168",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:27.2898042+02:00",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001783-different-versions/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001783-different-versions/cache/paket-graph.cache
@@ -1,0 +1,702 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:15.0272123+02:00",
+        "PackageName": "NodaTime",
+        "Versions": [
+          {
+            "Version": "0.1"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0-rc1"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.1.0-dev"
+          },
+          {
+            "Version": "1.1.0-dev-2013-31-01"
+          },
+          {
+            "Version": "1.1.0-rc1"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.2.0-rc1"
+          },
+          {
+            "Version": "1.2.0-rc2"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0-beta1"
+          },
+          {
+            "Version": "1.3.0-dev-20140515"
+          },
+          {
+            "Version": "1.3.0-dev-20140518"
+          },
+          {
+            "Version": "1.3.0",
+            "PackageDetails": {
+              "Name": "NodaTime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NodaTime/1.3.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.3.3"
+          },
+          {
+            "Version": "1.3.4"
+          },
+          {
+            "Version": "2.0.0-alpha-20160523"
+          },
+          {
+            "Version": "2.0.0-alpha20140807"
+          },
+          {
+            "Version": "2.0.0-alpha20140808"
+          },
+          {
+            "Version": "2.0.0-alpha20150718"
+          },
+          {
+            "Version": "2.0.0-alpha20150728"
+          },
+          {
+            "Version": "2.0.0-alpha20160523"
+          },
+          {
+            "Version": "2.0.0-alpha20160707"
+          },
+          {
+            "Version": "2.0.0-alpha20160729"
+          },
+          {
+            "Version": "2.0.0-beta20170123"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0-rc3"
+          },
+          {
+            "Version": "2.0.0",
+            "PackageDetails": {
+              "Name": "NodaTime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NodaTime/2.0.0",
+              "LicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Xml",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:12.707561+02:00",
+        "PackageName": "Newtonsoft.Json.FSharp",
+        "Versions": [
+          {
+            "Version": "3.2.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json.FSharp",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json.FSharp/3.2.2",
+              "LicenseUrl": "",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.1.2.1"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8"
+                },
+                {
+                  "PackageName": "NodaTime",
+                  "VersionRequirement": ">= 1.3"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:14.3302134+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/7.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/9.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:13.9880473+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FSharp.Core/3.1.2.1",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:37:13.005046+02:00",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001860-attribute/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001860-attribute/cache/paket-graph.cache
@@ -1,0 +1,12638 @@
+{
+  "https://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:48.6665866+02:00",
+        "PackageName": "MBrace.Runtime",
+        "Versions": [
+          {
+            "Version": "0.5.0-alpha"
+          },
+          {
+            "Version": "0.5.1-alpha"
+          },
+          {
+            "Version": "0.5.2-alpha"
+          },
+          {
+            "Version": "0.5.3-alpha"
+          },
+          {
+            "Version": "0.5.4-alpha"
+          },
+          {
+            "Version": "0.5.5-alpha"
+          },
+          {
+            "Version": "0.5.6-alpha"
+          },
+          {
+            "Version": "0.5.7-alpha"
+          },
+          {
+            "Version": "0.5.8-alpha"
+          },
+          {
+            "Version": "0.5.9-alpha"
+          },
+          {
+            "Version": "0.5.10-alpha"
+          },
+          {
+            "Version": "0.5.11-alpha"
+          },
+          {
+            "Version": "0.5.12-alpha"
+          },
+          {
+            "Version": "0.5.13-alpha"
+          },
+          {
+            "Version": "0.10.0-alpha"
+          },
+          {
+            "Version": "0.10.1-alpha"
+          },
+          {
+            "Version": "0.10.2-alpha"
+          },
+          {
+            "Version": "0.10.3-alpha"
+          },
+          {
+            "Version": "0.10.4-alpha"
+          },
+          {
+            "Version": "0.10.5-alpha"
+          },
+          {
+            "Version": "0.10.6-alpha"
+          },
+          {
+            "Version": "0.10.7-alpha"
+          },
+          {
+            "Version": "0.10.8-alpha"
+          },
+          {
+            "Version": "0.10.9-alpha"
+          },
+          {
+            "Version": "0.10.10-alpha"
+          },
+          {
+            "Version": "0.11.0-alpha"
+          },
+          {
+            "Version": "0.11.1-alpha"
+          },
+          {
+            "Version": "0.11.2-alpha"
+          },
+          {
+            "Version": "0.11.3-alpha"
+          },
+          {
+            "Version": "0.11.4-alpha"
+          },
+          {
+            "Version": "0.11.5-alpha"
+          },
+          {
+            "Version": "0.11.6-alpha"
+          },
+          {
+            "Version": "0.11.7-alpha"
+          },
+          {
+            "Version": "0.11.8-alpha"
+          },
+          {
+            "Version": "0.11.9-alpha"
+          },
+          {
+            "Version": "0.11.10-alpha"
+          },
+          {
+            "Version": "0.11.11-alpha"
+          },
+          {
+            "Version": "0.11.12-alpha"
+          },
+          {
+            "Version": "0.12.0-beta"
+          },
+          {
+            "Version": "0.12.1-beta"
+          },
+          {
+            "Version": "0.12.2-beta"
+          },
+          {
+            "Version": "0.13.0-beta"
+          },
+          {
+            "Version": "0.13.1-beta"
+          },
+          {
+            "Version": "0.13.2-beta"
+          },
+          {
+            "Version": "0.14.0-beta"
+          },
+          {
+            "Version": "0.14.1-beta"
+          },
+          {
+            "Version": "0.15.0-beta"
+          },
+          {
+            "Version": "0.15.1-beta"
+          },
+          {
+            "Version": "0.15.2-beta"
+          },
+          {
+            "Version": "0.15.3-beta"
+          },
+          {
+            "Version": "0.16.0-beta"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17"
+          },
+          {
+            "Version": "1.0.18"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0",
+            "PackageDetails": {
+              "Name": "MBrace.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MBrace.Runtime/1.3.0",
+              "LicenseUrl": "https://github.com/mbraceproject/MBrace.Core/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FsPickler",
+                  "VersionRequirement": ">= 2.1 < 2.2"
+                },
+                {
+                  "PackageName": "FsPickler.Json",
+                  "VersionRequirement": ">= 2.1 < 2.2"
+                },
+                {
+                  "PackageName": "MBrace.Core",
+                  "VersionRequirement": "1.3"
+                },
+                {
+                  "PackageName": "Vagabond",
+                  "VersionRequirement": ">= 0.13 < 0.14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.3.1",
+            "PackageDetails": {
+              "Name": "MBrace.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MBrace.Runtime/1.3.1",
+              "LicenseUrl": "https://github.com/mbraceproject/MBrace.Core/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FsPickler",
+                  "VersionRequirement": ">= 2.1 < 2.2"
+                },
+                {
+                  "PackageName": "FsPickler.Json",
+                  "VersionRequirement": ">= 2.1 < 2.2"
+                },
+                {
+                  "PackageName": "MBrace.Core",
+                  "VersionRequirement": "1.3.1"
+                },
+                {
+                  "PackageName": "Vagabond",
+                  "VersionRequirement": ">= 0.13.1 < 0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:43",
+        "PackageName": "MBrace.Azure.Management",
+        "Versions": [
+          {
+            "Version": "0.16.2-beta"
+          },
+          {
+            "Version": "0.16.3-beta"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10"
+          },
+          {
+            "Version": "1.1.11"
+          },
+          {
+            "Version": "1.1.12"
+          },
+          {
+            "Version": "1.1.13"
+          },
+          {
+            "Version": "1.1.14"
+          },
+          {
+            "Version": "1.1.15"
+          },
+          {
+            "Version": "1.1.16"
+          },
+          {
+            "Version": "1.1.17"
+          },
+          {
+            "Version": "1.1.18"
+          },
+          {
+            "Version": "1.1.19"
+          },
+          {
+            "Version": "1.1.20"
+          },
+          {
+            "Version": "1.1.21"
+          },
+          {
+            "Version": "1.1.22"
+          },
+          {
+            "Version": "1.1.23"
+          },
+          {
+            "Version": "1.1.24"
+          },
+          {
+            "Version": "1.1.25"
+          },
+          {
+            "Version": "1.2"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3",
+            "PackageDetails": {
+              "Name": "MBrace.Azure.Management",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MBrace.Azure.Management/1.4.3",
+              "LicenseUrl": "https://github.com/mbraceproject/MBrace.Azure/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "MBrace.Azure",
+                  "VersionRequirement": ">= 1.4.3"
+                },
+                {
+                  "PackageName": "MBrace.Core",
+                  "VersionRequirement": ">= 1.3 < 1.4"
+                },
+                {
+                  "PackageName": "MBrace.Runtime",
+                  "VersionRequirement": ">= 1.3 < 1.4"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0 < 2.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.Libraries",
+                  "VersionRequirement": ">= 2.0 < 3.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.ServiceBus",
+                  "VersionRequirement": ">= 0.18.0-prerelease < 1.0.0-prerelease"
+                },
+                {
+                  "PackageName": "WindowsAzure.ServiceBus",
+                  "VersionRequirement": ">= 3.0 < 4.0"
+                },
+                {
+                  "PackageName": "WindowsAzure.Storage",
+                  "VersionRequirement": ">= 7.0 < 8.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:55",
+        "PackageName": "Vagabond",
+        "Versions": [
+          {
+            "Version": "0.3.0"
+          },
+          {
+            "Version": "0.3.1"
+          },
+          {
+            "Version": "0.3.2"
+          },
+          {
+            "Version": "0.5.0"
+          },
+          {
+            "Version": "0.5.1"
+          },
+          {
+            "Version": "0.5.2"
+          },
+          {
+            "Version": "0.5.3"
+          },
+          {
+            "Version": "0.5.4"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.6.1"
+          },
+          {
+            "Version": "0.6.2"
+          },
+          {
+            "Version": "0.6.3"
+          },
+          {
+            "Version": "0.6.4"
+          },
+          {
+            "Version": "0.6.5"
+          },
+          {
+            "Version": "0.6.6"
+          },
+          {
+            "Version": "0.6.7"
+          },
+          {
+            "Version": "0.6.8"
+          },
+          {
+            "Version": "0.6.9"
+          },
+          {
+            "Version": "0.6.10"
+          },
+          {
+            "Version": "0.6.11"
+          },
+          {
+            "Version": "0.6.12"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.7.1"
+          },
+          {
+            "Version": "0.7.2"
+          },
+          {
+            "Version": "0.7.3"
+          },
+          {
+            "Version": "0.7.4"
+          },
+          {
+            "Version": "0.7.5"
+          },
+          {
+            "Version": "0.7.6"
+          },
+          {
+            "Version": "0.7.7"
+          },
+          {
+            "Version": "0.7.8"
+          },
+          {
+            "Version": "0.7.9"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.8.1"
+          },
+          {
+            "Version": "0.8.2"
+          },
+          {
+            "Version": "0.8.3"
+          },
+          {
+            "Version": "0.8.4"
+          },
+          {
+            "Version": "0.8.5"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.9.1"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.12.1"
+          },
+          {
+            "Version": "0.12.2"
+          },
+          {
+            "Version": "0.12.3"
+          },
+          {
+            "Version": "0.12.4"
+          },
+          {
+            "Version": "0.12.5"
+          },
+          {
+            "Version": "0.12.6"
+          },
+          {
+            "Version": "0.12.7"
+          },
+          {
+            "Version": "0.12.8"
+          },
+          {
+            "Version": "0.12.9"
+          },
+          {
+            "Version": "0.12.10"
+          },
+          {
+            "Version": "0.12.11"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.13.1",
+            "PackageDetails": {
+              "Name": "Vagabond",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Vagabond/0.13.1",
+              "LicenseUrl": "https://github.com/nessos/Vagabond/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FsPickler",
+                  "VersionRequirement": ">= 2.1 < 2.2"
+                },
+                {
+                  "PackageName": "Mono.Cecil",
+                  "VersionRequirement": ">= 0.9.6.3 < 0.9.7"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.14.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:28.5755212+02:00",
+        "PackageName": "Microsoft.WindowsAzure.Management.ServiceBus",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "0.9.10-preview"
+          },
+          {
+            "Version": "0.9.11-preview"
+          },
+          {
+            "Version": "0.10.0-preview"
+          },
+          {
+            "Version": "0.10.1-preview"
+          },
+          {
+            "Version": "0.10.2-preview"
+          },
+          {
+            "Version": "0.11.0-preview"
+          },
+          {
+            "Version": "0.11.1-preview"
+          },
+          {
+            "Version": "0.12.0-preview"
+          },
+          {
+            "Version": "0.13.0-preview"
+          },
+          {
+            "Version": "0.14.0-preview"
+          },
+          {
+            "Version": "0.15.0-preview"
+          },
+          {
+            "Version": "0.15.1-preview"
+          },
+          {
+            "Version": "0.15.2-preview"
+          },
+          {
+            "Version": "0.16.0-preview"
+          },
+          {
+            "Version": "0.17.0-preview"
+          },
+          {
+            "Version": "0.17.1-preview"
+          },
+          {
+            "Version": "0.18.0-preview",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.ServiceBus/0.18.0-preview",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "0.19.0-preview",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.ServiceBus/0.19.0-preview",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:13.4738751+02:00",
+        "PackageName": "System.Collections.Concurrent",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.12-rc2-24027"
+          },
+          {
+            "Version": "4.0.12"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Collections.Concurrent",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Concurrent/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:22.5968908+02:00",
+        "PackageName": "System.Runtime.Numerics",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Numerics",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Numerics/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:57.4215952+02:00",
+        "PackageName": "Hyak.Common",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.1",
+            "PackageDetails": {
+              "Name": "Hyak.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Hyak.Common/1.1.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.9",
+                  "FrameworkRestrictions": "portable-net403+win+wpa81, >= net40-full"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "portable-net403+win+wpa81, >= net40-full"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14",
+                  "FrameworkRestrictions": "portable-net403+win+wpa81, >= net40-full"
+                },
+                {
+                  "PackageName": "Microsoft.Net.Http",
+                  "VersionRequirement": ">= 2.2.22",
+                  "FrameworkRestrictions": "portable-net403+win+wpa81, >= net40-full"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 7.0.1",
+                  "FrameworkRestrictions": "portable-net403+win+wpa81, >= net40-full"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3",
+            "PackageDetails": {
+              "Name": "Hyak.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Hyak.Common/1.1.3",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 9.0.1 < 10.0",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3.1",
+                  "FrameworkRestrictions": "netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3 < 5.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3 < 5.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:10.0780929+02:00",
+        "PackageName": "Microsoft.WindowsAzure.Management.Compute",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "0.9.10-preview"
+          },
+          {
+            "Version": "0.9.11-preview"
+          },
+          {
+            "Version": "0.9.12-preview"
+          },
+          {
+            "Version": "0.9.13-preview"
+          },
+          {
+            "Version": "0.9.14-preview"
+          },
+          {
+            "Version": "0.9.15-preview"
+          },
+          {
+            "Version": "0.9.16-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.3.0"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.1.2"
+          },
+          {
+            "Version": "7.0.0"
+          },
+          {
+            "Version": "8.0.0"
+          },
+          {
+            "Version": "9.0.0"
+          },
+          {
+            "Version": "9.1.0"
+          },
+          {
+            "Version": "9.2.0"
+          },
+          {
+            "Version": "9.2.1"
+          },
+          {
+            "Version": "11.2.1"
+          },
+          {
+            "Version": "12.0.0"
+          },
+          {
+            "Version": "12.0.1"
+          },
+          {
+            "Version": "12.2.0-preview"
+          },
+          {
+            "Version": "12.3.0"
+          },
+          {
+            "Version": "12.3.1"
+          },
+          {
+            "Version": "12.5.0"
+          },
+          {
+            "Version": "12.6.0"
+          },
+          {
+            "Version": "12.7.0"
+          },
+          {
+            "Version": "12.8.0"
+          },
+          {
+            "Version": "13.0",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Compute",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Compute/13.0.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "14.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Compute",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Compute/14.0.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:22.2088908+02:00",
+        "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices.RuntimeInformation",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices.RuntimeInformation/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:58.9460912+02:00",
+        "PackageName": "Microsoft.Azure.KeyVault.Core",
+        "Versions": [
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.KeyVault.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.KeyVault.Core/1.0.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.0.0-preview"
+          },
+          {
+            "Version": "2.0.2-preview"
+          },
+          {
+            "Version": "2.0.3-preview"
+          },
+          {
+            "Version": "2.0.4",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.KeyVault.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.KeyVault.Core/2.0.4",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:25.5098885+02:00",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:03.1680928+02:00",
+        "PackageName": "Microsoft.Azure.Management.Sql",
+        "Versions": [
+          {
+            "Version": "0.9.0-prerelease"
+          },
+          {
+            "Version": "0.9.1-prerelease"
+          },
+          {
+            "Version": "0.10.0-prerelease"
+          },
+          {
+            "Version": "0.11.0-prerelease"
+          },
+          {
+            "Version": "0.11.1-prerelease"
+          },
+          {
+            "Version": "0.12.0-prerelease"
+          },
+          {
+            "Version": "0.14.0-prerelease"
+          },
+          {
+            "Version": "0.14.1-prerelease"
+          },
+          {
+            "Version": "0.14.2-prerelease"
+          },
+          {
+            "Version": "0.14.3-prerelease"
+          },
+          {
+            "Version": "0.15.0-prerelease"
+          },
+          {
+            "Version": "0.16.0-prerelease"
+          },
+          {
+            "Version": "0.16.1-prerelease"
+          },
+          {
+            "Version": "0.16.2-prerelease"
+          },
+          {
+            "Version": "0.17.0-prerelease"
+          },
+          {
+            "Version": "0.18.0-prerelease"
+          },
+          {
+            "Version": "0.19.0-prerelease"
+          },
+          {
+            "Version": "0.20.0-prerelease"
+          },
+          {
+            "Version": "0.21.0-prerelease"
+          },
+          {
+            "Version": "0.22.0-prerelease"
+          },
+          {
+            "Version": "0.25.0-prerelease"
+          },
+          {
+            "Version": "0.26.0-prerelease"
+          },
+          {
+            "Version": "0.28.0-prerelease"
+          },
+          {
+            "Version": "0.29.0-prerelease"
+          },
+          {
+            "Version": "0.30.0-prerelease"
+          },
+          {
+            "Version": "0.31.0-prerelease"
+          },
+          {
+            "Version": "0.32.0-prerelease"
+          },
+          {
+            "Version": "0.33.0-prerelease"
+          },
+          {
+            "Version": "0.34.0-prerelease"
+          },
+          {
+            "Version": "0.35.0-prerelease"
+          },
+          {
+            "Version": "0.36.0-prerelease"
+          },
+          {
+            "Version": "0.37.0-prerelease"
+          },
+          {
+            "Version": "0.38.0-prerelease"
+          },
+          {
+            "Version": "0.39.0-prerelease"
+          },
+          {
+            "Version": "0.40.0-prerelease"
+          },
+          {
+            "Version": "0.41.0-prerelease"
+          },
+          {
+            "Version": "0.42.0-prerelease"
+          },
+          {
+            "Version": "0.43.0-prerelease"
+          },
+          {
+            "Version": "0.44.0-prerelease"
+          },
+          {
+            "Version": "0.45.0-prerelease"
+          },
+          {
+            "Version": "0.46.0-prerelease"
+          },
+          {
+            "Version": "0.47.0-prerelease"
+          },
+          {
+            "Version": "0.48.0-prerelease"
+          },
+          {
+            "Version": "0.49.0-prerelease",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Management.Sql",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Management.Sql/0.49.0-prerelease",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.1 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.50.0-prerelease"
+          },
+          {
+            "Version": "0.51.0-prerelease"
+          },
+          {
+            "Version": "0.52.0-prerelease"
+          },
+          {
+            "Version": "0.53.0-prerelease"
+          },
+          {
+            "Version": "0.54.0-prerelease"
+          },
+          {
+            "Version": "0.55.0-prerelease"
+          },
+          {
+            "Version": "0.55.1-prerelease"
+          },
+          {
+            "Version": "1.1.0-preview"
+          },
+          {
+            "Version": "1.2.0-preview"
+          },
+          {
+            "Version": "1.3.0-preview",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Management.Sql",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Management.Sql/1.3.0-preview",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime",
+                  "VersionRequirement": ">= 2.3.6 < 3.0",
+                  "FrameworkRestrictions": ">= net452, >= netstandard14"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+                  "VersionRequirement": ">= 3.3.5 < 4.0",
+                  "FrameworkRestrictions": ">= net452, >= netstandard14"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:17.7168865+02:00",
+        "PackageName": "System.Net.Sockets",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10-beta-23123"
+          },
+          {
+            "Version": "4.1.0-beta-23225"
+          },
+          {
+            "Version": "4.1.0-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Net.Sockets",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Sockets/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:51",
+        "PackageName": "Microsoft.WindowsAzure.Management",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management/4.1.1",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:51",
+        "PackageName": "Microsoft.WindowsAzure.Common.Dependencies",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Common.Dependencies",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Common.Dependencies/1.1.1",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.9",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Net.Http",
+                  "VersionRequirement": ">= 2.2.22",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.4",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:01.0685971+02:00",
+        "PackageName": "Microsoft.Azure.Management.Compute",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "5.0.1-preview"
+          },
+          {
+            "Version": "6.0.0-preview"
+          },
+          {
+            "Version": "7.0.0-preview"
+          },
+          {
+            "Version": "8.0.0"
+          },
+          {
+            "Version": "8.1.0"
+          },
+          {
+            "Version": "8.2.0"
+          },
+          {
+            "Version": "9.0.0"
+          },
+          {
+            "Version": "9.1.0"
+          },
+          {
+            "Version": "10.0.0-prerelease"
+          },
+          {
+            "Version": "11.0.0-prerelease"
+          },
+          {
+            "Version": "11.1.0-prerelease"
+          },
+          {
+            "Version": "11.1.1-prerelease"
+          },
+          {
+            "Version": "11.2.0-prerelease"
+          },
+          {
+            "Version": "11.3.0-prerelease"
+          },
+          {
+            "Version": "11.3.1-prerelease"
+          },
+          {
+            "Version": "12.0.0-prerelease"
+          },
+          {
+            "Version": "12.0.1-prerelease"
+          },
+          {
+            "Version": "13.0.0-prerelease"
+          },
+          {
+            "Version": "13.0.1-prerelease"
+          },
+          {
+            "Version": "13.0.2-prerelease"
+          },
+          {
+            "Version": "13.0.3-prerelease"
+          },
+          {
+            "Version": "13.0.4-prerelease",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Management.Compute",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Management.Compute/13.0.4-prerelease",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+                  "VersionRequirement": ">= 3.1 < 4.0",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+                  "VersionRequirement": ">= 3.3.1 < 4.0",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "13.1.0-prerelease"
+          },
+          {
+            "Version": "14.0.0-prerelease"
+          },
+          {
+            "Version": "14.1.0-prerelease",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Management.Compute",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Management.Compute/14.1.0-prerelease",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime",
+                  "VersionRequirement": ">= 2.3.5 < 3.0",
+                  "FrameworkRestrictions": ">= net45, netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+                  "VersionRequirement": ">= 3.3.5 < 4.0",
+                  "FrameworkRestrictions": ">= net45, netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:16.6798884+02:00",
+        "PackageName": "System.IO.FileSystem.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:48.4125869+02:00",
+        "PackageName": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/1.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320301",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.1",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/1.0.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320301",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.2",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/1.0.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320301",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.3",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/1.0.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320301",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.4",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/1.0.4",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320301",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "1.0.5",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/1.0.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320301",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.5.0-alpha"
+          },
+          {
+            "Version": "2.5.1-alpha"
+          },
+          {
+            "Version": "2.6.0-alpha"
+          },
+          {
+            "Version": "2.6.1-alpha"
+          },
+          {
+            "Version": "2.6.2-alpha"
+          },
+          {
+            "Version": "2.7.10703-rc"
+          },
+          {
+            "Version": "2.7.10703.1814-rc"
+          },
+          {
+            "Version": "2.7.10707.1513-rc"
+          },
+          {
+            "Version": "2.8.10804.1442-rc"
+          },
+          {
+            "Version": "2.9.10826.1824",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.9.10826.1824",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.10.10910.1511",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.10.10910.1511",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.11.10918.1222",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.11.10918.1222",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.12.111071459",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.12.111071459",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.13.112171830",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.13.112171830",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.13.112191810",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.13.112191810",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.14.201151115",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.14.201151115",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.15.204151539",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.15.204151539",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.16.204221202",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.16.204221202",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.17.206230854",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.17.206230854",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.18.206251556",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.18.206251556",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.19.208020213",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.19.208020213",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.20.301151232",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.20.301151232",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.21.301221612",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.21.301221612",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.22.302111727",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.22.302111727",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.23.302261847",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.23.302261847",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.24.304111323",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.24.304111323",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.25.305061457",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.25.305061457",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.26.305100852",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.26.305100852",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.26.305102204",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.26.305102204",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.27.306291202",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.27.306291202",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.28.0",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.0",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.28.1",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.1",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.28.2",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.2",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.28.3",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.3",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "2.28.4",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.4",
+              "LicenseUrl": "https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.110281957-alpha"
+          },
+          {
+            "Version": "3.1.203031538-alpha"
+          },
+          {
+            "Version": "3.2.204281119-alpha"
+          },
+          {
+            "Version": "3.3.205061641-alpha"
+          },
+          {
+            "Version": "3.4.206191646-alpha"
+          },
+          {
+            "Version": "3.5.207081303-alpha"
+          },
+          {
+            "Version": "3.5.208012240-alpha"
+          },
+          {
+            "Version": "3.5.208051316-alpha"
+          },
+          {
+            "Version": "3.6.210231457-alpha"
+          },
+          {
+            "Version": "3.6.212011103-alpha"
+          },
+          {
+            "Version": "3.6.212012344-alpha"
+          },
+          {
+            "Version": "3.6.212041202-alpha"
+          },
+          {
+            "Version": "3.7.301251358-alpha"
+          },
+          {
+            "Version": "3.8.301280212-alpha"
+          },
+          {
+            "Version": "3.9.302111717-alpha"
+          },
+          {
+            "Version": "3.9.302261508-alpha"
+          },
+          {
+            "Version": "3.9.304210845",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.9.304210845",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.10.305052128",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.10.305052128",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.10.305110106",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.10.305110106",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.10.305161347",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.10.305161347",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.10.305231913",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.10.305231913",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.11.0",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.11.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.11.305310302-alpha"
+          },
+          {
+            "Version": "3.12.0",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.12.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.0",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.13.1",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.2",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.3",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.4",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.4",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.5",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.6",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.6",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net461, >= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.7",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.7",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NetStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.8",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.8",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=317295",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= netstandard14"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.13.9",
+            "PackageDetails": {
+              "Name": "Microsoft.IdentityModel.Clients.ActiveDirectory",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.IdentityModel.Clients.ActiveDirectory/3.13.9",
+              "LicenseUrl": "https://go.microsoft.com/fwlink/?linkid=841311",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= netstandard14"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= netstandard14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:07.2905922+02:00",
+        "PackageName": "Microsoft.Rest.ClientRuntime",
+        "Versions": [
+          {
+            "Version": "0.9.4"
+          },
+          {
+            "Version": "0.9.5"
+          },
+          {
+            "Version": "0.9.6"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "1.8.2"
+          },
+          {
+            "Version": "1.9.0"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Rest.ClientRuntime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Rest.ClientRuntime/2.3.2",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 9.0.1 < 10.0",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.3.3"
+          },
+          {
+            "Version": "2.3.4"
+          },
+          {
+            "Version": "2.3.5"
+          },
+          {
+            "Version": "2.3.6",
+            "PackageDetails": {
+              "Name": "Microsoft.Rest.ClientRuntime",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Rest.ClientRuntime/2.3.6",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 9.0.1 < 10.0",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.0.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:56.3775896+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.0.0.1",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:21.8648942+02:00",
+        "PackageName": "System.Runtime.InteropServices",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.InteropServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.InteropServices/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, net462, >= net463, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netcore11, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:20.4648868+02:00",
+        "PackageName": "System.Runtime",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22231"
+          },
+          {
+            "Version": "4.0.20-beta-22416"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:23.5368885+02:00",
+        "PackageName": "System.Security.Cryptography.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:53",
+        "PackageName": "Mono.Cecil",
+        "Versions": [
+          {
+            "Version": "0.9.4.0"
+          },
+          {
+            "Version": "0.9.4.1"
+          },
+          {
+            "Version": "0.9.5.0"
+          },
+          {
+            "Version": "0.9.5.1"
+          },
+          {
+            "Version": "0.9.5.2"
+          },
+          {
+            "Version": "0.9.5.3"
+          },
+          {
+            "Version": "0.9.5.4"
+          },
+          {
+            "Version": "0.9.6.0-rev1"
+          },
+          {
+            "Version": "0.9.6.0"
+          },
+          {
+            "Version": "0.9.6.1"
+          },
+          {
+            "Version": "0.9.6.2"
+          },
+          {
+            "Version": "0.9.6.3"
+          },
+          {
+            "Version": "0.9.6.4",
+            "PackageDetails": {
+              "Name": "Mono.Cecil",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Mono.Cecil/0.9.6.4",
+              "LicenseUrl": "http://opensource.org/licenses/mit-license.php",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "0.10.0-beta1"
+          },
+          {
+            "Version": "0.10.0-beta1-v2"
+          },
+          {
+            "Version": "0.10.0-beta2"
+          },
+          {
+            "Version": "0.10.0-beta3"
+          },
+          {
+            "Version": "0.10.0-beta4"
+          },
+          {
+            "Version": "0.10.0-beta5"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:52",
+        "PackageName": "Microsoft.WindowsAzure.Management.Monitoring",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "0.9.10-preview"
+          },
+          {
+            "Version": "0.9.11-preview"
+          },
+          {
+            "Version": "0.10.0-preview"
+          },
+          {
+            "Version": "0.10.1-preview"
+          },
+          {
+            "Version": "0.10.2-preview"
+          },
+          {
+            "Version": "0.10.3-preview"
+          },
+          {
+            "Version": "0.11.0-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.1",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Monitoring",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Monitoring/4.1.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.1 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:23.0709048+02:00",
+        "PackageName": "System.Security.Cryptography.Algorithms",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Algorithms",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Algorithms/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.Apple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, net461, >= net463, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:27.4310219+02:00",
+        "PackageName": "MBrace.Flow",
+        "Versions": [
+          {
+            "Version": "0.9.8-alpha"
+          },
+          {
+            "Version": "0.9.9-alpha"
+          },
+          {
+            "Version": "0.9.10-alpha"
+          },
+          {
+            "Version": "0.9.11-alpha"
+          },
+          {
+            "Version": "0.9.12-alpha"
+          },
+          {
+            "Version": "0.9.13-alpha"
+          },
+          {
+            "Version": "0.9.14-alpha"
+          },
+          {
+            "Version": "0.10.0-alpha"
+          },
+          {
+            "Version": "0.10.1-alpha"
+          },
+          {
+            "Version": "0.10.2-alpha"
+          },
+          {
+            "Version": "0.10.3-alpha"
+          },
+          {
+            "Version": "0.10.4-alpha"
+          },
+          {
+            "Version": "0.10.5-alpha"
+          },
+          {
+            "Version": "0.10.6-alpha"
+          },
+          {
+            "Version": "0.10.7-alpha"
+          },
+          {
+            "Version": "0.10.8-alpha"
+          },
+          {
+            "Version": "0.10.9-alpha"
+          },
+          {
+            "Version": "0.10.10-alpha"
+          },
+          {
+            "Version": "0.11.0-alpha"
+          },
+          {
+            "Version": "0.11.1-alpha"
+          },
+          {
+            "Version": "0.11.2-alpha"
+          },
+          {
+            "Version": "0.11.3-alpha"
+          },
+          {
+            "Version": "0.11.4-alpha"
+          },
+          {
+            "Version": "0.11.5-alpha"
+          },
+          {
+            "Version": "0.11.6-alpha"
+          },
+          {
+            "Version": "0.11.7-alpha"
+          },
+          {
+            "Version": "0.11.8-alpha"
+          },
+          {
+            "Version": "0.11.9-alpha"
+          },
+          {
+            "Version": "0.11.10-alpha"
+          },
+          {
+            "Version": "0.11.11-alpha"
+          },
+          {
+            "Version": "0.11.12-alpha"
+          },
+          {
+            "Version": "0.12.0-beta"
+          },
+          {
+            "Version": "0.12.1-beta"
+          },
+          {
+            "Version": "0.12.2-beta"
+          },
+          {
+            "Version": "0.13.0-beta"
+          },
+          {
+            "Version": "0.13.1-beta"
+          },
+          {
+            "Version": "0.13.2-beta"
+          },
+          {
+            "Version": "0.14.0-beta"
+          },
+          {
+            "Version": "0.14.1-beta"
+          },
+          {
+            "Version": "0.15.0-beta"
+          },
+          {
+            "Version": "0.15.1-beta"
+          },
+          {
+            "Version": "0.15.2-beta"
+          },
+          {
+            "Version": "0.15.3-beta"
+          },
+          {
+            "Version": "0.16.0-beta"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17"
+          },
+          {
+            "Version": "1.0.18"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1",
+            "PackageDetails": {
+              "Name": "MBrace.Flow",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MBrace.Flow/1.3.1",
+              "LicenseUrl": "https://github.com/mbraceproject/MBrace.Core/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.0"
+                },
+                {
+                  "PackageName": "MBrace.Core",
+                  "VersionRequirement": "1.3.1"
+                },
+                {
+                  "PackageName": "Streams",
+                  "VersionRequirement": ">= 0.4 < 0.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.4.0",
+            "PackageDetails": {
+              "Name": "MBrace.Flow",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MBrace.Flow/1.4.0",
+              "LicenseUrl": "https://github.com/mbraceproject/MBrace.Core/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 3.0"
+                },
+                {
+                  "PackageName": "MBrace.Core",
+                  "VersionRequirement": "1.4"
+                },
+                {
+                  "PackageName": "Streams",
+                  "VersionRequirement": ">= 0.4 < 0.5"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:26.0263903+02:00",
+        "PackageName": "System.Xml.XDocument",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.0.11-rc2-24027"
+          },
+          {
+            "Version": "4.0.11"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Xml.XDocument",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Xml.XDocument/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:45",
+        "PackageName": "Microsoft.Bcl",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.16-rc"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0-beta"
+          },
+          {
+            "Version": "1.1.2-rc"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl/1.1.10",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:52",
+        "PackageName": "Microsoft.WindowsAzure.Management.Sql",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "0.9.10-preview"
+          },
+          {
+            "Version": "0.9.11-preview"
+          },
+          {
+            "Version": "0.9.12-preview"
+          },
+          {
+            "Version": "0.9.13-preview"
+          },
+          {
+            "Version": "0.9.14-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.2",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Sql",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Sql/5.2.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:28.6290222+02:00",
+        "PackageName": "Microsoft.Bcl.Async",
+        "Versions": [
+          {
+            "Version": "1.0.11-beta"
+          },
+          {
+            "Version": "1.0.12-beta"
+          },
+          {
+            "Version": "1.0.14-rc"
+          },
+          {
+            "Version": "1.0.16",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.16",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkID=296434",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.0.19"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.165",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.165",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.0.19"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.166-beta"
+          },
+          {
+            "Version": "1.0.166",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.166",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.0.19",
+                  "FrameworkRestrictions": ">= net10"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.7",
+                  "FrameworkRestrictions": "wpav8.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "1.0.168",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Async",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Bcl.Async/1.0.168",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.8"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:14.7823734+02:00",
+        "PackageName": "System.Globalization.Calendars",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Globalization.Calendars",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Globalization.Calendars/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:12.9813754+02:00",
+        "PackageName": "System.AppContext",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.AppContext",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.AppContext/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:16.4568877+02:00",
+        "PackageName": "System.IO.FileSystem",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.FileSystem",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.FileSystem/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:43",
+        "PackageName": "MBrace.Core",
+        "Versions": [
+          {
+            "Version": "0.5.0-alpha"
+          },
+          {
+            "Version": "0.5.1-alpha"
+          },
+          {
+            "Version": "0.5.2-alpha"
+          },
+          {
+            "Version": "0.5.3-alpha"
+          },
+          {
+            "Version": "0.5.4-alpha"
+          },
+          {
+            "Version": "0.5.5-alpha"
+          },
+          {
+            "Version": "0.5.6-alpha"
+          },
+          {
+            "Version": "0.5.7-alpha"
+          },
+          {
+            "Version": "0.5.8-alpha"
+          },
+          {
+            "Version": "0.5.9-alpha"
+          },
+          {
+            "Version": "0.5.10-alpha"
+          },
+          {
+            "Version": "0.5.11-alpha"
+          },
+          {
+            "Version": "0.5.12-alpha"
+          },
+          {
+            "Version": "0.5.13-alpha"
+          },
+          {
+            "Version": "0.9.0-alpha"
+          },
+          {
+            "Version": "0.9.1-alpha"
+          },
+          {
+            "Version": "0.9.2-alpha"
+          },
+          {
+            "Version": "0.9.3-alpha"
+          },
+          {
+            "Version": "0.9.4-alpha"
+          },
+          {
+            "Version": "0.9.5-alpha"
+          },
+          {
+            "Version": "0.9.6-alpha"
+          },
+          {
+            "Version": "0.9.7-alpha"
+          },
+          {
+            "Version": "0.9.8-alpha"
+          },
+          {
+            "Version": "0.9.9-alpha"
+          },
+          {
+            "Version": "0.9.10-alpha"
+          },
+          {
+            "Version": "0.9.11-alpha"
+          },
+          {
+            "Version": "0.9.12-alpha"
+          },
+          {
+            "Version": "0.9.13-alpha"
+          },
+          {
+            "Version": "0.9.14-alpha"
+          },
+          {
+            "Version": "0.10.0-alpha"
+          },
+          {
+            "Version": "0.10.1-alpha"
+          },
+          {
+            "Version": "0.10.2-alpha"
+          },
+          {
+            "Version": "0.10.3-alpha"
+          },
+          {
+            "Version": "0.10.4-alpha"
+          },
+          {
+            "Version": "0.10.5-alpha"
+          },
+          {
+            "Version": "0.10.6-alpha"
+          },
+          {
+            "Version": "0.10.7-alpha"
+          },
+          {
+            "Version": "0.10.8-alpha"
+          },
+          {
+            "Version": "0.10.9-alpha"
+          },
+          {
+            "Version": "0.10.10-alpha"
+          },
+          {
+            "Version": "0.11.0-alpha"
+          },
+          {
+            "Version": "0.11.1-alpha"
+          },
+          {
+            "Version": "0.11.2-alpha"
+          },
+          {
+            "Version": "0.11.3-alpha"
+          },
+          {
+            "Version": "0.11.4-alpha"
+          },
+          {
+            "Version": "0.11.5-alpha"
+          },
+          {
+            "Version": "0.11.6-alpha"
+          },
+          {
+            "Version": "0.11.7-alpha"
+          },
+          {
+            "Version": "0.11.8-alpha"
+          },
+          {
+            "Version": "0.11.9-alpha"
+          },
+          {
+            "Version": "0.11.10-alpha"
+          },
+          {
+            "Version": "0.11.11-alpha"
+          },
+          {
+            "Version": "0.11.12-alpha"
+          },
+          {
+            "Version": "0.12.0-beta"
+          },
+          {
+            "Version": "0.12.1-beta"
+          },
+          {
+            "Version": "0.12.2-beta"
+          },
+          {
+            "Version": "0.13.0-beta"
+          },
+          {
+            "Version": "0.13.1-beta"
+          },
+          {
+            "Version": "0.13.2-beta"
+          },
+          {
+            "Version": "0.14.0-beta"
+          },
+          {
+            "Version": "0.14.1-beta"
+          },
+          {
+            "Version": "0.15.0-beta"
+          },
+          {
+            "Version": "0.15.1-beta"
+          },
+          {
+            "Version": "0.15.2-beta"
+          },
+          {
+            "Version": "0.15.3-beta"
+          },
+          {
+            "Version": "0.16.0-beta"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17"
+          },
+          {
+            "Version": "1.0.18"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1",
+            "PackageDetails": {
+              "Name": "MBrace.Core",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MBrace.Core/1.3.1",
+              "LicenseUrl": "https://github.com/mbraceproject/MBrace.Core/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.4.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:23.3728895+02:00",
+        "PackageName": "System.Security.Cryptography.Encoding",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.Encoding",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.Encoding/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:13.6293748+02:00",
+        "PackageName": "System.Collections.Immutable",
+        "Versions": [
+          {
+            "Version": "1.1.32-beta"
+          },
+          {
+            "Version": "1.1.33-beta"
+          },
+          {
+            "Version": "1.1.34-rc"
+          },
+          {
+            "Version": "1.1.36"
+          },
+          {
+            "Version": "1.1.37-beta-23019"
+          },
+          {
+            "Version": "1.1.37-beta-23109"
+          },
+          {
+            "Version": "1.1.37"
+          },
+          {
+            "Version": "1.1.38-beta-23225"
+          },
+          {
+            "Version": "1.1.38-beta-23409"
+          },
+          {
+            "Version": "1.1.38-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-24027"
+          },
+          {
+            "Version": "1.2",
+            "PackageDetails": {
+              "Name": "System.Collections.Immutable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Immutable/1.2.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1",
+            "PackageDetails": {
+              "Name": "System.Collections.Immutable",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Collections.Immutable/1.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:27.2878888+02:00",
+        "PackageName": "WindowsAzure.ServiceBus",
+        "Versions": [
+          {
+            "Version": "0.0.1"
+          },
+          {
+            "Version": "0.5.0.0"
+          },
+          {
+            "Version": "0.6.0.0"
+          },
+          {
+            "Version": "1.5.0.0"
+          },
+          {
+            "Version": "1.6.0.0"
+          },
+          {
+            "Version": "1.7.0.0"
+          },
+          {
+            "Version": "1.7.0.1"
+          },
+          {
+            "Version": "1.8.0.0"
+          },
+          {
+            "Version": "2.0.0-alpha"
+          },
+          {
+            "Version": "2.0.0-beta"
+          },
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.0.1.0"
+          },
+          {
+            "Version": "2.1.0.0"
+          },
+          {
+            "Version": "2.1.1.0"
+          },
+          {
+            "Version": "2.1.2.0"
+          },
+          {
+            "Version": "2.1.3.0"
+          },
+          {
+            "Version": "2.1.4.0"
+          },
+          {
+            "Version": "2.2.0.0"
+          },
+          {
+            "Version": "2.2.1.0"
+          },
+          {
+            "Version": "2.2.1.1"
+          },
+          {
+            "Version": "2.2.2.0"
+          },
+          {
+            "Version": "2.2.3.0"
+          },
+          {
+            "Version": "2.2.4.0"
+          },
+          {
+            "Version": "2.2.5.0"
+          },
+          {
+            "Version": "2.2.6.0"
+          },
+          {
+            "Version": "2.2.7.0"
+          },
+          {
+            "Version": "2.3.0.0"
+          },
+          {
+            "Version": "2.3.1.0"
+          },
+          {
+            "Version": "2.3.2.0"
+          },
+          {
+            "Version": "2.3.2.1"
+          },
+          {
+            "Version": "2.3.2.2"
+          },
+          {
+            "Version": "2.3.3.0"
+          },
+          {
+            "Version": "2.3.4.0"
+          },
+          {
+            "Version": "2.4.1.0"
+          },
+          {
+            "Version": "2.4.1.1"
+          },
+          {
+            "Version": "2.4.2.0"
+          },
+          {
+            "Version": "2.4.3.0"
+          },
+          {
+            "Version": "2.4.4.0"
+          },
+          {
+            "Version": "2.4.5.0"
+          },
+          {
+            "Version": "2.4.6.0"
+          },
+          {
+            "Version": "2.4.7.0"
+          },
+          {
+            "Version": "2.4.8.0"
+          },
+          {
+            "Version": "2.4.9.0"
+          },
+          {
+            "Version": "2.4.10.0"
+          },
+          {
+            "Version": "2.5.0.0"
+          },
+          {
+            "Version": "2.5.1.0"
+          },
+          {
+            "Version": "2.5.2.0"
+          },
+          {
+            "Version": "2.5.3.0"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "2.6.1"
+          },
+          {
+            "Version": "2.6.2"
+          },
+          {
+            "Version": "2.6.4"
+          },
+          {
+            "Version": "2.6.5"
+          },
+          {
+            "Version": "2.6.6"
+          },
+          {
+            "Version": "2.6.7"
+          },
+          {
+            "Version": "2.7.0"
+          },
+          {
+            "Version": "2.7.1"
+          },
+          {
+            "Version": "2.7.2"
+          },
+          {
+            "Version": "2.7.3"
+          },
+          {
+            "Version": "2.7.5"
+          },
+          {
+            "Version": "2.7.6"
+          },
+          {
+            "Version": "2.8.0"
+          },
+          {
+            "Version": "2.8.1"
+          },
+          {
+            "Version": "2.8.2"
+          },
+          {
+            "Version": "3.0.0-preview"
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.1-preview"
+          },
+          {
+            "Version": "3.0.1",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.2",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.3",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.4",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.4",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.6",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.6",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.7",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.7",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.8",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.8",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.0.9",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.0.9",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.1",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ""
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.2",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ">= 3.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.3",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ">= 3.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.4",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.4",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.ConfigurationManager",
+                  "VersionRequirement": ">= 3.1"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.1.5",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.6",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.6",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.7",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.1.7",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.2.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.1",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.2.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.2",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.2.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.3",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.2.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2.4",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.2.4",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.1",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.3.2",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.3.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.4.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.1",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.4.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.2",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.4.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.3",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.4.3",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.4",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.4.4",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": true,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.5",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.4.5",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.4.6",
+            "PackageDetails": {
+              "Name": "WindowsAzure.ServiceBus",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.ServiceBus/3.4.6",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=218949",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:12.0483734+02:00",
+        "PackageName": "Microsoft.WindowsAzure.Management.Network",
+        "Versions": [
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "2.2.2"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.3.1"
+          },
+          {
+            "Version": "2.3.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "6.1.1"
+          },
+          {
+            "Version": "6.1.2"
+          },
+          {
+            "Version": "7.0.0"
+          },
+          {
+            "Version": "7.0.2"
+          },
+          {
+            "Version": "7.0.3"
+          },
+          {
+            "Version": "7.0.4"
+          },
+          {
+            "Version": "7.0.5"
+          },
+          {
+            "Version": "7.1.0"
+          },
+          {
+            "Version": "7.1.1"
+          },
+          {
+            "Version": "7.1.2"
+          },
+          {
+            "Version": "7.1.3"
+          },
+          {
+            "Version": "8.0",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Network",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Network/8.0.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.1 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "8.1.0"
+          },
+          {
+            "Version": "8.2.0",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Network",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Network/8.2.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.1 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:55.2825898+02:00",
+        "PackageName": "Argu",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "2.0"
+          },
+          {
+            "Version": "2.1"
+          },
+          {
+            "Version": "3.0.0-alpha001"
+          },
+          {
+            "Version": "3.0.0-alpha002"
+          },
+          {
+            "Version": "3.0.0-alpha003"
+          },
+          {
+            "Version": "3.0.0-alpha004"
+          },
+          {
+            "Version": "3.0.0-alpha005"
+          },
+          {
+            "Version": "3.0.0-alpha006"
+          },
+          {
+            "Version": "3.0.0-alpha007"
+          },
+          {
+            "Version": "3.0.0-alpha008"
+          },
+          {
+            "Version": "3.0.0-alpha009"
+          },
+          {
+            "Version": "3.0.0-alpha010"
+          },
+          {
+            "Version": "3.0.0-alpha011"
+          },
+          {
+            "Version": "3.0.0-beta01"
+          },
+          {
+            "Version": "3.0.0-beta02"
+          },
+          {
+            "Version": "3.0.0-beta03"
+          },
+          {
+            "Version": "3.0.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.0.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.0.1",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.0.1",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.1.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.1.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "3.2",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.2.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Argu/3.3.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.4.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.4.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.5.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.5.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.6.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.6.1",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.6.1",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "3.7.0",
+            "PackageDetails": {
+              "Name": "Argu",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Argu/3.7.0",
+              "LicenseUrl": "https://github.com/fsprojects/Argu/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= net463, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:52",
+        "PackageName": "Microsoft.WindowsAzure.Management.Scheduler",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "0.9.10-preview"
+          },
+          {
+            "Version": "0.9.11-preview"
+          },
+          {
+            "Version": "0.9.12-preview"
+          },
+          {
+            "Version": "0.9.13-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.1.3"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.2.1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.1.1"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "6.2",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Scheduler",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Scheduler/6.2.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:14.5348741+02:00",
+        "PackageName": "System.Diagnostics.Tracing",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.20-beta-22605"
+          },
+          {
+            "Version": "4.0.20-beta-22816"
+          },
+          {
+            "Version": "4.0.20-beta-23019"
+          },
+          {
+            "Version": "4.0.20-beta-23109"
+          },
+          {
+            "Version": "4.0.20"
+          },
+          {
+            "Version": "4.0.21-beta-23225"
+          },
+          {
+            "Version": "4.0.21-beta-23409"
+          },
+          {
+            "Version": "4.0.21-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Diagnostics.Tracing",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Diagnostics.Tracing/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:25.2013887+02:00",
+        "PackageName": "System.Spatial",
+        "Versions": [
+          {
+            "Version": "5.7.0",
+            "PackageDetails": {
+              "Name": "System.Spatial",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Spatial/5.7.0",
+              "LicenseUrl": "http://go.microsoft.com/?linkid=9809688",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "System.Spatial",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Spatial/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:01.6380932+02:00",
+        "PackageName": "Microsoft.Azure.Management.ResourceManager",
+        "Versions": [
+          {
+            "Version": "1.0.0-preview"
+          },
+          {
+            "Version": "1.1.1-preview"
+          },
+          {
+            "Version": "1.1.2-preview"
+          },
+          {
+            "Version": "1.1.3-preview"
+          },
+          {
+            "Version": "1.1.4-preview"
+          },
+          {
+            "Version": "1.1.5-preview",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Management.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Management.ResourceManager/1.1.5-preview",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+                  "VersionRequirement": ">= 3.1 < 4.0",
+                  "FrameworkRestrictions": ">= net45"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+                  "VersionRequirement": ">= 3.3.1 < 4.0",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.2.0-preview"
+          },
+          {
+            "Version": "1.3.0-preview"
+          },
+          {
+            "Version": "1.3.1-preview"
+          },
+          {
+            "Version": "1.4.0-preview"
+          },
+          {
+            "Version": "1.5.0-preview",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Management.ResourceManager",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Management.ResourceManager/1.5.0-preview",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime",
+                  "VersionRequirement": ">= 2.3.5 < 3.0",
+                  "FrameworkRestrictions": ">= net45, netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+                  "VersionRequirement": ">= 3.3.5 < 4.0",
+                  "FrameworkRestrictions": ">= net45, netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:28.3345374+02:00",
+        "PackageName": "Streams",
+        "Versions": [
+          {
+            "Version": "0.1.0"
+          },
+          {
+            "Version": "0.1.5"
+          },
+          {
+            "Version": "0.2.0"
+          },
+          {
+            "Version": "0.2.2"
+          },
+          {
+            "Version": "0.2.3"
+          },
+          {
+            "Version": "0.2.4"
+          },
+          {
+            "Version": "0.2.5"
+          },
+          {
+            "Version": "0.2.6"
+          },
+          {
+            "Version": "0.2.7"
+          },
+          {
+            "Version": "0.2.8"
+          },
+          {
+            "Version": "0.2.9"
+          },
+          {
+            "Version": "0.3.0"
+          },
+          {
+            "Version": "0.4.0",
+            "PackageDetails": {
+              "Name": "Streams",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Streams/0.4.0",
+              "LicenseUrl": "https://github.com/nessos/Streams/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            }
+          },
+          {
+            "Version": "0.4.1",
+            "PackageDetails": {
+              "Name": "Streams",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Streams/0.4.1",
+              "LicenseUrl": "https://github.com/nessos/Streams/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:25.4008883+02:00",
+        "PackageName": "System.Threading.Timer",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Threading.Timer",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Threading.Timer/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard12"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:29.1393932+02:00",
+        "PackageName": "WindowsAzure.Storage",
+        "Versions": [
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.6"
+          },
+          {
+            "Version": "1.7.0.0"
+          },
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "2.0.1.0"
+          },
+          {
+            "Version": "2.0.2.0"
+          },
+          {
+            "Version": "2.0.3.0"
+          },
+          {
+            "Version": "2.0.4.0"
+          },
+          {
+            "Version": "2.0.4.1"
+          },
+          {
+            "Version": "2.0.5.0"
+          },
+          {
+            "Version": "2.0.5.1"
+          },
+          {
+            "Version": "2.0.6.0"
+          },
+          {
+            "Version": "2.0.6.1"
+          },
+          {
+            "Version": "2.1.0.0-rc"
+          },
+          {
+            "Version": "2.1.0.0"
+          },
+          {
+            "Version": "2.1.0.2"
+          },
+          {
+            "Version": "2.1.0.3"
+          },
+          {
+            "Version": "2.1.0.4"
+          },
+          {
+            "Version": "3.0.0.0"
+          },
+          {
+            "Version": "3.0.1.0"
+          },
+          {
+            "Version": "3.0.2.0"
+          },
+          {
+            "Version": "3.0.3.0"
+          },
+          {
+            "Version": "3.1.0.0"
+          },
+          {
+            "Version": "3.1.0.1"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.2.0"
+          },
+          {
+            "Version": "4.2.1"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1-preview"
+          },
+          {
+            "Version": "4.3.2-preview"
+          },
+          {
+            "Version": "4.4.0-preview"
+          },
+          {
+            "Version": "4.4.1-preview"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.0.1-preview"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3-preview"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1-preview"
+          },
+          {
+            "Version": "6.1.0"
+          },
+          {
+            "Version": "6.1.1-preview"
+          },
+          {
+            "Version": "6.2.0"
+          },
+          {
+            "Version": "6.2.1-preview"
+          },
+          {
+            "Version": "6.2.2-preview"
+          },
+          {
+            "Version": "7.0.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.Storage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/7.0.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=331471",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.KeyVault.Core",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": "wpv8.0, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.Services.Client",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "7.0.1-preview"
+          },
+          {
+            "Version": "7.0.2-preview"
+          },
+          {
+            "Version": "7.1.0",
+            "PackageDetails": {
+              "Name": "WindowsAzure.Storage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/7.1.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=331471",
+              "IsUnlisted": true,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.KeyVault.Core",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": "wpv8.0, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.Services.Client",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "7.1.1-preview"
+          },
+          {
+            "Version": "7.1.2",
+            "PackageDetails": {
+              "Name": "WindowsAzure.Storage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/7.1.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=331471",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.KeyVault.Core",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": "wpv8.0, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.Services.Client",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": ">= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                }
+              ]
+            }
+          },
+          {
+            "Version": "7.1.3-preview"
+          },
+          {
+            "Version": "7.2",
+            "PackageDetails": {
+              "Name": "WindowsAzure.Storage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/7.2.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=331471",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.KeyVault.Core",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": "wpv8.0, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.Data.Services.Client",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": ">= net40, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 9.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Spatial",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "7.2.1",
+            "PackageDetails": {
+              "Name": "WindowsAzure.Storage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/7.2.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=331471",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.KeyVault.Core",
+                  "VersionRequirement": ">= 1.0",
+                  "FrameworkRestrictions": "wpv8.0, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40, >= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.Data.Services.Client",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": ">= net40, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.8",
+                  "FrameworkRestrictions": "winv4.5, wpv8.0, wpav8.1, >= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 9.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Spatial",
+                  "VersionRequirement": ">= 5.6.4",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "8.0.0"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.1.0"
+          },
+          {
+            "Version": "8.1.1"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:52:58.6400906+02:00",
+        "PackageName": "Microsoft.Azure.Common",
+        "Versions": [
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.1",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Common/2.1.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Hyak.Common",
+                  "VersionRequirement": ">= 1.0.2"
+                },
+                {
+                  "PackageName": "Microsoft.Azure.Common.Dependencies",
+                  "VersionRequirement": ">= 1.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "2.1.3"
+          },
+          {
+            "Version": "2.1.4",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Common/2.1.4",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Hyak.Common",
+                  "VersionRequirement": ">= 1.1.3",
+                  "FrameworkRestrictions": ">= net45, netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:17.8758871+02:00",
+        "PackageName": "System.Reflection.Metadata",
+        "Versions": [
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.18-beta"
+          },
+          {
+            "Version": "1.0.19-rc"
+          },
+          {
+            "Version": "1.0.21"
+          },
+          {
+            "Version": "1.0.22-beta-23019"
+          },
+          {
+            "Version": "1.0.22-beta-23109"
+          },
+          {
+            "Version": "1.0.22"
+          },
+          {
+            "Version": "1.0.23-beta-23225"
+          },
+          {
+            "Version": "1.0.23-beta-23409"
+          },
+          {
+            "Version": "1.1.0-alpha-00009"
+          },
+          {
+            "Version": "1.1.0-alpha-00012"
+          },
+          {
+            "Version": "1.1.0-alpha-00014"
+          },
+          {
+            "Version": "1.1.0-alpha-00015"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1-beta-23516"
+          },
+          {
+            "Version": "1.2.0-rc2-23826"
+          },
+          {
+            "Version": "1.2.0-rc3-23811"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1-beta-23918"
+          },
+          {
+            "Version": "1.3.0-rc2-24027"
+          },
+          {
+            "Version": "1.3",
+            "PackageDetails": {
+              "Name": "System.Reflection.Metadata",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Metadata/1.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.1.37",
+                  "FrameworkRestrictions": "portable-net45+win8"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.2",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, winv4.5, wpav8.1, >= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "1.4.1-beta-24227-04"
+          },
+          {
+            "Version": "1.4.1-beta-24322-03"
+          },
+          {
+            "Version": "1.4.1-beta-24430-01"
+          },
+          {
+            "Version": "1.4.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2",
+            "PackageDetails": {
+              "Name": "System.Reflection.Metadata",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Reflection.Metadata/1.4.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.1.37",
+                  "FrameworkRestrictions": "portable-net45+win8"
+                },
+                {
+                  "PackageName": "System.Collections.Immutable",
+                  "VersionRequirement": ">= 1.3.1",
+                  "FrameworkRestrictions": "monoandroid, monotouch, xamarinios, xamarinmac, winv4.5, wpav8.1, >= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:13.8303874+02:00",
+        "PackageName": "System.Console",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.0.0-rc2-24027"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Console",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Console/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:50",
+        "PackageName": "Microsoft.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "2.1.3-beta"
+          },
+          {
+            "Version": "2.1.6-rc"
+          },
+          {
+            "Version": "2.1.10"
+          },
+          {
+            "Version": "2.2.3-beta"
+          },
+          {
+            "Version": "2.2.7-beta"
+          },
+          {
+            "Version": "2.2.10-rc"
+          },
+          {
+            "Version": "2.2.13"
+          },
+          {
+            "Version": "2.2.15"
+          },
+          {
+            "Version": "2.2.18"
+          },
+          {
+            "Version": "2.2.19"
+          },
+          {
+            "Version": "2.2.20"
+          },
+          {
+            "Version": "2.2.22"
+          },
+          {
+            "Version": "2.2.23-beta"
+          },
+          {
+            "Version": "2.2.27-beta"
+          },
+          {
+            "Version": "2.2.28"
+          },
+          {
+            "Version": "2.2.29",
+            "PackageDetails": {
+              "Name": "Microsoft.Net.Http",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Net.Http/2.2.29",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.10"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:16.1963774+02:00",
+        "PackageName": "System.IO.Compression.ZipFile",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression.ZipFile",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression.ZipFile/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:06.0466796+02:00",
+        "PackageName": "Microsoft.Data.OData",
+        "Versions": [
+          {
+            "Version": "5.0.0.50403"
+          },
+          {
+            "Version": "5.0.1-rc"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2-rc"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.1.0-rc"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0-rc2"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.2.0-rc1"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.3.0-rc1"
+          },
+          {
+            "Version": "5.3.0"
+          },
+          {
+            "Version": "5.4.0-rc1"
+          },
+          {
+            "Version": "5.4.0"
+          },
+          {
+            "Version": "5.5.0-alpha1"
+          },
+          {
+            "Version": "5.5.0-alpha2"
+          },
+          {
+            "Version": "5.5.0-rc1"
+          },
+          {
+            "Version": "5.5.0"
+          },
+          {
+            "Version": "5.6.0-alpha1"
+          },
+          {
+            "Version": "5.6.0-rc1"
+          },
+          {
+            "Version": "5.6.0"
+          },
+          {
+            "Version": "5.6.1"
+          },
+          {
+            "Version": "5.6.2"
+          },
+          {
+            "Version": "5.6.3"
+          },
+          {
+            "Version": "5.6.4"
+          },
+          {
+            "Version": "5.6.5-beta"
+          },
+          {
+            "Version": "5.7.0-beta"
+          },
+          {
+            "Version": "5.7.0-rc"
+          },
+          {
+            "Version": "5.7",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.OData",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.OData/5.7.0",
+              "LicenseUrl": "http://go.microsoft.com/?linkid=9809688",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Data.Edm",
+                  "VersionRequirement": "5.7"
+                },
+                {
+                  "PackageName": "System.Spatial",
+                  "VersionRequirement": "5.7"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.8.0-beta"
+          },
+          {
+            "Version": "5.8.0"
+          },
+          {
+            "Version": "5.8.1"
+          },
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.OData",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.OData/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Data.Edm",
+                  "VersionRequirement": "5.8.2"
+                },
+                {
+                  "PackageName": "System.Spatial",
+                  "VersionRequirement": "5.8.2"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:12.6268885+02:00",
+        "PackageName": "Newtonsoft.Json",
+        "Versions": [
+          {
+            "Version": "3.5.8"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          },
+          {
+            "Version": "4.0.4"
+          },
+          {
+            "Version": "4.0.5"
+          },
+          {
+            "Version": "4.0.6"
+          },
+          {
+            "Version": "4.0.7"
+          },
+          {
+            "Version": "4.0.8"
+          },
+          {
+            "Version": "4.5.1"
+          },
+          {
+            "Version": "4.5.2"
+          },
+          {
+            "Version": "4.5.3"
+          },
+          {
+            "Version": "4.5.4"
+          },
+          {
+            "Version": "4.5.5"
+          },
+          {
+            "Version": "4.5.6"
+          },
+          {
+            "Version": "4.5.7"
+          },
+          {
+            "Version": "4.5.8"
+          },
+          {
+            "Version": "4.5.9"
+          },
+          {
+            "Version": "4.5.10"
+          },
+          {
+            "Version": "4.5.11"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.0.3"
+          },
+          {
+            "Version": "5.0.4"
+          },
+          {
+            "Version": "5.0.5"
+          },
+          {
+            "Version": "5.0.6"
+          },
+          {
+            "Version": "5.0.7"
+          },
+          {
+            "Version": "5.0.8"
+          },
+          {
+            "Version": "6.0.1-beta1"
+          },
+          {
+            "Version": "6.0.1"
+          },
+          {
+            "Version": "6.0.2"
+          },
+          {
+            "Version": "6.0.3"
+          },
+          {
+            "Version": "6.0.4"
+          },
+          {
+            "Version": "6.0.5"
+          },
+          {
+            "Version": "6.0.6"
+          },
+          {
+            "Version": "6.0.7"
+          },
+          {
+            "Version": "6.0.8"
+          },
+          {
+            "Version": "7.0.1-beta1"
+          },
+          {
+            "Version": "7.0.1-beta2"
+          },
+          {
+            "Version": "7.0.1-beta3"
+          },
+          {
+            "Version": "7.0.1"
+          },
+          {
+            "Version": "8.0.1-beta1"
+          },
+          {
+            "Version": "8.0.1-beta2"
+          },
+          {
+            "Version": "8.0.1-beta3"
+          },
+          {
+            "Version": "8.0.1-beta4"
+          },
+          {
+            "Version": "8.0.1"
+          },
+          {
+            "Version": "8.0.2"
+          },
+          {
+            "Version": "8.0.3"
+          },
+          {
+            "Version": "8.0.4-beta1"
+          },
+          {
+            "Version": "9.0.1-beta1"
+          },
+          {
+            "Version": "9.0.1",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Newtonsoft.Json/9.0.1",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "9.0.2-beta1"
+          },
+          {
+            "Version": "9.0.2-beta2"
+          },
+          {
+            "Version": "10.0.1-beta1"
+          },
+          {
+            "Version": "10.0.1"
+          },
+          {
+            "Version": "10.0.2",
+            "PackageDetails": {
+              "Name": "Newtonsoft.Json",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Newtonsoft.Json/10.0.2",
+              "LicenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.CSharp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ComponentModel.TypeConverter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Formatters",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard10, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XmlDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:20.6288881+02:00",
+        "PackageName": "System.Runtime.Handles",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Runtime.Handles",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Runtime.Handles/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:52",
+        "PackageName": "Microsoft.WindowsAzure.Management.MediaServices",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.1.1"
+          },
+          {
+            "Version": "2.1.2"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.1",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.MediaServices",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.MediaServices/4.1.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.1 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:51",
+        "PackageName": "Microsoft.WindowsAzure.Common",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "0.9.10-preview"
+          },
+          {
+            "Version": "0.9.11-preview"
+          },
+          {
+            "Version": "0.9.12-preview"
+          },
+          {
+            "Version": "0.9.13-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Common",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Common/1.4.1",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Common.Dependencies",
+                  "VersionRequirement": ">= 1.1.1"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:15.4298741+02:00",
+        "PackageName": "System.IO",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.10-beta-22231"
+          },
+          {
+            "Version": "4.0.10-beta-22416"
+          },
+          {
+            "Version": "4.0.10-beta-22605"
+          },
+          {
+            "Version": "4.0.10-beta-22816"
+          },
+          {
+            "Version": "4.0.10-beta-23019"
+          },
+          {
+            "Version": "4.0.10-beta-23109"
+          },
+          {
+            "Version": "4.0.10"
+          },
+          {
+            "Version": "4.0.11-beta-23225"
+          },
+          {
+            "Version": "4.0.11-beta-23409"
+          },
+          {
+            "Version": "4.0.11-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard10, netstandard13, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:46",
+        "PackageName": "Microsoft.Bcl.Build",
+        "Versions": [
+          {
+            "Version": "1.0.0-rc"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9-beta"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17-beta"
+          },
+          {
+            "Version": "1.0.20-beta"
+          },
+          {
+            "Version": "1.0.21",
+            "PackageDetails": {
+              "Name": "Microsoft.Bcl.Build",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Bcl.Build/1.0.21",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:07.658594+02:00",
+        "PackageName": "Microsoft.Win32.Primitives",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Win32.Primitives",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Win32.Primitives/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "Microsoft.NETCore.Targets",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:52",
+        "PackageName": "Microsoft.WindowsAzure.Management.Libraries",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.0",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Libraries",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Libraries/2.0.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Common",
+                  "VersionRequirement": ">= 1.3 < 2.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management",
+                  "VersionRequirement": ">= 2.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.Compute",
+                  "VersionRequirement": ">= 5.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.MediaServices",
+                  "VersionRequirement": ">= 2.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.Monitoring",
+                  "VersionRequirement": ">= 1.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.Network",
+                  "VersionRequirement": ">= 3.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.Scheduler",
+                  "VersionRequirement": ">= 3.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.Sql",
+                  "VersionRequirement": ">= 3.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.Storage",
+                  "VersionRequirement": ">= 3.0"
+                },
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Management.WebSites",
+                  "VersionRequirement": ">= 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:53",
+        "PackageName": "Microsoft.WindowsAzure.Management.WebSites",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "0.9.9-preview"
+          },
+          {
+            "Version": "0.9.10-preview"
+          },
+          {
+            "Version": "0.9.11-preview"
+          },
+          {
+            "Version": "0.9.12-preview"
+          },
+          {
+            "Version": "0.9.13-preview"
+          },
+          {
+            "Version": "0.9.14-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "3.0.0-prerelease"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1-prerelease"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2-prerelease"
+          },
+          {
+            "Version": "3.0.3-prerelease"
+          },
+          {
+            "Version": "3.0.4-prerelease"
+          },
+          {
+            "Version": "3.0.5-prerelease"
+          },
+          {
+            "Version": "3.0.6-prerelease"
+          },
+          {
+            "Version": "3.0.7-prerelease"
+          },
+          {
+            "Version": "3.1.0-prerelease"
+          },
+          {
+            "Version": "3.1.1-prerelease"
+          },
+          {
+            "Version": "3.2.0-prerelease"
+          },
+          {
+            "Version": "4.0",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.WebSites",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.WebSites/4.0.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.WindowsAzure.Common",
+                  "VersionRequirement": ">= 1.3 < 2.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.1-prerelease"
+          },
+          {
+            "Version": "4.1.0-prerelease"
+          },
+          {
+            "Version": "4.1.1-prerelease"
+          },
+          {
+            "Version": "4.2.0-prerelease"
+          },
+          {
+            "Version": "4.3.0-prerelease"
+          },
+          {
+            "Version": "4.4.0-prerelease"
+          },
+          {
+            "Version": "4.4.1-prerelease"
+          },
+          {
+            "Version": "4.4.2-prerelease"
+          },
+          {
+            "Version": "4.5.0-prerelease"
+          },
+          {
+            "Version": "5.0.0-prerelease"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:04.3130927+02:00",
+        "PackageName": "Microsoft.Data.Edm",
+        "Versions": [
+          {
+            "Version": "5.7.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.Edm",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.Edm/5.7.0",
+              "LicenseUrl": "http://go.microsoft.com/?linkid=9809688",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.Edm",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.Edm/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:15.9823888+02:00",
+        "PackageName": "System.IO.Compression",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.1.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.IO.Compression",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.IO.Compression/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Buffers",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:42",
+        "PackageName": "FsPickler.Json",
+        "Versions": [
+          {
+            "Version": "0.9.4-alpha"
+          },
+          {
+            "Version": "0.9.5-alpha"
+          },
+          {
+            "Version": "0.9.5.1-alpha"
+          },
+          {
+            "Version": "0.9.6"
+          },
+          {
+            "Version": "0.9.7"
+          },
+          {
+            "Version": "0.9.8"
+          },
+          {
+            "Version": "0.9.9"
+          },
+          {
+            "Version": "0.9.10"
+          },
+          {
+            "Version": "0.9.11"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17"
+          },
+          {
+            "Version": "1.0.18"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.2.7"
+          },
+          {
+            "Version": "1.2.8"
+          },
+          {
+            "Version": "1.2.9"
+          },
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "1.2.12"
+          },
+          {
+            "Version": "1.2.13"
+          },
+          {
+            "Version": "1.2.14"
+          },
+          {
+            "Version": "1.2.15"
+          },
+          {
+            "Version": "1.2.16"
+          },
+          {
+            "Version": "1.2.17"
+          },
+          {
+            "Version": "1.2.18"
+          },
+          {
+            "Version": "1.2.19"
+          },
+          {
+            "Version": "1.2.20"
+          },
+          {
+            "Version": "1.2.21"
+          },
+          {
+            "Version": "1.2.22"
+          },
+          {
+            "Version": "1.2.23"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.3.3"
+          },
+          {
+            "Version": "1.3.4"
+          },
+          {
+            "Version": "1.3.5"
+          },
+          {
+            "Version": "1.3.6"
+          },
+          {
+            "Version": "1.3.7"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.7.1"
+          },
+          {
+            "Version": "1.7.2"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1",
+            "PackageDetails": {
+              "Name": "FsPickler.Json",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FsPickler.Json/2.1.0",
+              "LicenseUrl": "https://github.com/nessos/FsPickler/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FsPickler",
+                  "VersionRequirement": "2.1"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.5"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:17.5088871+02:00",
+        "PackageName": "System.Net.Http",
+        "Versions": [
+          {
+            "Version": "2.0.20126.16343"
+          },
+          {
+            "Version": "2.0.20505.0"
+          },
+          {
+            "Version": "2.0.20710.0"
+          },
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1-beta-23225"
+          },
+          {
+            "Version": "4.0.1-beta-23409"
+          },
+          {
+            "Version": "4.0.1-beta-23516"
+          },
+          {
+            "Version": "4.0.1-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.1"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0"
+          },
+          {
+            "Version": "4.3.1",
+            "PackageDetails": {
+              "Name": "System.Net.Http",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Net.Http/4.3.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.DiagnosticSource",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.WindowsRuntime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= net46, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard11, netstandard13, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:43",
+        "PackageName": "MBrace.Azure",
+        "Versions": [
+          {
+            "Version": "0.5.0-alpha"
+          },
+          {
+            "Version": "0.5.1-alpha"
+          },
+          {
+            "Version": "0.5.2-alpha"
+          },
+          {
+            "Version": "0.5.3-alpha"
+          },
+          {
+            "Version": "0.5.4-alpha"
+          },
+          {
+            "Version": "0.5.5-alpha"
+          },
+          {
+            "Version": "0.5.6-alpha"
+          },
+          {
+            "Version": "0.5.7-alpha"
+          },
+          {
+            "Version": "0.5.8-alpha"
+          },
+          {
+            "Version": "0.5.9-alpha"
+          },
+          {
+            "Version": "0.5.10-alpha"
+          },
+          {
+            "Version": "0.5.11-alpha"
+          },
+          {
+            "Version": "0.5.12-alpha"
+          },
+          {
+            "Version": "0.5.13-alpha"
+          },
+          {
+            "Version": "0.6.0-alpha"
+          },
+          {
+            "Version": "0.6.1-alpha"
+          },
+          {
+            "Version": "0.6.2-alpha"
+          },
+          {
+            "Version": "0.6.3-alpha"
+          },
+          {
+            "Version": "0.6.4-alpha"
+          },
+          {
+            "Version": "0.6.5-alpha"
+          },
+          {
+            "Version": "0.6.6-alpha"
+          },
+          {
+            "Version": "0.6.7-alpha"
+          },
+          {
+            "Version": "0.6.8-alpha"
+          },
+          {
+            "Version": "0.6.9-alpha"
+          },
+          {
+            "Version": "0.6.10-alpha"
+          },
+          {
+            "Version": "0.7.0-alpha"
+          },
+          {
+            "Version": "0.10.0-alpha"
+          },
+          {
+            "Version": "0.10.1-alpha"
+          },
+          {
+            "Version": "0.10.2-alpha"
+          },
+          {
+            "Version": "0.10.3-alpha"
+          },
+          {
+            "Version": "0.10.4-alpha"
+          },
+          {
+            "Version": "0.10.5-alpha"
+          },
+          {
+            "Version": "0.10.6-alpha"
+          },
+          {
+            "Version": "0.12.0-beta"
+          },
+          {
+            "Version": "0.12.1-beta"
+          },
+          {
+            "Version": "0.12.2-beta"
+          },
+          {
+            "Version": "0.12.3-beta"
+          },
+          {
+            "Version": "0.13.0-beta"
+          },
+          {
+            "Version": "0.13.1-beta"
+          },
+          {
+            "Version": "0.14.0-beta"
+          },
+          {
+            "Version": "0.14.1-beta"
+          },
+          {
+            "Version": "0.15.0-beta"
+          },
+          {
+            "Version": "0.15.1-beta"
+          },
+          {
+            "Version": "0.15.2-beta"
+          },
+          {
+            "Version": "0.16.0-beta"
+          },
+          {
+            "Version": "0.16.1-beta"
+          },
+          {
+            "Version": "0.16.2-beta"
+          },
+          {
+            "Version": "0.16.3-beta"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.1.4"
+          },
+          {
+            "Version": "1.1.5"
+          },
+          {
+            "Version": "1.1.6"
+          },
+          {
+            "Version": "1.1.7"
+          },
+          {
+            "Version": "1.1.8"
+          },
+          {
+            "Version": "1.1.9"
+          },
+          {
+            "Version": "1.1.10"
+          },
+          {
+            "Version": "1.1.11"
+          },
+          {
+            "Version": "1.1.12"
+          },
+          {
+            "Version": "1.1.13"
+          },
+          {
+            "Version": "1.1.14"
+          },
+          {
+            "Version": "1.1.15"
+          },
+          {
+            "Version": "1.1.16"
+          },
+          {
+            "Version": "1.1.17"
+          },
+          {
+            "Version": "1.1.18"
+          },
+          {
+            "Version": "1.1.19"
+          },
+          {
+            "Version": "1.1.20"
+          },
+          {
+            "Version": "1.1.21"
+          },
+          {
+            "Version": "1.1.22"
+          },
+          {
+            "Version": "1.1.23"
+          },
+          {
+            "Version": "1.1.24"
+          },
+          {
+            "Version": "1.1.25"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.4.1"
+          },
+          {
+            "Version": "1.4.2"
+          },
+          {
+            "Version": "1.4.3",
+            "PackageDetails": {
+              "Name": "MBrace.Azure",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/MBrace.Azure/1.4.3",
+              "LicenseUrl": "https://github.com/mbraceproject/MBrace.Azure/blob/master/LICENSE.md",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Argu",
+                  "VersionRequirement": ">= 3.0 < 4.0"
+                },
+                {
+                  "PackageName": "MBrace.Core",
+                  "VersionRequirement": ">= 1.3 < 1.4"
+                },
+                {
+                  "PackageName": "MBrace.Runtime",
+                  "VersionRequirement": ">= 1.3 < 1.4"
+                },
+                {
+                  "PackageName": "System.Reflection.Metadata",
+                  "VersionRequirement": ""
+                },
+                {
+                  "PackageName": "WindowsAzure.ServiceBus",
+                  "VersionRequirement": ">= 3.0 < 4.0"
+                },
+                {
+                  "PackageName": "WindowsAzure.Storage",
+                  "VersionRequirement": ">= 7.0 < 8.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:24.1403896+02:00",
+        "PackageName": "System.Security.Cryptography.X509Certificates",
+        "Versions": [
+          {
+            "Version": "4.0.0-beta-22231"
+          },
+          {
+            "Version": "4.0.0-beta-22416"
+          },
+          {
+            "Version": "4.0.0-beta-22605"
+          },
+          {
+            "Version": "4.0.0-beta-22816"
+          },
+          {
+            "Version": "4.0.0-beta-23019"
+          },
+          {
+            "Version": "4.0.0-beta-23109"
+          },
+          {
+            "Version": "4.0.0-beta-23123"
+          },
+          {
+            "Version": "4.0.0-beta-23225"
+          },
+          {
+            "Version": "4.0.0-beta-23409"
+          },
+          {
+            "Version": "4.0.0-beta-23516"
+          },
+          {
+            "Version": "4.1.0-rc2-24027"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.Security.Cryptography.X509Certificates",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.Security.Cryptography.X509Certificates/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "runtime.native.System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Cng",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Csp",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, net46, >= net461, netstandard13, netstandard14, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.OpenSsl",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": "dnxcore50, >= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:07.440102+02:00",
+        "PackageName": "Microsoft.Rest.ClientRuntime.Azure",
+        "Versions": [
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14-preview"
+          },
+          {
+            "Version": "1.0.15-preview"
+          },
+          {
+            "Version": "1.0.16-preview"
+          },
+          {
+            "Version": "1.0.17-preview"
+          },
+          {
+            "Version": "1.0.18-preview"
+          },
+          {
+            "Version": "1.0.19-preview"
+          },
+          {
+            "Version": "1.0.20"
+          },
+          {
+            "Version": "1.0.21"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1.0"
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.5.0"
+          },
+          {
+            "Version": "2.5.1"
+          },
+          {
+            "Version": "2.5.2"
+          },
+          {
+            "Version": "2.5.3"
+          },
+          {
+            "Version": "2.5.4"
+          },
+          {
+            "Version": "2.6.0"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.0.1"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.3.0"
+          },
+          {
+            "Version": "3.3.1"
+          },
+          {
+            "Version": "3.3.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Rest.ClientRuntime.Azure",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Rest.ClientRuntime.Azure/3.3.2",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime",
+                  "VersionRequirement": ">= 2.3.2 < 3.0",
+                  "FrameworkRestrictions": ">= net45, netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.0.12",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "3.3.3"
+          },
+          {
+            "Version": "3.3.4"
+          },
+          {
+            "Version": "3.3.5",
+            "PackageDetails": {
+              "Name": "Microsoft.Rest.ClientRuntime.Azure",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Microsoft.Rest.ClientRuntime.Azure/3.3.5",
+              "LicenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Rest.ClientRuntime",
+                  "VersionRequirement": ">= 2.3.5 < 3.0",
+                  "FrameworkRestrictions": ">= net45, netstandard11, >= netstandard15"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": "netstandard11, >= netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.1"
+          },
+          {
+            "Version": "4.0.2"
+          },
+          {
+            "Version": "4.0.3"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:44",
+        "PackageName": "Microsoft.Azure.Common.Dependencies",
+        "Versions": [
+          {
+            "Version": "1.0",
+            "PackageDetails": {
+              "Name": "Microsoft.Azure.Common.Dependencies",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Azure.Common.Dependencies/1.0.0",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Bcl",
+                  "VersionRequirement": ">= 1.1.9",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Async",
+                  "VersionRequirement": ">= 1.0.168",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Bcl.Build",
+                  "VersionRequirement": ">= 1.0.14",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Microsoft.Net.Http",
+                  "VersionRequirement": ">= 2.2.22",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                },
+                {
+                  "PackageName": "Newtonsoft.Json",
+                  "VersionRequirement": ">= 6.0.4",
+                  "FrameworkRestrictions": "portable-net45+wp80+wpa81+win, >= net40"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:12.1148995+02:00",
+        "PackageName": "NETStandard.Library",
+        "Versions": [
+          {
+            "Version": "1.5.0-rc2-24027"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1-preview1-24530-04"
+          },
+          {
+            "Version": "1.6.1",
+            "PackageDetails": {
+              "Name": "NETStandard.Library",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/NETStandard.Library/1.6.1",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.NETCore.Platforms",
+                  "VersionRequirement": ">= 1.1",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "Microsoft.Win32.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.AppContext",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Collections.Concurrent",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tracing",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Globalization.Calendars",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.IO.Compression",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.IO.Compression.ZipFile",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.IO.FileSystem.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Http",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Net.Sockets",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.ObjectModel",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Reflection.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime.Handles",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.InteropServices.RuntimeInformation",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net45, >= netstandard11"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Algorithms",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.X509Certificates",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net46, >= netstandard13"
+                },
+                {
+                  "PackageName": "System.Text.Encoding",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.Encoding.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net451, >= netstandard12"
+                },
+                {
+                  "PackageName": "System.Xml.ReaderWriter",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Xml.XDocument",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:53",
+        "PackageName": "Microsoft.WindowsAzure.Management.Storage",
+        "Versions": [
+          {
+            "Version": "0.9.0-preview"
+          },
+          {
+            "Version": "0.9.1-preview"
+          },
+          {
+            "Version": "0.9.2-preview"
+          },
+          {
+            "Version": "0.9.3-preview"
+          },
+          {
+            "Version": "0.9.4-preview"
+          },
+          {
+            "Version": "0.9.5-preview"
+          },
+          {
+            "Version": "0.9.6-preview"
+          },
+          {
+            "Version": "0.9.7-preview"
+          },
+          {
+            "Version": "0.9.8-preview"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          },
+          {
+            "Version": "3.2.1"
+          },
+          {
+            "Version": "3.2.2"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "5.0.0"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.1.1"
+          },
+          {
+            "Version": "6.0.0"
+          },
+          {
+            "Version": "6.0.1",
+            "PackageDetails": {
+              "Name": "Microsoft.WindowsAzure.Management.Storage",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.WindowsAzure.Management.Storage/6.0.1",
+              "LicenseUrl": "http://aka.ms/windowsazureapache2",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Azure.Common",
+                  "VersionRequirement": ">= 2.0.4 < 3.0"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:41:42",
+        "PackageName": "FsPickler",
+        "Versions": [
+          {
+            "Version": "0.6"
+          },
+          {
+            "Version": "0.6.1"
+          },
+          {
+            "Version": "0.6.2"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.7.1"
+          },
+          {
+            "Version": "0.7.2"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.8.1"
+          },
+          {
+            "Version": "0.8.2"
+          },
+          {
+            "Version": "0.8.3"
+          },
+          {
+            "Version": "0.8.4"
+          },
+          {
+            "Version": "0.8.4.1"
+          },
+          {
+            "Version": "0.8.4.2"
+          },
+          {
+            "Version": "0.8.5"
+          },
+          {
+            "Version": "0.8.5.1"
+          },
+          {
+            "Version": "0.8.5.2"
+          },
+          {
+            "Version": "0.8.5.3"
+          },
+          {
+            "Version": "0.8.6"
+          },
+          {
+            "Version": "0.8.6.1"
+          },
+          {
+            "Version": "0.8.6.2"
+          },
+          {
+            "Version": "0.9.4-alpha"
+          },
+          {
+            "Version": "0.9.5-alpha"
+          },
+          {
+            "Version": "0.9.5.1-alpha"
+          },
+          {
+            "Version": "0.9.6"
+          },
+          {
+            "Version": "0.9.7"
+          },
+          {
+            "Version": "0.9.8"
+          },
+          {
+            "Version": "0.9.9"
+          },
+          {
+            "Version": "0.9.10"
+          },
+          {
+            "Version": "0.9.11"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.0.1"
+          },
+          {
+            "Version": "1.0.2"
+          },
+          {
+            "Version": "1.0.3"
+          },
+          {
+            "Version": "1.0.4"
+          },
+          {
+            "Version": "1.0.5"
+          },
+          {
+            "Version": "1.0.6"
+          },
+          {
+            "Version": "1.0.7"
+          },
+          {
+            "Version": "1.0.8"
+          },
+          {
+            "Version": "1.0.9"
+          },
+          {
+            "Version": "1.0.10"
+          },
+          {
+            "Version": "1.0.11"
+          },
+          {
+            "Version": "1.0.12"
+          },
+          {
+            "Version": "1.0.13"
+          },
+          {
+            "Version": "1.0.14"
+          },
+          {
+            "Version": "1.0.15"
+          },
+          {
+            "Version": "1.0.16"
+          },
+          {
+            "Version": "1.0.17"
+          },
+          {
+            "Version": "1.0.18"
+          },
+          {
+            "Version": "1.0.19"
+          },
+          {
+            "Version": "1.2.0"
+          },
+          {
+            "Version": "1.2.1"
+          },
+          {
+            "Version": "1.2.2"
+          },
+          {
+            "Version": "1.2.3"
+          },
+          {
+            "Version": "1.2.4"
+          },
+          {
+            "Version": "1.2.5"
+          },
+          {
+            "Version": "1.2.6"
+          },
+          {
+            "Version": "1.2.7"
+          },
+          {
+            "Version": "1.2.8"
+          },
+          {
+            "Version": "1.2.9"
+          },
+          {
+            "Version": "1.2.10"
+          },
+          {
+            "Version": "1.2.11"
+          },
+          {
+            "Version": "1.2.12"
+          },
+          {
+            "Version": "1.2.13"
+          },
+          {
+            "Version": "1.2.14"
+          },
+          {
+            "Version": "1.2.15"
+          },
+          {
+            "Version": "1.2.16"
+          },
+          {
+            "Version": "1.2.17"
+          },
+          {
+            "Version": "1.2.18"
+          },
+          {
+            "Version": "1.2.19"
+          },
+          {
+            "Version": "1.2.20"
+          },
+          {
+            "Version": "1.2.21"
+          },
+          {
+            "Version": "1.2.22"
+          },
+          {
+            "Version": "1.2.23"
+          },
+          {
+            "Version": "1.3.0"
+          },
+          {
+            "Version": "1.3.1"
+          },
+          {
+            "Version": "1.3.2"
+          },
+          {
+            "Version": "1.3.3"
+          },
+          {
+            "Version": "1.3.4"
+          },
+          {
+            "Version": "1.3.5"
+          },
+          {
+            "Version": "1.3.6"
+          },
+          {
+            "Version": "1.3.7"
+          },
+          {
+            "Version": "1.4.0"
+          },
+          {
+            "Version": "1.5.0"
+          },
+          {
+            "Version": "1.5.1"
+          },
+          {
+            "Version": "1.5.2"
+          },
+          {
+            "Version": "1.6.0"
+          },
+          {
+            "Version": "1.6.1"
+          },
+          {
+            "Version": "1.6.2"
+          },
+          {
+            "Version": "1.7.0"
+          },
+          {
+            "Version": "1.7.1"
+          },
+          {
+            "Version": "1.7.2"
+          },
+          {
+            "Version": "1.8.0"
+          },
+          {
+            "Version": "1.8.1"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.1",
+            "PackageDetails": {
+              "Name": "FsPickler",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/FsPickler/2.1.0",
+              "LicenseUrl": "https://github.com/nessos/FsPickler/blob/master/License.md",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "2.2.0"
+          },
+          {
+            "Version": "2.3.0"
+          },
+          {
+            "Version": "2.4.0"
+          },
+          {
+            "Version": "3.0.0"
+          },
+          {
+            "Version": "3.1.0"
+          },
+          {
+            "Version": "3.2.0"
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-02T00:53:07.1391093+02:00",
+        "PackageName": "Microsoft.Data.Services.Client",
+        "Versions": [
+          {
+            "Version": "5.0.0.50403"
+          },
+          {
+            "Version": "5.0.1-rc"
+          },
+          {
+            "Version": "5.0.1"
+          },
+          {
+            "Version": "5.0.2-rc"
+          },
+          {
+            "Version": "5.0.2"
+          },
+          {
+            "Version": "5.1.0-rc"
+          },
+          {
+            "Version": "5.1.0-rc1"
+          },
+          {
+            "Version": "5.1.0-rc2"
+          },
+          {
+            "Version": "5.1.0"
+          },
+          {
+            "Version": "5.2.0-rc1"
+          },
+          {
+            "Version": "5.2.0"
+          },
+          {
+            "Version": "5.3.0-rc1"
+          },
+          {
+            "Version": "5.3.0"
+          },
+          {
+            "Version": "5.4.0-rc1"
+          },
+          {
+            "Version": "5.4.0"
+          },
+          {
+            "Version": "5.5.0-alpha1"
+          },
+          {
+            "Version": "5.5.0-alpha2"
+          },
+          {
+            "Version": "5.5.0-rc1"
+          },
+          {
+            "Version": "5.5.0"
+          },
+          {
+            "Version": "5.6.0-alpha1"
+          },
+          {
+            "Version": "5.6.0-rc1"
+          },
+          {
+            "Version": "5.6.0"
+          },
+          {
+            "Version": "5.6.1"
+          },
+          {
+            "Version": "5.6.2"
+          },
+          {
+            "Version": "5.6.3"
+          },
+          {
+            "Version": "5.6.4"
+          },
+          {
+            "Version": "5.6.5-beta"
+          },
+          {
+            "Version": "5.7.0-beta"
+          },
+          {
+            "Version": "5.7.0-rc"
+          },
+          {
+            "Version": "5.7",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.Services.Client",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.Services.Client/5.7.0",
+              "LicenseUrl": "http://go.microsoft.com/?linkid=9809688",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": "5.7"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          },
+          {
+            "Version": "5.8.0-beta"
+          },
+          {
+            "Version": "5.8.0"
+          },
+          {
+            "Version": "5.8.1"
+          },
+          {
+            "Version": "5.8.2",
+            "PackageDetails": {
+              "Name": "Microsoft.Data.Services.Client",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/Microsoft.Data.Services.Client/5.8.2",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?linkid=833178",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "Microsoft.Data.OData",
+                  "VersionRequirement": "5.8.2"
+                },
+                {
+                  "PackageName": "System.ComponentModel.EventBasedAsync",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Dynamic.Runtime",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard11"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard11"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001871-suave/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001871-suave/cache/paket-graph.cache
@@ -1,0 +1,548 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:01.3953148+02:00",
+        "PackageName": "Suave",
+        "Versions": [
+          {
+            "Version": "0.0.1"
+          },
+          {
+            "Version": "0.0.2"
+          },
+          {
+            "Version": "0.0.3"
+          },
+          {
+            "Version": "0.0.4"
+          },
+          {
+            "Version": "0.0.5"
+          },
+          {
+            "Version": "0.1.78"
+          },
+          {
+            "Version": "0.2.0"
+          },
+          {
+            "Version": "0.3.0"
+          },
+          {
+            "Version": "0.4.0"
+          },
+          {
+            "Version": "0.5.0"
+          },
+          {
+            "Version": "0.6.0"
+          },
+          {
+            "Version": "0.7.0"
+          },
+          {
+            "Version": "0.8.0"
+          },
+          {
+            "Version": "0.9.0"
+          },
+          {
+            "Version": "0.10.0"
+          },
+          {
+            "Version": "0.11.0"
+          },
+          {
+            "Version": "0.12.0"
+          },
+          {
+            "Version": "0.13.0"
+          },
+          {
+            "Version": "0.14.0"
+          },
+          {
+            "Version": "0.15.0"
+          },
+          {
+            "Version": "0.16.0"
+          },
+          {
+            "Version": "0.17.0"
+          },
+          {
+            "Version": "0.18.0"
+          },
+          {
+            "Version": "0.19.0"
+          },
+          {
+            "Version": "0.19.1"
+          },
+          {
+            "Version": "0.20.0"
+          },
+          {
+            "Version": "0.20.1"
+          },
+          {
+            "Version": "0.20.2"
+          },
+          {
+            "Version": "0.21.0"
+          },
+          {
+            "Version": "0.21.1"
+          },
+          {
+            "Version": "0.22.0"
+          },
+          {
+            "Version": "0.23.0"
+          },
+          {
+            "Version": "0.24.0"
+          },
+          {
+            "Version": "0.25.0"
+          },
+          {
+            "Version": "0.26.0"
+          },
+          {
+            "Version": "0.26.1"
+          },
+          {
+            "Version": "0.26.2"
+          },
+          {
+            "Version": "0.27.0"
+          },
+          {
+            "Version": "0.28.0"
+          },
+          {
+            "Version": "0.28.1"
+          },
+          {
+            "Version": "0.29.0-alpha"
+          },
+          {
+            "Version": "0.29.0-alpha2"
+          },
+          {
+            "Version": "0.29.0"
+          },
+          {
+            "Version": "0.29.1"
+          },
+          {
+            "Version": "0.30.0"
+          },
+          {
+            "Version": "0.31.0"
+          },
+          {
+            "Version": "0.31.1"
+          },
+          {
+            "Version": "0.31.2"
+          },
+          {
+            "Version": "0.32.0-owin"
+          },
+          {
+            "Version": "0.32.0-owin2"
+          },
+          {
+            "Version": "0.32.0"
+          },
+          {
+            "Version": "0.32.1"
+          },
+          {
+            "Version": "0.33.0-libuv"
+          },
+          {
+            "Version": "0.33.0-libuv1"
+          },
+          {
+            "Version": "0.33.0-libuv2"
+          },
+          {
+            "Version": "0.33.0"
+          },
+          {
+            "Version": "0.34.0-nsrefactor"
+          },
+          {
+            "Version": "0.34.0-nsrefactor1"
+          },
+          {
+            "Version": "1.0.0-beta1"
+          },
+          {
+            "Version": "1.0.0-beta2"
+          },
+          {
+            "Version": "1.0.0"
+          },
+          {
+            "Version": "1.1.0"
+          },
+          {
+            "Version": "1.1.1"
+          },
+          {
+            "Version": "1.1.2"
+          },
+          {
+            "Version": "1.1.3"
+          },
+          {
+            "Version": "2.0.0-alpha3"
+          },
+          {
+            "Version": "2.0.0-alpha4"
+          },
+          {
+            "Version": "2.0.0-alpha5"
+          },
+          {
+            "Version": "2.0.0-alpha6"
+          },
+          {
+            "Version": "2.0.0-alpha7"
+          },
+          {
+            "Version": "2.0.0-rc1"
+          },
+          {
+            "Version": "2.0.0-rc2"
+          },
+          {
+            "Version": "2.0.0-rc3"
+          },
+          {
+            "Version": "2.0.0-rc4"
+          },
+          {
+            "Version": "2.0.0-rc5"
+          },
+          {
+            "Version": "2.0.0-rc6"
+          },
+          {
+            "Version": "2.0.0-rc7"
+          },
+          {
+            "Version": "2.0.0-rc8"
+          },
+          {
+            "Version": "2.0.0"
+          },
+          {
+            "Version": "2.0.1"
+          },
+          {
+            "Version": "2.0.2"
+          },
+          {
+            "Version": "2.0.3"
+          },
+          {
+            "Version": "2.0.4"
+          },
+          {
+            "Version": "2.0.5-alpha"
+          },
+          {
+            "Version": "2.0.5"
+          },
+          {
+            "Version": "2.1.0",
+            "PackageDetails": {
+              "Name": "Suave",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Suave/2.1.0",
+              "LicenseUrl": "https://github.com/SuaveIO/Suave/blob/master/COPYING",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.0.1",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.1.2",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Data.Common",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Process",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization.Extensions",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Security",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Serialization.Json",
+                  "VersionRequirement": ">= 4.0.2",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Claims",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Security.Cryptography.Primitives",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:01.4943136+02:00",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:01.1968165+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001883-chessie/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001883-chessie/cache/paket-graph.cache
@@ -1,0 +1,258 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:04.5143175+02:00",
+        "PackageName": "Chessie",
+        "Versions": [
+          {
+            "Version": "0.6",
+            "PackageDetails": {
+              "Name": "Chessie",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Chessie/0.6.0",
+              "LicenseUrl": "http://github.com/fsprojects/Chessie/blob/master/LICENSE.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": "",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                },
+                {
+                  "PackageName": "FSharp.Core",
+                  "VersionRequirement": ">= 4.0.1.7-alpha",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard16"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:05.6193161+02:00",
+        "PackageName": "System.ValueTuple",
+        "Versions": [
+          {
+            "Version": "0.0.1-alpha"
+          },
+          {
+            "Version": "4.0.0-rc3-24212-01"
+          },
+          {
+            "Version": "4.3.0-preview1-24530-04"
+          },
+          {
+            "Version": "4.3.0",
+            "PackageDetails": {
+              "Name": "System.ValueTuple",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/System.ValueTuple/4.3.0",
+              "LicenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= netstandard10"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      },
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:05.5243313+02:00",
+        "PackageName": "FSharp.Core",
+        "Versions": [
+          {
+            "Version": "2.0.0.0"
+          },
+          {
+            "Version": "3.0.2"
+          },
+          {
+            "Version": "3.1.2"
+          },
+          {
+            "Version": "3.1.2.1"
+          },
+          {
+            "Version": "3.1.2.5"
+          },
+          {
+            "Version": "4.0.0"
+          },
+          {
+            "Version": "4.0.0.1"
+          },
+          {
+            "Version": "4.0.1.5"
+          },
+          {
+            "Version": "4.0.1.7-alpha"
+          },
+          {
+            "Version": "4.1.0"
+          },
+          {
+            "Version": "4.1.0.2"
+          },
+          {
+            "Version": "4.1.2"
+          },
+          {
+            "Version": "4.1.12"
+          },
+          {
+            "Version": "4.1.17",
+            "PackageDetails": {
+              "Name": "FSharp.Core",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/FSharp.Core/4.1.17",
+              "LicenseUrl": "https://github.com/fsharp/fsharp/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "System.Collections",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Console",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Debug",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Diagnostics.Tools",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Globalization",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.IO",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Expressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Linq.Queryable",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Net.Requests",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Resources.ResourceManager",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Extensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Runtime.Numerics",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Text.RegularExpressions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks",
+                  "VersionRequirement": ">= 4.0.11",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Tasks.Parallel",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Thread",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.ThreadPool",
+                  "VersionRequirement": ">= 4.0.10",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.Threading.Timer",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard16"
+                },
+                {
+                  "PackageName": "System.ValueTuple",
+                  "VersionRequirement": ">= 4.3",
+                  "FrameworkRestrictions": ">= net10, netstandard10, netstandard11, netstandard12, netstandard13, netstandard14, netstandard15"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001883-machine/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001883-machine/cache/paket-graph.cache
@@ -1,0 +1,64 @@
+{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:42:08.1138207+02:00",
+        "PackageName": "Machine.Specifications",
+        "Versions": [
+          {
+            "Version": "0.11",
+            "PackageDetails": {
+              "Name": "Machine.Specifications",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/Machine.Specifications/0.11.0",
+              "LicenseUrl": "http://github.com/machine/machine.specifications/blob/master/License.txt",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "NETStandard.Library",
+                  "VersionRequirement": ">= 1.6",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TextWriterTraceListener",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Diagnostics.TraceSource",
+                  "VersionRequirement": ">= 4.0",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.Extensions",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Reflection.TypeExtensions",
+                  "VersionRequirement": ">= 4.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XPath",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                },
+                {
+                  "PackageName": "System.Xml.XPath.XDocument",
+                  "VersionRequirement": ">= 4.0.1",
+                  "FrameworkRestrictions": ">= netstandard13"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/cache/paket-graph.cache
+++ b/integrationtests/scenarios/i001922-convert-nuget-with-analyzers/cache/paket-graph.cache
@@ -1,0 +1,23 @@
+{
+  "https://api.nuget.org/v3/index.json": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:38:04.5323281+02:00",
+        "PackageName": "StyleCop.Analyzers",
+        "Versions": [
+          {
+            "Version": "1.0.0",
+            "PackageDetails": {
+              "Name": "StyleCop.Analyzers",
+              "DownloadLink": "https://www.nuget.org/api/v2/package/StyleCop.Analyzers/1.0.0",
+              "LicenseUrl": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/1.0.0/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": []
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/Paket.Core.preview3/Paket.Core.fsproj
+++ b/src/Paket.Core.preview3/Paket.Core.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="$(PaketCoreSourcesDir)\Dependencies\NuGetV2.fs" />
     <Compile Include="$(PaketCoreSourcesDir)\Dependencies\DependenciesFileParser.fs" />
     <Compile Include="$(PaketCoreSourcesDir)\PaketConfigFiles\RuntimeGraph.fs" />
+    <Compile Include="$(PaketCoreSourcesDir)\PaketConfigFiles\GraphCache.fs" />
     <Compile Include="$(PaketCoreSourcesDir)\PaketConfigFiles\InstallModel.fs" />
     <Compile Include="$(PaketCoreSourcesDir)\PaketConfigFiles\ReferencesFile.fs" />
     <Compile Include="$(PaketCoreSourcesDir)\PaketConfigFiles/SolutionFile.fs" />

--- a/src/Paket.Core/Dependencies/DependenciesFileParser.fs
+++ b/src/Paket.Core/Dependencies/DependenciesFileParser.fs
@@ -36,7 +36,7 @@ module DependenciesFileParser =
         let penultimateItem = Math.Max(parts.Length - 2, 0)
         let promoted = parts |> promote penultimateItem
         String.Join(".", promoted)
-
+        
     let parseVersionRequirement (text : string) : VersionRequirement =
         try
             let inline parsePrerelease (versions:SemVerInfo list) (texts : string list) = 

--- a/src/Paket.Core/Installation/UpdateProcess.fs
+++ b/src/Paket.Core/Installation/UpdateProcess.fs
@@ -140,7 +140,13 @@ let selectiveUpdate force getSha1 getSortedVersionsF getPackageDetailsF getRunti
 
         getVersionsF,getPackageDetailsF,groups
 
-    let resolution = dependenciesFile.Resolve(force, getSha1, getVersionsF, getPackageDetailsF, getRuntimeGraphFromPackage, groupsToUpdate, updateMode)
+    let resolution =
+        dependenciesFile.Resolve(
+            force, getSha1,
+            getVersionsF |> GraphCache.liftGetVersionsF,
+            getPackageDetailsF |> GraphCache.liftGetPackageDetailsF,
+            getRuntimeGraphFromPackage |> GraphCache.liftGetRuntimeGraphFromPackage,
+            groupsToUpdate, updateMode)
 
     let groups = 
         dependenciesFile.Groups

--- a/src/Paket.Core/PackageAnalysis/FindOutdated.fs
+++ b/src/Paket.Core/PackageAnalysis/FindOutdated.fs
@@ -51,7 +51,13 @@ let FindOutdated strict includingPrereleases groupNameFilter environment = trial
         | None -> dependenciesFile.Groups
         | Some gname -> dependenciesFile.Groups |> Map.filter(fun k g -> k.ToString() = gname)
 
-    let newResolution = dependenciesFile.Resolve(force, getSha1, getVersionsF, NuGetV2.GetPackageDetails alternativeProjectRoot root true, RuntimeGraph.getRuntimeGraphFromNugetCache root, checkedDepsGroups, PackageResolver.UpdateMode.UpdateAll)
+    let newResolution =
+        dependenciesFile.Resolve(
+            force, getSha1,
+            getVersionsF |> GraphCache.liftGetVersionsF,
+            NuGetV2.GetPackageDetails alternativeProjectRoot root true |> GraphCache.liftGetPackageDetailsF,
+            RuntimeGraph.getRuntimeGraphFromNugetCache root |> GraphCache.liftGetRuntimeGraphFromPackage,
+            checkedDepsGroups, PackageResolver.UpdateMode.UpdateAll)
 
     let checkedLockGroups = 
         match groupNameFilter with

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -123,6 +123,7 @@
     <Compile Include="Dependencies\NuGetV2.fs" />
     <Compile Include="Dependencies\DependenciesFileParser.fs" />
     <Compile Include="PaketConfigFiles\RuntimeGraph.fs" />
+    <Compile Include="PaketConfigFiles\GraphCache.fs" />
     <Compile Include="PaketConfigFiles\InstallModel.fs" />
     <Compile Include="PaketConfigFiles\ReferencesFile.fs" />
     <Compile Include="PaketConfigFiles/SolutionFile.fs" />

--- a/src/Paket.Core/PaketConfigFiles/GraphCache.fs
+++ b/src/Paket.Core/PaketConfigFiles/GraphCache.fs
@@ -1,0 +1,435 @@
+﻿/// Contains logic for saving and loading the graph cache.
+module Paket.GraphCache
+
+open Paket.Domain
+open PackageResolver
+open System.Collections.Generic
+open System.Collections.Concurrent
+open Newtonsoft.Json.Linq
+open System
+
+
+// Once this works properly I'd like to enable this by default.
+let graphCacheFile = System.Environment.GetEnvironmentVariable("PAKET_GRAPH_CACHE")
+let preventOnlineRead = System.Environment.GetEnvironmentVariable("PAKET_GRAPH_CACHE_PREVENT_ONLINE") = "true"
+let isGraphCacheEnabled = not <| System.String.IsNullOrWhiteSpace(graphCacheFile)
+
+type NuGetSourceUri = string
+type RuntimeGraphCache =
+  | NotJetCached
+  | CachedData of RuntimeGraph option
+module RuntimeGraphCache =
+    let getData = function NotJetCached -> None | CachedData s -> Some s
+    let simplify x = Option.defaultValue NotJetCached x
+    let ofOption x =
+        match x with
+        | None -> NotJetCached
+        | Some d -> CachedData d
+type CachedInfo =
+  { // Versions list must time-out somehow, maybe we even ignore that later - But we use it to make tests faster ...
+    VersionListRetrieved : System.DateTime
+    Details : Map<SemVerInfo, PackageDetails option * RuntimeGraphCache>
+  }
+  static member FromVersions versions =
+    { VersionListRetrieved = System.DateTime.Now
+      Details = versions |> Seq.map (fun v -> v, (None, NotJetCached)) |> Map.ofSeq }
+  static member FromPackageDetails (ver:SemVerInfo) (details:PackageDetails) =
+    { VersionListRetrieved = System.DateTime()
+      Details = [ ver, (Some details, NotJetCached) ] |> Map.ofSeq }
+  static member FromRuntimeGraph (ver:SemVerInfo) (graph:RuntimeGraph option) =
+    { VersionListRetrieved = System.DateTime()
+      Details = [ ver, (None, CachedData graph) ] |> Map.ofSeq }
+module CachedInfo =
+  let updateVersions versions x =
+    let emptyMap = versions |> Seq.map (fun v -> v, (None, NotJetCached)) |> Map.ofSeq
+    { x with
+        VersionListRetrieved = System.DateTime.Now
+        Details = Map.merge (fun _ right -> right) emptyMap x.Details }
+  let updatePackageDetails ver packageDetail (x:CachedInfo) =
+    let runtimeInfo = x.Details |> Map.tryFind ver |> Option.map snd |> RuntimeGraphCache.simplify
+    { x with
+        VersionListRetrieved = System.DateTime.Now
+        Details = x.Details |> Map.add ver (Some packageDetail, runtimeInfo) }
+  let updateRuntimeInfo ver runtimeInfo (x:CachedInfo) =
+    let packageDetail = x.Details |> Map.tryFind ver |> Option.bind fst
+    { x with
+        VersionListRetrieved = System.DateTime.Now
+        Details = x.Details |> Map.add ver (packageDetail, CachedData runtimeInfo) }
+(*
+{
+    "http://nuget.org": {
+        // Maybe sometime...
+        "SourceType": "Local", // Or "V2" or "V3"
+        "Packages": [
+            {
+                "PackageName": "<PackageName>",
+                "VersionsRetrieved": "<datetIme>"
+                "Versions": [
+                {
+                    "Version": "1.0.0",
+                    "PackageDetails": {
+                        "Name": "",
+                        "DownloadLink": "",
+                        "LicenseUrl": "",
+                        "IsUnlisted": true,
+                        "Dependencies":
+                            [
+                                { "PackageName": "", "VersionRequirement": "", "FrameworkRestrictions": "" },
+                                { "PackageName": "", "VersionRequirement": "", "FrameworkRestrictions": "" }
+                            ]
+                    },
+                    "RuntimeGraphData": {
+                        "supports": {
+                            "uwp.10.0.app": {
+                              "uap10.0": [
+                                "win10-x86",
+                                "win10-x86-aot",
+                                "win10-x64",
+                                "win10-x64-aot",
+                                "win10-arm",
+                                "win10-arm-aot"
+                              ]
+                            }
+                        },
+                        "runtimes": {
+                            "win": {
+                              "#import": [ "any" ]
+                              "Microsoft.Win32.Primitives": {
+                                "runtime.win.Microsoft.Win32.Primitives": "4.3.0"
+}}}
+
+*)
+
+let inline internal (!>) (x:^a) : ^b = ((^a or ^b) : (static member op_Implicit : ^a -> ^b) x)
+let internal writeRuntimeGraph (r:RuntimeGraph option) =
+    match r with
+    | Some graph ->
+        RuntimeGraphParser.writeRuntimeGraphJ graph
+    | None ->
+        let n = JObject()
+        n
+let internal writePackageDetails (pack:PackageDetails) =
+    let n = JObject()
+    n.Add("Name", !>pack.Name.Name)
+    n.Add("DownloadLink", !>pack.DownloadLink)
+    n.Add("LicenseUrl", !>pack.LicenseUrl)
+    n.Add("IsUnlisted", !>pack.Unlisted)
+    let deps = JArray()
+    pack.DirectDependencies
+    |> Seq.iter (fun (packName, versionReq, restriction) ->
+        let dep = JObject()
+        dep.Add("PackageName", !>packName.Name)
+        dep.Add("VersionRequirement", !>versionReq.ToString())
+        match Requirements.getRestrictionList restriction with
+        | [] -> ()
+        | list -> dep.Add("FrameworkRestrictions", !>(System.String.Join(", ",list)))
+        deps.Add(dep))
+    n.Add("Dependencies", deps)
+    n
+let internal writePackageVersion version details runtime =
+    let n = JObject()
+    n.Add("Version", !> version.ToString())
+    details |> Option.iter (fun details ->
+        n.Add("PackageDetails", writePackageDetails details))
+    runtime |> Option.iter (fun runtime ->
+        n.Add("RuntimeGraphData", writeRuntimeGraph runtime))
+    n
+
+let internal writePackage (name:PackageName) cache =
+    let n = JObject()
+    let versions = JArray()
+    cache.Details
+    |> Map.toSeq
+    |> Seq.iter (fun (version, (details, runtime)) ->
+        writePackageVersion version details (runtime |> RuntimeGraphCache.getData)
+        |> fun s -> versions.Add(s))
+    n.Add("VersionsRetrieved", !> cache.VersionListRetrieved)
+    n.Add("PackageName", !> name.Name)
+    n.Add("Versions", versions)
+    n
+let internal writeSource data =
+    let s = JObject()
+    let packages = JArray()
+    data
+    |> Seq.iter (fun ((name:PackageName), cache) ->
+        let n = writePackage name cache
+        packages.Add(n))
+    s.Add("Packages", packages)
+    //let sourceType =
+    //s.Add("SourceType",  )
+    s
+
+let createGraphJson (data : seq<NuGetSourceUri * PackageName * CachedInfo>) : JObject =
+
+    let j = JObject()
+    data
+    |> Seq.groupBy (fun (fst, _, _) -> fst)
+    |> Seq.iter (fun (source, group) ->
+        group
+        |> Seq.map (fun (_, name, cache) -> name, cache)
+        |> writeSource
+        |> fun s -> j.Add(source, s))
+    j
+
+let internal readPackageDependency (j:JObject) : PackageName * VersionRequirement * Requirements.FrameworkRestrictions =
+    let name =
+        match j.["PackageName"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> failwithf "Need Name in PackageDetails element"
+        |> PackageName
+
+    let versionRequirement =
+        match j.["VersionRequirement"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> failwithf "Need Name in PackageDetails element"
+        |> VersionRequirement.Parse
+
+    let frameworkRestrictions =
+        match j.["FrameworkRestrictions"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> ""
+        |> fun s -> if System.String.IsNullOrWhiteSpace s then [] else Requirements.parseRestrictions true s
+    name, versionRequirement, Requirements.FrameworkRestrictions.FrameworkRestrictionList frameworkRestrictions
+
+let internal readPackageDetails source (j:JObject) : PackageDetails =
+    let name =
+        match j.["Name"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> failwithf "Need Name in PackageDetails element"
+        |> PackageName
+    let downloadLink =
+        match j.["DownloadLink"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> failwithf "Need DownloadLink in PackageDetails element"
+    let licenseUrl =
+        match j.["LicenseUrl"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> failwithf "Need LicenseUrl in PackageDetails element"
+    let unlisted =
+        match j.["IsUnlisted"] with
+        | :? JValue as v -> System.Boolean.Parse(v.ToString())
+        | _ -> failwithf "Need LicenseUrl in PackageDetails element"
+    let dependencies =
+        match j.["Dependencies"] with
+        | :? JArray as deps -> deps
+        | _ -> failwithf "Need LicenseUrl in PackageDetails element"
+        :> IEnumerable<JToken>
+        |> Seq.map (fun j -> j :?> JObject |> readPackageDependency)
+        |> Set.ofSeq
+    { Name  = name
+      Source = Paket.PackageSources.PackageSource.NuGetV2Source source
+      DownloadLink = downloadLink
+      LicenseUrl =licenseUrl
+      Unlisted = unlisted
+      DirectDependencies = dependencies }
+
+let internal readRuntimeGraph (j:JObject) : RuntimeGraph option =
+    match j.["runtimes"] with
+    | :? JObject as s ->
+        RuntimeGraphParser.readRuntimeGraphJ j |> Some
+    | _ -> None
+
+let internal readVersion source (jObject:JObject) : SemVerInfo * PackageDetails option * RuntimeGraphCache =
+    let version =
+        match jObject.["Version"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> failwithf "Need PacakgeName in package element"
+        |> SemVer.Parse
+    let packageDetails =
+        match jObject.["PackageDetails"] with
+        | :? JObject as o -> readPackageDetails source o |> Some
+        | _ -> None
+    let runtimeGraph =
+        match jObject.["RuntimeGraphData"] with
+        | :? JObject as o -> readRuntimeGraph o |> Some
+        | _ -> None
+        |> RuntimeGraphCache.ofOption
+    version, packageDetails, runtimeGraph
+
+let internal readPackage source (jObject:JObject) : PackageName * CachedInfo =
+    let versionsRetrieved =
+        match jObject.["VersionsRetrieved"] with
+        | :? JValue as v -> DateTime.Parse( v.ToString() )
+        | _ ->
+            // TODO: add logging?
+            DateTime()
+
+    let packageName =
+        match jObject.["PackageName"] with
+        | :? JValue as v -> v.ToString()
+        | _ -> failwithf "Need PacakgeName in package element"
+        |> PackageName
+    let details =
+        match jObject.["Versions"] with
+        | :? JArray as ar -> ar
+        | _ -> failwithf "Need Versions as JArray element"
+        :> IEnumerable<JToken>
+        |> Seq.map (fun j -> j :?> JObject |> readVersion source)
+        |> Seq.map (fun (ver, packageDetails, runtimeGraph) -> ver, (packageDetails, runtimeGraph))
+        |> Map.ofSeq
+
+    packageName, { VersionListRetrieved = versionsRetrieved; Details = details }
+
+let internal readSource sourceName (jObject:JObject) : seq<PackageName * CachedInfo> =
+    let packages =
+        match jObject.["Packages"] with
+        | :? JArray as packages -> packages
+        | null -> failwithf "Packages element was missing in source"
+        | _ -> failwithf "Invalid data in Packages element."
+        :> IEnumerable<JToken>
+        |> Seq.map (fun j ->
+            readPackage sourceName (j :?> JObject))
+    //let sourceType =
+    //    match jObject.["SourceType"] with
+    //    | :? JValue as v -> v.ToString()
+    //    | _ -> failwithf "Need PacakgeName in package element"
+
+    packages
+
+
+let readGraphJson (j:JObject) : seq<NuGetSourceUri * PackageName * CachedInfo> =
+
+    j :> IEnumerable<KeyValuePair<string, JToken>>
+    |> Seq.collect (fun kv ->
+        readSource kv.Key (kv.Value :?> JObject)
+        |> Seq.map (fun (packName, cache) -> kv.Key, packName, cache))
+
+// Notes:
+// - No entry means: Version list was never retrieved
+// - We need to be carefull when caching the list of versions...
+let private tree = ConcurrentDictionary<NuGetSourceUri * PackageName, CachedInfo>()
+let updateCacheFile () =
+    tree
+    |> Seq.toList
+    |> Seq.map (fun kv ->
+        let uri, name = kv.Key
+        uri, name,kv.Value)
+    |> createGraphJson
+    |> fun j -> System.IO.File.WriteAllText(graphCacheFile, j.ToString())
+
+let readCacheFile () =
+    if System.IO.File.Exists graphCacheFile then
+        System.IO.File.ReadAllText(graphCacheFile)
+        |> JObject.Parse
+        |> readGraphJson
+        |> Seq.iter (fun (source, packName, cache) ->
+            tree.AddOrUpdate((source,packName), cache, (fun _ oldCache ->
+                // TODO merge...
+                cache))
+            |> ignore)
+
+
+let tryGetCacheEntry (source:Paket.PackageSources.PackageSource) name =
+    let fixSource (cache:CachedInfo) =
+        { cache with
+            Details =
+                cache.Details
+                |> Map.map (fun _ (packageDetails, runtimeGraph) ->
+                    match packageDetails with
+                    | Some detail -> Some { detail with Source = source }, runtimeGraph
+                    | None -> packageDetails, runtimeGraph) }
+
+    match tree.TryGetValue((source.Url,name)) with
+    | true, cache ->
+        Some (fixSource cache)
+    | _ -> None
+
+do
+    if isGraphCacheEnabled then
+        readCacheFile()
+
+let updateVersions (source:Paket.PackageSources.PackageSource) packageName versions =
+    tree.AddOrUpdate((source.Url,packageName), CachedInfo.FromVersions versions, (fun _ oldVal ->
+        oldVal |> CachedInfo.updateVersions versions))
+    |> ignore
+    updateCacheFile()
+
+let updatePackageDetails packageName (ver:SemVerInfo) (packageDetails:PackageDetails) =
+    tree.AddOrUpdate((packageDetails.Source.Url,packageName), CachedInfo.FromPackageDetails ver packageDetails, (fun _ oldVal ->
+        oldVal |> CachedInfo.updatePackageDetails ver packageDetails))
+    |> ignore
+    updateCacheFile()
+
+let updateRuntimeGraph (source:Paket.PackageSources.PackageSource) packageName (ver:SemVerInfo) (graph:RuntimeGraph option) =
+    tree.AddOrUpdate((source.Url,packageName), CachedInfo.FromRuntimeGraph ver graph, (fun _ oldVal ->
+        oldVal |> CachedInfo.updateRuntimeInfo ver graph))
+    |> ignore
+    updateCacheFile()
+
+type GetVersionF = PackageSources.PackageSource list -> ResolverStrategy -> GroupName -> PackageName -> seq<SemVerInfo * PackageSources.PackageSource list>
+let liftGetVersionsF (getVersionF:GetVersionF) : GetVersionF =
+  if not isGraphCacheEnabled then getVersionF else
+    let cachedGetVersionF sources resolver group name =
+        sources
+        |> Seq.map (fun (source:PackageSources.PackageSource) ->
+            match tryGetCacheEntry source name with
+            | Some cache ->
+                cache.Details
+                |> Map.toSeq
+                |> Seq.map fst
+                |> Seq.map (fun v -> v, source)
+                |> Some
+            | None -> None)
+        |> Seq.fold (fun (s) item ->
+            s |> Option.bind (fun curList -> item |> Option.map (fun versions -> versions :: curList))) (Some [])
+        |> Option.map (fun items ->
+            items
+            |> Seq.concat
+            |> Seq.groupBy fst
+            |> Seq.map (fun (k, g) -> k, g |> Seq.map snd |> Seq.toList))
+        |> Option.defaultWith (fun () ->
+            // At least one source was not cached -> retrieve from server
+            if preventOnlineRead then failwithf "At least one package source of %A was not found locally, and 'Prevent Online Read' was request." sources
+            let onlineData = getVersionF sources resolver group name
+            // update cache
+            onlineData
+            |> Seq.collect (fun (ver, sources) -> sources |> Seq.map (fun s -> s, ver))
+            |> Seq.groupBy fst
+            |> Seq.map (fun (k, g) -> k, g |> Seq.map snd |> Seq.toList)
+            |> Seq.iter (fun (source, versions) -> updateVersions source name versions)
+
+            onlineData)
+
+    cachedGetVersionF
+
+type GetPackageDetailsF = PackageSources.PackageSource list -> GroupName -> PackageName -> SemVerInfo -> PackageDetails
+let liftGetPackageDetailsF (getPackageDetailsF:GetPackageDetailsF) : GetPackageDetailsF =
+  if not isGraphCacheEnabled then getPackageDetailsF else
+    let cachedGetPackageDetailsF sources group name semVer =
+        sources
+        |> Seq.choose (fun (source:PackageSources.PackageSource) ->
+            match tryGetCacheEntry source name with
+            | Some cache -> cache.Details |> Map.tryFind semVer
+            | None -> None)
+        |> Seq.tryHead
+        |> Option.bind fst
+        |> Option.defaultWith (fun _ ->
+            // No package-details cached jet
+            if preventOnlineRead then failwithf "No package details for package %O are cached jet in any of the sources %A, and 'Prevent Online Read' was request." name sources
+            let details = getPackageDetailsF sources group name semVer
+            // update cache
+            updatePackageDetails name semVer details
+
+            details)
+
+    cachedGetPackageDetailsF
+
+type GetRuntimeGraphF = GroupName -> ResolvedPackage -> RuntimeGraph option
+let liftGetRuntimeGraphFromPackage (getRuntimeGraphFromPackage:GetRuntimeGraphF) : GetRuntimeGraphF =
+  if not isGraphCacheEnabled then getRuntimeGraphFromPackage else
+    let cachedGetRuntimeGraphFromPackage group resolvedPackage =
+        match tryGetCacheEntry resolvedPackage.Source resolvedPackage.Name with
+        | Some cache -> cache.Details |> Map.tryFind resolvedPackage.Version |> Option.map snd
+        | None -> None
+        |> RuntimeGraphCache.simplify
+        |> RuntimeGraphCache.getData
+        |> Option.defaultWith (fun _ ->
+            // No package-details cached jet
+            if preventOnlineRead then failwithf "No runtime graph data for package %O is cached jet, and 'Prevent Online Read' was request." resolvedPackage.Name
+            let details = getRuntimeGraphFromPackage group resolvedPackage
+            // update cache
+            updateRuntimeGraph resolvedPackage.Source resolvedPackage.Name resolvedPackage.Version details
+
+            details)
+
+    cachedGetRuntimeGraphFromPackage

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -34,8 +34,8 @@
     <StartWorkingDirectory>D:\temp\coreclrtest</StartWorkingDirectory>
     <StartArguments>install</StartArguments>
     <StartWorkingDirectory>C:\dev\src\Paket\integrationtests\scenarios\loading-scripts\dependencies-file-flag\temp</StartWorkingDirectory>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>C:\PROJ\Paket\integrationtests\scenarios\i001145-excludes\temp</StartWorkingDirectory>
+    <StartArguments>install --createnewbindingfiles</StartArguments>
+    <StartWorkingDirectory>C:\PROJ\Paket\integrationtests\scenarios\i001270-force-redirects\temp</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -408,6 +408,8 @@ let why (results: ParseResults<WhyArgs>) =
 
 
 let main() =
+    //System.Environment.SetEnvironmentVariable("PAKET_GRAPH_CACHE_PREVENT_ONLINE", "true")
+    //System.Environment.SetEnvironmentVariable("PAKET_GRAPH_CACHE", @"C:\PROJ\Paket\integrationtests\scenarios\i001270-force-redirects\cache\paket-graph.cache")
     use consoleTrace = Logging.event.Publish |> Observable.subscribe Logging.traceToConsole
     let paketVersion = AssemblyVersionInformation.AssemblyInformationalVersion
 

--- a/tests/Paket.Tests/GraphCaching/GraphCachingParsingAndWriting.fs
+++ b/tests/Paket.Tests/GraphCaching/GraphCachingParsingAndWriting.fs
@@ -1,0 +1,153 @@
+﻿[<NUnit.Framework.TestFixture>]
+[<NUnit.Framework.Category "Graph Caching">]
+module Paket.GraphCachingParserTests
+
+open System.IO
+open NUnit.Framework
+open FsUnit
+open TestHelpers
+open Paket
+open Paket.Domain
+open Newtonsoft.Json.Linq
+
+[<Test>]
+let ``can parse version requirements``() =
+    let graphString = """{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:05.9741447+02:00",
+        "PackageName": "bootstrap",
+        "Versions": [
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "bootstrap",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/bootstrap/3.2.0",
+              "LicenseUrl": "https://github.com/twbs/bootstrap/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "jquery",
+                  "VersionRequirement": ">= 1.9"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}"""
+    let graph =
+        GraphCache.readGraphJson (JObject.Parse graphString)
+        |> Seq.map (fun (source, packagename, cache) -> source, (packagename, cache))
+        |> Seq.groupBy fst
+        |> Seq.map (fun (source, group) -> source, group |> Seq.map snd |> dict)
+        |> dict
+    let cache = graph.["http://www.nuget.org/api/v2"].[PackageName "bootstrap"]
+    let details, runtimeGraph = cache.Details.[SemVer.Parse "3.2.0"]
+    runtimeGraph |> shouldEqual (GraphCache.RuntimeGraphCache.CachedData None)
+    details |> shouldNotEqual None
+    let d = details.Value
+    d.DirectDependencies.Count |> shouldEqual 1
+    //d.DirectDependencies.[0]
+
+[<Test>]
+let ``can parse empty versions``() =
+    let graphString = """{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:05.9741447+02:00",
+        "PackageName": "bootstrap",
+        "Versions": [
+          {
+            "Version": "3.1.0",
+          },
+          {
+            "Version": "1.1.0",
+          },
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "bootstrap",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/bootstrap/3.2.0",
+              "LicenseUrl": "https://github.com/twbs/bootstrap/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "jquery",
+                  "VersionRequirement": ">= 1.9"
+                }
+              ]
+            },
+            "RuntimeGraphData": {}
+          }
+        ]
+      }
+    ]
+  }
+}"""
+    let graph =
+        GraphCache.readGraphJson (JObject.Parse graphString)
+        |> Seq.map (fun (source, packagename, cache) -> source, (packagename, cache))
+        |> Seq.groupBy fst
+        |> Seq.map (fun (source, group) -> source, group |> Seq.map snd |> dict)
+        |> dict
+    let cache = graph.["http://www.nuget.org/api/v2"].[PackageName "bootstrap"]
+    cache.Details.Count |> shouldEqual 3
+
+    // TODO: Tests version ordering
+[<Test>]
+let ``can parse versions of runtime graph``() =
+    let graphString = """{
+  "http://www.nuget.org/api/v2": {
+    "Packages": [
+      {
+        "VersionsRetrieved": "2017-05-01T23:26:05.9741447+02:00",
+        "PackageName": "bootstrap",
+        "Versions": [
+          {
+            "Version": "3.2.0",
+            "PackageDetails": {
+              "Name": "bootstrap",
+              "DownloadLink": "http://www.nuget.org/api/v2/package/bootstrap/3.2.0",
+              "LicenseUrl": "https://github.com/twbs/bootstrap/blob/master/LICENSE",
+              "IsUnlisted": false,
+              "Dependencies": [
+                {
+                  "PackageName": "jquery",
+                  "VersionRequirement": ">= 1.9"
+                }
+              ]
+            },
+            "RuntimeGraphData": {
+              "runtimes": {
+                "any": {
+                  "#import": [],
+                  "System.Collections": {
+                    "runtime.any.System.Collections": ">= 4.3"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}"""
+    let graph =
+        GraphCache.readGraphJson (JObject.Parse graphString)
+        |> Seq.map (fun (source, packagename, cache) -> source, (packagename, cache))
+        |> Seq.groupBy fst
+        |> Seq.map (fun (source, group) -> source, group |> Seq.map snd |> dict)
+        |> dict
+    let cache = graph.["http://www.nuget.org/api/v2"].[PackageName "bootstrap"]
+    cache.Details.Count |> shouldEqual 1
+    let _, runtime = cache.Details.[SemVer.Parse "3.2.0"]
+    runtime |> shouldNotEqual (GraphCache.RuntimeGraphCache.CachedData None)
+    runtime |> shouldNotEqual (GraphCache.RuntimeGraphCache.NotJetCached)
+    (**)

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -321,6 +321,7 @@
     <Compile Include="Packaging\TemplateFileParsing.fs" />
     <Compile Include="Packaging\RemotePushUrlSpecs.fs" />
     <Compile Include="ScriptGeneration\LoadingScriptTests.fs" />
+    <Compile Include="GraphCaching\GraphCachingParsingAndWriting.fs" />
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
to improve the speed of the integration tests suite.

If I can make this work for the test suite we might use it later for a global cache?