### PR TITLE
Update nuget url in install.sh (fixes #2579)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,10 +9,10 @@ TMP=/tmp/paket/src
 LIB=/usr/local/lib
 BIN=/usr/local/bin
 
-LATEST=$(curl -s -G -d '$filter=Id%20eq%20'"'"'Paket'"'"'%20and%20IsPrerelease%20eq%20false&$orderby=LastUpdated%20desc&$top=1' "http://www.nuget.org/api/v2/Packages()" | sed -n 's;.*src="\([^"]*\).*;\1;p')
+LATEST=$(curl -s -G -d '$filter=Id%20eq%20'"'"'Paket'"'"'%20and%20IsPrerelease%20eq%20false&$orderby=LastUpdated%20desc&$top=1' "https://www.nuget.org/api/v2/Packages()" | sed -n 's;.*src="\([^"]*\).*;\1;p')
 
 if [ ! "$LATEST" ]; then
-  echo "Could not find a paket source on nuget.org. Please check your internet connection and access to http://www.nuget.org."
+  echo "Could not find a paket source on nuget.org. Please check your internet connection and access to https://www.nuget.org."
   exit 1
 fi
 


### PR DESCRIPTION
Fixes https://github.com/fsprojects/Paket/issues/2579, where install.sh no longer works.

Basically just a 2 character change to go from `http` to `https` because nuget has changed their behaviour to serve zero length content responses on the http endpoint. 
