### PR TITLE
[WIP] Fix Feed Warnings and add blacklisting

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -243,8 +243,7 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
         let tryV2 (nugetSource:NugetSource) force =
             NuGetV2.getDetailsFromNuGet
                 force
-                (nugetSource.Authentication |> Option.map toBasicAuth)
-                nugetSource.Url
+                nugetSource
                 packageName
                 version
 
@@ -254,8 +253,7 @@ let rec private getPackageDetails alternativeProjectRoot root force (sources:Pac
                 | Some url ->
                     NuGetV2.getDetailsFromNuGet
                         force
-                        (nugetSource.Authentication |> Option.map toBasicAuth)
-                        url
+                        { nugetSource with Url = url } //= .Authentication |> Option.map toBasicAuth)
                         packageName
                         version
                 | _ ->

--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -85,6 +85,8 @@ let private followODataLink auth url =
         return res
     }
 
+let private tryGetAllVersionsFromNugetODataWithFilterWarnings = System.Collections.Concurrent.ConcurrentDictionary<_,_>()
+
 let tryGetAllVersionsFromNugetODataWithFilter (auth, nugetURL, package:PackageName) =
     let url = sprintf "%s/Packages?semVerLevel=2.0.0&$filter=Id eq '%O'" nugetURL package
     NuGetRequestGetVersions.ofSimpleFunc url (fun _ ->
@@ -92,7 +94,14 @@ let tryGetAllVersionsFromNugetODataWithFilter (auth, nugetURL, package:PackageNa
             try
                 let! result = followODataLink auth url
                 return SuccessResponse result
-            with _ ->
+            with exn ->
+                match tryGetAllVersionsFromNugetODataWithFilterWarnings.TryGetValue nugetURL with
+                | true, true -> ()
+                | _, _ ->
+                    eprintfn "Possible Performance degration, could not retrieve '%s', ignoring further warnings for this source" url
+                    tryGetAllVersionsFromNugetODataWithFilterWarnings.TryAdd(nugetURL, true) |> ignore
+                if verbose then
+                    printfn "Error while retrieving data from '%s': %O" url exn
                 let url = sprintf "%s/Packages?semVerLevel=2.0.0&$filter=tolower(Id) eq '%s'" nugetURL (package.CompareString)
                 try
                     let! result = followODataLink auth url
@@ -240,176 +249,144 @@ let parseODataEntryDetails (url,nugetURL,packageName:PackageName,version:SemVerI
         | ODataSearchResult.Match entry -> entry
 
 
-let getDetailsFromNuGetViaODataFast auth nugetURL (packageName:PackageName) (version:SemVerInfo) =
-    let foundEmpty = ref false
-    let isBlessed = urlIsNugetGallery nugetURL || urlIsMyGet nugetURL
-                        
+let getDetailsFromNuGetViaODataFast nugetSource (packageName:PackageName) (version:SemVerInfo) =
     async {
         let normalizedVersion = version.Normalize()
-        let fallback6 () =
+        let urls =
+            [ // Nuget feeds should support this.
+              UrlToTry.From
+                (UrlId.GetVersion_ById { LoweredPackageId = true; NormalizedVersion = false })
+                "1_%s/Packages(Id='%s',Version='%O')"
+                nugetSource.Url
+                (packageName.CompareString)
+                version
+              // DevExpress needs normalized versions? https://github.com/fsprojects/Paket/issues/2599
+              UrlToTry.From
+                (UrlId.GetVersion_ById { LoweredPackageId = true; NormalizedVersion = true })
+                "1_%s/Packages(Id='%s',Version='%O')"
+                nugetSource.Url
+                (packageName.CompareString)
+                normalizedVersion
+              // Use original casing.            
+              UrlToTry.From
+                (UrlId.GetVersion_ById { LoweredPackageId = false; NormalizedVersion = true })
+                "1_%s/Packages(Id='%s',Version='%O')"
+                nugetSource.Url
+                (packageName.ToString())
+                normalizedVersion
+              UrlToTry.From
+                (UrlId.GetVersion_ById { LoweredPackageId = false; NormalizedVersion = false })
+                "1_%s/Packages(Id='%s',Version='%O')"
+                nugetSource.Url
+                (packageName.ToString())
+                version
+              // We couldn't find by ID, try to search via filter.
+              // Start without toLower because of ProGet performance https://github.com/fsprojects/Paket/issues/2466
+              UrlToTry.From
+                (UrlId.GetVersion_Filter
+                    ({ LoweredPackageId = false; NormalizedVersion = true },
+                     { ToLower = false; NormalizedVersion = true }))
+                "2_%s/Packages?$filter=(Id eq '%s') and (NormalizedVersion eq '%s')"
+                nugetSource.Url
+                (packageName.ToString())
+                normalizedVersion
+              // Try to find with all normalized
+              UrlToTry.From
+                (UrlId.GetVersion_Filter
+                    ({ LoweredPackageId = true; NormalizedVersion = true },
+                     { ToLower = true; NormalizedVersion = true }))
+                "2_%s/Packages?$filter=(tolower(Id) eq '%s') and (NormalizedVersion eq '%s')"
+                nugetSource.Url
+                (packageName.CompareString)
+                normalizedVersion
+              // SonarType does not support NormalizedVersion, see https://issues.sonatype.org/browse/NEXUS-6159
+              // and https://github.com/fsprojects/Paket/issues/2320
+              UrlToTry.From
+                (UrlId.GetVersion_Filter({ LoweredPackageId = false; NormalizedVersion = true }, { ToLower = false; NormalizedVersion = false }))
+                "2_%s/Packages?$filter=(Id eq '%s') and (Version eq '%s')"
+                nugetSource.Url
+                (packageName.ToString())
+                normalizedVersion
+              // Not sure
+              UrlToTry.From
+                (UrlId.GetVersion_Filter({ LoweredPackageId = true; NormalizedVersion = false }, { ToLower = true; NormalizedVersion = false }))
+                "2_%s/Packages?$filter=(tolower(Id) eq '%s') and (Version eq '%O')"
+                nugetSource.Url
+                (packageName.CompareString)
+                version
+              // Not sure
+              UrlToTry.From
+                (UrlId.GetVersion_Filter({ LoweredPackageId = true; NormalizedVersion = true }, { ToLower = true; NormalizedVersion = false }))
+                "2_%s/Packages?$filter=(tolower(Id) eq '%s') and (Version eq '%O')"
+                nugetSource.Url
+                (packageName.CompareString)
+                normalizedVersion
+            ]
+        let handleEntryUrl url =
             async {
                 try
-                    let url = sprintf "%s/Packages(Id='%s',Version='%O')" nugetURL (packageName.CompareString) normalizedVersion
-                    let! raw = getFromUrl(auth,url,acceptXml)
+                    let! raw = getFromUrl(nugetSource.BasicAuth,url,acceptXml)
                     if verbose then
                         tracefn "Response from %s:" url
                         tracefn ""
                         tracefn "%s" raw
                     let doc = getXmlDoc url raw
-                    return parseODataEntryDetails(url,nugetURL,packageName,version,doc) |> ODataSearchResult.Match
-                with _ when !foundEmpty ->
-                    return EmptyResult
-            }
-
-        let fallback5 () =
-            async {
-                try
-                    let url = sprintf "%s/Packages(Id='%s',Version='%O')" nugetURL (packageName.CompareString) version
-                    let! raw = getFromUrl(auth,url,acceptXml)
-                    if verbose then
-                        tracefn "Response from %s:" url
-                        tracefn ""
-                        tracefn "%s" raw
-                    let doc = getXmlDoc url raw
-                    match parseODataEntryDetails(url,nugetURL,packageName,version,doc) |> ODataSearchResult.Match with
-                    | EmptyResult when isBlessed ->
-                        return EmptyResult
-                    | EmptyResult ->
-                        foundEmpty := true
-                        if verbose then tracefn "No results, trying again with direct detail access and normalizedVersion."
-                        return! fallback6()
-                    | res -> return res
-                with _ ->
-                    return! fallback6()
-            }
-
-        let fallback4 () =
-            async {
-                try
-                    let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%s') and (Version eq '%O')" nugetURL (packageName.CompareString) normalizedVersion
-                    let! raw = getFromUrl(auth,url,acceptXml)
-                    if verbose then
-                        tracefn "Response from %s:" url
-                        tracefn ""
-                        tracefn "%s" raw
-                    let doc = getXmlDoc url raw
-                    match parseODataListDetails(url,nugetURL,packageName,version,doc) with
-                    | EmptyResult when isBlessed ->
-                        return EmptyResult
-                    | EmptyResult ->
-                        foundEmpty := true
-                        if verbose then tracefn "No results, trying again with direct detail access."
-                        return! fallback5()
-                    | res -> return res
-                with _ ->
-                    return! fallback5()
-            }
-
-        let fallback3 () =
-            async {
-                try
-                    let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%s') and (Version eq '%O')" nugetURL (packageName.CompareString) version
-                    let! raw = getFromUrl(auth,url,acceptXml)
-                    if verbose then
-                        tracefn "Response from %s:" url
-                        tracefn ""
-                        tracefn "%s" raw
-                    let doc = getXmlDoc url raw
-                    match parseODataListDetails(url,nugetURL,packageName,version,doc) with
-                    | EmptyResult when isBlessed ->
-                        return EmptyResult
-                    | EmptyResult ->
-                        foundEmpty := true
-                        if verbose then tracefn "No results, trying again with NormalizedVersion as Version."
-                        return! fallback4()
-                    | res -> return res
+                    let res = parseODataEntryDetails(url,nugetSource.Url,packageName,version,doc)
+                    return Choice1Of2 (res |> ODataSearchResult.Match)
                 with ex ->
-                    return! fallback4()
+                    return Choice2Of2 ex
             }
-
-        let fallback2 () =
+        let handleListUrl url =
             async {
                 try
-                    let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%s') and (NormalizedVersion eq '%O')" nugetURL (packageName.CompareString) version
-                    let! raw = getFromUrl(auth,url,acceptXml)
+                    let! raw = getFromUrl(nugetSource.BasicAuth,url,acceptXml)
                     if verbose then
                         tracefn "Response from %s:" url
                         tracefn ""
                         tracefn "%s" raw
                     let doc = getXmlDoc url raw
-                    match parseODataListDetails(url,nugetURL,packageName,version,doc) with
-                    | EmptyResult when isBlessed ->
-                        return EmptyResult
+                    match parseODataListDetails(url,nugetSource.Url,packageName,version,doc) with
                     | EmptyResult ->
-                        foundEmpty := true
-                        if verbose then tracefn "No results, trying again with Version instead of NormalizedVersion."
-                        return! fallback3()
-                    | res -> return res
+                        return Choice2Of2 (exn "Empty response is not trusted")
+                    | res -> return Choice1Of2 res
                 with ex ->
-                    return! fallback3()
+                    return Choice2Of2 ex
             }
-       
-        let fallback () =
-            async {
-                try
-                    let url = sprintf "%s/Packages?$filter=(tolower(Id) eq '%s') and (NormalizedVersion eq '%O')" nugetURL (packageName.CompareString) normalizedVersion
-                    let! raw = getFromUrl(auth,url,acceptXml)
-                    if verbose then
-                        tracefn "Response from %s:" url
-                        tracefn ""
-                        tracefn "%s" raw
-                    let doc = getXmlDoc url raw
-                    match parseODataListDetails(url,nugetURL,packageName,version,doc) with
-                    | EmptyResult when isBlessed ->
-                        return EmptyResult
-                    | EmptyResult ->
-                        foundEmpty := true
-                        if verbose then tracefn "No results, trying again with Version as NormalizedVersion."
-                        return! fallback2()
-                    | res -> return res
-                with ex ->
-                    return! fallback2()
-            }
+        let handleUrl (url:string) =
+            let realUrl = url.Substring(2)
+            if url.StartsWith "1_"
+            then handleEntryUrl realUrl
+            else handleListUrl realUrl
+        let tryAgain c =
+            match c with
+            | Choice1Of2 _ -> false
+            | _ -> true
 
-        let firstUrl = sprintf "%s/Packages?$filter=(Id eq '%s') and (NormalizedVersion eq '%s')" nugetURL (packageName.ToString()) normalizedVersion
-        try
-            let! raw = getFromUrl(auth,firstUrl,acceptXml)
-            if verbose then
-                tracefn "Response from %s:" firstUrl
-                tracefn ""
-                tracefn "%s" raw
-            let doc = getXmlDoc firstUrl raw
-            match parseODataListDetails(firstUrl,nugetURL,packageName,version,doc) with
-            | EmptyResult ->
-                foundEmpty := true
-                if verbose then tracefn "No results, trying again with case-insensitive version."
-                return! fallback()
-            | res -> return res
-        with ex ->
-            // TODO: Remove this 'with' eventually when this warning is no longer reported
-            traceWarnfn "Failed to getDetailsFromNuGetViaODataFast '%s'. Trying with Version instead of NormalizedVersion (Please report this warning!): %O" firstUrl ex
-            return! fallback()
+        let! result = NuGetCache.tryAndBlacklistUrl true nugetSource tryAgain handleUrl urls
+        match result with
+        | Choice1Of2 res -> return res
+        | Choice2Of2 ex -> return raise (exn("error", ex))
     }
 
-    
+
 /// Gets package details from NuGet via OData
-let getDetailsFromNuGetViaOData auth nugetURL (packageName:PackageName) (version:SemVerInfo) =
+let getDetailsFromNuGetViaOData nugetSource (packageName:PackageName) (version:SemVerInfo) =
     let queryPackagesProtocol (packageName:PackageName) =
         async {
-            let url = sprintf "%s/Packages(Id='%O',Version='%O')" nugetURL packageName version
-            let! response = safeGetFromUrl(auth,url,acceptXml)
+            let url = sprintf "%s/Packages(Id='%O',Version='%O')" nugetSource.Url packageName version
+            let! response = safeGetFromUrl(nugetSource.BasicAuth,url,acceptXml)
 
             let! raw =
                 match response with
                 | SafeWebResult.SuccessResponse r -> async { return Some r }
                 | SafeWebResult.NotFound -> async { return None }
                 | SafeWebResult.UnknownError err when
-                        urlIsMyGet nugetURL ||
-                        urlIsNugetGallery nugetURL ||
-                        urlSimilarToTfsOrVsts nugetURL ->
+                        urlIsMyGet nugetSource.Url ||
+                        urlIsNugetGallery nugetSource.Url ||
+                        urlSimilarToTfsOrVsts nugetSource.Url ->
                     raise <|
                         System.Exception(
-                            sprintf "Could not get package details for %O from %s" packageName nugetURL,
+                            sprintf "Could not get package details for %O from %s" packageName nugetSource.Url,
                             err.SourceException)
                 | SafeWebResult.UnknownError err ->
                     traceWarnfn "Failed to find defails '%s' from '%s'. trying again with /odata/Packages. Please report this." err.SourceException.Message url
@@ -417,8 +394,8 @@ let getDetailsFromNuGetViaOData auth nugetURL (packageName:PackageName) (version
                         tracefn "Details of last error (%s): %O" url err.SourceException
                     async {
                         try
-                            let url = sprintf "%s/odata/Packages(Id='%O',Version='%O')" nugetURL packageName version
-                            let! raw = getXmlFromUrl(auth,url)
+                            let url = sprintf "%s/odata/Packages(Id='%O',Version='%O')" nugetSource.Url packageName version
+                            let! raw = getXmlFromUrl(nugetSource.BasicAuth,url)
                             return Some raw
                         with e ->
                             return raise <| System.AggregateException(err.SourceException, e)
@@ -431,7 +408,7 @@ let getDetailsFromNuGetViaOData auth nugetURL (packageName:PackageName) (version
             match raw with
             | Some raw ->
                 let doc = getXmlDoc url raw
-                return parseODataEntryDetails(url,nugetURL,packageName,version,doc) |> ODataSearchResult.Match
+                return parseODataEntryDetails(url,nugetSource.Url,packageName,version,doc) |> ODataSearchResult.Match
             | None -> return ODataSearchResult.EmptyResult }
 
     async {
@@ -440,22 +417,22 @@ let getDetailsFromNuGetViaOData auth nugetURL (packageName:PackageName) (version
                 // See https://github.com/fsprojects/Paket/issues/2213
                 // TODO: There is a bug in VSTS, so we can't trust this protocol. Remove when VSTS is fixed
                 // TODO: TFS has the same bug
-                if urlSimilarToTfsOrVsts nugetURL then queryPackagesProtocol packageName
-                else getDetailsFromNuGetViaODataFast auth nugetURL packageName version
+                if urlSimilarToTfsOrVsts nugetSource.Url then queryPackagesProtocol packageName
+                else getDetailsFromNuGetViaODataFast nugetSource packageName version
             return result
-        with e when not (urlSimilarToTfsOrVsts nugetURL) ->
-            traceWarnfn "Failed to get package details '%s'. This feed's implementation might be broken." e.Message
+        with e when not (urlSimilarToTfsOrVsts nugetSource.Url) ->
+            traceWarnfn "Failed to get package details '%s'. This feeds implementation might be broken." e.Message
             if verbose then tracefn "Details: %O" e
             return! queryPackagesProtocol packageName
     }
 
-let getDetailsFromNuGet force auth nugetURL packageName version =
+let getDetailsFromNuGet force nugetSource packageName version =
     getDetailsFromCacheOr
         force
-        nugetURL
+        nugetSource.Url
         packageName
         version
-        (fun () -> getDetailsFromNuGetViaOData auth nugetURL packageName version)
+        (fun () -> getDetailsFromNuGetViaOData nugetSource packageName version)
 
 
 

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -76,6 +76,8 @@ type KnownNuGetSources =
 type NugetSource = 
     { Url : string
       Authentication : NugetSourceAuthentication option }
+    member x.BasicAuth =
+        x.Authentication |> Option.map toBasicAuth
 
 type NugetV3SourceResourceJSON = 
     { [<JsonProperty("@type")>]
@@ -87,9 +89,10 @@ type NugetV3SourceRootJSON =
     { [<JsonProperty("resources")>]
       Resources : NugetV3SourceResourceJSON [] }
 
-type NugetV3Source = 
-    { Url : string
-      Authentication : NugetSourceAuthentication option }
+type NugetV3Source = NugetSource
+//type NugetV3Source = 
+//    { Url : string
+//      Authentication : NugetSourceAuthentication option }
 
 type NugetV3ResourceType = 
     | AutoComplete


### PR DESCRIPTION
initial sketch at trying to remove repeated feed warnings and blacklist feeds.

I think this implementation has still some problems:
 - [x] Feeds might be blacklisted on error as we even blacklist on valid but empty responses
        This is not trivial to fix and probably needs some trial and error with real feeds. And me going though all the old issues again ...
- [ ] We decided to get rid of the warning on restore as well. This PR does not implement that part jet (as I want to do those changes separately to make this easier to review for now.

This should in effect reduce the amount of warnings and at the same time improve the performance by less "doomed to fail" requests. Lets see what the CI says.