### PR TITLE
Restore cli tools via paket

### DIFF
--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -42,6 +42,9 @@ type ResolvedPackage = {
     member self.HasFrameworkRestrictions =
         getExplicitRestriction self.Settings.FrameworkRestrictions <> FrameworkRestriction.NoRestriction
 
+    member self.IsCliToolPackage() =
+        self.Name.ToString().StartsWith "dotnet-"
+
     member private self.Display
         with get() =
             let deps =

--- a/src/Paket.Core/Installation/InstallProcess.fs
+++ b/src/Paket.Core/Installation/InstallProcess.fs
@@ -327,6 +327,7 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
         let toolsVersion = project.GetToolsVersion()
         if verbose then
             verbosefn "Installing to %s with ToolsVersion %O" project.FileName toolsVersion
+
         let directDependencies, errorMessages =
             referenceFile.Groups
             |> Seq.map (fun kv ->

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -170,7 +170,7 @@ let CreateInstallModel(alternativeProjectRoot, root, groupName, sources, caches,
         return (groupName,package.Name), (package,model)
     }
 
-let createAlternativeNuGetConfig (alternativeConfigFileInfo:FileInfo) =    
+let createAlternativeNuGetConfig (alternativeConfigFileInfo:FileInfo) =
     let config = """<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
@@ -277,8 +277,8 @@ let Restore(dependenciesFileName,projectFile,force,group,referencesFileNames,ign
             let cliTools = System.Collections.Generic.List<_>()
             let fi = FileInfo projectFile.FileName
             let newFileName = FileInfo(Path.Combine(fi.Directory.FullName,"obj",fi.Name + ".references"))            
-            let alternativeConfigFileName = FileInfo(Path.Combine(fi.Directory.FullName,"obj",fi.Name + ".NuGet.Config"))            
-                        
+            let alternativeConfigFileName = FileInfo(Path.Combine(fi.Directory.FullName,"obj",fi.Name + ".NuGet.Config"))
+
             if not newFileName.Directory.Exists then
                 newFileName.Directory.Create()
             
@@ -319,7 +319,7 @@ let Restore(dependenciesFileName,projectFile,force,group,referencesFileNames,ign
                             (if direct then "Direct" else "Transitive") + "," +
                             kv.Key.ToString()
                         
-                        if packageName.ToString().StartsWith "dotnet-" then
+                        if package.IsCliToolPackage() then
                             cliTools.Add package
                         else
                             list.Add line
@@ -328,6 +328,7 @@ let Restore(dependenciesFileName,projectFile,force,group,referencesFileNames,ign
             if output = "" then
                 if File.Exists(newFileName.FullName) then
                     File.Delete(newFileName.FullName)
+
             elif not newFileName.Exists || File.ReadAllText(newFileName.FullName) <> output then
                 File.WriteAllText(newFileName.FullName,output)                
                 tracefn " - %s created" newFileName.FullName

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -285,7 +285,9 @@ let Restore(dependenciesFileName,projectFile,force,group,referencesFileNames,ign
             createAlternativeNuGetConfig alternativeConfigFileName
             
             for kv in groups do
-                let hull = lockFile.GetOrderedPackageHull(kv.Key,referencesFile)
+                let hull,cliToolsInGroup = lockFile.GetOrderedPackageHull(kv.Key,referencesFile)
+                cliTools.AddRange cliToolsInGroup
+
                 let depsGroup =
                     match dependenciesFile.Groups |> Map.tryFind kv.Key with
                     | Some group -> group
@@ -319,10 +321,7 @@ let Restore(dependenciesFileName,projectFile,force,group,referencesFileNames,ign
                             (if direct then "Direct" else "Transitive") + "," +
                             kv.Key.ToString()
                         
-                        if package.IsCliToolPackage() then
-                            cliTools.Add package
-                        else
-                            list.Add line
+                        list.Add line
                 
             let output = String.Join(Environment.NewLine,list)
             if output = "" then

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -194,14 +194,14 @@ let createPaketPropsFile (cliTools:ResolvedPackage seq) (fileInfo:FileInfo) =
             
         let content = 
             sprintf """<?xml version="1.0" encoding="utf-8" standalone="no"?>
-    <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-      <PropertyGroup>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
         <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-      </PropertyGroup>
-      <ItemGroup>
+    </PropertyGroup>
+    <ItemGroup>
 %s
-      </ItemGroup>
-    </Project>""" 
+    </ItemGroup>
+</Project>""" 
              (String.Join(Environment.NewLine,cliParts))
 
         if not fileInfo.Exists || File.ReadAllText(fileInfo.FullName) <> content then 


### PR DESCRIPTION
/cc @enricosada @alfonsogarciacaro @davkean @dsplaisted

This PR allows `dotnet restore` to create a `obj/PROJECTNAME.fsproj.paket.props` file with the following content:

    <?xml version="1.0" encoding="utf-8" standalone="no"?>
    <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
      <PropertyGroup>
        <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
      </PropertyGroup>
      <ItemGroup>
        <DotNetCliToolReference Include="dotnet-fable" Version="1.1.6" /> // or whatever cli tool we find
      </ItemGroup>
    </Project>

With this we can get rid of maintaining DotNetCliToolReference in our precious csproj/fsproj.
This became an issue since version number of dotnet-fable and Fable.Core need to match. Which involved manual work and some degree of giving a fuck.

used in https://github.com/fable-compiler/fable-suave-scaffold/pull/132

Open question:

* how do we really detect a cli tool. At the moment we check package name starts with "dotnet-"