### PR TITLE
Fix for usage of the new csproj with targetFramework #2450

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1477,7 +1477,7 @@ module ProjectFile =
                         if String.IsNullOrWhiteSpace buildPlatform && attempted <> [] then
                             let tested = String.Join(", ", attempted)
                             traceWarnfn "No platform specified; found output path node for the %s platform after failing to find one for the following: %s" x tested
-                        Path.Combine(s , targetFramework).TrimEnd [|'\\'|] |> normalizePath
+                        Path.Combine(s.TrimEnd [|'\\'|] , targetFramework) |> normalizePath
 
         tryNextPlat platforms []
 

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -208,8 +208,8 @@
     <Compile Include="ReferencesFile\ReferencesFileSpecs.fs" />
     <Compile Include="LocalFile\LocalFileSpecs.fs" />
     <Compile Include="Simplifier\BasicScenarioSpecs.fs" />
-    <None Include="ProjectFile\TestData\EmptyCsharpGuid.csprojtest">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <None Include="ProjectFile\TestData\MicrosoftNetSdkWithTargetFrameworkAndOutputPath.csprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\EmptyFsharpGuid.fsprojtest">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -273,6 +273,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="ProjectFile\TestData\Unity.csprojtest">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\EmptyCsharpGuid.csprojtest">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="ProjectFile\TestData\MicrosoftNetSdkWithTargetFramework.csprojtest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Compile Include="ProjectFile\ConditionSpecs.fs" />

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -48,6 +48,29 @@ let ``should detect output path for proj file``
     outPath.ToLowerInvariant() |> shouldEqual (expected.ToLowerInvariant())
 
 [<Test>]
+let ``should detect output path for netsdk csproj file``
+        ([<Values("MicrosoftNetSdkWithTargetFramework.csprojtest")>] project)
+        ([<Values("Debug", "Release", "dEbUg", "rElEaSe")>] configuration) =
+    ensureDir ()
+    let projectFile = ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s" project).Value 
+    let target = projectFile.GetTargetProfile().ToString()
+    let outPath = projectFile.GetOutputDirectory configuration ""
+    let expected = (System.IO.Path.Combine(@"bin", configuration, target) |> normalizePath)
+    outPath.ToLowerInvariant() |> shouldEqual (expected.ToLowerInvariant())
+
+[<Test>]
+let ``should detect output path for netsdk with outputPath csproj file``
+        ([<Values("MicrosoftNetSdkWithTargetFrameworkAndOutputPath.csprojtest")>] project)
+        ([<Values("Release")>] configuration) =
+    ensureDir ()
+    let projectFile = ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s" project).Value 
+    let target = projectFile.GetTargetProfile().ToString()
+    let outPath = projectFile.GetOutputDirectory configuration ""
+    let expected = (System.IO.Path.Combine(@"bin", configuration,"netstandard1.4_bin", target) |> normalizePath)
+    outPath.ToLowerInvariant() |> shouldEqual (expected.ToLowerInvariant())
+
+
+[<Test>]
 let ``should detect framework profile for ProjectWithConditions file`` () =
     ensureDir ()
     ProjectFile.TryLoad("./ProjectFile/TestData/ProjectWithConditions.fsprojtest").Value.GetTargetProfile()

--- a/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/TargetFrameworkSpecs.fs
@@ -29,6 +29,10 @@ let TestData: obj[][] =
             portable;
             "portable-net45+win8+wp8+wpa81";
             (DotNetFramework FrameworkVersion.V4_5)|];
+        [|"MicrosoftNetSdkWithTargetFramework.csprojtest";
+            (SinglePlatform(DotNetStandard DotNetStandardVersion.V1_4));
+            "netstandard1.4";
+            (DotNetStandard DotNetStandardVersion.V1_4)|];
     |]
     
 [<Test>]

--- a/tests/Paket.Tests/ProjectFile/TestData/MicrosoftNetSdkWithTargetFramework.csprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/MicrosoftNetSdkWithTargetFramework.csprojtest
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>TestPaket</AssemblyName>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/Paket.Tests/ProjectFile/TestData/MicrosoftNetSdkWithTargetFrameworkAndOutputPath.csprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/MicrosoftNetSdkWithTargetFrameworkAndOutputPath.csprojtest
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>TestPaket</AssemblyName>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\netstandard1.4_bin\</OutputPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Hi it's a quick fix of the problem with dotnet pack on the new csproj when using template with type project.
It should fix #2450 

The issue with TargetFrameworks is still there for now. But it's a bigger rework as for now we only return one outputpath where we should return multiple one.