### PR TITLE
Adding missing documentation for specific_version/SpecificVersion

### DIFF
--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -226,6 +226,15 @@ It's possible to influence the `Private` property for references in project file
 
     nuget Newtonsoft.Json copy_local: false
 
+### specific_version settings
+
+It's possible to influence the `SpecificVersion` property for references in project files:
+
+    [lang=paket]
+    source https://nuget.org/api/v2
+
+    nuget Newtonsoft.Json specific_version: false
+
 ### CopyToOutputDirectory settings
 
 It's possible to influence the `CopyToOutputDirectory` property for content references in project files:

--- a/docs/content/references-files.md
+++ b/docs/content/references-files.md
@@ -38,6 +38,13 @@ It's possible to influence the `Private` property for references in project file
     [lang=paket]
     Newtonsoft.Json copy_local: false
 
+## specific_version settings
+
+It's possible to influence the `SpecificVersion` property for references in project files:
+
+    [lang=paket]
+    Newtonsoft.Json specific_version: false
+
 ## import_targets settings
 
 If you don't want to import `.targets` and `.props` files you can disable it via the `import_targets` switch:


### PR DESCRIPTION
As #2413 got merged i am hereby adding the missing documentation for the new specific_version option.