### PR TITLE
Fix minor typo "up 2 date" -> "up to date"

### DIFF
--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -409,7 +409,7 @@ let Restore(dependenciesFileName,projectFile,force,group,referencesFileNames,ign
         else false
 
     if isEarlyExit () then
-        tracefn "Last restore is still up 2 date."
+        tracefn "Last restore is still up to date."
     else
         let dependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
 


### PR DESCRIPTION
All other instances of the phrase use the correct "up to date".