### PR TITLE
Don't use the global cache when paket.local is given. fixes #2690

### DIFF
--- a/integrationtests/Paket.IntegrationTests/LocalOverrideSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/LocalOverrideSpecs.fs
@@ -11,8 +11,10 @@ open FsUnit
 open NUnit.Framework
 
 [<Test>]
-let ``#1633 paket.local local source override``() = 
-    paket "restore" "i001633-local-source-override" |> ignore
+let ``#1633 paket.local local source override``() =
+    clearPackage "NUnit"
+
+    paketEx true "restore" "i001633-local-source-override" |> ignore
     let doc = new XmlDocument()
     Path.Combine(
         scenarioTempPath "i001633-local-source-override",
@@ -28,8 +30,18 @@ let ``#1633 paket.local local source override``() =
     |> Option.map (fun n -> n.InnerText)
     |> shouldEqual (Some "true")
 
+    // The package should not be in cache
+    isPackageCached "NUnit"
+    |> shouldEqual []
+
+    // Issue #2690
+    paketEx true "restore" "i001633-local-source-override" |> ignore
+
+    // The package should not be in cache
+    isPackageCached "NUnit"
+    |> shouldEqual []
+
 let replaceInFile filePath (searchText: string) replaceText =
     File.ReadAllText filePath
     |> fun x -> x.Replace(searchText, replaceText)
     |> fun x -> File.WriteAllText (filePath, x)
-    

--- a/integrationtests/Paket.IntegrationTests/NuGetV3Specs.fs
+++ b/integrationtests/Paket.IntegrationTests/NuGetV3Specs.fs
@@ -16,3 +16,19 @@ let ``#1387 update package in v3``() =
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001387-nugetv3","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Bender"].Version
     |> shouldEqual (SemVer.Parse "3.0.29.0")
+
+[<Test>]
+let ``#2700-1 v3 works properly``() =
+    paketEx true "update" "i002700-1" |> ignore
+    let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i002700-1","paket.lock"))
+    let mainGroup = lockFile.Groups.[Constants.MainDependencyGroup]
+    mainGroup.Resolution.[PackageName "Microsoft.CSharp"].Source.Url
+    |> shouldEqual "https://www.myget.org/F/dotnet-core-svc/api/v3/index.json"
+
+[<Test>]
+let ``#2700-2 v2 is not upgraded to v3``() =
+    updateEx true "i002700-2" |> ignore
+    let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i002700-2","paket.lock"))
+    let mainGroup = lockFile.Groups.[Constants.MainDependencyGroup]
+    mainGroup.Resolution.[PackageName "Microsoft.CSharp"].Source.Url
+    |> shouldEqual "https://www.myget.org/F/dotnet-core-svc"

--- a/integrationtests/Paket.IntegrationTests/TestHelper.fs
+++ b/integrationtests/Paket.IntegrationTests/TestHelper.fs
@@ -206,3 +206,39 @@ let updateShouldFindPackageConflict packageName scenario =
         printfn "Ninject conflict test passed"
         #endif
         ()
+
+let clearPackage name =
+    // ~/.nuget/packages
+    let userPackageFolder = Paket.Constants.UserNuGetPackagesFolder
+
+    // %APPDATA%/NuGet/Cache
+    let nugetCache = Paket.Constants.NuGetCacheFolder
+
+    for cacheDir in [ nugetCache; userPackageFolder ] do
+        if Directory.Exists cacheDir then
+            Directory.EnumerateDirectories(cacheDir)
+            |> Seq.filter (fun n -> Path.GetFileName n |> String.startsWithIgnoreCase name)
+            |> Seq.iter (fun n -> Directory.Delete(n, true))
+            Directory.EnumerateFiles(cacheDir)
+            |> Seq.filter (fun n -> Path.GetFileName n |> String.startsWithIgnoreCase name)
+            |> Seq.iter (fun n -> File.Delete(n))
+
+let isPackageCached name =
+    // ~/.nuget/packages
+    let userPackageFolder = Paket.Constants.UserNuGetPackagesFolder
+
+    // %APPDATA%/NuGet/Cache
+    let nugetCache = Paket.Constants.NuGetCacheFolder
+
+    [ nugetCache; userPackageFolder ]
+    |> List.collect (fun cacheDir ->
+        if Directory.Exists cacheDir then
+            let dirs =
+                Directory.EnumerateDirectories(cacheDir)
+                |> Seq.filter (fun n -> Path.GetFileName n |> String.startsWithIgnoreCase name)
+            let files =
+                Directory.EnumerateFiles(cacheDir)
+                |> Seq.filter (fun n -> Path.GetFileName n |> String.startsWithIgnoreCase name)
+            Seq.append dirs files
+            |> Seq.toList
+        else [])

--- a/integrationtests/scenarios/i002700-1/before/paket.dependencies
+++ b/integrationtests/scenarios/i002700-1/before/paket.dependencies
@@ -1,0 +1,3 @@
+source https://www.myget.org/F/dotnet-core-svc/api/v3/index.json
+
+nuget Microsoft.CSharp prerelease

--- a/integrationtests/scenarios/i002700-2/before/paket.dependencies
+++ b/integrationtests/scenarios/i002700-2/before/paket.dependencies
@@ -1,0 +1,3 @@
+source https://www.myget.org/F/dotnet-core-svc
+
+nuget Microsoft.CSharp prerelease

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -448,7 +448,7 @@ let GetVersions force alternativeProjectRoot root (sources, packageName:PackageN
 
                                 return v2Feeds
                        | NuGetV3 source ->
-                            let! versionsAPI = PackageSources.getNuGetV3Resource source AllVersionsAPI
+                            let! versionsAPI = NuGetV3.getNuGetV3Resource source NuGetV3.AllVersionsAPI
                             let auth = source.Authentication |> Option.map toCredentials
                             return [ getVersionsCached "V3" tryNuGetV3 (nugetSource, auth, versionsAPI, packageName) ]
                        | LocalNuGet(path,Some _) ->

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -5,6 +5,8 @@ open Newtonsoft.Json
 open System.IO
 open System.Collections.Generic
 
+open System
+open System.Threading.Tasks
 open Paket.Domain
 open Paket.NuGetCache
 open Paket.Utils
@@ -13,6 +15,85 @@ open Paket.PackageSources
 open Paket.Requirements
 open Paket.Logging
 open Paket.PlatformMatching
+
+
+type NugetV3SourceResourceJSON = 
+    { [<JsonProperty("@type")>]
+      Type : string
+      [<JsonProperty("@id")>]
+      ID : string }
+
+type NugetV3SourceRootJSON = 
+    { [<JsonProperty("resources")>]
+      Resources : NugetV3SourceResourceJSON [] }
+
+//type NugetV3Source = 
+//    { Url : string
+//      Authentication : NugetSourceAuthentication option }
+
+type NugetV3ResourceType =
+    | AutoComplete
+    | AllVersionsAPI
+    //| Registration
+    | PackageIndex
+
+    member this.AsString =
+        match this with
+        | AutoComplete -> "SearchAutoCompleteService"
+        //| Registration -> "RegistrationsBaseUrl"
+        | AllVersionsAPI -> "PackageBaseAddress/3.0.0"
+        | PackageIndex -> "PackageDisplayMetadataUriTemplate"
+
+// Cache for nuget indices of sources
+type ResourceIndex = Map<NugetV3ResourceType,string>
+let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<NugetV3Source,Task<ResourceIndex>>()
+
+let getNuGetV3Resource (source : NugetV3Source) (resourceType : NugetV3ResourceType) : Async<string> =
+    let key = source
+    let getResourcesRaw () =
+        async {
+            let basicAuth = source.Authentication |> Option.map toCredentials
+            let! rawData = safeGetFromUrl(basicAuth, source.Url, acceptJson)
+            let rawData =
+                match rawData with
+                | NotFound ->
+                    raise <| new Exception(sprintf "Could not load resources (404) from '%s'" source.Url)
+                | UnknownError e ->
+                    raise <| new Exception(sprintf "Could not load resources from '%s'" source.Url, e.SourceException)
+                | SuccessResponse x -> x
+
+            let json = JsonConvert.DeserializeObject<NugetV3SourceRootJSON>(rawData)
+            let resources =
+                json.Resources
+                |> Seq.distinctBy(fun x -> x.Type.ToLower())
+                |> Seq.map(fun x -> x.Type.ToLower(), x.ID)
+            let map =
+                resources
+                |> Seq.choose (fun (res, value) ->
+                    let resType =
+                        match res.ToLower() with
+                        | "searchautocompleteservice" -> Some AutoComplete
+                        //| "registrationsbaseurl" -> Some Registration
+                        | "packagedisplaymetadatauritemplate" -> Some PackageIndex
+                        | "packagebaseaddress/3.0.0" -> Some AllVersionsAPI
+                        | _ -> None
+                    match resType with
+                    | None -> None
+                    | Some k ->
+                        Some (k, value))
+                |> Seq.distinctBy fst
+                |> Map.ofSeq
+            return map
+        } |> Async.StartAsTask
+
+    async {
+        let t = nugetV3Resources.GetOrAdd(key, (fun _ -> getResourcesRaw()))
+        let! res = t |> Async.AwaitTask
+        return
+            match res.TryFind resourceType with
+            | Some s -> s
+            | None -> failwithf "could not find an %s endpoint for %s" (resourceType.ToString()) source.Url
+    }
 
 /// [omit]
 type JSONResource = 
@@ -70,7 +151,7 @@ let getSearchAPI(auth,nugetUrl) =
             | None -> return None
             | Some v3Path -> 
                 let source = { Url = v3Path; Authentication = auth }
-                let! v3res = PackageSources.getNuGetV3Resource source AutoComplete |> Async.Catch
+                let! v3res = getNuGetV3Resource source AutoComplete |> Async.Catch
                 return 
                     match v3res with
                     | Choice1Of2 s -> Some s
@@ -87,7 +168,7 @@ let getAllVersionsAPI(auth,nugetUrl) =
             | None -> return None
             | Some v3Path ->
                 let source = { Url = v3Path; Authentication = auth }
-                let! v3res = PackageSources.getNuGetV3Resource source AllVersionsAPI |> Async.Catch
+                let! v3res = getNuGetV3Resource source AllVersionsAPI |> Async.Catch
                 return
                     match v3res with
                     | Choice1Of2 s -> Some s
@@ -176,12 +257,6 @@ let FindPackages(auth, nugetURL, packageNamePrefix, maxResults) =
         return! getPackages(auth, nugetURL, packageNamePrefix, maxResults)
     }
 
-type Registration = 
-    { [<JsonProperty("catalogEntry")>]
-      CatalogEntry : string
-      
-      [<JsonProperty("packageContent")>]
-      PackageContent : string }
 
 type CatalogDependency = 
     { [<JsonProperty("id")>]
@@ -201,43 +276,128 @@ type Catalog =
       
       [<JsonProperty("listed")>]
       Listed : System.Nullable<bool>
+
+      [<JsonProperty("version")>]
+      Version : string
       
       [<JsonProperty("dependencyGroups")>]
       DependencyGroups : CatalogDependencyGroup [] }
 
-let getRegistration (source : NugetV3Source) (packageName:PackageName) (version:SemVerInfo) =
+
+type PackageIndexPackage =
+    { [<JsonProperty("@type")>]
+      Type: string
+      [<JsonProperty("packageContent")>]
+      DownloadLink: string
+      [<JsonProperty("catalogEntry")>]
+      PackageDetails: Catalog
+      }
+
+type PackageIndexPage =
+    { [<JsonProperty("@id")>]
+      Id: string
+      [<JsonProperty("@type")>]
+      Type: string
+      [<JsonProperty("items")>]
+      Packages: PackageIndexPackage []
+      [<JsonProperty("count")>]
+      Count: int
+      [<JsonProperty("lower")>]
+      Lower: string
+      [<JsonProperty("upper")>]
+      Upper: string }
+
+type PackageIndex = 
+    { [<JsonProperty("@id")>]
+      Id: string
+      [<JsonProperty("items")>]
+      Pages: PackageIndexPage []
+      [<JsonProperty("count")>]
+      Count : int }
+
+let private getPackageIndexRaw (source : NugetV3Source) (packageName:PackageName) =
     async {
-        let! registrationUrl = PackageSources.getNuGetV3Resource source Registration
-        let url = sprintf "%s%s/%s.json" registrationUrl (packageName.ToString().ToLower()) (version.Normalize())
+        let! registrationUrl = getNuGetV3Resource source PackageIndex
+        let url = registrationUrl.Replace("{id-lower}", packageName.ToString().ToLower()) // sprintf "%s%s/%s.json" registrationUrl (packageName.ToString().ToLower()) (version.Normalize())
         let! rawData = safeGetFromUrl (source.Authentication |> Option.map toCredentials, url, acceptJson)
         return
             match rawData with
             | NotFound -> None //raise <| System.Exception(sprintf "could not get registration data (404) from '%s'" url)
             | UnknownError err ->
                 raise <| System.Exception(sprintf "could not get registration data from %s" url, err.SourceException)
-            | SuccessResponse x -> Some (JsonConvert.DeserializeObject<Registration>(x))
+            | SuccessResponse x -> Some (JsonConvert.DeserializeObject<PackageIndex>(x))
     }
 
-let getCatalog url auth =
+let private getPackageIndexMemoized =
+    memoizeAsync (fun (source, packageName) -> getPackageIndexRaw source packageName)
+let getPackageIndex source packageName = getPackageIndexMemoized (source, packageName)
+
+
+let private getPackageIndexPageRaw (source:NugetV3Source) (url:string) =
     async {
-        let! rawData = safeGetFromUrl (auth, url, acceptJson)
+        let! rawData = safeGetFromUrl (source.Authentication |> Option.map toCredentials, url, acceptJson)
         return
             match rawData with
-            | NotFound ->
-                raise <| System.Exception(sprintf "could not get catalog data (404) from '%s'" url)
+            | NotFound -> raise <| System.Exception(sprintf "could not get registration data (404) from '%s'" url)
             | UnknownError err ->
-                raise <| System.Exception(sprintf "could not get catalog data from %s" url, err.SourceException)
-            | SuccessResponse x -> JsonConvert.DeserializeObject<Catalog>(x)
+                raise <| System.Exception(sprintf "could not get registration data from %s" url, err.SourceException)
+            | SuccessResponse x -> JsonConvert.DeserializeObject<PackageIndexPage>(x)
+    }
+
+let private getPackageIndexPageMemoized =
+    memoizeAsync (fun (source, url) -> getPackageIndexPageRaw source url)
+let getPackageIndexPage source (page:PackageIndexPage) = getPackageIndexPageMemoized (source, page.Id)
+
+
+let getRelevantPage (source:NugetV3Source) (index:PackageIndex) (version:SemVerInfo) =
+    async {
+        let pages =
+            index.Pages
+            |> Seq.filter (fun p -> SemVer.Parse p.Lower <= version && version <= SemVer.Parse p.Upper)
+            |> Seq.toList
+
+        match pages with
+        | [ page ] ->
+            let! resolvedPage = async {
+                if page.Count > 0 && (isNull page.Packages || page.Packages.Length = 0) then
+                    return! getPackageIndexPage source page
+                else return page }
+            if page.Count > 0 && (isNull page.Packages || page.Packages.Length = 0) then
+                failwithf "Page should contain packages!"
+
+            let packages =
+                resolvedPage.Packages
+                    |> Seq.filter (fun p -> SemVer.Parse p.PackageDetails.Version = version)
+                    |> Seq.toList
+            match packages with
+            | [ package ] -> return Some package
+            | _ -> return failwithf "Version '%O' should be part of part of page '%s' but wasn't." version page.Id
+        | [] ->
+            return None
+        | _ :: _ ->
+            return failwithf "Mulitple pages of V3 index '%s' match with version '%O'" index.Id version
+
+        //let! rawData = safeGetFromUrl (auth, url, acceptJson)
+        //return
+        //    match rawData with
+        //    | NotFound ->
+        //        raise <| System.Exception(sprintf "could not get catalog data (404) from '%s'" url)
+        //    | UnknownError err ->
+        //        raise <| System.Exception(sprintf "could not get catalog data from %s" url, err.SourceException)
+        //    | SuccessResponse x -> JsonConvert.DeserializeObject<Catalog>(x)
     }
 
 let getPackageDetails (source:NugetV3Source) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
     async {
-        let! registrationData = getRegistration source packageName version
-        match registrationData with
+        let! pageIndex = getPackageIndex source packageName// version
+        match pageIndex with
         | None -> return EmptyResult
-        | Some registrationData ->
-        let! catalogData = getCatalog registrationData.CatalogEntry (source.Authentication |> Option.map toCredentials)
-
+        | Some pageIndex ->
+        let! relevantPage = getRelevantPage source pageIndex version
+        match relevantPage with
+        | None -> return EmptyResult
+        | Some relevantPage ->
+        let catalogData = relevantPage.PackageDetails
         let dependencyGroups, dependencies = 
             if catalogData.DependencyGroups = null then
                 [], []
@@ -281,7 +441,7 @@ let getPackageDetails (source:NugetV3Source) (packageName:PackageName) (version:
               PackageName = packageName.ToString()
               SourceUrl = source.Url
               Unlisted = unlisted
-              DownloadUrl = registrationData.PackageContent
+              DownloadUrl = relevantPage.DownloadLink
               LicenseUrl = catalogData.LicenseUrl
               Version = version.Normalize()
               CacheVersion = NuGetPackageCache.CurrentCacheVersion }

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -39,13 +39,13 @@ let CopyToCaches force caches fileName =
                 traceWarnfn "Could not copy %s to cache %s%s%s" fileName cache.Location Environment.NewLine exn.Message)
 
 /// returns - package, libs files, props files, targets files, analyzers files
-let private extractPackage caches (package:PackageInfo) alternativeProjectRoot root source groupName version includeVersionInPath force =
+let private extractPackage caches (package:PackageInfo) alternativeProjectRoot root isLocalOverride source groupName version includeVersionInPath force =
     let downloadAndExtract force detailed = async {
         let cfg = defaultArg package.Settings.StorageConfig PackagesFolderGroupConfig.Default
 
         let! fileName,folder = 
-            NuGet.DownloadPackage(
-                alternativeProjectRoot, root, cfg, source, caches, groupName, 
+            NuGet.DownloadAndExtractPackage(
+                alternativeProjectRoot, root, isLocalOverride, cfg, source, caches, groupName, 
                 package.Name, version, package.IsCliTool, includeVersionInPath, force, detailed)
 
         CopyToCaches force caches fileName
@@ -110,10 +110,10 @@ let ExtractPackage(alternativeProjectRoot, root, groupName, sources, caches, for
                     | None -> failwithf "The NuGet source %s for package %O was not found in the paket.dependencies file with sources %A" package.Source.Url package.Name sources
                     | Some s -> s 
 
-                return! extractPackage caches package alternativeProjectRoot root source groupName v includeVersionInPath force
+                return! extractPackage caches package alternativeProjectRoot root localOverride source groupName v includeVersionInPath force
 
             | LocalNuGet(path,_) as source ->
-                return! extractPackage caches package alternativeProjectRoot root source groupName v includeVersionInPath force
+                return! extractPackage caches package alternativeProjectRoot root localOverride source groupName v includeVersionInPath force
         }
 
         // manipulate overridenFile after package extraction

--- a/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
+++ b/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
@@ -204,7 +204,7 @@ module RuntimeGraph =
         let config = PackagesFolderGroupConfig.NoPackagesFolder
         // 1. downloading packages into cache
         let targetFileName, _ =
-            NuGet.DownloadPackage (None, root, config, package.Source, [], groupName, package.Name, package.Version, package.IsCliTool, false, false, false)
+            NuGet.DownloadAndExtractPackage (None, root, false, config, package.Source, [], groupName, package.Name, package.Version, package.IsCliTool, false, false, false)
             |> Async.RunSynchronously
 
         let extractedDir = NuGetCache.ExtractPackageToUserFolder (targetFileName, package.Name, package.Version, package.IsCliTool, null) |> Async.RunSynchronously

--- a/src/Paket.Core/Versioning/SemVer.fs
+++ b/src/Paket.Core/Versioning/SemVer.fs
@@ -156,6 +156,7 @@ type SemVerInfo =
 
             | _ -> invalidArg "yobj" "cannot compare values of different types"
 
+
 ///  Parser which allows to deal with [Semantic Versioning](http://semver.org/) (SemVer).
 module SemVer = 
     /// Parses the given version string into a SemVerInfo which can be printed using ToString() or compared

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,8 +31,8 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>C:\proj\testing\VS2017PerfIssue\</StartWorkingDirectory>
+    <StartArguments>update</StartArguments>
+    <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -42,8 +42,8 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
-    <StartArguments>install</StartArguments>
-    <StartWorkingDirectory>C:\proj\testing\VS2017PerfIssue\</StartWorkingDirectory>
+    <StartArguments>update</StartArguments>
+    <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">14.0</VisualStudioVersion>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -31,7 +31,7 @@
     <StartAction>Project</StartAction>
     <StartProgram>paket.exe</StartProgram>
     <StartAction>Project</StartAction>
-    <StartArguments>update</StartArguments>
+    <StartArguments>restore</StartArguments>
     <StartWorkingDirectory>C:\proj\testing\</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
See #2690 

paket.local + new sdk style projects is no longer supported.