### PR TITLE
Better hash checks in bootstrapper

### DIFF
--- a/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
@@ -71,16 +71,19 @@ namespace Paket.Bootstrapper.DownloadStrategies
             }
         }
 
-        protected override void DownloadHashFileCore(string latestVersion)
+        protected override string DownloadHashFileCore(string latestVersion)
         {
-            var cached = Path.Combine(_paketCacheDir, latestVersion, "paket-sha256.txt");
+            var cached = GetHashFilePathInCache(latestVersion);
 
             if (!FileSystemProxy.FileExists(cached))
             {
                 ConsoleImpl.WriteInfo("Hash file of version {0} not found in cache.", latestVersion);
 
-                EffectiveStrategy.DownloadHashFile(latestVersion);
+                var effectivePath = EffectiveStrategy.DownloadHashFile(latestVersion);
+                FileSystemProxy.CopyFile(effectivePath, cached, true);
             }
+
+            return cached;
         }
 
         protected override void SelfUpdateCore(string latestVersion)
@@ -116,7 +119,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
         private bool ValidateHash(string version, string paketFile)
         {
-            var hashFile = Path.Combine(_paketCacheDir, version, "paket-sha256.txt");
+            var hashFile = GetHashFilePathInCache(version);
 
             if (!FileSystemProxy.FileExists(hashFile))
             {
@@ -145,6 +148,11 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
                 return string.Equals(expectedHash, hash, StringComparison.OrdinalIgnoreCase);
             }
+        }
+
+        private string GetHashFilePathInCache(string version)
+        {
+            return Path.Combine(_paketCacheDir, version, "paket-sha256.txt");
         }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
@@ -11,6 +11,11 @@ namespace Paket.Bootstrapper.DownloadStrategies
     {
         public override string Name { get { return String.Format("{0} - cached", EffectiveStrategy.Name); } }
 
+        public override bool CanDownloadHashFile
+        {
+            get { return EffectiveStrategy.CanDownloadHashFile; }
+        }
+
         private readonly string _paketCacheDir =
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NuGet", "Cache", "Paket");
 
@@ -49,7 +54,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             }
         }
 
-        protected override void DownloadVersionCore(string latestVersion, string target)
+        protected override void DownloadVersionCore(string latestVersion, string target, string hashfile)
         {
             var cached = Path.Combine(_paketCacheDir, latestVersion, "paket.exe");
 
@@ -57,15 +62,15 @@ namespace Paket.Bootstrapper.DownloadStrategies
             {
                 ConsoleImpl.WriteInfo("Version {0} not found in cache.", latestVersion);
 
-                DownloadAndPlaceInCache(latestVersion, target, cached);
+                DownloadAndPlaceInCache(latestVersion, target, cached, hashfile);
                 return;
             }
 
-            if (!ValidateHash(latestVersion, cached))
+            if (!BootstrapperHelper.ValidateHash(FileSystemProxy, hashfile, latestVersion, cached))
             {
                 ConsoleImpl.WriteWarning("Version {0} found in cache but it's hash isn't valid.", latestVersion);
 
-                DownloadAndPlaceInCache(latestVersion, target, cached);
+                DownloadAndPlaceInCache(latestVersion, target, cached, hashfile);
                 return;
             }
 
@@ -74,28 +79,33 @@ namespace Paket.Bootstrapper.DownloadStrategies
             FileSystemProxy.CopyFile(cached, target, true);
         }
 
