### PR TITLE
improve another error when restoring packages.

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -653,8 +653,9 @@ let DownloadPackage(alternativeProjectRoot, root, (source : PackageSource), cach
                       | Some(Credentials(_)) -> true
                       | _ -> false)
                         -> do! download false (attempt + 1)
-                | exn when String.IsNullOrWhiteSpace !downloadUrl -> failwithf "Could not download %O %O.%s    %s" packageName version Environment.NewLine exn.Message
-                | exn -> failwithf "Could not download %O %O from %s.%s    %s" packageName version !downloadUrl Environment.NewLine exn.Message }
+                | exn when String.IsNullOrWhiteSpace !downloadUrl ->
+                    raise <| Exception(sprintf "Could not download %O %O." packageName version, exn)
+                | exn -> raise <| Exception(sprintf "Could not download %O %O from %s." packageName version !downloadUrl, exn) }
 
     async {
         do! download true 0

--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -252,8 +252,8 @@ let getDetailsFromNuGetViaOData auth nugetURL (packageName:PackageName) (version
                 traceWarnfn "Failed to get package details (again) '%s'. This feeds implementation might be broken." e.Message
                 if verbose then tracefn "Details: %O" e
                 // try uppercase version as workaround for https://github.com/fsprojects/Paket/issues/2145 - Bad!
-                let name = PackageName.ToString()
-                let uppercase = PackageName.ToString().[0].ToString().ToUpper() + name.Substring(1)
+                let name = packageName.ToString()
+                let uppercase = packageName.ToString().[0].ToString().ToUpper() + name.Substring(1)
                 return! queryPackagesProtocol (PackageName uppercase)
     }
 


### PR DESCRIPTION
Related https://github.com/fsprojects/Paket/pull/2423

Instead of 
```
Paket failed with:
-> Could not download FSharp.Core 4.2.
       Could not get package details for Paket.NuGetV2+name@255-5 from https://www.nuget.org/api/v2
```

print

```
Paket failed with:
-> Could not download FSharp.Core 4.2.
-> Could not get package details for Paket.NuGetV2+name@255-4 from https://www.nuget.org/api/v2
-> WebException: The remote server returned an error: (404) Not Found.
```

WTF is `Paket.NuGetV2+name@255-4`? `PackageName` overrides `ToString` but it is not working?

