### PR TITLE
Fix multiple sources (performance)

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -38,7 +38,7 @@
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
       </PackageReference>
     </ItemGroup>
-    
+
     <PropertyGroup>
       <PaketCliToolFilePath>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).paket.clitools</PaketCliToolFilePath>
     </PropertyGroup>

--- a/build.sh
+++ b/build.sh
@@ -29,3 +29,4 @@ else
   fi
   mono packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
 fi
+

--- a/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
@@ -64,6 +64,7 @@
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />

--- a/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
@@ -142,7 +142,10 @@ let ``#1635 should tell about auth issue``() =
         update "i001635-wrong-pw" |> ignore
         failwith "error expected"
     with
-    | exn when exn.Message.Contains("Could not find versions for package Argu") -> ()
+    | exn when exn.Message.Contains("Unable to retrieve package versions for 'Argu'") -> 
+        exn.Message.Contains "Request to 'https://www.myget.org/F/paket-test/api/v3/index.json' failed with: 'Unauthorized'"
+            |> shouldEqual true
+        ()
 
 
 #if INTERACTIVE

--- a/src/Paket.Core.preview3/app.config
+++ b/src/Paket.Core.preview3/app.config
@@ -4,7 +4,7 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
@@ -13,7 +13,52 @@
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
-    <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.1.1" />
+    <assemblyIdentity name="System.Collections.NonGeneric" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Collections.Specialized" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.ComponentModel.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.ComponentModel.TypeConverter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.13.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Reflection.Emit.Lightweight" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Runtime.Serialization.Formatters" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Text.RegularExpressions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Xml.XmlDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
   </dependentAssembly>
 </assemblyBinding></runtime></configuration>

--- a/src/Paket.Core/Common/Utils.fs
+++ b/src/Paket.Core/Common/Utils.fs
@@ -980,6 +980,15 @@ module Seq =
         ) |> fun (xs,ys) ->
             List.rev xs :> seq<_>, List.rev ys :> seq<_>
 
