### PR TITLE
Fix interactive package search

### DIFF
--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -313,12 +313,17 @@ let findPackages silent (results : ParseResults<_>) =
 
     match results.TryGetResult <@ FindPackagesArgs.SearchText @> with
     | None ->
-        let searchText = ref ""
-        while !searchText <> ":q" do
+        let rec repl () =
             if not silent then
                 tracefn " - Please enter search text (:q for exit):"
-            searchText := Console.ReadLine()
-            searchAndPrint !searchText
+
+            match Console.ReadLine() with
+            | ":q" -> ()
+            | searchText ->
+                searchAndPrint searchText
+                repl ()
+
+        repl ()
 
     | Some searchText -> searchAndPrint searchText
 


### PR DESCRIPTION
Interactive package search currently searches for `:q` even though the user wants to exit the search:


```sh
$ mono bin/paket.exe find-packages
Paket version 5.0.0-rc008
 - Please enter search text (:q for exit):
fake
FAKE
FakeSign
Faker
FakeO
FakeHost
FakeData
FAKEX
FAKE.SQL
FAKE.IIS
FAKE.Lib
Fake.AWS
FakeN.Web
FSharp.FakeTargets
FakeHttp
FakeDb
FakeDbSet
FAKE.Core
FAKE.Gallio
Faker.Net
Sitecore.FakeDb
 - Please enter search text (:q for exit):
:q
Quartz
jQuery
jQuery.Validation
jQuery.UI.Combined
Microsoft.jQuery.Unobtrusive.Ajax
Microsoft.jQuery.Unobtrusive.Validation
AspNet.ScriptManager.jQuery
Q
QR
Qiwi
QB
QLIB
QB1
QLog
qunit
QKit
Qlue
QLSLib
Qi.Data
Qvc
Performance:
 - Average Request Time: 419 milliseconds
 - Number of Requests: 3
 - Runtime: 4 seconds
```