### PR TITLE
Filter FSharp.Core 4.2 because it was leftpadded

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 5.0.0-rc002 - 08.06.2017
+#### 5.0.0-rc003 - 09.06.2017
 * Internals: Started proper dotnetcore integration (disabled by default, can be enabled via setting `PAKET_DISABLE_RUNTIME_RESOLUTION` to `false`):
   * Paket now properly understands runtime and reference assemblies
   * Paket now understands the runtime graph and restores runtime dependencies

--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -900,8 +900,11 @@ let GetVersions force alternativeProjectRoot root (sources, packageName:PackageN
                             File.WriteAllText(errorFile.FullName,DateTime.Now.ToString())
                     with _ -> ()
                     None)
-            |> Array.map (fun (s,versions) -> versions |> Array.map (fun v -> v,s))
-            |> Array.concat }
+            |> Array.collect (fun (s,versions) -> 
+                if packageName = PackageName "FSharp.Core" then
+                    versions |> Array.filter (fun v -> v <> "4.2.0") |> Array.map (fun v -> v,s) // HACK: since version was leftpadded
+                else
+                    versions |> Array.map (fun v -> v,s)) }
     let! versions = async {
         let! trial1 = trial force
         match trial1 with


### PR DESCRIPTION
Workaround to reduce issue spreading