### PR TITLE
Make MSBuild track Paket.Restore.targets for incremental builds

### DIFF
--- a/src/Paket/embedded/Paket.Restore.targets
+++ b/src/Paket/embedded/Paket.Restore.targets
@@ -2,6 +2,9 @@
   <!-- Prevent dotnet template engine to parse this file -->
   <!--/-:cnd:noEmit-->
   <PropertyGroup>
+    <!-- make MSBuild track this file for incremental builds. -->
+    <!-- ref https://blogs.msdn.microsoft.com/msbuild/2005/09/26/how-to-ensure-changes-to-a-custom-target-file-prompt-a-rebuild/ -->
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <!-- Mark that this target file has been loaded.  -->
     <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
     <PaketToolsPath>$(MSBuildThisFileDirectory)</PaketToolsPath>


### PR DESCRIPTION
https://blogs.msdn.microsoft.com/msbuild/2005/09/26/how-to-ensure-changes-to-a-custom-target-file-prompt-a-rebuild/


Currently "paket install" seems to just always overwrite all project files. This means after an install i will need to build all projects, anyway (because the timestamp changed).

I would (at a later unspecified time) like to modify it so it doesn't do this. But then for incremental builds to continue working correctly, MSBuild needs to know that it should track our targets file for incremental builds.