### PR TITLE
use SourceLink for local builds too

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -211,12 +211,14 @@ Target "Build" (fun _ ->
         !! solutionFile
         |> MSBuildReleaseExt "" [
                 "VisualStudioVersion", "14.0"
-                "ToolsVersion"       , "14.0"  
+                "ToolsVersion"       , "14.0"
         ] "Rebuild"
         |> ignore
     else
         !! solutionFile
-        |> MSBuildReleaseExt "" [] "Rebuild"
+        |> MSBuildReleaseExt "" [
+                "SourceLinkCreate"   , "true"
+        ] "Rebuild"
         |> ignore
 )
 
@@ -258,6 +260,7 @@ Target "DotnetBuild" (fun _ ->
             { c with
                 Project = proj
                 ToolPath = dotnetExePath
+                AdditionalArgs = [ "/p:SourceLinkCreate=true" ]
             })
     )
 )


### PR DESCRIPTION
I [noticed](https://github.com/ctaggart/SourceLink/issues/181#issuecomment-299630165) that the published nupkg didn't have source link enabled. It is only enabled by default on build servers like AppVeyor. This enables it when run via FAKE. Once a [FAKE helper](https://github.com/ctaggart/SourceLink/issues/212) is added for `dotnet sourcelink test`, it would be good to add a test build step.