-        private void DownloadAndPlaceInCache(string latestVersion, string target, string cached)
+        private void DownloadAndPlaceInCache(string latestVersion, string target, string cached, string hashfile)
         {
-            EffectiveStrategy.DownloadVersion(latestVersion, target);
+            EffectiveStrategy.DownloadVersion(latestVersion, target, hashfile);
 
             ConsoleImpl.WriteTrace("Caching version {0} for later", latestVersion);
             FileSystemProxy.CreateDirectory(Path.GetDirectoryName(cached));
             FileSystemProxy.CopyFile(target, cached);
-
-            if (!ValidateHash(latestVersion, cached))
-            {
-                ConsoleImpl.WriteWarning("Hash of downloaded paket.exe is invalid");
-            }
         }
 
         protected override string DownloadHashFileCore(string latestVersion)
         {
+            if (!EffectiveStrategy.CanDownloadHashFile)
+            {
+                return null;
+            }
+
             var cached = GetHashFilePathInCache(latestVersion);
 
             if (!FileSystemProxy.FileExists(cached))
             {
                 ConsoleImpl.WriteInfo("Hash file of version {0} not found in cache.", latestVersion);
                 var effectivePath = EffectiveStrategy.DownloadHashFile(latestVersion);
+                if(effectivePath == null)
+                {
+                    // 'EffectiveStrategy.CanDownloadHashFile' should have returned false...
+                    return null;
+                }
 
                 ConsoleImpl.WriteTrace("Copying hash file in cache.");
                 ConsoleImpl.WriteTrace("{0} -> {1}", effectivePath, cached);
@@ -134,39 +144,6 @@ namespace Paket.Bootstrapper.DownloadStrategies
                     }
                 })
                 .FirstOrDefault() ?? "0";
-        }
-
-        private bool ValidateHash(string version, string paketFile)
-        {
-            var hashFile = GetHashFilePathInCache(version);
-
-            if (!FileSystemProxy.FileExists(hashFile))
-            {
-                ConsoleImpl.WriteInfo("No hash file of version {0} found in cache.", version);
-
-                return true;
-            }
-
-            var dict = FileSystemProxy.ReadAllLines(hashFile)
-                                      .Select(i => i.Split(' '))
-                                      .ToDictionary(i => i[1], i => i[0]);
-
-            string expectedHash;
-            if (!dict.TryGetValue("paket.exe", out expectedHash))
-            {
-                FileSystemProxy.DeleteFile(hashFile);
-
-                throw new InvalidDataException("Paket hash file is corrupted");
-            }
-
-            using (var stream = FileSystemProxy.OpenRead(paketFile))
-            using (var sha = SHA256.Create())
-            {
-                byte[] checksum = sha.ComputeHash(stream);
-                var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
-
-                return string.Equals(expectedHash, hash, StringComparison.OrdinalIgnoreCase);
-            }
         }
 
         private string GetHashFilePathInCache(string version)

--- a/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
@@ -146,7 +146,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
                 .FirstOrDefault() ?? "0";
         }
 
-        private string GetHashFilePathInCache(string version)
+        public string GetHashFilePathInCache(string version)
         {
             return Path.Combine(_paketCacheDir, version, "paket-sha256.txt");
         }

--- a/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
@@ -6,17 +6,17 @@ namespace Paket.Bootstrapper.DownloadStrategies
     public abstract class DownloadStrategy : IDownloadStrategy
     {
         public abstract string Name { get; }
+        public abstract bool CanDownloadHashFile { get; }
+
         public IDownloadStrategy FallbackStrategy { get; set; }
         public string GetLatestVersion(bool ignorePrerelease)
         {
             return Wrap(() => GetLatestVersionCore(ignorePrerelease), "GetLatestVersion");
         }
 
-        public void DownloadVersion(string latestVersion, string target)
+        public void DownloadVersion(string latestVersion, string target, string hashfile)
         {
-            DownloadHashFile(latestVersion);
-
-            Wrap(() => DownloadVersionCore(latestVersion, target), "DownloadVersion");
+            Wrap(() => DownloadVersionCore(latestVersion, target, hashfile), "DownloadVersion");
         }
 
         public void SelfUpdate(string latestVersion)
@@ -30,7 +30,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
         }
 
         protected abstract string GetLatestVersionCore(bool ignorePrerelease);
-        protected abstract void DownloadVersionCore(string latestVersion, string target);
+        protected abstract void DownloadVersionCore(string latestVersion, string target, string hashfile);
         protected abstract void SelfUpdateCore(string latestVersion);
         protected abstract string DownloadHashFileCore(string latestVersion);
 

--- a/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
@@ -24,15 +24,15 @@ namespace Paket.Bootstrapper.DownloadStrategies
             Wrap(() => SelfUpdateCore(latestVersion), "SelfUpdate");
         }
 
-        public void DownloadHashFile(string latestVersion)
+        public string DownloadHashFile(string latestVersion)
         {
-            Wrap(() => DownloadHashFileCore(latestVersion), "DownloadHashFile");
+            return Wrap(() => DownloadHashFileCore(latestVersion), "DownloadHashFile");
         }
 
         protected abstract string GetLatestVersionCore(bool ignorePrerelease);
         protected abstract void DownloadVersionCore(string latestVersion, string target);
         protected abstract void SelfUpdateCore(string latestVersion);
