### PR TITLE
we need to prefer package over group settings

### DIFF
--- a/src/Paket.Core/Installation/DependencyChangeDetection.fs
+++ b/src/Paket.Core/Installation/DependencyChangeDetection.fs
@@ -51,7 +51,7 @@ let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFil
             let lockFileGroup = lockFile.Groups |> Map.tryFind groupName 
             depsGroup.Packages
             |> Seq.map (fun d ->
-                d.Name, { d with Settings = depsGroup.Options.Settings + d.Settings })
+                d.Name, { d with Settings = d.Settings + depsGroup.Options.Settings })
             |> Seq.map (fun (name,dependenciesFilePackage) ->
                 name, dependenciesFilePackage,
                 match lockFileGroup with
@@ -60,7 +60,7 @@ let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFil
                     match group.TryFind name with
                     | Some lockFilePackage ->
                         getChanges groupName transitives 
-                            { dependenciesFilePackage with Settings = depsGroup.Options.Settings + dependenciesFilePackage.Settings }
+                            { dependenciesFilePackage with Settings = dependenciesFilePackage.Settings + depsGroup.Options.Settings }
                             lockFilePackage
                     | _ -> [PackageNotFoundInLockFile])
             |> Seq.filter (fun (_,_, changes) -> changes.Length > 0)
@@ -73,7 +73,7 @@ let findNuGetChangesInDependenciesFile(dependenciesFile:DependenciesFile,lockFil
             | None -> Map.empty
             | Some group ->
                 group.Packages
-                |> Seq.map (fun d -> d.Name,{ d with Settings = group.Options.Settings + d.Settings })
+                |> Seq.map (fun d -> d.Name,{ d with Settings = d.Settings + group.Options.Settings })
                 |> Map.ofSeq
 
         [for t in lockFile.GetTopLevelDependencies(groupName) do


### PR DESCRIPTION
we need to prefer package over group settings, fixes https://github.com/fsprojects/Paket/issues/2682

Note: I didn't fully understand the root cause but (especially why a particular comparison contained "None"), but it seems to be obvious that we need to prefer package over group settings (and therefore have them in front of the "+"). @forki could you please quickly review if that makes sense?

This might have lead to incorrect comparisons of restrictions (but I don't get why I saw in the debugger a comparsion of "generate_load_scripts = Some true" with "generate_load_scripts = None" 

From my understanding it should never be "None" no matter the order of the arguments?!