### PR TITLE
Additional work for #913 : allow empty framework conditionals in paket.template

### DIFF
--- a/src/Paket.Core/Packaging/NupkgWriter.fs
+++ b/src/Paket.Core/Packaging/NupkgWriter.fs
@@ -101,7 +101,7 @@ module internal NupkgWriter =
             g
 
 
-        let buildDependencyNodes (excludedDependencies, add, dependencyList: (Paket.Domain.PackageName * VersionRequirement) list)  =
+        let buildDependencyNodes (excludedDependencies, add, dependencyList)  =
             dependencyList
             |> List.filter (fun (a, _) -> Set.contains a excludedDependencies |> not)
             |> List.map  (fun (a, b) -> a, b)

--- a/src/Paket.Core/Packaging/NupkgWriter.fs
+++ b/src/Paket.Core/Packaging/NupkgWriter.fs
@@ -94,9 +94,11 @@ module internal NupkgWriter =
                 dep.SetAttributeValue(XName.Get "version", version)
             dep
 
-        let buildGroupNode (framework:FrameworkIdentifier, add) = 
+        let buildGroupNode (framework:FrameworkIdentifier option, add) = 
             let g = XElement(ns + "group")
-            g.SetAttributeValue(XName.Get "targetFramework", framework.ToString())
+            match framework with
+            | Some f -> g.SetAttributeValue(XName.Get "targetFramework", f.ToString())
+            | _ -> ()
             add g
             g
 
@@ -108,7 +110,7 @@ module internal NupkgWriter =
             |> List.iter (buildDependencyNode >> add)
 
         let buildDependencyNodesByGroup excludedDependencies add dependencyGroup  =
-            let node = buildGroupNode(dependencyGroup.Framework.Value, add)
+            let node = buildGroupNode(dependencyGroup.Framework, add)
             buildDependencyNodes(excludedDependencies, node.Add, dependencyGroup.Dependencies)
 
         let buildDependenciesNode excludedDependencies dependencyGroups =

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1893,7 +1893,7 @@ type ProjectFile with
             RequireLicenseAcceptance = propMap "RequireLicenseAcceptance" false tryBool
             Tags = propMap "Tags" [] splitString
             DevelopmentDependency = propMap "DevelopmentDependency" false tryBool
-            Dependencies = [] //propOr "Dependencies" []
+            DependencyGroups = []
             ExcludedDependencies = Set.empty //propOr "ExcludedDependencies" 
             ExcludedGroups = Set.empty // propOr "ExcludedGroups" Set.empty
             References = [] //propOr "References" []

--- a/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
+++ b/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
@@ -58,9 +58,13 @@ let ``should serialize dependencies``() =
     let optional = 
         { OptionalPackagingInfo.Epmty with 
             Tags = [ "f#"; "rules" ]
-            Dependencies = 
-                [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]", None
-                  PackageName "xUnit", VersionRequirement.Parse "2.0", None ] }
+            DependencyGroups =
+                [
+                   { Framework = None
+                     Dependencies =
+                        [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]"
+                          PackageName "xUnit", VersionRequirement.Parse "2.0" ] }
+                ] }
     
     let doc = NupkgWriter.nuspecDoc (core, optional)
     doc.ToString() 
@@ -96,9 +100,13 @@ let ``#913 should serialize dependencies by group``() =
     let optional = 
         { OptionalPackagingInfo.Epmty with 
             Tags = [ "f#"; "rules" ]
-            Dependencies = 
-                [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]", Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
-                  PackageName "xUnit", VersionRequirement.Parse "2.0", Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5)) ] }
+            DependencyGroups =
+              [
+                { Framework = Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
+                  Dependencies =
+                    [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]"
+                      PackageName "xUnit", VersionRequirement.Parse "2.0" ] }
+              ] }
     
     let doc = NupkgWriter.nuspecDoc (core, optional)
     doc.ToString() 
@@ -137,11 +145,61 @@ let ``#913 should serialize dependencies by group with 2 group``() =
     let optional = 
         { OptionalPackagingInfo.Epmty with 
             Tags = [ "f#"; "rules" ]
-            Dependencies = 
-                [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]", Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
-                  PackageName "xUnit", VersionRequirement.Parse "2.0", Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
-                  PackageName "Paket.Core", VersionRequirement.Parse "[3.1]", Some(FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V1_3))
-                  PackageName "xUnit", VersionRequirement.Parse "2.0", Some(FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V1_3)) ] }
+            DependencyGroups =
+              [
+                { Framework = Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
+                  Dependencies =
+                    [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]"
+                      PackageName "xUnit", VersionRequirement.Parse "2.0" ] }
+                { Framework = Some(FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V1_3))
+                  Dependencies =
+                    [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]"
+                      PackageName "xUnit", VersionRequirement.Parse "2.0" ] }
+              ] }
+    
+    let doc = NupkgWriter.nuspecDoc (core, optional)
+    doc.ToString() 
+    |> normalizeLineEndings
+    |> shouldEqual (normalizeLineEndings result)
+
+[<Test>]
+let ``should serialize dependencies by group with empty group``() = 
+    let result = """<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata>
+    <id>Paket.Tests</id>
+    <version>1.0.0.0</version>
+    <authors>Two, Authors</authors>
+    <description>A description</description>
+    <tags>f# rules</tags>
+    <dependencies>
+      <group targetFramework="net461" />
+      <group targetFramework="netstandard1.3">
+        <dependency id="Paket.Core" version="[3.1.0]" />
+        <dependency id="xUnit" version="2.0.0" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>"""
+
+    let core : CompleteCoreInfo =
+        { Id = "Paket.Tests"
+          Version = SemVer.Parse "1.0.0.0" |> Some
+          Authors = [ "Two"; "Authors" ]
+          Description = "A description"
+          Symbols = false }
+    
+    let optional = 
+        { OptionalPackagingInfo.Epmty with 
+            Tags = [ "f#"; "rules" ]
+            DependencyGroups =
+              [
+                { Framework = Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_6_1))
+                  Dependencies = [] }
+                { Framework = Some(FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V1_3))
+                  Dependencies =
+                    [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]"
+                      PackageName "xUnit", VersionRequirement.Parse "2.0" ] }
+              ] }
     
     let doc = NupkgWriter.nuspecDoc (core, optional)
     doc.ToString() 

