### PR TITLE
Paket.Restore.targets: use fixed version ([1.0])

### DIFF
--- a/src/Paket/embedded/Paket.Restore.targets
+++ b/src/Paket/embedded/Paket.Restore.targets
@@ -38,7 +38,7 @@
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
-        <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+        <Version>[%(PaketReferencesFileLinesInfo.PackageVersion)]</Version>
       </PackageReference>
     </ItemGroup>
 
@@ -56,7 +56,7 @@
         <PackageVersion>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[1])</PackageVersion>
       </PaketCliToolFileLinesInfo>
       <DotNetCliToolReference Include="%(PaketCliToolFileLinesInfo.PackageName)">
-        <Version>%(PaketCliToolFileLinesInfo.PackageVersion)</Version>
+        <Version>[%(PaketCliToolFileLinesInfo.PackageVersion)]</Version>
       </DotNetCliToolReference>
     </ItemGroup>
 


### PR DESCRIPTION
fixes https://github.com/fsprojects/Paket/issues/2653

When the version is specified without the braces, then it will choose any version equal or higher, with preference for the lowest.