+    let tryTake n (s:#seq<_>) =
+        let mutable i = 0
+        seq {
+            use e = s.GetEnumerator()
+            while (i < n && e.MoveNext()) do
+                i <- i + 1
+                yield e.Current
+        }
+
 [<RequireQualifiedAccess>]
 module List =
     // Try to find an element in a list.

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -121,6 +121,12 @@ let tryNuGetV3 (auth, nugetV3Url, package:PackageName) =
 
 let rec private getPackageDetails alternativeProjectRoot root force (sources:PackageSource list) packageName (version:SemVerInfo) : Async<PackageResolver.PackageDetails> =
     async {
+        let inCache =
+            sources
+            |> Seq.choose(fun source ->
+                NuGetCache.tryGetDetailsFromCache force source.Url packageName version |> Option.map (fun details -> source, details))
+            |> Seq.tryHead
+
         let tryV2 (nugetSource:NugetSource) force =
             NuGetV2.getDetailsFromNuGet
                 force
@@ -156,30 +162,23 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
                         | ODataSearchResult.EmptyResult -> return! trySelectFirst rest
                     | [] -> return None
                 }
-            sources
-            |> List.sortBy (fun source ->
-                match source with  // put local caches to the end
-                | LocalNuGet(_,Some _) -> true
-                | _ -> false)
-            |> List.map (fun source -> source, async {
-                try
+            match inCache with
+            | Some (source, ODataSearchResult.Match result) -> async { return Some (source, result) }
+            | _ ->
+                sources
+                |> List.sortBy (fun source ->
+                    // put local caches to the end
+                    // prefer nuget gallery
                     match source with
-                    | NuGetV2 nugetSource ->
-                        return! tryV2 nugetSource force
-                    | NuGetV3 nugetSource when NuGetV2.urlSimilarToTfsOrVsts nugetSource.Url  ->
-                        match NuGetV3.calculateNuGet2Path nugetSource.Url with
-                        | Some url ->
-                            let nugetSource : NugetSource =
-                                { Url = url
-                                  Authentication = nugetSource.Authentication }
+                    | LocalNuGet(_,Some _) -> 10
+                    | s when s.NuGetType = KnownNuGetSources.OfficialNuGetGallery -> 1
+                    | _ -> 3)
+                |> List.map (fun source -> source, async {
+                    try
+                        match source with
+                        | NuGetV2 nugetSource ->
                             return! tryV2 nugetSource force
-                        | _ ->
-                            return! tryV3 nugetSource force
-                    | NuGetV3 nugetSource ->
-                        try
-                            return! tryV3 nugetSource force
-                        with
-                        | exn ->
+                        | NuGetV3 nugetSource when urlSimilarToTfsOrVsts nugetSource.Url  ->
                             match NuGetV3.calculateNuGet2Path nugetSource.Url with
                             | Some url ->
                                 let nugetSource : NugetSource =
@@ -187,24 +186,37 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
                                       Authentication = nugetSource.Authentication }
                                 return! tryV2 nugetSource force
                             | _ ->
-                                raise exn
                                 return! tryV3 nugetSource force
+                        | NuGetV3 nugetSource ->
+                            try
+                                return! tryV3 nugetSource force
+                            with
+                            | exn ->
+                                match NuGetV3.calculateNuGet2Path nugetSource.Url with
+                                | Some url ->
+                                    let nugetSource : NugetSource =
+                                        { Url = url
+                                          Authentication = nugetSource.Authentication }
+                                    return! tryV2 nugetSource force
+                                | _ ->
+                                    raise exn
+                                    return! tryV3 nugetSource force
 
-                    | LocalNuGet(path,hasCache) ->
-                        return! NuGetLocal.getDetailsFromLocalNuGetPackage hasCache.IsSome alternativeProjectRoot root path packageName version
-                with 
-                | :? System.IO.IOException as exn ->
-                    // Handling IO exception here for less noise in output: https://github.com/fsprojects/Paket/issues/2480
-                    if verbose then
-                        traceWarnfn "I/O error for source '%O': %O" source exn
-                    else
-                        traceWarnfn "I/O error for source '%O': %s" source exn.Message
-                    return EmptyResult 
-                | e ->
-                    traceWarnfn "Source '%O' exception: %O" source e
-                    //let capture = ExceptionDispatchInfo.Capture e
-                    return EmptyResult })
-            |> trySelectFirst
+                        | LocalNuGet(path,hasCache) ->
+                            return! NuGetLocal.getDetailsFromLocalNuGetPackage hasCache.IsSome alternativeProjectRoot root path packageName version
+                    with
+                    | :? System.IO.IOException as exn ->
+                        // Handling IO exception here for less noise in output: https://github.com/fsprojects/Paket/issues/2480
+                        if verbose then
+                            traceWarnfn "I/O error for source '%O': %O" source exn
+                        else
+                            traceWarnfn "I/O error for source '%O': %s" source exn.Message
+                        return EmptyResult
+                    | e ->
+                        traceWarnfn "Source '%O' exception: %O" source e
+                        //let capture = ExceptionDispatchInfo.Capture e
+                        return EmptyResult })
+                |> trySelectFirst
 
         let! maybePackageDetails = getPackageDetails force
         let! source,nugetObject =
