### PR TITLE
fix crash when a package contains an invalid file (ie is packaged inc…

### DIFF
--- a/src/Paket.Core/Common/Logging.fsi
+++ b/src/Paket.Core/Common/Logging.fsi
@@ -26,6 +26,10 @@ val traceErrorfn : Printf.StringFormat<'a,unit> -> 'a
 
 val traceWarnfn : Printf.StringFormat<'a,unit> -> 'a
 
+val traceWarnIfNotBefore : 'a ->  Printf.StringFormat<'b,unit> -> 'b
+val traceErrorIfNotBefore : 'a ->  Printf.StringFormat<'b,unit> -> 'b
+
+val getOmittedWarningCount : unit -> int
 
 type Trace = {
     Level: TraceLevel

--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -79,6 +79,8 @@ type NuGetRequestGetVersions =
 type UnparsedPackageFile =
     { FullPath : string
       PathWithinPackage : string }
+    member x.BasePath =
+        x.FullPath.Substring(0, x.FullPath.Length - (x.PathWithinPackage.Length + 1))
 
 module NuGetConfig =
     open System.Text

--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -190,7 +190,7 @@ let private handleODataEntry nugetURL packageName version entry =
                 match PlatformMatching.extractPlatforms false restriction with
                 | Some p -> Some p
                 | None ->
-                    Logging.traceWarnfn "Could not detect any platforms from '%s' in package %O %O" restriction packageName version
+                    Logging.traceWarnIfNotBefore ("Package", restriction, packageName, version) "Could not detect any platforms from '%s' in package %O %O, please tell the package authors" restriction packageName version
                     None
              else Some PlatformMatching.ParsedPlatformPath.Empty)
             |> Option.map (fun pp -> name, version, pp)

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -256,7 +256,7 @@ let getPackageDetails (source:NugetV3Source) (packageName:PackageName) (version:
                         | x ->
                             let restrictions, problems = Requirements.parseRestrictionsLegacy false x
                             for problem in problems do
-                                Logging.traceErrorfn "Could not detect any platforms from '%s' in %O %O" problem.Framework packageName version
+                                Logging.traceErrorIfNotBefore ("Package", problem.Framework, packageName, version) "Could not detect any platforms from '%s' in %O %O, please tell the package authors" problem.Framework packageName version
                             restrictions
                     (PackageName dep.Id), (VersionRequirement.Parse dep.Range), targetFramework)
                 |> Seq.toList

--- a/src/Paket.Core/Dependencies/Nuspec.fs
+++ b/src/Paket.Core/Dependencies/Nuspec.fs
@@ -36,7 +36,7 @@ module internal NuSpecParserHelper =
             match PlatformMatching.extractPlatforms false framework with
             | Some pp -> Some (name, version, pp)
             | None ->
-                Logging.traceWarnfn "Could not detect any platforms from '%s' in '%s'" framework fileName
+                Logging.traceWarnIfNotBefore ("NuSpecFile", framework, fileName) "Could not detect any platforms from '%s' in '%s', please tell the package authors" framework fileName
                 None
         | _ -> Some(name,version, PlatformMatching.ParsedPlatformPath.Empty)
 
@@ -84,7 +84,7 @@ type Nuspec =
                     match PlatformMatching.extractPlatforms false framework with
                     | Some p -> Some p
                     | None ->
-                        Logging.traceWarnfn "Could not detect any platforms from '%s' in '%s'" framework fileName
+                        Logging.traceWarnIfNotBefore ("NuSpecFile", framework, fileName) "Could not detect any platforms from '%s' in '%s', please tell the package authors" framework fileName
                         None
                 | _ -> Some PlatformMatching.ParsedPlatformPath.Empty)
 

