### PR TITLE
Docfix test runners clarification for #1501

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -35,8 +35,9 @@ the path. This makes it much easier to reference files in the package and you
 don't have to edit these references when you update a package.
 
 If you really need to have the version in the path for certain packages (like
-`xunit.runners.visualstudio`) you
+`xunit.runners.visualstudio` or `MSTest.TestAdapter`) you
 [can still do that](nuget-dependencies.html#Putting-the-version-number-in-the-path).
+Without the `version_in_path` flag, your unit tests will disappear from the Visual Studio Test Explorer.
 
 ## NuGet allows to use multiple versions of the same package. Can I do that with Paket?
 

--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -254,6 +254,15 @@ source https://nuget.org/api/v2
 nuget xunit.runner.visualstudio >= 2.0 version_in_path: true
 ```
 
+You need this if you are using custom test runners in Visual Studio, 
+like `xunit.runners.visualstudio` or `MSTest.TestAdapter`.
+The [Visual Studio Test Runner caches the 
+packages](https://stackoverflow.com/questions/35103781/why-is-the-visual-studio-2015-2017-test-runner-not-discovering-my-xunit-v2-tests)
+in `%TEMP%\VisualStudioTestExplorerExtensions`, 
+and depends on the directory names being unique per version, and the presence of a packages.config in the test project.
+Adding the `version_in_path` flag makes your unit tests appear in the Visual Studio Test Explorer again.
+
+
 ### Controlling whether content files should be copied to the project
 
 The `content` modifier controls the installation of any content files:

--- a/src/Paket.Core/Installation/BindingRedirects.fs
+++ b/src/Paket.Core/Installation/BindingRedirects.fs
@@ -157,13 +157,16 @@ let private applyBindingRedirects isFirstGroup cleanBindingRedirects (allKnownLi
     |> List.filter (fun e -> isFirstGroup && (cleanBindingRedirects || isMarked e) && libIsContained e)
     |> List.iter (fun e -> e.Remove())
 
-    let config = Seq.fold setRedirect config bindingRedirects
-    indentAssemblyBindings config
-    use newContents = new StringReader(config.ToString())
-    let newText = XDocument.Load(newContents, LoadOptions.None).ToString()
-    if newText <> original then
-        use f = File.Open(configFilePath, FileMode.Create)
-        config.Save(f, SaveOptions.DisableFormatting)
+    try
+        let config = Seq.fold setRedirect config bindingRedirects
+        indentAssemblyBindings config
+        use newContents = new StringReader(config.ToString())
+        let newText = XDocument.Load(newContents, LoadOptions.None).ToString()
+        if newText <> original then
+            use f = File.Open(configFilePath, FileMode.Create)
+            config.Save(f, SaveOptions.DisableFormatting)
+    with
+    | exn -> failwithf "Binding Redirects in %s failed.%s%s" configFilePath Environment.NewLine exn.Message
 
 /// Applies a set of binding redirects to all .config files in a specific folder.
 let applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles cleanBindingRedirects rootPath allKnownLibNames bindingRedirects =

--- a/src/Paket.Core/Installation/BindingRedirects.fs
+++ b/src/Paket.Core/Installation/BindingRedirects.fs
@@ -157,16 +157,13 @@ let private applyBindingRedirects isFirstGroup cleanBindingRedirects (allKnownLi
     |> List.filter (fun e -> isFirstGroup && (cleanBindingRedirects || isMarked e) && libIsContained e)
     |> List.iter (fun e -> e.Remove())
 
-    try
-        let config = Seq.fold setRedirect config bindingRedirects
-        indentAssemblyBindings config
-        use newContents = new StringReader(config.ToString())
-        let newText = XDocument.Load(newContents, LoadOptions.None).ToString()
-        if newText <> original then
-            use f = File.Open(configFilePath, FileMode.Create)
-            config.Save(f, SaveOptions.DisableFormatting)
-    with
-    | exn -> failwithf "Binding Redirects in %s failed.%s%s" configFilePath Environment.NewLine exn.Message
+    let config = Seq.fold setRedirect config bindingRedirects
+    indentAssemblyBindings config
+    use newContents = new StringReader(config.ToString())
+    let newText = XDocument.Load(newContents, LoadOptions.None).ToString()
+    if newText <> original then
+        use f = File.Open(configFilePath, FileMode.Create)
+        config.Save(f, SaveOptions.DisableFormatting)
 
 /// Applies a set of binding redirects to all .config files in a specific folder.
 let applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles cleanBindingRedirects rootPath allKnownLibNames bindingRedirects =


### PR DESCRIPTION
Explain why VS test needs version-in-path flag set.