@@ -347,11 +359,8 @@ let GetVersions force alternativeProjectRoot root (sources, packageName:PackageN
                                 | Some v3Url -> return (getVersionsCached "V3" tryNuGetV3 (nugetSource, auth, v3Url, packageName)) :: v2Feeds
                        | NuGetV3 source ->
                             let! versionsAPI = PackageSources.getNuGetV3Resource source AllVersionsAPI
-                            let req = tryNuGetV3
-                                            (source.Authentication |> Option.map toBasicAuth,
-                                             versionsAPI,
-                                             packageName)
-                            return [ req ]
+                            let auth = source.Authentication |> Option.map toBasicAuth
+                            return [ getVersionsCached "V3" tryNuGetV3 (nugetSource, auth, versionsAPI, packageName) ]
                        | LocalNuGet(path,Some _) ->
                             return [ NuGetLocal.getAllVersionsFromLocalPath (true, path, packageName, alternativeProjectRoot, root) ]
                        | LocalNuGet(path,None) ->

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -364,7 +364,7 @@ let GetVersions force alternativeProjectRoot root (sources, packageName:PackageN
                     let! runningTasks, result =
                         requests
                         |> List.map NuGetCache.NuGetRequestGetVersions.run
-                        |> Async.tryFind (fun req -> req.IsSuccess)
+                        |> Async.tryFindSequential (fun req -> req.IsSuccess)
                     let zippedTasks =
                         Array.zip (requests |> List.toArray) runningTasks
                         |> Array.map (fun (req, task) ->

--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -255,8 +255,6 @@ let getDetailsFromNuGetViaODataFast auth nugetURL (packageName:PackageName) (ver
             return! fallback()
     }
 
-let urlSimilarToTfsOrVsts url =
-    String.containsIgnoreCase "visualstudio.com" url || (String.containsIgnoreCase "/_packaging/" url && String.containsIgnoreCase "/nuget/v" url)
 
 /// Gets package details from NuGet via OData
 let getDetailsFromNuGetViaOData auth nugetURL (packageName:PackageName) (version:SemVerInfo) =
@@ -270,9 +268,9 @@ let getDetailsFromNuGetViaOData auth nugetURL (packageName:PackageName) (version
                 | SafeWebResult.SuccessResponse r -> async { return Some r }
                 | SafeWebResult.NotFound -> async { return None }
                 | SafeWebResult.UnknownError err when
-                        String.containsIgnoreCase "myget.org" nugetURL ||
-                        String.containsIgnoreCase "nuget.org" nugetURL ||
-                        String.containsIgnoreCase "visualstudio.com" nugetURL ->
+                        urlIsMyGet nugetURL ||
+                        urlIsNugetGallery nugetURL ||
+                        urlSimilarToTfsOrVsts nugetURL ->
                     raise <|
                         System.Exception(
                             sprintf "Could not get package details for %O from %s" packageName nugetURL,

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -131,7 +131,11 @@ let FindAutoCompleteVersionsForPackage(nugetURL, auth, package, includingPrerele
 
 
 let internal findVersionsForPackage(v3Url, auth, packageName:Domain.PackageName) =
-    let url = sprintf "%s%O/index.json?semVerLevel=2.0.0" v3Url packageName
+    // Comment from http://api.nuget.org/v3/index.json
+    // explicitely says
+    // Base URL of Azure storage where NuGet package registration info for NET Core is stored, in the format https://api.nuget.org/v3-flatcontainer/{id-lower}/{id-lower}.{version-lower}.nupkg
+    // so I guess we need to take "id-lower" here -> myget actually needs tolower
+    let url = sprintf "%s%s/index.json?semVerLevel=2.0.0" v3Url (packageName.CompareString)
     NuGetRequestGetVersions.ofSimpleFunc url (fun _ ->
         async {
             let! response = safeGetFromUrl(auth,url,acceptJson) // NuGet is showing old versions first

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -835,7 +835,7 @@ let Resolve (getVersionsRaw, getPreferredVersionsRaw, getPackageDetailsRaw, grou
     let workerQueue = ResolverRequestQueue.Create()
     let workers =
         // start maximal 8 requests at the same time.
-        [ 0 .. 1 ]
+        [ 0 .. 5 ]
         |> List.map (fun _ -> ResolverRequestQueue.startProcessing cts.Token workerQueue)
 
     // mainly for failing unit-tests to be faster

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -835,7 +835,7 @@ let Resolve (getVersionsRaw, getPreferredVersionsRaw, getPackageDetailsRaw, grou
     let workerQueue = ResolverRequestQueue.Create()
     let workers =
         // start maximal 8 requests at the same time.
-        [ 0 .. 7 ]
+        [ 0 .. 1 ]
         |> List.map (fun _ -> ResolverRequestQueue.startProcessing cts.Token workerQueue)
 
     // mainly for failing unit-tests to be faster

--- a/src/Paket.Core/Installation/InstallProcess.fs
+++ b/src/Paket.Core/Installation/InstallProcess.fs
@@ -306,6 +306,7 @@ let installForDotnetSDK root (project:ProjectFile) =
 
 /// Installs all packages from the lock file.
 let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile, lockFile : LockFile, projectsAndReferences : (ProjectFile * ReferencesFile) list, updatedGroups) =
+    tracefn " - Creating model and downloading packages."
     let packagesToInstall =
         if options.OnlyReferenced then
             projectsAndReferences
@@ -322,8 +323,11 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
     let model = CreateModel(options.AlternativeProjectRoot, root, options.Force, dependenciesFile, lockFile, Set.ofSeq packagesToInstall, updatedGroups) |> Map.ofArray
     let lookup = lockFile.GetDependencyLookupTable()
     let projectCache = Dictionary<string, ProjectFile option>();
-
+    
+    let prefix = dependenciesFile.Directory.Length + 1
+    let norm (s:string) = (s.Substring prefix).Replace('\\', '/')
     for project, referenceFile in projectsAndReferences do
+        tracefn " - %s -> %s" (norm referenceFile.FileName) (norm project.FileName)
         let toolsVersion = project.GetToolsVersion()
         if verbose then
             verbosefn "Installing to %s with ToolsVersion %O" project.FileName toolsVersion

--- a/src/Paket.Core/Installation/UpdateProcess.fs
+++ b/src/Paket.Core/Installation/UpdateProcess.fs
@@ -207,6 +207,7 @@ let SmartInstall(dependenciesFile, updateMode, options : UpdaterOptions) =
     let projectsAndReferences = RestoreProcess.findAllReferencesFiles root |> returnOrFail
 
     if not options.NoInstall then
+        tracefn "Installing into projects:"
         let forceTouch = hasChanged && options.Common.TouchAffectedRefs
         InstallProcess.InstallIntoProjects(options.Common, forceTouch, dependenciesFile, lockFile, projectsAndReferences, updatedGroups)
         GarbageCollection.CleanUp(root, dependenciesFile, lockFile)

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -143,6 +143,7 @@
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -8,6 +8,7 @@ open Paket.Logging
 open Chessie.ErrorHandling
 
 open Newtonsoft.Json
+open System.Threading.Tasks
 
 let private envVarRegex = Regex("^%(\w*)%$", RegexOptions.Compiled)
 
@@ -85,14 +86,12 @@ type NugetV3ResourceType =
         | Registration -> "RegistrationsBaseUrl"
         | AllVersionsAPI -> "PackageBaseAddress/3.0.0"
 
-let private nugetV3Resources = ref Map.empty 
+let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<_,_>()
         
-let getNuGetV3Resource (source : NugetV3Source) (resourceType : NugetV3ResourceType) =
-    async {
-        let key = (source, resourceType)
-        match !nugetV3Resources |> Map.tryFind key with
-        | Some x -> return x
-        | None -> 
+let getNuGetV3Resource (source : NugetV3Source) (resourceType : NugetV3ResourceType) : Async<string> =
+    let key = (source, resourceType) 
+    let getResourceRaw () = 
+        async {
             let basicAuth = source.Authentication |> Option.map toBasicAuth
             let! rawData = safeGetFromUrl(basicAuth, source.Url, acceptJson)
             let rawData =
@@ -107,34 +106,29 @@ let getNuGetV3Resource (source : NugetV3Source) (resourceType : NugetV3ResourceT
             let resources = 
                 json.Resources 
                 |> Seq.distinctBy(fun x -> x.Type.ToLower())
-                |> Seq.map(fun x -> x.Type.ToLower(), x.ID) 
+                |> Seq.map(fun x -> x.Type.ToLower(), x.ID)
+            for (res, value) in resources do
+                let resType =
+                    match res.ToLower() with
+                    | "searchautocompleteservice" -> Some AutoComplete
+                    | "registrationsbaseurl" -> Some Registration
+                    | "packagebaseaddress/3.0.0" -> Some AllVersionsAPI
+                    | _ -> None
+                match resType with
+                | None -> ()
+                | Some _ ->
+                    nugetV3Resources.AddOrUpdate(key, (fun _ -> Task.FromResult value), (fun _ _ -> Task.FromResult value))
+                        |> ignore
+        
+            match nugetV3Resources.TryGetValue key with
+            | true, v when v.IsCompleted -> return v.Result
+            | _ -> return failwithf "could not find an %s endpoint for %s" (resourceType.ToString()) source.Url
+        } |> Async.StartAsTask
 
-            let newMap = 
-                lock !nugetV3Resources (fun() ->
-                    let newMap =
-                        resources
-                        |> Seq.fold(fun m (res, value) ->
-                            let resType =
-                                match res.ToLower() with
-                                | "searchautocompleteservice" -> Some AutoComplete
-                                | "registrationsbaseurl" -> Some Registration
-                                | "packagebaseaddress/3.0.0" -> Some AllVersionsAPI
-                                | _ -> None
-                            match resType with
-                            | None -> m
-                            | Some resType ->
-                                m |> Map.add (source, resType) value
-                        ) !nugetV3Resources
-                            
-                    nugetV3Resources := newMap
-                        
-                    newMap)
-
-            return
-                match newMap |> Map.tryFind key with
-                | Some x -> x
-                | None ->
-                    failwithf "could not find an %s endpoint for %s" (resourceType.ToString()) source.Url
+    async {
+        let t = nugetV3Resources.GetOrAdd(key, (fun _ -> getResourceRaw()))
+        let! res = t |> Async.AwaitTask
+        return res
     }
 let userNameRegex = Regex("username[:][ ]*[\"]([^\"]*)[\"]", RegexOptions.IgnoreCase ||| RegexOptions.Compiled)
 let passwordRegex = Regex("password[:][ ]*[\"]([^\"]*)[\"]", RegexOptions.IgnoreCase ||| RegexOptions.Compiled)

--- a/src/Paket.Core/paket.references
+++ b/src/Paket.Core/paket.references
@@ -3,8 +3,7 @@ FSharp.Core
 Mono.Cecil
 Chessie
 FSharp.Compiler.Tools
-
-
+System.Net.Http
 
 File:Globbing.fs Common\
 File:AssemblyReader.fs Common\

--- a/src/Paket.preview3/app.config
+++ b/src/Paket.preview3/app.config
@@ -4,7 +4,7 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.0.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
@@ -13,7 +13,57 @@
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
+    <assemblyIdentity name="System.Collections.NonGeneric" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Collections.Specialized" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.ComponentModel.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.ComponentModel.TypeConverter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.13.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Reflection.Emit.Lightweight" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Runtime.Serialization.Formatters" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Text.RegularExpressions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
     <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.1.1" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Xml.XmlDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
   </dependentAssembly>
 </assemblyBinding></runtime></configuration>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,7 +31,7 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>update</StartArguments>
+    <StartArguments>update --verbose</StartArguments>
     <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,7 +31,7 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>update --verbose</StartArguments>
+    <StartArguments>update</StartArguments>
     <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,8 +31,8 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>update --verbose</StartArguments>
-    <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
+    <StartArguments>update</StartArguments>
+    <StartWorkingDirectory>C:\proj\Paket\integrationtests\scenarios\i001635-wrong-pw\temp</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,8 +31,8 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>install --createnewbindingfiles</StartArguments>
-    <StartWorkingDirectory>D:\code\FSharpx.Collections</StartWorkingDirectory>
+    <StartArguments>update --verbose</StartArguments>
+    <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -32,7 +32,7 @@
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
     <StartArguments>update</StartArguments>
-    <StartWorkingDirectory>C:\proj\Paket\integrationtests\scenarios\i001635-wrong-pw\temp</StartWorkingDirectory>
+    <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -69,6 +69,7 @@
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -333,6 +333,7 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />

--- a/tests/Paket.Tests/ProjectFile/UpdateFromNugetSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/UpdateFromNugetSpecs.fs
@@ -6,8 +6,8 @@ open FsUnit
 open System.Xml
 open System.IO
 
-let convertAndCompare source expectedResult =
-    let projectFile = ProjectFile.LoadFromString("Test.csproj", source)
+let convertAndCompare file source expectedResult =
+    let projectFile = ProjectFile.LoadFromString(file, source)
     ProjectFile.removeNuGetPackageImportStamp projectFile
     let actualResult = Utils.normalizeXml projectFile.Document
     let normalizedExpected =
@@ -36,7 +36,7 @@ let ``should remove NuGetPackageImportStamp and empty PropertyGroup``() =
   </PropertyGroup>
 </Project>"""
     
-    convertAndCompare projectFile expectedResult
+    convertAndCompare "HardCodeString.proj" projectFile expectedResult
 
 [<Test>]
 let ``should remove NuGetPackageImportStamp but not PropertyGroup with items``() =
@@ -56,7 +56,7 @@ let ``should remove NuGetPackageImportStamp but not PropertyGroup with items``()
   </PropertyGroup>
 </Project>"""
     
-    convertAndCompare projectFile expectedResult
+    convertAndCompare "HardCodeString.proj" projectFile expectedResult
 
 let testDataRootPath = Path.Combine(__SOURCE_DIRECTORY__, "TestData")
 let TestData: obj[][] = [|
@@ -70,5 +70,6 @@ let TestData: obj[][] = [|
 [<Test>]
 [<TestCaseSource("TestData")>]
 let ``should not modify projects without NuGetPackageImportStamp`` projectFile =
-    let text = File.ReadAllText (Path.Combine(testDataRootPath, projectFile))
-    convertAndCompare text text
+    let file = Path.Combine(testDataRootPath, projectFile)
+    let text = File.ReadAllText file
+    convertAndCompare file text text


### PR DESCRIPTION
Fixes https://github.com/fsprojects/Paket/issues/2369

Main problem was using the v2 api for myget which seems to be painfully slow. We always used v2 for all sources besides nuget, even when v3 uri was specified.
@forki  was this intended?

Solves
```
source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
source https://dotnet.myget.org/F/cli-deps/api/v3/index.json
source https://www.nuget.org/api/v2/

nuget FSharp.Core >= 4.1.0
nuget FSharp.NET.Sdk >= 1.0.0
```

in

```
Performance:
 - Resolver: 46 seconds (1 runs)
    - Runtime: 8 seconds
    - Blocked (retrieving package versions): 25 seconds (6 times)
    - Blocked (retrieving package details): 12 seconds (33 times)
    - Not Blocked (retrieving package details): 36 times
    - Not Blocked (retrieving package versions): 63 times
 - Disk IO: 10 seconds
 - Average Request Time: 1 second
 - Number of Requests: 232
```

I also added other performance improvements which brought the runtime down to 4 Minutes (instead of hours), but switching to myget was the final breakthrough:

- Properly cancel requests when we no longer need the result by delegating the cancellation token
- Do `GetVersion` requests of a SINGLE source sequentially (because we should already put the fastest one first in the common case -> fewer requests)
- Switch to System.Net.Http instead of WebRequest to have a single code-base for netcore and full.
- Add messages to the install-process to make it more obvious what paket is doing
  The install-process is taking more and more time and users are wondering what paket is doing so I added some output
