### PR TITLE
align with spec requirements, meaning no leading zeroes on semVers

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
+++ b/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
@@ -80,7 +80,7 @@ module RuntimeGraphParser =
           | :? JObject as spec ->
               let imports =
                 match spec.["#import"] with
-                | :? JArray as j -> [ for t in j -> Rid.Of (string t.Value) ]
+                | :? JArray as j -> [ for t in j -> Rid.Of (string t) ]
                 | null -> []
                 | o -> failwithf "unknown stuff in '#import' value: %O" o
               let dependencies =

--- a/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
+++ b/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
@@ -64,7 +64,7 @@ module RuntimeGraphParser =
                 [ for s in t.Value :?> JObject :> IEnumerable<KeyValuePair<string, JToken>> do
                     match FrameworkDetection.Extract s.Key with
                     | Some fid ->
-                        yield fid, [ for rid in (s.Value :?> JArray) -> Rid.Of (string rid) ]
+                        yield fid, [ for rid in (s.Value :?> JArray) -> Rid.Of (rid.Value<string>()) ]
                     | None -> failwithf "could not detect framework-identifier '%s'" s.Key ]
                 |> Map.ofSeq } ]
     (*{
@@ -80,7 +80,7 @@ module RuntimeGraphParser =
           | :? JObject as spec ->
               let imports =
                 match spec.["#import"] with
-                | :? JArray as j -> [ for t in j -> Rid.Of (string t) ]
+                | :? JArray as j -> [ for t in j -> Rid.Of (t.Value<string>()) ]
                 | null -> []
                 | o -> failwithf "unknown stuff in '#import' value: %O" o
               let dependencies =

--- a/src/Paket.Core/Versioning/SemVer.fs
+++ b/src/Paket.Core/Versioning/SemVer.fs
@@ -171,9 +171,13 @@ module SemVer =
         memoize <| fun (version : string) ->
             try
 
-                /// sanity check to make sure that all of the integers in the string are positive.
+                /// sanity check to make sure that all of the integers in the string are positive, and that no parts lead zeroes
                 /// because we use raw substrings with dashes this is very complex :(
-                version.Split([|'.'|]) |> Array.iter (fun s -> match Int32.TryParse s with | true, s when s < 0 -> failwith "no negatives!" | _ -> ignore ())
+                version.Split([|'.'|]) |> Array.iter (fun s ->
+                    match Int32.TryParse s, s.StartsWith("0") with
+                    | (true, s), _ when s < 0 -> failwith "no negatives!"
+                    | _, true -> failwith "no leading zeroes"
+                    | _, _-> ignore ())
 
                 if version.Contains("!") then 
                     failwithf "Invalid character found in %s" version

--- a/src/Paket.Core/Versioning/SemVer.fs
+++ b/src/Paket.Core/Versioning/SemVer.fs
@@ -3,7 +3,7 @@
 open System
 open System.Text.RegularExpressions
 
-module utils =  
+module utils =
     let zipOpt l1 l2 =
         let llength = if l1 = Unchecked.defaultof<_> then 0 else List.length l1
         let rlength = if l2 = Unchecked.defaultof<_> then 0 else List.length l2
@@ -15,7 +15,7 @@ module utils =
         }
 
 [<CustomEquality; CustomComparison>]
-type PreReleaseSegment = 
+type PreReleaseSegment =
     | AlphaNumeric of string
     | Numeric of bigint
 
@@ -31,8 +31,8 @@ type PreReleaseSegment =
             | _ -> invalidArg "yobj" "can't compare to other types of objects."
 
     override x.GetHashCode() = hash x
-    override x.Equals yobj = 
-        match yobj with 
+    override x.Equals yobj =
+        match yobj with
         | :? PreReleaseSegment as y ->
             match x, y with
             | AlphaNumeric a, AlphaNumeric b -> a = b
@@ -43,13 +43,13 @@ type PreReleaseSegment =
 
 /// Information about PreRelease packages.
 [<CustomEquality; CustomComparison>]
-type PreRelease = 
+type PreRelease =
     { Origin : string
       Name : string
       Values : PreReleaseSegment list }
-    
-    static member TryParse (str : string) = 
-        if String.IsNullOrEmpty str then None 
+
+    static member TryParse (str : string) =
+        if String.IsNullOrEmpty str then None
         else
             let name = Regex("^(?<name>[a-zA-Z]+)").Match(str).Value
 
@@ -57,26 +57,26 @@ type PreRelease =
                 match bigint.TryParse segment with
                 | true, bint -> Numeric bint
                 | false, _ -> AlphaNumeric segment
-                    
+
             let values = str.Split([|'.'|]) |> Array.map parse |> List.ofArray
             Some { Origin = str; Name = name; Values = values}
 
-    override x.Equals(yobj) = 
+    override x.Equals(yobj) =
         match yobj with
         | :? PreRelease as y -> x.Origin = y.Origin
         | _ -> false
 
     override x.ToString() = x.Origin
-    
+
     override x.GetHashCode() = hash x.Origin
     interface System.IComparable with
-        member x.CompareTo yobj = 
+        member x.CompareTo yobj =
             match yobj with
-            | :? PreRelease as y -> 
+            | :? PreRelease as y ->
                 utils.zipOpt x.Values y.Values
-                |> Seq.fold (fun cmp (a, b) -> 
+                |> Seq.fold (fun cmp (a, b) ->
                     if cmp <> 0 then cmp
-                    else 
+                    else
                         match a, b with
                         | None, Some _ -> -1
                         | Some _, None -> 1
@@ -86,7 +86,7 @@ type PreRelease =
 
 /// Contains the version information.
 [<CustomEquality; CustomComparison; StructuredFormatDisplay("{AsString}")>]
-type SemVerInfo = 
+type SemVerInfo =
     { /// MAJOR version when you make incompatible API changes.
       Major : uint32
       /// MINOR version when you add functionality in a backwards-compatible manner.
@@ -100,43 +100,43 @@ type SemVerInfo =
       BuildMetaData : string
       // The original version text
       Original : string option }
-    
-    member x.Normalize() = 
-        let build = 
+
+    member x.Normalize() =
+        let build =
             if String.IsNullOrEmpty x.Build |> not && x.Build <> "0" then "." + x.Build
             else ""
-                        
-        let pre = 
+
+        let pre =
             match x.PreRelease with
             | Some preRelease -> sprintf "-%s" preRelease.Origin
             | None -> ""
 
         sprintf "%d.%d.%d%s%s" x.Major x.Minor x.Patch build pre
 
-    member x.NormalizeToShorter() = 
+    member x.NormalizeToShorter() =
         let s = x.Normalize()
         let s2 = sprintf "%d.%d" x.Major x.Minor
         if s = s2 + ".0" then s2 else s
 
-    override x.ToString() = 
+    override x.ToString() =
         match x.Original with
         | Some version -> version.Trim()
         | None -> x.Normalize()
-    
+
     member x.AsString
         with get() = x.ToString()
 
-    override x.Equals(yobj) = 
+    override x.Equals(yobj) =
         match yobj with
-        | :? SemVerInfo as y -> 
-            x.Major = y.Major && x.Minor = y.Minor && x.Patch = y.Patch && x.PreRelease = y.PreRelease && x.Build = y.Build && x.BuildMetaData = y.BuildMetaData 
+        | :? SemVerInfo as y ->
+            x.Major = y.Major && x.Minor = y.Minor && x.Patch = y.Patch && x.PreRelease = y.PreRelease && x.Build = y.Build && x.BuildMetaData = y.BuildMetaData
         | _ -> false
-    
+
     override x.GetHashCode() = hash (x.Minor, x.Minor, x.Patch, x.PreRelease, x.Build)
     interface System.IComparable with
-        member x.CompareTo yobj = 
+        member x.CompareTo yobj =
             match yobj with
-            | :? SemVerInfo as y -> 
+            | :? SemVerInfo as y ->
                 if x.Major <> y.Major then compare x.Major y.Major
                 else if x.Minor <> y.Minor then compare x.Minor y.Minor
                 else if x.Patch <> y.Patch then compare x.Patch y.Patch
@@ -144,7 +144,7 @@ type SemVerInfo =
                     match Int32.TryParse x.Build, Int32.TryParse y.Build with
                     | (true, b1), (true, b2) -> compare b1 b2
                     | _ -> compare x.Build y.Build
-                else 
+                else
                     match x.PreRelease, y.PreRelease with
                     | None, None -> 0
                     | Some p, None -> -1
@@ -157,7 +157,7 @@ type SemVerInfo =
             | _ -> invalidArg "yobj" "cannot compare values of different types"
 
 ///  Parser which allows to deal with [Semantic Versioning](http://semver.org/) (SemVer).
-module SemVer = 
+module SemVer =
     /// Parses the given version string into a SemVerInfo which can be printed using ToString() or compared
     /// according to the rules described in the [SemVer docs](http://semver.org/).
     /// ## Sample
@@ -167,23 +167,24 @@ module SemVer =
     ///     parse "1.2.3-alpha2"   > parse "1.2.3-alpha"    // true
     ///     parse "1.2.3-alpha002" > parse "1.2.3-alpha1"   // true
     ///     parse "1.5.0-beta.2"   > parse "1.5.0-rc.1"     // false
-    let Parse = 
+    let Parse =
         memoize <| fun (version : string) ->
             try
 
                 /// sanity check to make sure that all of the integers in the string are positive, and that no parts lead zeroes
                 /// because we use raw substrings with dashes this is very complex :(
                 version.Split([|'.'|]) |> Array.iter (fun s ->
-                    match Int32.TryParse s, s.StartsWith("0") with
-                    | (true, s), _ when s < 0 -> failwith "no negatives!"
-                    | _, true -> failwith "no leading zeroes"
-                    | _, _-> ignore ())
+                    match Int32.TryParse s, s.StartsWith("0"), s = "0" with
+                    | (true, s), _, _ when s < 0 -> failwith "no negatives!"
+                    | _, _, true -> ignore () // if the value _is_ zero that's fine
+                    | _, true, _ -> failwith "no leading zeroes"
+                    | _, _, _ -> ignore ())
 
-                if version.Contains("!") then 
+                if version.Contains("!") then
                     failwithf "Invalid character found in %s" version
-                if version.Contains("..") then 
+                if version.Contains("..") then
                     failwithf "Empty version part found in %s" version
-        
+
                 let firstDash = version.IndexOf("-")
                 let plusIndex = version.IndexOf("+")
 
@@ -193,12 +194,12 @@ module SemVer =
                     | -1 -> version
                     | n -> version.Substring(0, n)
 
-                let prerelease = 
+                let prerelease =
                     match firstDash, plusIndex with
                     | -1, _ -> ""
                     | d, p when p = -1 -> version.Substring(d+1)
                     | d, p -> version.Substring(d+1, (p - 1 - d) )
-            
+
                 /// there can only be one piece of build metadata, and it is signified by a + and then any number of dot-separated alpha-numeric groups.
                 /// this just greedily takes the whole remaining string :(
                 let buildmeta =
@@ -206,7 +207,7 @@ module SemVer =
                     | -1 -> ""
                     | n when plusIndex = version.Length - 1 -> ""
                     | n -> version.Substring(plusIndex + 1)
-        
+
                 let major, minor, patch, build =
                     match majorMinorPatch.Split([|'.'|]) with
                     | [|M; m; p; b|] -> uint32 M, uint32 m, uint32 p, b

--- a/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
@@ -359,10 +359,10 @@ let ``should pin down version requirement during add``() =
     let config = """source https://www.nuget.org/api/v2
 nuget Microsoft.AspNet.WebApi ~> 1.0"""
 
-    let cfg = DependenciesFile.FromSource(config).AddFixedPackage(Constants.MainDependencyGroup, PackageName "Microsoft.AspNet.WebApi","1.0.071.9432")
-    
+    let cfg = DependenciesFile.FromSource(config).AddFixedPackage(Constants.MainDependencyGroup, PackageName "Microsoft.AspNet.WebApi","1.0.71.9432")
+
     let expected = """source https://www.nuget.org/api/v2
-nuget Microsoft.AspNet.WebApi 1.0.071.9432"""
+nuget Microsoft.AspNet.WebApi 1.0.71.9432"""
 
     cfg.ToString()
     |> shouldEqual (normalizeLineEndings expected)
@@ -400,14 +400,14 @@ nuget Moq"""
     |> shouldEqual (normalizeLineEndings expected)
 
 [<Test>]
-let ``should add Microsoft.AspNet.WebApi package in first group``() = 
+let ``should add Microsoft.AspNet.WebApi package in first group``() =
     let config = """source https://www.nuget.org/api/v2
 
 group Build
 nuget Moq"""
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "Microsoft.AspNet.WebApi","")
-    
+
     let expected = """source https://www.nuget.org/api/v2
 nuget Microsoft.AspNet.WebApi
 

--- a/tests/Paket.Tests/DependenciesFile/VersionRangeSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/VersionRangeSpecs.fs
@@ -23,8 +23,8 @@ let ``can detect specific version``() =
 let ``can detect ordinary Between``() = 
     parseRange "~> 2.2" |> shouldEqual (VersionRange.Between("2.2","3.0"))
     parseRange "~> 1.2" |> shouldEqual (VersionRange.Between("1.2","2.0"))
-    (VersionRequirement(parseRange "~> 1.0",PreReleaseStatus.All)).IsInRange(SemVer.Parse("1.0.071.9556")) |> shouldEqual true
-    (VersionRequirement(parseRange "~> 1.0",PreReleaseStatus.All)).IsInRange(SemVer.Parse("1.0.071.9432")) |> shouldEqual true
+    (VersionRequirement(parseRange "~> 1.0",PreReleaseStatus.All)).IsInRange(SemVer.Parse("1.0.71.9556")) |> shouldEqual true
+    (VersionRequirement(parseRange "~> 1.0",PreReleaseStatus.All)).IsInRange(SemVer.Parse("1.0.71.9432")) |> shouldEqual true
 
 [<Test>]
 let ``can detect lower versions for ~>``() = 

--- a/tests/Paket.Tests/Versioning/SemVerSpecs.fs
+++ b/tests/Paket.Tests/Versioning/SemVerSpecs.fs
@@ -150,13 +150,6 @@ let ``version core elements must be non-negative (SemVer 2.0.0/2)`` () =
     shouldFail<exn>(fun () -> SemVer.Parse "1.1.-1" |> ignore)
     shouldFail<exn>(fun () -> SemVer.Parse "1.-1.1" |> ignore)
     shouldFail<exn>(fun () -> SemVer.Parse "-1.1.1" |> ignore)
-    
-
-[<Test>]
-let ``version core elements should accept leading zeroes (NuGet compat)`` () =
-    SemVer.Parse "01.1.1" |> ignore
-    SemVer.Parse "1.01.1" |> ignore
-    SemVer.Parse "1.1.01" |> ignore
 
 [<Test>]
 let ``pre-release identifiers must not contain invalid characters (SemVer 2.0.0/9)`` () =
@@ -206,10 +199,6 @@ let ``should accept SemVer2 prereleases`` () =
     semVer.Patch |> shouldEqual 0u
     semVer.BuildMetaData |> shouldEqual "foobar"
     semVer.PreRelease |> shouldEqual None
-
-[<Test>]
-let ``should accept version with leading zero`` () =
-    SemVer.Parse("1.0.071.9556").ToString() |> shouldEqual "1.0.071.9556"
 
 [<Test>]
 let ``should accept version with minus in prerelease`` () =


### PR DESCRIPTION
per the spec:

>A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and **MUST NOT** contain leading zeroes. X is the major version, Y is the minor version, and Z is the patch version. Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0.

Emphasis mine