### PR TITLE
Fix exception when paket outdated runs on a repo with a http zip dependency

### DIFF
--- a/completion/paket-completion.zsh
+++ b/completion/paket-completion.zsh
@@ -707,6 +707,7 @@ _paket-outdated() {
   args=(
     $global_options
     "${(f)$(_paket_group_option 'specify dependency group (default: all groups)')}"
+    '(-f --force)'{-f,--force}'[force download and reinstallation of all dependencies]'
     '(--ignore-constraints)'--ignore-constraints'[ignore version constraints in the paket.dependencies file]'
     '(--pre --include-prereleases)'{--pre,--include-prereleases}'[consider prerelease versions as updates]'
   )

--- a/src/Paket.Core/Dependencies/RemoteDownload.fs
+++ b/src/Paket.Core/Dependencies/RemoteDownload.fs
@@ -268,6 +268,7 @@ let downloadRemoteFiles(remoteFile:ResolvedSourceFile,destination) = async {
         let authentication = auth remoteFile.AuthKey url
         match Path.GetExtension(destination).ToLowerInvariant() with
         | ".zip" ->
+            CleanDir targetFolder.FullName
             do! downloadFromUrl(authentication, url) destination
             ZipFile.ExtractToDirectory(destination, targetFolder.FullName)
         | _ -> do! downloadFromUrl(authentication, url) destination

--- a/src/Paket.Core/PackageAnalysis/FindOutdated.fs
+++ b/src/Paket.Core/PackageAnalysis/FindOutdated.fs
@@ -25,9 +25,8 @@ let private adjustVersionRequirements strict includingPrereleases (dependenciesF
     DependenciesFile(dependenciesFile.FileName, groups, dependenciesFile.Lines)
 
 /// Finds all outdated packages.
-let FindOutdated strict includingPrereleases groupNameFilter environment = trial {
+let FindOutdated strict force includingPrereleases groupNameFilter environment = trial {
     let! lockFile = environment |> PaketEnv.ensureLockFileExists
-    let force = true
 
     let dependenciesFile =
         environment.DependenciesFile
@@ -83,7 +82,7 @@ let private printOutdated changed =
                 tracefn "    * %O %O -> %O" packageName oldVersion newVersion
 
 /// Prints all outdated packages.
-let ShowOutdated strict includingPrereleases groupName environment = trial {
-    let! allOutdated = FindOutdated strict includingPrereleases groupName environment
+let ShowOutdated strict force includingPrereleases groupName environment = trial {
+    let! allOutdated = FindOutdated strict force includingPrereleases groupName environment
     printOutdated allOutdated
 }

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -338,16 +338,24 @@ type Dependencies(dependenciesFileName: string) =
                 |> Array.choose (fun (p:ProjectFile) -> p.FindReferencesFile())
             if Array.isEmpty referencesFiles then
                 traceWarnfn "No paket.references files found for which packages could be installed."
-            else 
+            else
                 this.Restore(force, group, Array.toList referencesFiles, touchAffectedRefs, ignoreChecks,  failOnFailedChecks, targetFramework)
 
     /// Lists outdated packages.
-    member this.ShowOutdated(strict: bool,includePrereleases: bool, groupName: string Option): unit =
-        FindOutdated.ShowOutdated strict includePrereleases groupName |> this.Process
+    [<Obsolete("Use ShowOutdated with the force parameter set to true to get the old behavior")>]
+    member this.ShowOutdated(strict: bool, includePrereleases: bool, groupName: string Option): unit =
+        this.ShowOutdated(strict, true, includePrereleases, groupName)
+
+    member this.ShowOutdated(strict: bool, force: bool, includePrereleases: bool, groupName: string Option): unit =
+        FindOutdated.ShowOutdated strict force includePrereleases groupName |> this.Process
 
     /// Finds all outdated packages.
-    member this.FindOutdated(strict: bool,includePrereleases: bool, groupName: string Option): (string * string * SemVerInfo) list =
-        FindOutdated.FindOutdated strict includePrereleases groupName
+    [<Obsolete("Use FindOutdated with the force parameter set to true to get the old behavior")>]
+    member this.FindOutdated(strict: bool, includePrereleases: bool, groupName: string Option): (string * string * SemVerInfo) list =
+        this.FindOutdated(strict, true, includePrereleases, groupName)
+
+    member this.FindOutdated(strict: bool, force: bool, includePrereleases: bool, groupName: string Option): (string * string * SemVerInfo) list =
+        FindOutdated.FindOutdated strict force includePrereleases groupName
         |> this.Process
         |> List.map (fun (g, p,_,newVersion) -> g.ToString(),p.ToString(),newVersion)
 

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -171,6 +171,7 @@ with
             | Load_Script_Type_Legacy(_) -> "[obsolete]"
 
 type OutdatedArgs =
+    | [<Unique;AltCommandLine("-f")>] Force
     | [<Unique>] Ignore_Constraints
 
     | [<Unique;AltCommandLine("-g")>] Group of name:string
@@ -181,6 +182,7 @@ with
     interface IArgParserTemplate with
         member this.Usage =
             match this with
+            | Force -> "force download and reinstallation of all dependencies"
             | Ignore_Constraints -> "ignore version constraints in the paket.dependencies file"
 
             | Group(_) -> "specify dependency group (default: all groups)"

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -298,13 +298,14 @@ let install (results : ParseResults<_>) =
         alternativeProjectRoot)
 
 let outdated (results : ParseResults<_>) =
+    let force = results.Contains <@ OutdatedArgs.Force @>
     let strict = results.Contains <@ OutdatedArgs.Ignore_Constraints @> |> not
     let includePrereleases = results.Contains <@ OutdatedArgs.Include_Prereleases @>
     let group =
         (results.TryGetResult<@ OutdatedArgs.Group @>,
          results.TryGetResult<@ OutdatedArgs.Group_Legacy @>)
         |> legacyOption results "--group" "group"
-    Dependencies.Locate().ShowOutdated(strict, false, includePrereleases, group)
+    Dependencies.Locate().ShowOutdated(strict, force, includePrereleases, group)
 
 let remove (results : ParseResults<_>) =
     let packageName =

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -304,7 +304,7 @@ let outdated (results : ParseResults<_>) =
         (results.TryGetResult<@ OutdatedArgs.Group @>,
          results.TryGetResult<@ OutdatedArgs.Group_Legacy @>)
         |> legacyOption results "--group" "group"
-    Dependencies.Locate().ShowOutdated(strict, includePrereleases, group)
+    Dependencies.Locate().ShowOutdated(strict, false, includePrereleases, group)
 
 let remove (results : ParseResults<_>) =
     let packageName =
@@ -594,7 +594,7 @@ let findPackageVersions (results : ParseResults<_>) =
                    results.TryGetResult <@ FindPackageVersionsArgs.Source_Legacy @>)
                   |> legacyOption results "--source" "source"
         discoverPackageSources arg dependencies
-        
+
     let root =
         match dependencies with
         | Some d ->


### PR DESCRIPTION
http zip dependencies will be extracted after download. As it stands, Paket
forces the download, see
https://github.com/fsprojects/Paket/blob/master/src/Paket.Core/PackageAnalysis/FindOutdated.fs#L30

Without this fix, Paket fails to overwrite existing extracted files. Hence, delete the dependency's target folder before attempting the download.

Relates to https://github.com/fsprojects/Paket/issues/1845#issuecomment-302731123