-        protected abstract void DownloadHashFileCore(string latestVersion);
+        protected abstract string DownloadHashFileCore(string latestVersion);
 
         private void Wrap(Action action, string actionName)
         {

--- a/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
@@ -114,13 +114,15 @@ namespace Paket.Bootstrapper.DownloadStrategies
             }
         }
 
-        protected override void DownloadHashFileCore(string latestVersion)
+        protected override string DownloadHashFileCore(string latestVersion)
         {
             var url = String.Format(Constants.PaketCheckSumDownloadUrlTemplate, latestVersion);
             ConsoleImpl.WriteInfo("Starting download from {0}", url);
 
             var tmpFile = BootstrapperHelper.GetTempFile("paket-sha256.txt");
             WebRequestProxy.DownloadFile(url, tmpFile);
+
+            return tmpFile;
         }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
@@ -20,6 +20,11 @@ namespace Paket.Bootstrapper.DownloadStrategies
         private IFileSystemProxy FileSystemProxy { get; set; }
         public override string Name { get { return "Github"; } }
 
+        public override bool CanDownloadHashFile
+        {
+            get { return true; }
+        }
+
         public GitHubDownloadStrategy(IWebRequestProxy webRequestProxy, IFileSystemProxy fileSystemProxy)
         {
             WebRequestProxy = webRequestProxy;
@@ -70,13 +75,33 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return versions;
         }
 
-        protected override void DownloadVersionCore(string latestVersion, string target)
+        protected override void DownloadVersionCore(string latestVersion, string target, string hashfile)
         {
             var url = String.Format(Constants.PaketExeDownloadUrlTemplate, latestVersion);
             ConsoleImpl.WriteInfo("Starting download from {0}", url);
 
             var tmpFile = BootstrapperHelper.GetTempFile("paket");
             WebRequestProxy.DownloadFile(url, tmpFile);
+
+            if (!BootstrapperHelper.ValidateHash(FileSystemProxy, hashfile, latestVersion, tmpFile))
+            {
+                ConsoleImpl.WriteWarning("Hash of downloaded paket.exe is invalid, retrying once");
+
+                WebRequestProxy.DownloadFile(url, tmpFile);
+
+                if (!BootstrapperHelper.ValidateHash(FileSystemProxy, hashfile, latestVersion, tmpFile))
+                {
+                    ConsoleImpl.WriteWarning("Hash of downloaded paket.exe still invalid (Using the file anyway)");
+                }
+                else
+                {
+                    ConsoleImpl.WriteTrace("Hash of downloaded file successfully found in {0}", hashfile);
+                }
+            }
+            else
+            {
+                ConsoleImpl.WriteTrace("Hash of downloaded file successfully found in {0}", hashfile);
+            }
 
             FileSystemProxy.CopyFile(tmpFile, target, true);
             FileSystemProxy.DeleteFile(tmpFile);

--- a/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
@@ -7,6 +7,6 @@ namespace Paket.Bootstrapper.DownloadStrategies
         string GetLatestVersion(bool ignorePrerelease);
         void DownloadVersion(string latestVersion, string target);
         void SelfUpdate(string latestVersion);
-        void DownloadHashFile(string latestVersion);
+        string DownloadHashFile(string latestVersion);
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
@@ -5,8 +5,9 @@ namespace Paket.Bootstrapper.DownloadStrategies
         string Name { get; }
         IDownloadStrategy FallbackStrategy { get; set; }
         string GetLatestVersion(bool ignorePrerelease);
-        void DownloadVersion(string latestVersion, string target);
+        void DownloadVersion(string latestVersion, string target, string hashFile);
         void SelfUpdate(string latestVersion);
         string DownloadHashFile(string latestVersion);
+        bool CanDownloadHashFile { get; }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
@@ -226,9 +226,10 @@ namespace Paket.Bootstrapper.DownloadStrategies
             FileSystemProxy.DeleteDirectory(randomFullPath, true);
         }
 
-        protected override void DownloadHashFileCore(string latestVersion)
+        protected override string DownloadHashFileCore(string latestVersion)
         {
             // TODO: implement get hash file
+            return null;
         }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