--- a/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
+++ b/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
@@ -206,6 +206,56 @@ let ``should serialize dependencies by group with empty group``() =
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings result)
 
+[<Test>]
+let ``should serialize dependencies with global group``() = 
+    let result = """<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata>
+    <id>Paket.Tests</id>
+    <version>1.0.0.0</version>
+    <authors>Two, Authors</authors>
+    <description>A description</description>
+    <tags>f# rules</tags>
+    <dependencies>
+      <group>
+        <dependency id="FSharp.Core" version="1.0.0" />
+      </group>
+      <group targetFramework="net461" />
+      <group targetFramework="netstandard1.3">
+        <dependency id="Paket.Core" version="[3.1.0]" />
+        <dependency id="xUnit" version="2.0.0" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>"""
+
+    let core : CompleteCoreInfo =
+        { Id = "Paket.Tests"
+          Version = SemVer.Parse "1.0.0.0" |> Some
+          Authors = [ "Two"; "Authors" ]
+          Description = "A description"
+          Symbols = false }
+    
+    let optional = 
+        { OptionalPackagingInfo.Epmty with 
+            Tags = [ "f#"; "rules" ]
+            DependencyGroups =
+              [
+                { Framework = None
+                  Dependencies =
+                    [ PackageName "FSharp.Core", VersionRequirement.Parse "1.0.0" ] }
+                { Framework = Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_6_1))
+                  Dependencies = [] }
+                { Framework = Some(FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V1_3))
+                  Dependencies =
+                    [ PackageName "Paket.Core", VersionRequirement.Parse "[3.1]"
+                      PackageName "xUnit", VersionRequirement.Parse "2.0" ] }
+              ] }
+    
+    let doc = NupkgWriter.nuspecDoc (core, optional)
+    doc.ToString() 
+    |> normalizeLineEndings
+    |> shouldEqual (normalizeLineEndings result)
+
 
 [<Test>]
 let ``should serialize frameworkAssemblues``() = 

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -252,6 +252,7 @@ description
 version
     1.0
 dependencies
+    xunit 2.0.0
     framework: net461
     framework: net45
         FSharp.Core 4.3.1
@@ -267,14 +268,21 @@ dependencies
            | CompleteInfo (_, opt)
            | ProjectInfo (_, opt) -> opt
     
-    sut.DependencyGroups |> List.length |> shouldEqual 3
+    sut.DependencyGroups |> List.length |> shouldEqual 4
     match sut.DependencyGroups with
-    | [ g1; g2; g3 ] ->
-        g1.Framework |> shouldEqual (Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_6_1)))
-        g1.Dependencies |> List.length |> shouldEqual 0
+    | [ g1; g2; g3; g4 ] ->
+        g1.Framework |> shouldEqual None
+        match g1.Dependencies with
+        | [ name, range ] ->
+            name |> shouldEqual (PackageName "xunit")
+            range.Range |> shouldEqual (Specific (SemVer.Parse "2.0.0"))
+        | _ -> Assert.Fail()
 
-        g2.Framework |> shouldEqual (Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_5)))
-        match g2.Dependencies with
+        g2.Framework |> shouldEqual (Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_6_1)))
+        g2.Dependencies |> List.length |> shouldEqual 0
+
+        g3.Framework |> shouldEqual (Some(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_5)))
+        match g3.Dependencies with
         | [ name1, range1; name2, range2 ] ->
             name1 |> shouldEqual (PackageName "FSharp.Core")
             range1.Range |> shouldEqual (Specific (SemVer.Parse "4.3.1"))
@@ -282,8 +290,8 @@ dependencies
             range2.Range |> shouldEqual (Minimum (SemVer.Parse "0"))
         | _ -> Assert.Fail()
 
-        g3.Framework |> shouldEqual (Some(FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V1_1)))
-        match g3.Dependencies with
+        g4.Framework |> shouldEqual (Some(FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V1_1)))
+        match g4.Dependencies with
         | [name, range] ->
             name |> shouldEqual (PackageName "FSharp.Core")
             range.Range |> shouldEqual (Specific (SemVer.Parse "4.3.1"))            


### PR DESCRIPTION
This is some additional work for #913 to allow you to specify empty framework conditionals in your paket.template file.

```
type file
id My.Thing
authors Bob McBob
description
    A longer description
    on two lines.
version
    1.0
dependencies
    framework: net461
    framework: net45
        FSharp.Core 4.3.1
    framework: netstandard11
        FSharp.Core 4.3.1
```

This results in a framework group with no dependencies.

```
    <dependencies>
      <group targetFramework="net461" />
      <group targetFramework="net45">
        <dependency id="FSharp.Core" version="4.3.1" />
      </group>
      <group targetFramework="netstandard1.1">
        <dependency id="FSharp.Core" version="4.3.1" />
      </group>
    </dependencies>
```