### PR TITLE
Don't crash in DownloadHashFile

### DIFF
--- a/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
@@ -109,6 +109,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
                 ConsoleImpl.WriteTrace("Copying hash file in cache.");
                 ConsoleImpl.WriteTrace("{0} -> {1}", effectivePath, cached);
+                FileSystemProxy.CreateDirectory(Path.GetDirectoryName(cached));
                 FileSystemProxy.CopyFile(effectivePath, cached, true);
             }
 


### PR DESCRIPTION
When the cache folder didn't exists DownloadHashFile was crashing instead of working as expected.

See https://github.com/fsprojects/Paket/pull/2368#issuecomment-304475286 comment by @matthid for context (Sorry).