@@ -68,6 +68,11 @@ namespace Paket.Bootstrapper.DownloadStrategies
             get { return "Nuget"; }
         }
 
+        public override bool CanDownloadHashFile
+        {
+            get { return false; }
+        }
+
         protected override string GetLatestVersionCore(bool ignorePrerelease)
         {
             IEnumerable<string> allVersions = null;
@@ -100,7 +105,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return latestVersion != null ? latestVersion.Original : String.Empty;
         }
 
-        protected override void DownloadVersionCore(string latestVersion, string target)
+        protected override void DownloadVersionCore(string latestVersion, string target, string hashfile)
         {
             var apiHelper = new NugetApiHelper(PaketNugetPackageName, NugetSource);
 

--- a/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
@@ -118,9 +118,9 @@ namespace Paket.Bootstrapper.DownloadStrategies
             }
         }
 
-        protected override void DownloadHashFileCore(string latestVersion)
+        protected override string DownloadHashFileCore(string latestVersion)
         {
-            _effectiveStrategy.DownloadHashFile(latestVersion);
+            return _effectiveStrategy.DownloadHashFile(latestVersion);
         }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
@@ -59,9 +59,9 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return latestVersion;
         }
 
-        protected override void DownloadVersionCore(string latestVersion, string target)
+        protected override void DownloadVersionCore(string latestVersion, string target, string hashfile)
         {
-            _effectiveStrategy.DownloadVersion(latestVersion, target);
+            _effectiveStrategy.DownloadVersion(latestVersion, target, hashfile);
             TouchTarget(target);
         }
 
@@ -71,6 +71,11 @@ namespace Paket.Bootstrapper.DownloadStrategies
         }
 
         public override string Name { get { return string.Format("{0} (temporarily ignore updates)", EffectiveStrategy.Name); } }
+
+        public override bool CanDownloadHashFile
+        {
+            get { return EffectiveStrategy.CanDownloadHashFile; }
+        }
 
         public IDownloadStrategy EffectiveStrategy {
             get { return _effectiveStrategy; }

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -130,10 +130,21 @@ namespace Paket.Bootstrapper
 
                     if ((comparison > 0 && specificVersionRequested) || comparison < 0)
                     {
+                        string hashFile = null;
+                        if (downloadStrategy.CanDownloadHashFile)
+                        {
+                            ConsoleImpl.WriteTrace("Downloading hash for v{0} ...", latestVersion);
+                            var downloadHashWatch = Stopwatch.StartNew();
+                            hashFile = downloadStrategy.DownloadHashFile(latestVersion);
+                            downloadHashWatch.Stop();
+
+                            ConsoleImpl.WriteTrace("Hash download took {0:0.##} second(s)", downloadHashWatch.Elapsed.TotalSeconds);
+                        }
+
                         ConsoleImpl.WriteTrace("Downloading v{0} ...", latestVersion);
 
                         var downloadWatch = Stopwatch.StartNew();
-                        downloadStrategy.DownloadVersion(latestVersion, dlArgs.Target);
+                        downloadStrategy.DownloadVersion(latestVersion, dlArgs.Target, hashFile);
                         downloadWatch.Stop();
 
                         ConsoleImpl.WriteTrace("Download took {0:0.##} second(s)", downloadWatch.Elapsed.TotalSeconds);

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
@@ -135,10 +135,10 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockFileProxy.Setup(x => x.FileExists(ItHasFilename("paket.exe"))).Returns(true);
 
             //act
-            sut.DownloadVersion("any", "any");
+            sut.DownloadVersion("any", "any", null);
 
             //assert
-            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Never);
             mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
         }
 
@@ -149,10 +149,10 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
 
             //act
-            sut.DownloadVersion("any", "any");
+            sut.DownloadVersion("any", "any", null);
 
             //assert
-            mockEffectiveStrategy.Verify(x => x.DownloadVersion("any", "any"));
+            mockEffectiveStrategy.Verify(x => x.DownloadVersion("any", "any", null));
             mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
         }
 
@@ -177,10 +177,10 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
 
             //act
-            sut.DownloadVersion("any", "any");
+            sut.DownloadVersion("any", "any", null);
 
             //assert
-            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
         }
 
@@ -198,10 +198,10 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
 
             //act
