### PR TITLE
Add default NuGet source back to find-packages

### DIFF
--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -308,7 +308,8 @@ let findPackages silent (results : ParseResults<_>) =
         | Some source, _ ->
             [PackageSource.NuGetV2Source source]
         | _, Some dependencies ->
-            dependencies.GetSources() |> Seq.map (fun kv -> kv.Value) |> List.concat
+            PackageSources.DefaultNuGetSource ::
+            (dependencies.GetSources() |> Seq.map (fun kv -> kv.Value) |> List.concat)
         | _ ->
             failwithf "Could not find '%s' at or above current directory, and no explicit source was given as parameter (e.g. 'paket.exe find-packages source https://www.nuget.org/api/v2')."
                 Constants.DependenciesFileName


### PR DESCRIPTION
As noted by @fsoikin in https://github.com/fsprojects/Paket/commit/aa5f1b7a5f7ef050e6466b8eeac479daf144acbd#commitcomment-22938166 I unintentionally removed the default NuGet source. Thanks for the heads-up, @fsoikin!

We should probably release 5.4.6 such that Paket doesn't stay broken until 5.5-alpha is released. I apologize for the trouble!