### PR TITLE
show stack trace in verbose mode (closes #2480)

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -193,7 +193,10 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
                     | LocalNuGet(path,hasCache) ->
                         return! NuGetLocal.getDetailsFromLocalNuGetPackage hasCache.IsSome alternativeProjectRoot root path packageName version
                 with e ->
-                    traceWarnfn "Source '%O' exception: %O" source e
+                    if verbose then
+                      traceWarnfn "Source '%O' exception: %O" source e
+                    else
+                      traceWarnfn "Source '%O' exception: %s" source e.Message
                     //let capture = ExceptionDispatchInfo.Capture e
                     return EmptyResult })
             |> trySelectFirst

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -195,9 +195,9 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
                 with 
                 | :? System.IO.IOException as exn ->
                     if verbose then
-                        traceWarnfn "Source '%O' exception: %O" source exn
+                        traceWarnfn "I/O error for source '%O': %O" source exn
                     else
-                        traceWarnfn "Source '%O' exception: %s" source exn.Message
+                        traceWarnfn "I/O error for source '%O': %s" source exn.Message
                     return EmptyResult 
                 | e ->
                     traceWarnfn "Source '%O' exception: %O" source e

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -192,11 +192,15 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
 
                     | LocalNuGet(path,hasCache) ->
                         return! NuGetLocal.getDetailsFromLocalNuGetPackage hasCache.IsSome alternativeProjectRoot root path packageName version
-                with e ->
+                with 
+                | :? System.IO.IOException as exn ->
                     if verbose then
-                      traceWarnfn "Source '%O' exception: %O" source e
+                        traceWarnfn "Source '%O' exception: %O" source exn
                     else
-                      traceWarnfn "Source '%O' exception: %s" source e.Message
+                        traceWarnfn "Source '%O' exception: %s" source exn.Message
+                    return EmptyResult 
+                | e ->
+                    traceWarnfn "Source '%O' exception: %O" source e
                     //let capture = ExceptionDispatchInfo.Capture e
                     return EmptyResult })
             |> trySelectFirst

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -194,6 +194,7 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
                         return! NuGetLocal.getDetailsFromLocalNuGetPackage hasCache.IsSome alternativeProjectRoot root path packageName version
                 with 
                 | :? System.IO.IOException as exn ->
+                    // Handling IO exception here for less noise in output: https://github.com/fsprojects/Paket/issues/2480
                     if verbose then
                         traceWarnfn "I/O error for source '%O': %O" source exn
                     else


### PR DESCRIPTION
minimize the output in normal mode when getPackageDetails have a problem.
See #2480 for more info.