### PR TITLE
revert paket push to WebClient

### DIFF
--- a/src/Paket.Core/PackageManagement/Releases.fs
+++ b/src/Paket.Core/PackageManagement/Releases.fs
@@ -27,7 +27,7 @@ let private doesNotExistsOrIsNewer (file : FileInfo) latest =
 
 /// Downloads the latest version of the given files to the destination dir
 let private downloadLatestVersionOf files destDir =
-    use client = createWebClient(Constants.GitHubUrl, None)
+    use client = createHttpClient(Constants.GitHubUrl, None)
 
     trial {
         let latest = "https://github.com/fsprojects/Paket/releases/latest";

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -21,7 +21,7 @@
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <OutputPath>..\..\bin</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;USE_WEB_CLIENT_FOR_UPLOAD</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <StartArguments>pack out out</StartArguments>
     <StartAction>Project</StartAction>
@@ -34,8 +34,8 @@
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
     <OutputPath>..\..\bin</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
+    <DefineConstants>TRACE;USE_WEB_CLIENT_FOR_UPLOAD</DefineConstants>
+    <WarningLevel>5</WarningLevel>
     <DocumentationFile>..\..\bin\Paket.Core.XML</DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/Paket.Core/Versioning/ConfigFile.fs
+++ b/src/Paket.Core/Versioning/ConfigFile.fs
@@ -126,7 +126,7 @@ let private setToken (token : string) (node : XmlElement) =
 
 /// Check if the provided credentials for a specific source are correct
 let checkCredentials(url, cred) = 
-    let client = Utils.createWebClient(url,cred)
+    let client = Utils.createHttpClient(url,cred)
     try 
         client.DownloadData (Uri url) |> ignore
         true

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -245,7 +245,7 @@ type PackageSource =
 
     static member WarnIfNoConnection (source,_) = 
         let n url auth =
-            use client = Utils.createWebClient(url, auth |> Option.map toBasicAuth)
+            use client = Utils.createHttpClient(url, auth |> Option.map toBasicAuth)
             try client.DownloadData url |> ignore 
             with _ ->
                 traceWarnfn "Unable to ping remote NuGet feed: %s." url


### PR DESCRIPTION
- revert paket push to `WebClient`. 
- add `PAKET_PUSH_HTTPCLIENT` to test out the httpclient push, 
- once stable we remove all parts ifdefd with `USE_WEB_CLIENT_FOR_UPLOAD`.