### PR TITLE
[WIP] Ignoring pre-release status when checking against resolved packages

### DIFF
--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -83,7 +83,7 @@ module DependencySetFilter =
         dependencies
         // exists any not matching stuff
         |> Seq.exists (fun (name, requirement, restriction) ->
-            if name = package.Name && not (requirement.IsInRange package.Version) then
+            if name = package.Name && not (requirement.IsInRange (package.Version, true)) then
                 tracefn "   Incompatible dependency: %O %O conflicts with resolved version %O" name requirement package.Version
                 true
             else false

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -42,8 +42,8 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
-    <StartArguments>pack output NuGet include-referenced-projects -v</StartArguments>
-    <StartWorkingDirectory>C:\temp\PaketPackRepro</StartWorkingDirectory>
+    <StartArguments>install</StartArguments>
+    <StartWorkingDirectory>D:\temp\pre</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">14.0</VisualStudioVersion>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -197,6 +197,7 @@
     <Compile Include="Resolver\PropertyTests.fs" />
     <Compile Include="Resolver\DependencyGroupsAndRestrictions.fs" />
     <Compile Include="Resolver\ResolverErrorSituationTests.fs" />
+    <Compile Include="Resolver\PrereleaseSpecs.fs" />
     <Compile Include="Lockfile\GeneratorSpecs.fs" />
     <Compile Include="Lockfile\GenerateWithOptionsSpecs.fs" />
     <Compile Include="Lockfile\GenerateAuthModeSpecs.fs" />

--- a/tests/Paket.Tests/Resolver/PrereleaseSpecs.fs
+++ b/tests/Paket.Tests/Resolver/PrereleaseSpecs.fs
@@ -1,0 +1,93 @@
+﻿module Paket.PrereleaseSpecs
+
+open Paket
+open NUnit.Framework
+open FsUnit
+open TestHelpers
+open Paket.Domain
+
+let graph = 
+  OfSimpleGraph [
+    "packageA","1.0.11250",["packageB", VersionRequirement(VersionRange.Between("1.0", "2.0"),PreReleaseStatus.No)]
+    "packageB","1.0.11203",[]
+    "packageB","1.0.11204-custom",[]
+    "packageB","2.0.0",[]
+  ]
+  
+let graphWithTransitiveDependencies = 
+  OfSimpleGraph [
+    "packageA","1.0.11250",["packageB", VersionRequirement(VersionRange.Between("1.0", "2.0"),PreReleaseStatus.No)]
+    "packageB","1.0.11203",["packageC", VersionRequirement(VersionRange.Between("1.0", "2.0"),PreReleaseStatus.No)]
+    "packageB","1.0.11204-custom",["packageC", VersionRequirement(VersionRange.Between("1.0", "2.0"),PreReleaseStatus.No)]
+    "packageB","2.0.0",["packageC", VersionRequirement(VersionRange.Between("2.0", "3.0"),PreReleaseStatus.No)]
+    "packageC","1.0.1",[]
+    "packageC","1.0.2-pre",[]
+  ]
+  
+let config1 = """
+source "https://www.nuget.org/api/v2"
+
+nuget PackageA
+nuget PackageB
+"""
+
+
+[<Test>]
+let ``should resolve config1``() = 
+    let cfg = DependenciesFile.FromSource(config1)
+    let resolved = ResolveWithGraph(cfg,noSha1, VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    getVersion resolved.[PackageName "packageA"] |> shouldEqual "1.0.11250"
+    getVersion resolved.[PackageName "packageB"] |> shouldEqual "1.0.11203"
+
+    
+let config2 = """
+source "https://www.nuget.org/api/v2"
+
+nuget PackageA
+nuget PackageB prerelease
+"""
+
+[<Test>]
+let ``should resolve prerelease config2``() = 
+    let cfg = DependenciesFile.FromSource(config2)
+    let resolved = ResolveWithGraph(cfg,noSha1, VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    getVersion resolved.[PackageName "packageA"] |> shouldEqual "1.0.11250"
+    getVersion resolved.[PackageName "packageB"] |> shouldEqual "1.0.11204-custom"
+    
+let config3 = """
+source "https://www.nuget.org/api/v2"
+
+nuget PackageA
+nuget PackageB 1.0.11204-custom
+"""
+
+[<Test>]
+let ``should resolve pinned config3``() = 
+    let cfg = DependenciesFile.FromSource(config3)
+    let resolved = ResolveWithGraph(cfg,noSha1, VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    getVersion resolved.[PackageName "packageA"] |> shouldEqual "1.0.11250"
+    getVersion resolved.[PackageName "packageB"] |> shouldEqual "1.0.11204-custom"
+    
+let config4 = """
+source "https://www.nuget.org/api/v2"
+
+nuget PackageA
+nuget PackageB == 2.0
+"""
+
+[<Test>]
+let ``should resolve overwritten config4``() = 
+    let cfg = DependenciesFile.FromSource(config4)
+    let resolved = ResolveWithGraph(cfg,noSha1, VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    getVersion resolved.[PackageName "packageA"] |> shouldEqual "1.0.11250"
+    getVersion resolved.[PackageName "packageB"] |> shouldEqual "2.0"
+
+    
+[<Test>]
+let ``should resolve prerelease config2 but no prerelease for transitive deps``() = 
+    let cfg = DependenciesFile.FromSource(config2)
+    let resolved = ResolveWithGraph(cfg,noSha1, VersionsFromGraphAsSeq graphWithTransitiveDependencies, PackageDetailsFromGraph graphWithTransitiveDependencies).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    getVersion resolved.[PackageName "packageA"] |> shouldEqual "1.0.11250"
+    getVersion resolved.[PackageName "packageB"] |> shouldEqual "1.0.11204-custom"
+    getVersion resolved.[PackageName "packageC"] |> shouldEqual "1.0.1"
+    


### PR DESCRIPTION
Ignoring pre-release status of a new requirement when checking it against packages that have already been resolved. #2471

The thinking is that if something dragged in a pre-relase version (e.g. the dependencies file) then we actually want pre-release of that package.

In my testing this seems to work. Even if the pre-release status is ignored in IsInRange(), the actual pre-release versions are still compared, so a requirement ">=2.0" will fail if a resolved package has version "2.0-pre". Could use some checking from someone who knows the code better though.