--- a/src/Paket.Core/PackageManagement/NugetConvert.fs
+++ b/src/Paket.Core/PackageManagement/NugetConvert.fs
@@ -286,7 +286,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
                     |> List.map (fun fw ->
                         let restrictions, problems = Requirements.parseRestrictionsLegacy false fw
                         for problem in problems do
-                            Logging.traceErrorfn "Could not detect any platforms from '%s' in %O %O" problem.Framework name version
+                            Logging.traceErrorfn "Could not detect any platforms from '%s' in %O %O, please tell the package authors" problem.Framework name version
                         restrictions)
                 | _ -> []
             let restrictions =

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -367,7 +367,7 @@ module InstallModel =
                     (FolderScanner.choose "invalid tfm" (fun plats ->
                     let parsed = PlatformMatching.extractPlatforms false plats
                     if parsed.IsNone then
-                        traceWarnfn "Could not detect any platforms from '%s' in '%s'" plats upf.FullPath
+                        traceWarnIfNotBefore ("File", plats, upf.BasePath) "Could not detect any platforms from '%s' in '%s', please tell the package authors" plats upf.FullPath
                     parsed)) >> FolderScanner.ParseResult.box) }
           { FolderScanner.AdvancedScanner.Name = "rid";
             FolderScanner.AdvancedScanner.Parser =

--- a/src/Paket.Core/Versioning/PlatformMatching.fs
+++ b/src/Paket.Core/Versioning/PlatformMatching.fs
@@ -44,7 +44,7 @@ let extractPlatforms warn path =
     match extractPlatformsPriv path with
     | None ->
         if warn then
-            traceWarnfn "Could not detect any platforms from '%s'" path
+            Logging.traceWarnIfNotBefore ("extractPlatforms", path) "Could not detect any platforms from '%s', please tell the package authors" path
         None
     | Some s -> Some s
 

--- a/src/Paket.Core/Versioning/PlatformMatching.fs
+++ b/src/Paket.Core/Versioning/PlatformMatching.fs
@@ -34,10 +34,8 @@ let private extractPlatformsPriv = memoize (fun path ->
         if platforms.Length = 0 then
             if splits.Length = 1 && splits.[0].StartsWith "profile" then
                 // might be something like portable4.6-profile151
-                let found =
-                    KnownTargetProfiles.FindPortableProfile splits.[0]
-                    |> ParsedPlatformPath.FromTargetProfile
-                Some { found with Name = path }
+                KnownTargetProfiles.TryFindPortableProfile splits.[0]
+                |> Option.map (ParsedPlatformPath.FromTargetProfile >> fun p -> { p with Name = path })
             else
                 None
         else Some { Name = path; Platforms = platforms })

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,8 +31,8 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>restore</StartArguments>
-    <StartWorkingDirectory>C:\temp\perf\</StartWorkingDirectory>
+    <StartArguments>update</StartArguments>
+    <StartWorkingDirectory>C:\proj\testing\testpaketfailure\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -100,6 +100,9 @@ let processWithValidation silent validateF commandF (result : ParseResults<'T>) 
                     )
 
                 tracefn " - Runtime: %s" (Utils.TimeSpanToReadableString realTime)
+                let omitted = Logging.getOmittedWarningCount()
+                if not verbose && omitted > 0 then
+                    traceWarnfn "Paket omitted '%d' warnings similar to the ones above. You can see them in verbose mode" omitted
 
 let processCommand silent commandF result =
     processWithValidation silent (fun _ -> true) commandF result

--- a/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
@@ -52,6 +52,11 @@ let ``Can detect uap10``() =
     p.ToTargetProfile false |> shouldEqual (Some (SinglePlatform (FrameworkIdentifier.UAP UAPVersion.V10)))
 
 [<Test>]
+let ``Doesn't fail on profiles``() =
+    let p = PlatformMatching.extractPlatforms false "profiles"
+    p |> shouldEqual None
+
+[<Test>]
 let ``Can detect uap10.1``() =
     let p = PlatformMatching.forceExtractPlatforms "UAP10.1"
     p.ToTargetProfile false |> shouldEqual (Some (SinglePlatform (FrameworkIdentifier.UAP UAPVersion.V10_1)))


### PR DESCRIPTION
…orrectly) in the lib/profile* folder.

Before

```
$ ../../Paket/bin/paket.exe update
Paket version 5.85.8
Resolving packages for group Main:
 - Microsoft.Portable.FSharp.Core is pinned to 4.1.20
     Microsoft.Portable.FSharp.Core 4.1.20 was unlisted
The owner of Microsoft.Portable.FSharp.Core 4.1.20 has unlisted the package. This could mean that the package version is deprecated or shouldn't be used anymore.
Locked version resolution written to C:\Proj\testing\testpaketfailure\paket.lock
Installing into projects:
 - Creating model and downloading packages.
Performance:
 - Resolver: 558 milliseconds (1 runs)
    - Runtime: 343 milliseconds
    - Blocked (retrieving package details): 214 milliseconds (1 times)
 - Disk IO: 12 seconds
 - Average Request Time: 75 milliseconds
 - Number of Requests: 2
 - Runtime: 14 seconds
Paket failed with
-> tried to find portable profile 'profiles' but it is unknown to paket
```

After 

```
$ ../../Paket/bin/paket.exe update
Paket version 5.89.0
Resolving packages for group Main:
 - Microsoft.Portable.FSharp.Core is pinned to 4.1.20
     Microsoft.Portable.FSharp.Core 4.1.20 was unlisted
The owner of Microsoft.Portable.FSharp.Core 4.1.20 has unlisted the package. This could mean that the package version is deprecated or shouldn't be used anymore.
C:\Proj\testing\testpaketfailure\paket.lock is already up-to-date
Installing into projects:
 - Creating model and downloading packages.
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\net20\FSharp.Core.dll'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\net20\FSharp.Core.optdata'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\net20\FSharp.Core.sigdata'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\net20\FSharp.Core.xml'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\net40\FSharp.Core.dll'
... snip some thousand lines ...
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\localize\ResponseFiles\LocComplete_FSharp.Core_ENU.txt'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\localize\ResponseFiles\OutputXML_FSharp.Core_ENU.xml'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\localize\RUS\FSharp.Core.dll.lct'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\localize\RUS\FSharp.Core.resources.dll'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\localize\TRK\FSharp.Core.dll.lct'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\localize\TRK\FSharp.Core.resources.dll'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\FSharp.Core.dll'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\FSharp.Core.optdata'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\FSharp.Core.sigdata'
Could not detect any platforms from 'profiles' in 'C:\Proj\testing\testpaketfailure\packages\Microsoft.Portable.FSharp.Core\lib\profiles\xamarinmac20\FSharp.Core.xml'
Performance:
 - Resolver: 580 milliseconds (1 runs)
    - Runtime: 370 milliseconds
    - Blocked (retrieving package details): 209 milliseconds (1 times)
 - Disk IO: 13 milliseconds
 - Average Request Time: 77 milliseconds
 - Number of Requests: 2
 - Runtime: 3 seconds
```