### PR TITLE
Fix the warning reported in #2440

### DIFF
--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -166,6 +166,7 @@ let ``#1429 pack deps without minimum-from-lock-file uses specifc dependencies f
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
         |> Async.RunSynchronously
+        |> ODataSearchResult.get
 
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldContain (PackageName "MySql.Data")
     let packageName, versionRequirement, restrictions = details |> getDependencies |> List.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> List.head 

--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -10,6 +10,7 @@ open System.Diagnostics
 open System.IO.Compression
 open Paket.Domain
 open Paket
+open Paket.NuGetCache
 
 let getDependencies = Paket.NuGet.NuGetPackageCache.getDependencies
 
@@ -97,6 +98,7 @@ let ``#1429 pack deps from template``() =
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
         |> Async.RunSynchronously
+        |> ODataSearchResult.get
 
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldContain (PackageName "MySql.Data")
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldNotContain (PackageName "PaketBug2") // it's not packed in same round
@@ -113,6 +115,7 @@ let ``#1429 pack deps``() =
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
         |> Async.RunSynchronously
+        |> ODataSearchResult.get
 
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldContain (PackageName "MySql.Data")
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldContain (PackageName "PaketBug2")
@@ -129,6 +132,7 @@ let ``#1429 pack deps using minimum-from-lock-file``() =
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
         |> Async.RunSynchronously
+        |> ODataSearchResult.get
 
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldContain (PackageName "MySql.Data")
     let packageName, versionRequirement, restrictions = details |> getDependencies |> List.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> List.head 
@@ -145,6 +149,7 @@ let ``#1429 pack deps without minimum-from-lock-file uses dependencies file rang
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
         |> Async.RunSynchronously
+        |> ODataSearchResult.get
 
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldContain (PackageName "MySql.Data")
     let packageName, versionRequirement, restrictions = details |> getDependencies |> List.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> List.head 
@@ -177,6 +182,7 @@ let ``#1429 pack deps with minimum-from-lock-file uses specifc dependencies file
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
         |> Async.RunSynchronously
+        |> ODataSearchResult.get
 
     details |> getDependencies |> List.map (fun (x,_,_) -> x) |> shouldContain (PackageName "MySql.Data")
     let packageName, versionRequirement, restrictions = details |> getDependencies |> List.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> List.head 

--- a/src/Paket.Core/Common/Async.fs
+++ b/src/Paket.Core/Common/Async.fs
@@ -55,7 +55,10 @@ module AsyncExtensions =
                             if t.IsCanceled then
                                 cancel (OperationCanceledException("The underlying task has been cancelled"))
                             elif t.IsFaulted then
-                                error t.Exception
+                                if t.Exception.InnerExceptions.Count = 1 then
+                                    error t.Exception.InnerExceptions.[0]
+                                else
+                                    error t.Exception
                             else success t.Result))
                         |> ignore
                 } |> fun a -> Async.Start(a, ct)

--- a/src/Paket.Core/Dependencies/NuGetLocal.fs
+++ b/src/Paket.Core/Dependencies/NuGetLocal.fs
@@ -27,7 +27,7 @@ let getAllVersionsFromLocalPath (isCache, localNugetPath, package:PackageName, a
                                 let _match = Regex(sprintf @"^%O\.(\d.*)\.nupkg" package, RegexOptions.IgnoreCase).Match(fi.Name)
                                 if _match.Groups.Count > 1 then Some _match.Groups.[1].Value else None)
                 |> Seq.toArray
-            return Result.Ok(versions)
+            return SuccessResponse(versions)
         })
 
 /// Reads packageName and version from .nupkg file name
@@ -109,4 +109,5 @@ let getDetailsFromLocalNuGetPackage isCache alternativeProjectRoot root localNuG
               Version = version.Normalize()
               Unlisted = isCache }
             |> NuGetPackageCache.withDependencies nuspec.Dependencies
+            |> ODataSearchResult.Match
     }

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -97,9 +97,11 @@ let getNuGetV3Resource (source : NugetV3Source) (resourceType : NugetV3ResourceT
             let! rawData = safeGetFromUrl(basicAuth, source.Url, acceptJson)
             let rawData =
                 match rawData with
-                | FSharp.Core.Result.Error e ->
+                | NotFound ->
+                    raise <| new Exception(sprintf "Could not load resources (404) from '%s'" source.Url)
+                | UnknownError e ->
                     raise <| new Exception(sprintf "Could not load resources from '%s'" source.Url, e.SourceException)
-                | FSharp.Core.Result.Ok x -> x
+                | SuccessResponse x -> x
 
             let json = JsonConvert.DeserializeObject<NugetV3SourceRootJSON>(rawData)
             let resources = 

--- a/tests/Paket.Tests/NuGetOData/EmptyFeedList.xml
+++ b/tests/Paket.Tests/NuGetOData/EmptyFeedList.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<feed xml:base="https://www.nuget.org/api/v2" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+  <id>http://schemas.datacontract.org/2004/07/</id>
+  <title />
+  <updated>2017-06-19T18:52:18Z</updated>
+  <link rel="self" href="https://www.nuget.org/api/v2/Packages" />
+  <author>
+    <name />
+  </author>
+</feed>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -135,6 +135,9 @@
     <Content Include="NuGetOData\Fleece.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="NuGetOData\EmptyFeedList.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="NuGetOData\ReadOnlyCollectionExtensions.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
fix the warning by implementing internal 404 propagation and handling. There is still room for improvement: For example there should be no point in requesting additional urls when one already told you that the package is not available. This might not be true for custom servers on all urls but it must be true for the one nuget.exe is using (otherwise it wouldn't work and the server would be useless/only work with paket).

fixes #2440 