### PR TITLE
Allow any whitespace to precede a comment, not only space.

### DIFF
--- a/src/Paket.Core/Common/Utils.fs
+++ b/src/Paket.Core/Common/Utils.fs
@@ -901,13 +901,15 @@ let normalizeLineEndings (text : string) =
     text.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", Environment.NewLine)
 
 let removeComment (text:string) =
-    let stripComment pos =
-        if pos = 0 || text.[pos-1] = ' ' then text.Substring(0,pos).Trim()
-        else text
-    match text.IndexOf "//", text.IndexOf "#" with
-    | -1 , -1 -> text
-    | -1, p | p , -1 -> stripComment p
-    | p1, p2 -> stripComment (min p1 p2) 
+    let rec stripComment pos =
+        if pos = 0 || (Char.IsWhiteSpace text.[pos-1]) then text.Substring(0,pos).Trim()
+        else remove (pos+1)
+    and remove (startAt: int) =
+        match text.IndexOf( "//", startAt ), text.IndexOf( "#", startAt ) with
+        | -1 , -1 -> text
+        | -1, p | p , -1 -> stripComment p
+        | p1, p2 -> stripComment (min p1 p2) 
+    remove 0
 
 // adapted from MiniRx
 // http://minirx.codeplex.com/

--- a/tests/Paket.Tests/ReferencesFile/ReferencesFileSpecs.fs
+++ b/tests/Paket.Tests/ReferencesFile/ReferencesFileSpecs.fs
@@ -465,7 +465,7 @@ let refFileWithComments = """
 # separate-line comment with hash
 Castle.Windsor # same-line comment with hash
 // separate-line comment with slashes
-Newtonsoft.Json // same-line comment with slashes
+Newtonsoft.Json\t// same-line comment with slashes
 
 // multiline
 // comment
@@ -474,7 +474,7 @@ Newtonsoft.Json // same-line comment with slashes
 # and a hash
 FSharp.Core //
 
-File: Some//File#With#Hashes.dot #and a comment after
+File: Some//File#With#Hashes.dot\t#and a comment after
 File: AnotherFile.txt //pluscomment
 
 // Some empty comments:
@@ -485,7 +485,8 @@ File: AnotherFile.txt //pluscomment
 
 [<Test>]
 let ``should parse and serialize reffiles with comments``() = 
-    let refFile = ReferencesFile.FromLines(toLines refFileWithComments).Groups.[Constants.MainDependencyGroup]
+    let file = refFileWithComments.Replace( "\\t", "\t" )
+    let refFile = ReferencesFile.FromLines(toLines file).Groups.[Constants.MainDependencyGroup]
 
     [for p in refFile.NugetPackages -> p.Name.Name]
         |> shouldEqual ["Castle.Windsor"; "Newtonsoft.Json"; "FSharp.Core"]


### PR DESCRIPTION
Fixes #2371.