### PR TITLE
Take into account xamarin.*.csharp.targets when finding location …

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1056,6 +1056,24 @@ module ProjectFile =
                 if String.startsWithIgnoreCase  "<import" node && 
                    (String.containsIgnoreCase "microsoft.csharp.targets" node || 
                      String.containsIgnoreCase "microsoft.fsharp.targets" node ||
+                     //List of xamarin csharp targets generated with following bash command inside $(MSBuildExtensionsPath)\Xamarin
+                     //find . -name "*.CSharp.targets" | sed 's#.*/##'   | tr '[:upper:]' '[:lower:]' | xargs printf '                     String.containsIgnoreCase "%s" node ||\n'
+                     String.containsIgnoreCase "xamarin.android.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.android.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.ios.appextension.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.ios.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.ios.objcbinding.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.ios.watchapp.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.monotouch.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.mac.appextension.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.mac.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.mac.objcbinding.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.tvos.appextension.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.tvos.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.tvos.objcbinding.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.watchos.app.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.watchos.appextension.csharp.targets" node ||
+                     String.containsIgnoreCase "xamarin.watchos.csharp.targets" node ||
                      String.containsIgnoreCase "fsharptargetspath" node)
                 then
                     iTarget <- l + 1


### PR DESCRIPTION
… for inserting framework specific props/targets.

E.g. the following NuGet packages generate target framework specific properties. 
```
framework: monoandroid70

source https://nuget.org/api/v2

nuget Xamarin.Android.Support.v4 == 25.3.1
nuget Xamarin.Android.Support.v7.RecyclerView == 25.3.1
nuget Xamarin.Android.Support.Design == 25.3.1
nuget Xamarin.Android.Support.v7.CardView == 25.3.1
```

```xml
<Choose>
    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v2.2' Or $(TargetFrameworkVersion) == 'v2.3' Or $(TargetFrameworkVersion) == 'v4.0.3' Or $(TargetFrameworkVersion) == 'v4.1' Or $(TargetFrameworkVersion) == 'v4.2' Or $(TargetFrameworkVersion) == 'v4.3' Or $(TargetFrameworkVersion) == 'v4.4' Or $(TargetFrameworkVersion) == 'v4.4W' Or $(TargetFrameworkVersion) == 'v5.0' Or $(TargetFrameworkVersion) == 'v5.1' Or $(TargetFrameworkVersion) == 'v6.0' Or $(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1')">
      <PropertyGroup
```

If not placed after the import of  `Xamarin.Android.CSharp.targets` those properties won't be defined resulting in a broken build. 

Not quite sure if or where to add tests for those, any hints appreciated! 
