### PR TITLE
Include package name in verbose report

### DIFF
--- a/src/Paket.Core/PackageResolver.fs
+++ b/src/Paket.Core/PackageResolver.fs
@@ -694,7 +694,7 @@ let Resolve (getVersionsF, getPackageDetailsF, groupName:GroupName, globalStrate
                     currentStep.CurrentResolution.Count 
                     (currentStep.CurrentResolution |> Seq.map (fun x -> sprintf "\n     - %O, %O" x.Key x.Value.Version) |> String.Concat)
                     currentStep.OpenRequirements.Count
-                    (currentStep.OpenRequirements  |> Seq.map (fun x -> sprintf "\n     - %O, %O" x.Parent x.VersionRequirement) |> String.Concat)
+                    (currentStep.OpenRequirements  |> Seq.map (fun x -> sprintf "\n     - %O, %O %O" x.Parent x.Name x.VersionRequirement) |> String.Concat)
 
                 let currentRequirement = 
                     getCurrentRequirement packageFilter currentStep.OpenRequirements stackpack.ConflictHistory


### PR DESCRIPTION
Instead of reporting unprocessed dependencies like this:

```
   Retrieved Explored Package  FluentAssertions 4.19.0
   1 packages in resolution.
     - FluentAssertions, 4.19.0
   4 requirements left
     - D:\dev\heco\comwork\tools\paket.dependencies, >= 3.3 < 4.0
     - D:\dev\heco\comwork\tools\paket.dependencies, >= 3.0 < 4.0
     - D:\dev\heco\comwork\tools\paket.dependencies, >= 2.0 < 3.0
     - D:\dev\heco\comwork\tools\paket.dependencies, >= 0.9 < 1.0
```

Report them like this:
```
   Found Explored Package  FluentAssertions 4.19.2
   1 packages in resolution.
     - FluentAssertions, 4.19.2
   4 requirements left
     - d:\Users\agross\Projekte\GROSSWEBER\Kunden\heco\heco\comwork\tools\paket.dependencies, FakeItEasy >= 3.3 < 4.0
     - d:\Users\agross\Projekte\GROSSWEBER\Kunden\heco\heco\comwork\tools\paket.dependencies, System.Windows.Interactivity >= 3.0 < 4.0
     - d:\Users\agross\Projekte\GROSSWEBER\Kunden\heco\heco\comwork\tools\paket.dependencies, Interop.CLMGRLib >= 2.0 < 3.0
     - d:\Users\agross\Projekte\GROSSWEBER\Kunden\heco\heco\comwork\tools\paket.dependencies, Machine.Specifications >= 0.9 < 1.0
```