-            sut.DownloadVersion("any", "any");
+            sut.DownloadVersion("any", "any", null);
 
             //assert
-            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Never);
             mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
         }
 
@@ -215,10 +215,10 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
 
             //act
-            Assert.Throws<InvalidDataException>(() => sut.DownloadVersion("any", "any"));
+            Assert.Throws<InvalidDataException>(() => sut.DownloadVersion("any", "any", null));
 
             //assert
-            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Never);
             mockFileProxy.Verify(x => x.DeleteFile(ItHasFilename("paket-sha256.txt")));
         }
 

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
@@ -1,6 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Reflection;
-using System.Text;
+using System.Security.Cryptography;
 using Moq;
 using NUnit.Framework;
 using Paket.Bootstrapper.DownloadStrategies;
@@ -53,19 +54,77 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         }
 
         [Test]
-        public void DownloadVersion()
+        public void DownloadVersion_NoHash()
         {
             //arrange
             var tempFileName = BootstrapperHelper.GetTempFile("paket");
-            mockWebProxy.Setup(x => x.DownloadFile(It.IsAny<string>(), It.IsAny<string>())).Verifiable();
 
             //act
             sut.DownloadVersion("2.57.1", "paketExeLocation", null);
 
             //assert
-            mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileName));
-            mockFileProxy.Verify(x => x.CopyFile(tempFileName, "paketExeLocation", true));
-            mockFileProxy.Verify(x => x.DeleteFile(tempFileName));
+            mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileName), Times.Once);
+            mockFileProxy.Verify(x => x.CopyFile(tempFileName, "paketExeLocation", true), Times.Once);
+            mockFileProxy.Verify(x => x.DeleteFile(tempFileName), Times.Once);
+        }
+
+        [Test]
+        public void DownloadVersion_HashFileNotFound()
+        {
+            //arrange
+            var tempFileName = BootstrapperHelper.GetTempFile("paket");
+
+            //act
+            sut.DownloadVersion("2.57.1", "paketExeLocation", @"C:\does_not_exists.txt");
+
+            //assert
+            mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileName), Times.Once);
+            mockFileProxy.Verify(x => x.CopyFile(tempFileName, "paketExeLocation", true), Times.Once);
+            mockFileProxy.Verify(x => x.DeleteFile(tempFileName), Times.Once);
+        }
+
+        [Test]
+        public void DownloadVersion_InvalidHashRetryOnce()
+        {
+            //arrange
+            var content = Guid.NewGuid().ToByteArray();
+            var sha = new SHA256Managed();
+            var checksum = sha.ComputeHash(new MemoryStream(content));
+            var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
+            mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(() => new MemoryStream(Guid.NewGuid().ToByteArray()));
+            mockFileProxy.Setup(x => x.FileExists(@"C:\invalid.txt")).Returns(true);
+            mockFileProxy.Setup(x => x.ReadAllLines(@"C:\invalid.txt")).Returns(new[] { hash + " paket.exe" });
+            var tempFileName = BootstrapperHelper.GetTempFile("paket");
+
+            //act
+            sut.DownloadVersion("2.57.1", "paketExeLocation", @"C:\invalid.txt");
+
+            //assert
+            mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileName), Times.Exactly(2));
+            mockFileProxy.Verify(x => x.CopyFile(tempFileName, "paketExeLocation", true), Times.Once);
+            mockFileProxy.Verify(x => x.DeleteFile(tempFileName), Times.Once);
+        }
+
+        [Test]
+        public void DownloadVersion_ValidHashOk()
+        {
+            //arrange
+            var content = Guid.NewGuid().ToByteArray();
+            var sha = new SHA256Managed();
+            var checksum = sha.ComputeHash(new MemoryStream(content));
+            var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
+            mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(new MemoryStream(content));
+            mockFileProxy.Setup(x => x.FileExists(@"C:\valid.txt")).Returns(true);
+            mockFileProxy.Setup(x => x.ReadAllLines(@"C:\valid.txt")).Returns(new[] { hash + " paket.exe" });
+            var tempFileName = BootstrapperHelper.GetTempFile("paket");
+
+            //act
+            sut.DownloadVersion("2.57.1", "paketExeLocation", @"C:\valid.txt");
+
+            //assert
+            mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileName), Times.Once);
+            mockFileProxy.Verify(x => x.CopyFile(tempFileName, "paketExeLocation", true), Times.Once);
+            mockFileProxy.Verify(x => x.DeleteFile(tempFileName), Times.Once);
         }
 
         [Test]
