### PR TITLE
Fixes mac install script by switching it to https for nuget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,10 +9,10 @@ TMP=/tmp/paket/src
 LIB=/usr/local/lib
 BIN=/usr/local/bin
 
-LATEST=$(curl -s -G -d '$filter=Id%20eq%20'"'"'Paket'"'"'%20and%20IsPrerelease%20eq%20false&$orderby=LastUpdated%20desc&$top=1' "http://www.nuget.org/api/v2/Packages()" | sed -n 's;.*src="\([^"]*\).*;\1;p')
+LATEST=$(curl -s -G -d '$filter=Id%20eq%20'"'"'Paket'"'"'%20and%20IsPrerelease%20eq%20false&$orderby=LastUpdated%20desc&$top=1' "https://www.nuget.org/api/v2/Packages()" | sed -n 's;.*src="\([^"]*\).*;\1;p')
 
 if [ ! "$LATEST" ]; then
-  echo "Could not find a paket source on nuget.org. Please check your internet connection and access to http://www.nuget.org."
+  echo "Could not find a paket source on nuget.org. Please check your internet connection and access to https://www.nuget.org."
   exit 1
 fi
 


### PR DESCRIPTION
I was trying to install on Mac, and ran into the issue saying it couldn't connect to "http://www.nuget.org".  After changing it to use HTTPS, the script worked.