### PR TITLE
make the bootstrapper search harder for the paket.dependencies file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,21 +14,13 @@ nuget:
   account_feed: false
   project_feed: true
 
-environment:
-  # these variables are common to all jobs
-  #common_var1: value1
+#environment:
+#  # these variables are common to all jobs
+#  #common_var1: value1
+#
+#  matrix:
+#    # first group
+#    - SkipIntegrationTests: true
+#    # second group
+#    - SkipNuGet: true
 
-  matrix:
-    # first group
-    - SkipIntegrationTests: true
-    # second group
-    - SkipNuGet: true
-
-#deploy:
-#  provider: NuGet
-#  server: https://ci.appveyor.com/nuget/paket # remove to push to NuGet.org
-#  #api_key:
-#  #  secure: m49OJ7+Jdt9an3jPcTukHA==
-#  #skip_symbols: false
-#  #symbol_server:           # remove to push symbols to SymbolSource.org
-#  artifact: /temp/.*\.nupkg/

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -243,13 +243,9 @@ namespace Paket.Bootstrapper
 
         private static bool GetIsMagicMode(IFileSystemProxy fileSystemProxy)
         {
-#if DEBUG
-            return true;
-#else
             // Magic mode is defined by the bootstrapper being renamed 'paket.exe'
             var fileName = Path.GetFileName(fileSystemProxy.GetExecutingAssemblyPath());
             return string.Equals(fileName, "paket.exe", StringComparison.OrdinalIgnoreCase);
-#endif
         }
 
         private static string GetHash(string input)

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -70,7 +70,7 @@ namespace Paket.Bootstrapper
             if (transparentMagicMode)
             {
                 // Transparent magic mode mean that we're renamed 'paket.exe' and --run wasn't passed
-                
+
                 // Virtually add a '-s'
                 options.Verbosity -= 1;
                 
@@ -104,6 +104,11 @@ namespace Paket.Bootstrapper
             }
 
             options.UnprocessedCommandArgs = commandArgs;
+
+            if ("true" == Environment.GetEnvironmentVariable("PAKET_BOOTSTRAPPER_TRACE"))
+            {
+                options.Verbosity = Verbosity.Trace;
+            }
 
             return options;
         }
@@ -238,9 +243,13 @@ namespace Paket.Bootstrapper
 
         private static bool GetIsMagicMode(IFileSystemProxy fileSystemProxy)
         {
+#if DEBUG
+            return true;
+#else
             // Magic mode is defined by the bootstrapper being renamed 'paket.exe'
             var fileName = Path.GetFileName(fileSystemProxy.GetExecutingAssemblyPath());
             return string.Equals(fileName, "paket.exe", StringComparison.OrdinalIgnoreCase);
+#endif
         }
 
         private static string GetHash(string input)

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -159,7 +159,7 @@ namespace Paket.Bootstrapper
             }
         }
 
