### PR TITLE
Don't query the fastest nuget API because it's considered harmful ;-(

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -315,16 +315,12 @@ let GetVersions force alternativeProjectRoot root (sources, packageName:PackageN
                        match nugetSource with
                        | NuGetV2 source ->
                             let auth = source.Authentication |> Option.map toBasicAuth
-                            if not force && (String.containsIgnoreCase "nuget.org" source.Url || String.containsIgnoreCase "myget.org" source.Url || String.containsIgnoreCase "visualstudio.com" source.Url) then
-                                [getVersionsCached "Json" NuGetV2.tryGetPackageVersionsViaJson (nugetSource, auth, source.Url, packageName) ]
-                            elif String.containsIgnoreCase "artifactory" source.Url then
+                            if String.containsIgnoreCase "artifactory" source.Url then
                                 [getVersionsCached "ODataNewestFirst" NuGetV2.tryGetAllVersionsFromNugetODataFindByIdNewestFirst (nugetSource, auth, source.Url, packageName) ]
                             else
                                 let v2Feeds =
                                     [ yield getVersionsCached "OData" NuGetV2.tryGetAllVersionsFromNugetODataFindById (nugetSource, auth, source.Url, packageName)
-                                      yield getVersionsCached "ODataWithFilter" NuGetV2.tryGetAllVersionsFromNugetODataWithFilter (nugetSource, auth, source.Url, packageName)
-                                      if not (String.containsIgnoreCase "teamcity" source.Url || String.containsIgnoreCase"feedservice.svc" source.Url  ) then
-                                        yield getVersionsCached "Json" NuGetV2.tryGetPackageVersionsViaJson (nugetSource, auth, source.Url, packageName) ]
+                                      yield getVersionsCached "ODataWithFilter" NuGetV2.tryGetAllVersionsFromNugetODataWithFilter (nugetSource, auth, source.Url, packageName) ]
 
                                 let apiV3 = NuGetV3.getAllVersionsAPI(source.Authentication,source.Url) |> Async.AwaitTask
                                 match apiV3 |> Async.RunSynchronously with

--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -88,20 +88,6 @@ let tryGetAllVersionsFromNugetODataFindByIdNewestFirst (auth, nugetURL, package:
         with _ -> return None
     }
 
-let tryGetPackageVersionsViaJson (auth, nugetURL, package:PackageName) =
-    async {
-        let url = sprintf "%s/package-versions/%O?includePrerelease=true" nugetURL package
-        let! raw = safeGetFromUrl (auth, url, acceptJson)
-
-        match raw with
-        | None -> return None
-        | Some data ->
-            try
-                let versions = Some(JsonConvert.DeserializeObject<string []> data)
-                return versions
-            with _ -> return None
-    }
-
 let parseODataDetails(url,nugetURL,packageName:PackageName,version:SemVerInfo,raw) =
     let doc = XmlDocument()
     try


### PR DESCRIPTION
Today's server update of nuget.org broke 4 integration tests that checks installation of unlisted packages.
After discussion with nuget team we are asked to not use that API because now it's only for "autocomplete". This is a bit unfortunate since this is usually the fastest responding API. But what can you do!?