@@ -85,6 +144,24 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileNameNew));
             mockFileProxy.Verify(x => x.MoveFile(Assembly.GetAssembly(typeof(GitHubDownloadStrategy)).Location, tempFileNameOld));
             mockFileProxy.Verify(x => x.MoveFile(tempFileNameNew, Assembly.GetAssembly(typeof(GitHubDownloadStrategy)).Location));
+        }
+
+        [Test]
+        public void DownloadHashFile()
+        {
+            var expectedPath = BootstrapperHelper.GetTempFile("paket-sha256.txt");
+            var expectedUrl = string.Format(GitHubDownloadStrategy.Constants.PaketCheckSumDownloadUrlTemplate, "42.0");
+
+            var hashFilePath = sut.DownloadHashFile("42.0");
+
+            Assert.That(hashFilePath, Is.EqualTo(expectedPath));
+            mockWebProxy.Verify(x => x.DownloadFile(expectedUrl, expectedPath), Times.Once);
+        }
+
+        [Test]
+        public void CanDownloadHashFile()
+        {
+            Assert.That(sut.CanDownloadHashFile, Is.True);
         }
     }
 }

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
@@ -60,7 +60,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockWebProxy.Setup(x => x.DownloadFile(It.IsAny<string>(), It.IsAny<string>())).Verifiable();
 
             //act
-            sut.DownloadVersion("2.57.1", "paketExeLocation");
+            sut.DownloadVersion("2.57.1", "paketExeLocation", null);
 
             //assert
             mockWebProxy.Verify(x => x.DownloadFile(It.IsAny<string>(), tempFileName));

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/NugetDownloadStrategyTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/NugetDownloadStrategyTests.cs
@@ -312,5 +312,22 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
         }
 
+        [Test]
+        public void DownloadHashFile()
+        {
+            CreateSystemUnderTestWithDefaultApi();
+
+            var hashFilePath = sut.DownloadHashFile("42.0");
+
+            Assert.That(hashFilePath, Is.Null);
+        }
+
+        [Test]
+        public void CanDownloadHashFile()
+        {
+            CreateSystemUnderTestWithDefaultApi();
+
+            Assert.That(sut.CanDownloadHashFile, Is.False);
+        }
     }
 }

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/NugetDownloadStrategyTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/NugetDownloadStrategyTests.cs
@@ -97,7 +97,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             CreateSystemUnderTestWithDefaultApi();
 
             //act
-            sut.DownloadVersion(null, "paket");
+            sut.DownloadVersion(null, "paket", null);
 
             //assert
             mockWebRequestProxy.Verify(x => x.DownloadFile("https://www.nuget.org/api/v2/package/Paket", It.IsAny<string>()));
@@ -113,7 +113,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             CreateSystemUnderTestWithDefaultApi();
 
             //act
-            sut.DownloadVersion("2.57.0", "paket");
+            sut.DownloadVersion("2.57.0", "paket", null);
 
             //assert
             mockWebRequestProxy.Verify(x => x.DownloadFile("https://www.nuget.org/api/v2/package/Paket/2.57.0", It.IsAny<string>()));
@@ -241,7 +241,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
                 .Returns(new[] { "paket.111.nupkg" });
 
             //act
-            sut.DownloadVersion(null, "paket");
+            sut.DownloadVersion(null, "paket", null);
 
             //assert
             mockFileProxy.Verify(x => x.CopyFile(It.Is<string>(s => s.StartsWith("anyNugetFolder") && s.EndsWith("paket.111.nupkg")), It.Is<string>(s => s.StartsWith("folder") && s.EndsWith("paket.latest.nupkg")), false));
@@ -258,7 +258,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             CreateSystemUnderTestWithNugetFolder();
 
             //act
