### PR TITLE
fix for #2451

### DIFF
--- a/src/Paket.Core/PackageManagement/Releases.fs
+++ b/src/Paket.Core/PackageManagement/Releases.fs
@@ -53,8 +53,6 @@ let private downloadLatestVersionOf files destDir =
     }
 
 /// Downloads the latest version of the paket.bootstrapper and paket.targets to the .paket dir
-let downloadLatestBootstrapperAndTargets fromBootstrapper environment =
+let downloadLatestBootstrapperAndTargets environment =
     let exeDir = Path.Combine(environment.RootDirectory.FullName, Constants.PaketFolderName)
-
-    let bootstrapperDownload = if fromBootstrapper then [] else [Constants.BootstrapperFileName]
-    downloadLatestVersionOf ([Constants.TargetsFileName] @ bootstrapperDownload) exeDir
+    downloadLatestVersionOf [Constants.TargetsFileName; Constants.BootstrapperFileName] exeDir

--- a/src/Paket.Core/PackageManagement/VSIntegration.fs
+++ b/src/Paket.Core/PackageManagement/VSIntegration.fs
@@ -32,7 +32,7 @@ let TurnOnAutoRestore fromBootstrapper environment =
 
     trial {
         do! TurnOffAutoRestore environment
-        do! downloadLatestBootstrapperAndTargets fromBootstrapper environment 
+        do! downloadLatestBootstrapperAndTargets environment 
         let paketTargetsPath = Path.Combine(exeDir, Constants.TargetsFileName)
 
         environment.Projects

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -354,7 +354,7 @@ type Dependencies(dependenciesFileName: string) =
         RunInLockedAccessMode(
             this.RootPath,
             fun () -> 
-                Releases.downloadLatestBootstrapperAndTargets fromBootstrapper |> this.Process
+                this.Process Releases.downloadLatestBootstrapperAndTargets
                 let bootStrapperFileName = Path.Combine(this.RootPath,Constants.PaketFolderName, Constants.BootstrapperFileName)
                 let paketFileName = FileInfo(Path.Combine(this.RootPath,Constants.PaketFolderName, Constants.PaketFileName))
                 let configFileName = FileInfo(Path.Combine(this.RootPath,Constants.PaketFolderName, Constants.PaketFileName + ".config"))


### PR DESCRIPTION
Problem #2451 exists not only on linux. Windows just doesn't allow executable to remove itself.

Problem is when `paket init` run with `--from-bootstrapper` it does not download bootstrapper. It's consistent decision, but after that its trying replace `.paket/paket.exe` with paket.bootstrapper.exe downloaded (or not) in first step.

This fix is symptomatic - download paket.bootstrapper.exe every time.

100% correct solution would be to replace `.paket/paket.exe` with bootstrapper from which `paket --from-boostrapper` was called. 
But finding parent process is platform-dependent and quite hairy for both .net framework on windows and mono on linux. I'm not sure its better than symptomatic fix.
Plus downloading fresh bootstrapper every time is not a bad idea:  `paket --from-bootstrapper` can be called from outdated bootstrapper.