-        private static void FillNonRunOptionsFromArguments(BootstrapperOptions options, List<string> commandArgs)
+        internal static void FillNonRunOptionsFromArguments(BootstrapperOptions options, List<string> commandArgs)
         {
             if (commandArgs.Contains(CommandArgs.PreferNuget))
             {

--- a/src/Paket.Bootstrapper/HelperProxies/FileSystemProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/FileSystemProxy.cs
@@ -8,6 +8,7 @@ namespace Paket.Bootstrapper.HelperProxies
 {
     class FileSystemProxy : IFileSystemProxy
     {
+        public string GetCurrentDirectory() { return Directory.GetCurrentDirectory(); }
         public bool FileExists(string filename) { return File.Exists(filename); }
         public void CopyFile(string fileFrom, string fileTo, bool overwrite) { File.Copy(fileFrom, fileTo, overwrite); }
         public void DeleteFile(string filename) { File.Delete(filename); }

--- a/src/Paket.Bootstrapper/HelperProxies/IFileSystemProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/IFileSystemProxy.cs
@@ -6,6 +6,7 @@ namespace Paket.Bootstrapper.HelperProxies
 {
     public interface IFileSystemProxy
     {
+        string GetCurrentDirectory();
         bool FileExists(string filename);
         void CopyFile(string fileFrom, string fileTo, bool overwrite = false);
         void DeleteFile(string filename);

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -56,6 +56,7 @@
     <Compile Include="BootstrapperOptions.cs" />
     <Compile Include="DownloadStrategies\IDownloadStrategy.cs" />
     <Compile Include="DownloadStrategies\IHaveEffectiveStrategy.cs" />
+    <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="PaketDependencies.cs" />
     <Compile Include="PaketRunner.cs" />
     <Compile Include="Verbosity.cs" />

--- a/src/Paket.Bootstrapper/PaketDependencies.cs
+++ b/src/Paket.Bootstrapper/PaketDependencies.cs
@@ -26,13 +26,34 @@ namespace Paket.Bootstrapper
             return null;
         }
 
+        public static string LocateDependenciesFile(DirectoryInfo folder)
+        {
+            var path = Path.Combine(folder.FullName, DEPENDENCY_FILE);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+            else
+            {
+                if (folder.Parent != null)
+                {
+                    return LocateDependenciesFile(folder.Parent);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
         public static string GetBootstrapperArgsForFolder(string folder)
         {
             try
             {
-                var path = Path.Combine(folder, DEPENDENCY_FILE);
-                if (!File.Exists(path))
+                var path = LocateDependenciesFile(new DirectoryInfo(folder));
+                if (path == null)
                 {
+                    ConsoleImpl.WriteTrace("Dependencies file was not found.");
                     return null;
                 }
 
@@ -44,9 +65,10 @@ namespace Paket.Bootstrapper
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 // ¯\_(ツ)_/¯
+                ConsoleImpl.WriteTrace("Error while retrieving arguments from paket.dependencies file: {0}", e);
                 return null;
             }
         }

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -23,6 +23,10 @@ namespace Paket.Bootstrapper
             Console.CancelKeyPress += CancelKeyPressed;
 
             var fileProxy = new FileSystemProxy();
+            var optionsBeforeDependenciesFile = ArgumentParser.ParseArgumentsAndConfigurations(args, ConfigurationManager.AppSettings,
+                Environment.GetEnvironmentVariables(), fileProxy, null);
+            ConsoleImpl.Verbosity = optionsBeforeDependenciesFile.Verbosity;
+
             var argumentsFromDependenciesFile =
                 WindowsProcessArguments.Parse(
                     PaketDependencies.GetBootstrapperArgsForFolder(Environment.CurrentDirectory));

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -29,7 +29,7 @@ namespace Paket.Bootstrapper
 
             var argumentsFromDependenciesFile =
                 WindowsProcessArguments.Parse(
-                    PaketDependencies.GetBootstrapperArgsForFolder(Environment.CurrentDirectory));
+                    PaketDependencies.GetBootstrapperArgsForFolder(fileProxy));
             var options = ArgumentParser.ParseArgumentsAndConfigurations(args, ConfigurationManager.AppSettings,
                 Environment.GetEnvironmentVariables(), fileProxy, argumentsFromDependenciesFile);
             if (options.ShowHelp)

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -24,7 +24,7 @@ namespace Paket.Bootstrapper
 
             var fileProxy = new FileSystemProxy();
             var optionsBeforeDependenciesFile = ArgumentParser.ParseArgumentsAndConfigurations(args, ConfigurationManager.AppSettings,
-                Environment.GetEnvironmentVariables(), fileProxy, null);
+                Environment.GetEnvironmentVariables(), fileProxy, Enumerable.Empty<string>());
             ConsoleImpl.Verbosity = optionsBeforeDependenciesFile.Verbosity;
 
             var argumentsFromDependenciesFile =

--- a/src/Paket.Bootstrapper/Properties/InternalsVisibleTo.cs
+++ b/src/Paket.Bootstrapper/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,4 @@
+﻿
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Paket.Bootstrapper.Tests")]


### PR DESCRIPTION
like paket is doing it.

@vbfox please review. In particular I don't like how we now parse the command line twice in order to set the verbosity (such that we can trace on errors when finding the dependencies file). A better idea is welcome.

I guess I still need to add a test for this (I'm first trying to get the FAKE build green again).