-            sut.DownloadVersion("2.57.0", "paket");
+            sut.DownloadVersion("2.57.0", "paket", null);
 
             //assert
             mockFileProxy.Verify(x => x.CopyFile(It.Is<string>(s => s.StartsWith("anyNugetFolder") && s.EndsWith("paket.2.57.0.nupkg")), It.Is<string>(s => s.StartsWith("folder") && s.EndsWith("paket.2.57.0.nupkg")), false));

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
@@ -162,10 +162,10 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             _mockFileProxy.Setup(fp => fp.Touch(Target)).Verifiable();
-            _mockEffectiveStrategy.Setup(x => x.DownloadVersion("any", Target)).Verifiable();
+            _mockEffectiveStrategy.Setup(x => x.DownloadVersion("any", Target, null)).Verifiable();
 
             //act
-            _sut.DownloadVersion("any", Target);
+            _sut.DownloadVersion("any", Target, null);
 
             //assert
             _mockEffectiveStrategy.Verify();

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
@@ -171,6 +171,26 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             _mockEffectiveStrategy.Verify();
             _mockFileProxy.Verify();
         }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CanDownloadHashFile(bool can)
+        {
+            _mockEffectiveStrategy.SetupGet(x => x.CanDownloadHashFile).Returns(can);
+            Assert.That(_sut.CanDownloadHashFile, Is.EqualTo(can));
+        }
+
+        [Test]
+        public void DownloadHashFile()
+        {
+            _mockEffectiveStrategy.Setup(x => x.DownloadHashFile("42.0")).Returns(@"C:\42.txt");
+
+            var hashFilePath = _sut.DownloadHashFile("42.0");
+
+            Assert.That(hashFilePath, Is.EqualTo(@"C:\42.txt"));
+            _mockEffectiveStrategy.Verify(x => x.DownloadHashFile("42.0"), Times.Once);
+        }
     }
 }
 

--- a/tests/Paket.Bootstrapper.Tests/StartPaketBootstrappingTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/StartPaketBootstrappingTests.cs
@@ -36,7 +36,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             mockFileProxy.Verify();
-            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.1", dlArgs.Target));
+            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.1", dlArgs.Target, null));
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             mockFileProxy.Verify();
-            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.3", dlArgs.Target));
+            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.3", dlArgs.Target, null));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             mockFileProxy.Verify();
-            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.3", dlArgs.Target));
+            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.3", dlArgs.Target, null));
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             mockFileProxy.Verify();
-            mockDownloadStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            mockDownloadStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Never);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             mockFileProxy.Verify();
-            mockDownloadStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            mockDownloadStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Once);
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             mockFileProxy.Verify();
-            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.1-alpha", dlArgs.Target));
+            mockDownloadStrategy.Verify(x => x.DownloadVersion("1.1-alpha", dlArgs.Target, null));
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace Paket.Bootstrapper.Tests
 
             //assert
             mockFileProxy.Verify();
-            mockFallbackStrategy.Verify(x => x.DownloadVersion("1.2", dlArgs.Target));
+            mockFallbackStrategy.Verify(x => x.DownloadVersion("1.2", dlArgs.Target, null));
         }
         
         [Test]
@@ -222,7 +222,7 @@ namespace Paket.Bootstrapper.Tests
             Action onSuccess = () => successCount++;
             dlArgs.LatestVersion = "1.5";
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
-            mockDownloadStrategy.Setup(x => x.DownloadVersion("1.5", "paket.exe")).Throws(new WebException());
+            mockDownloadStrategy.Setup(x => x.DownloadVersion("1.5", "paket.exe", null)).Throws(new WebException());
 
             //act
             Program.StartPaketBootstrapping(mockDownloadStrategy.Object, dlArgs, mockFileProxy.Object, onSuccess);


### PR DESCRIPTION
Quite a few changes related to hash file handling in the bootstrapper
* Correctly cache the hash file (It was never cashed before even if the cache strategy expected it to be)
* Make hash downloading a top-level operation only done when we know that the local version isn't the one we want 
  * Avoid downloading it only to check the remote version
  * Also avoid downloading twice when `TemporarilyIgnoreUpdatesDownloadStrategy` is used
* Check hash after every download from GitHub
  * It was only used to check if our cache is valid before, it's now being used to check if the download is valid directly after doing it
  * We re-try once if the hash is invalid and only warn if still invalid after a second download (Can be changed later, maybe we should let the fallback happen and download from nuget ?)

Fixes #2365 

I tested manually and don't see any weird behavior anymore with useless downloads. I'll add some unit tests to confirm and the PR will be good to go