### PR TITLE
[WIP] Parallel execution of bootstrapper

### DIFF
--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -106,31 +106,22 @@ Options:
             File.Move(oldPath, newPath);
         }
 
-        public static bool ValidateHash(IFileSystemProxy fileSystem, string hashFile, string version, string paketFile)
+        public static bool ValidateHash(IFileSystemProxy fileSystem, PaketHashFile hashFile, string version, string paketFile)
         {
             if (hashFile == null)
             {
-                ConsoleImpl.WriteTrace("No hash file expected, bypassing check.");
+                ConsoleImpl.WriteTrace("No hashFile file expected, bypassing check.");
                 return true;
             }
         
-            if (!fileSystem.FileExists(hashFile))
-            {
-                ConsoleImpl.WriteInfo("No hash file of version {0} found.", version);
-
-                return true;
-            }
-
-            var dict = fileSystem.ReadAllLines(hashFile)
+            var dict = hashFile.Content
                 .Select(i => i.Split(' '))
                 .ToDictionary(i => i[1], i => i[0]);
 
             string expectedHash;
             if (!dict.TryGetValue("paket.exe", out expectedHash))
             {
-                fileSystem.DeleteFile(hashFile);
-
-                throw new InvalidDataException("Paket hash file is corrupted");
+                throw new InvalidDataException("Paket hashFile file is corrupted");
             }
 
             using (var stream = fileSystem.OpenRead(paketFile))

--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -29,18 +29,35 @@ Options:
 --run <other args>             run the downloaded paket.exe with all following arguments";
         const string PaketBootstrapperUserAgent = "Paket.Bootstrapper";
 
-        internal static string GetLocalFileVersion(string target)
+        internal static string GetLocalFileVersion(string target, FileSystemProxy fileSystemProxy)
         {
-            if (!File.Exists(target)) return "";
+            if (!File.Exists(target))
+            {
+                ConsoleImpl.WriteTrace("File doesn't exists, no version information: {0}", target);
+                return "";
+            }
 
             try
             {
-                var bytes = File.ReadAllBytes(target);
-                var attr = Assembly.Load(bytes).GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false).Cast<AssemblyInformationalVersionAttribute>().FirstOrDefault();
-                if (attr == null) return "";
+                var bytes = new MemoryStream();
+                using (var stream = fileSystemProxy.OpenRead(target))
+                {
+                    stream.CopyTo(bytes);
+                }
+                var attr = Assembly.ReflectionOnlyLoad(bytes.ToArray()).GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false).Cast<AssemblyInformationalVersionAttribute>().FirstOrDefault();
+                if (attr == null)
+                {
+                    ConsoleImpl.WriteWarning("No assembly version found in {0}", target);
+                    return "";
+                }
+                
                 return attr.InformationalVersion;
             }
-            catch (Exception) { return ""; }
+            catch (Exception exception)
+            {
+                ConsoleImpl.WriteWarning("Unable to get file version from {0}: {1}", target, exception);
+                return "";
+            }
         }
 
         internal static string GetTempFile(string name)
@@ -130,6 +147,8 @@ Options:
                 byte[] checksum = sha.ComputeHash(stream);
                 var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
 
+                ConsoleImpl.WriteTrace("Expected hash  = {0}", expectedHash);
+                ConsoleImpl.WriteTrace("paket.exe hash = {0} ({1})", hash, paketFile);
                 return string.Equals(expectedHash, hash, StringComparison.OrdinalIgnoreCase);
             }
         }

--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -44,7 +44,7 @@ Options:
                 {
                     stream.CopyTo(bytes);
                 }
-                var attr = Assembly.ReflectionOnlyLoad(bytes.ToArray()).GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false).Cast<AssemblyInformationalVersionAttribute>().FirstOrDefault();
+                var attr = Assembly.Load(bytes.ToArray()).GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false).Cast<AssemblyInformationalVersionAttribute>().FirstOrDefault();
                 if (attr == null)
                 {
                     ConsoleImpl.WriteWarning("No assembly version found in {0}", target);

--- a/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/CacheDownloadStrategy.cs
@@ -16,7 +16,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             get { return EffectiveStrategy.CanDownloadHashFile; }
         }
 
-        private readonly string _paketCacheDir =
+        public static readonly string PaketCacheDir =
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NuGet", "Cache", "Paket");
 
         public IDownloadStrategy EffectiveStrategy { get; set; }
@@ -56,7 +56,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
         protected override void DownloadVersionCore(string latestVersion, string target, PaketHashFile hashFile)
         {
-            var cached = Path.Combine(_paketCacheDir, latestVersion, "paket.exe");
+            var cached = Path.Combine(PaketCacheDir, latestVersion, "paket.exe");
 
             if (!FileSystemProxy.FileExists(cached))
             {
@@ -96,7 +96,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             if (!BootstrapperHelper.ValidateHash(FileSystemProxy, hashFile, latestVersion, tempFile))
             {
                 throw new InvalidOperationException(
-                    string.Format("paket.exe was currupted after download by {0}: Invalid hash",
+                    string.Format("paket.exe was corrupted after download by {0}: Invalid hash",
                         EffectiveStrategy.Name));
             }
 
@@ -124,7 +124,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
             var cachedPath = GetHashFilePathInCache(latestVersion);
 
-            if (File.Exists(cachedPath))
+            if (FileSystemProxy.FileExists(cachedPath))
             {
                 // Maybe there's another bootstraper process running
                 // We trust it to close the file with the correct content
@@ -175,10 +175,10 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
         private string GetLatestVersionInCache(bool ignorePrerelease)
         {
-            FileSystemProxy.CreateDirectory(_paketCacheDir);
+            FileSystemProxy.CreateDirectory(PaketCacheDir);
             var zero = new SemVer();
 
-            return FileSystemProxy.GetDirectories(_paketCacheDir)
+            return FileSystemProxy.GetDirectories(PaketCacheDir)
                 .Select(Path.GetFileName)
                 .OrderByDescending(x =>
                 {
@@ -201,7 +201,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
         public string GetHashFilePathInCache(string version)
         {
-            return Path.Combine(_paketCacheDir, version, "paket-sha256.txt");
+            return Path.Combine(PaketCacheDir, version, "paket-sha256.txt");
         }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
@@ -14,7 +14,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return Wrap(() => GetLatestVersionCore(ignorePrerelease), "GetLatestVersion");
         }
 
-        public void DownloadVersion(string latestVersion, string target, string hashfile)
+        public void DownloadVersion(string latestVersion, string target, PaketHashFile hashfile)
         {
             Wrap(() => DownloadVersionCore(latestVersion, target, hashfile), "DownloadVersion");
         }
@@ -24,15 +24,15 @@ namespace Paket.Bootstrapper.DownloadStrategies
             Wrap(() => SelfUpdateCore(latestVersion), "SelfUpdate");
         }
 
-        public string DownloadHashFile(string latestVersion)
+        public PaketHashFile DownloadHashFile(string latestVersion)
         {
             return Wrap(() => DownloadHashFileCore(latestVersion), "DownloadHashFile");
         }
 
         protected abstract string GetLatestVersionCore(bool ignorePrerelease);
-        protected abstract void DownloadVersionCore(string latestVersion, string target, string hashfile);
+        protected abstract void DownloadVersionCore(string latestVersion, string target, PaketHashFile hashfile);
         protected abstract void SelfUpdateCore(string latestVersion);
-        protected abstract string DownloadHashFileCore(string latestVersion);
+        protected abstract PaketHashFile DownloadHashFileCore(string latestVersion);
 
         private void Wrap(Action action, string actionName)
         {

--- a/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/DownloadStrategy.cs
@@ -61,13 +61,13 @@ namespace Paket.Bootstrapper.DownloadStrategies
             {
                 var result = func();
                 watch.Stop();
-                ConsoleImpl.WriteTrace("[{0}] {1} took {2:0.##} second(s) and returned {3}.", Name, actionName, watch.Elapsed.TotalSeconds, result);
+                ConsoleImpl.WriteTrace("[{0}] {1} took {2:0.##} second(s) and returned '{3}'.", Name, actionName, watch.Elapsed.TotalSeconds, result);
                 return result;
             }
             catch (Exception exception)
             {
                 watch.Stop();
-                ConsoleImpl.WriteTrace("[{0}] {1} took {2:0.##} second(s) and failed with {3}.", Name, actionName, watch.Elapsed.TotalSeconds, exception.Message);
+                ConsoleImpl.WriteTrace("[{0}] {1} took {2:0.##} second(s) and failed with '{3}'.", Name, actionName, watch.Elapsed.TotalSeconds, exception.Message);
                 throw;
             }
         }

--- a/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
@@ -8,6 +8,15 @@ namespace Paket.Bootstrapper.DownloadStrategies
 {
     public class GitHubDownloadStrategy : DownloadStrategy
     {
+#if DEBUG && LOCAL_GITHUB
+        public static class Constants
+        {
+            public const string PaketReleasesLatestUrl = "http://127.0.0.1:8080/fsprojects/Paket/releases/latest";
+            public const string PaketReleasesUrl = "http://127.0.0.1:8080/fsprojects/Paket/releases";
+            public const string PaketExeDownloadUrlTemplate = "http://127.0.0.1:8080/fsprojects/Paket/releases/download/{0}/paket.exe";
+            public const string PaketCheckSumDownloadUrlTemplate = "http://127.0.0.1:8080/fsprojects/Paket/releases/download/{0}/paket-sha256.txt";
+        }
+#else
         public static class Constants
         {
             public const string PaketReleasesLatestUrl = "https://github.com/fsprojects/Paket/releases/latest";
@@ -15,6 +24,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             public const string PaketExeDownloadUrlTemplate = "https://github.com/fsprojects/Paket/releases/download/{0}/paket.exe";
             public const string PaketCheckSumDownloadUrlTemplate = "https://github.com/fsprojects/Paket/releases/download/{0}/paket-sha256.txt";
         }
+#endif
 
         private IWebRequestProxy WebRequestProxy { get; set; }
         private IFileSystemProxy FileSystemProxy { get; set; }

--- a/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
@@ -85,7 +85,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return versions;
         }
 
-        protected override void DownloadVersionCore(string latestVersion, string target, string hashfile)
+        protected override void DownloadVersionCore(string latestVersion, string target, PaketHashFile hashfile)
         {
             var url = String.Format(Constants.PaketExeDownloadUrlTemplate, latestVersion);
             ConsoleImpl.WriteInfo("Starting download from {0}", url);
@@ -149,15 +149,14 @@ namespace Paket.Bootstrapper.DownloadStrategies
             }
         }
 
-        protected override string DownloadHashFileCore(string latestVersion)
+        protected override PaketHashFile DownloadHashFileCore(string latestVersion)
         {
-            var url = String.Format(Constants.PaketCheckSumDownloadUrlTemplate, latestVersion);
+            var url = string.Format(Constants.PaketCheckSumDownloadUrlTemplate, latestVersion);
             ConsoleImpl.WriteInfo("Starting download from {0}", url);
 
-            var tmpFile = BootstrapperHelper.GetTempFile("paket-sha256.txt");
-            WebRequestProxy.DownloadFile(url, tmpFile);
+            var content = WebRequestProxy.DownloadString(url);
 
-            return tmpFile;
+            return PaketHashFile.FromString(content);
         }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/GitHubDownloadStrategy.cs
@@ -8,23 +8,17 @@ namespace Paket.Bootstrapper.DownloadStrategies
 {
     public class GitHubDownloadStrategy : DownloadStrategy
     {
+        public static class Constants
+        {
 #if DEBUG && LOCAL_GITHUB
-        public static class Constants
-        {
-            public const string PaketReleasesLatestUrl = "http://127.0.0.1:8080/fsprojects/Paket/releases/latest";
             public const string PaketReleasesUrl = "http://127.0.0.1:8080/fsprojects/Paket/releases";
-            public const string PaketExeDownloadUrlTemplate = "http://127.0.0.1:8080/fsprojects/Paket/releases/download/{0}/paket.exe";
-            public const string PaketCheckSumDownloadUrlTemplate = "http://127.0.0.1:8080/fsprojects/Paket/releases/download/{0}/paket-sha256.txt";
-        }
 #else
-        public static class Constants
-        {
-            public const string PaketReleasesLatestUrl = "https://github.com/fsprojects/Paket/releases/latest";
             public const string PaketReleasesUrl = "https://github.com/fsprojects/Paket/releases";
-            public const string PaketExeDownloadUrlTemplate = "https://github.com/fsprojects/Paket/releases/download/{0}/paket.exe";
-            public const string PaketCheckSumDownloadUrlTemplate = "https://github.com/fsprojects/Paket/releases/download/{0}/paket-sha256.txt";
-        }
 #endif
+            public const string PaketReleasesLatestUrl = PaketReleasesUrl + "/latest";
+            public const string PaketExeDownloadUrlTemplate = PaketReleasesUrl + "/download/{0}/paket.exe";
+            public const string PaketCheckSumDownloadUrlTemplate = PaketReleasesUrl + "/download/{0}/paket-sha256.txt";
+        }
 
         private IWebRequestProxy WebRequestProxy { get; set; }
         private IFileSystemProxy FileSystemProxy { get; set; }

--- a/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/IDownloadStrategy.cs
@@ -5,9 +5,9 @@ namespace Paket.Bootstrapper.DownloadStrategies
         string Name { get; }
         IDownloadStrategy FallbackStrategy { get; set; }
         string GetLatestVersion(bool ignorePrerelease);
-        void DownloadVersion(string latestVersion, string target, string hashFile);
+        void DownloadVersion(string latestVersion, string target, PaketHashFile hashFile);
         void SelfUpdate(string latestVersion);
-        string DownloadHashFile(string latestVersion);
+        PaketHashFile DownloadHashFile(string latestVersion);
         bool CanDownloadHashFile { get; }
     }
 }

--- a/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
@@ -105,7 +105,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return latestVersion != null ? latestVersion.Original : String.Empty;
         }
 
-        protected override void DownloadVersionCore(string latestVersion, string target, string hashfile)
+        protected override void DownloadVersionCore(string latestVersion, string target, PaketHashFile hashfile)
         {
             var apiHelper = new NugetApiHelper(PaketNugetPackageName, NugetSource);
 
@@ -231,7 +231,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             FileSystemProxy.DeleteDirectory(randomFullPath, true);
         }
 
-        protected override string DownloadHashFileCore(string latestVersion)
+        protected override PaketHashFile DownloadHashFileCore(string latestVersion)
         {
             // TODO: implement get hash file
             return null;

--- a/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
@@ -59,7 +59,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             return latestVersion;
         }
 
-        protected override void DownloadVersionCore(string latestVersion, string target, string hashfile)
+        protected override void DownloadVersionCore(string latestVersion, string target, PaketHashFile hashfile)
         {
             _effectiveStrategy.DownloadVersion(latestVersion, target, hashfile);
             TouchTarget(target);
@@ -123,7 +123,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             }
         }
 
-        protected override string DownloadHashFileCore(string latestVersion)
+        protected override PaketHashFile DownloadHashFileCore(string latestVersion)
         {
             return _effectiveStrategy.DownloadHashFile(latestVersion);
         }

--- a/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
@@ -79,15 +79,9 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
         public IDownloadStrategy EffectiveStrategy {
             get { return _effectiveStrategy; }
-            set {
-                if (value == null)
-                    throw new ArgumentException("TemporarilyIgnoreUpdatesDownloadStrategy needs a non-null EffectiveStrategy");
-
-                _effectiveStrategy = value;
-            }
         }
             
-        private IDownloadStrategy _effectiveStrategy;
+        private readonly IDownloadStrategy _effectiveStrategy;
 
         private bool IsOlderThanMaxFileAge()
         {

--- a/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategy.cs
@@ -31,7 +31,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
 
         protected override string GetLatestVersionCore(bool ignorePrerelease)
         {
-            var targetVersion = string.Empty;
+            string targetVersion;
             try 
             {
                 targetVersion = fileSystemProxy.GetLocalFileVersion(_target);

--- a/src/Paket.Bootstrapper/HelperProxies/FileSystemProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/FileSystemProxy.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
 
 namespace Paket.Bootstrapper.HelperProxies
 {
@@ -41,7 +42,7 @@ namespace Paket.Bootstrapper.HelperProxies
             {
                 try
                 {
-                    File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None).Dispose();
+                    File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None).Dispose();
                     shouldContinue = false;
                 }
                 catch (Exception exception)
@@ -50,6 +51,8 @@ namespace Paket.Bootstrapper.HelperProxies
                     {
                         throw;
                     }
+
+                    Thread.Sleep(200);
                 }
             }
         }

--- a/src/Paket.Bootstrapper/HelperProxies/IFileSystemProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/IFileSystemProxy.cs
@@ -27,5 +27,8 @@ namespace Paket.Bootstrapper.HelperProxies
 
         string GetExecutingAssemblyPath();
         string GetTempPath();
+
+        Stream CreateExclusive(string path);
+        void WaitForFileFinished(string path);
     }
 }

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;LOCAL_GITHUB</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
@@ -56,6 +56,7 @@
     <Compile Include="BootstrapperOptions.cs" />
     <Compile Include="DownloadStrategies\IDownloadStrategy.cs" />
     <Compile Include="DownloadStrategies\IHaveEffectiveStrategy.cs" />
+    <Compile Include="PaketHashFile.cs" />
     <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="PaketDependencies.cs" />
     <Compile Include="PaketRunner.cs" />

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;LOCAL_GITHUB</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/src/Paket.Bootstrapper/PaketHashFile.cs
+++ b/src/Paket.Bootstrapper/PaketHashFile.cs
@@ -35,5 +35,10 @@ namespace Paket.Bootstrapper
                 }
             }
         }
+
+        public override string ToString()
+        {
+            return string.Join("\r\n", Content);
+        }
     }
 }

--- a/src/Paket.Bootstrapper/PaketHashFile.cs
+++ b/src/Paket.Bootstrapper/PaketHashFile.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Paket.Bootstrapper
+{
+    public class PaketHashFile
+    {
+        public List<string> Content { get; private set; }
+
+        public PaketHashFile(List<string> content)
+        {
+            Content = content;
+        }
+
+        public static PaketHashFile FromStrings(IEnumerable<string> lines)
+        {
+            return new PaketHashFile(lines as List<string> ?? lines.ToList());
+        }
+
+        public static PaketHashFile FromString(string value)
+        {
+            return FromStrings(value.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        public void WriteToStream(Stream stream)
+        {
+            using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
+            {
+                foreach (var line in Content)
+                {
+                    writer.WriteLine(line);
+                }
+            }
+        }
+    }
+}

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -138,7 +138,7 @@ namespace Paket.Bootstrapper
 
                     if ((comparison > 0 && specificVersionRequested) || comparison < 0)
                     {
-                        string hashFile = null;
+                        PaketHashFile hashFile = null;
                         if (downloadStrategy.CanDownloadHashFile)
                         {
                             ConsoleImpl.WriteTrace("Downloading hash for v{0} ...", latestVersion);

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -74,7 +74,7 @@ namespace Paket.Bootstrapper
             var exitCode = 1;
             if (File.Exists(target))
             {
-                var localVersion = BootstrapperHelper.GetLocalFileVersion(target);
+                var localVersion = BootstrapperHelper.GetLocalFileVersion(target, new FileSystemProxy());
                 Console.WriteLine("Detected existing paket.exe ({0}). Cancelling normally.", localVersion);
                 exitCode = 0;
             }
@@ -114,7 +114,7 @@ namespace Paket.Bootstrapper
                 ConsoleImpl.WriteInfo("Checking Paket version ({0})...", versionRequested);
                 ConsoleImpl.WriteTrace("Target path is {0}", dlArgs.Target);
                 var localVersion = fileSystemProxy.GetLocalFileVersion(dlArgs.Target);
-                ConsoleImpl.WriteTrace("File in target path version: v{0}", localVersion);
+                ConsoleImpl.WriteTrace("File in target path version: v{0}", localVersion ?? "UNKNOWN");
 
                 var specificVersionRequested = true;
                 var latestVersion = dlArgs.LatestVersion;

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -87,7 +87,11 @@ namespace Paket.Bootstrapper
             {
                 if (!fileSystemProxy.FileExists(dlArgs.Target))
                     Environment.ExitCode = 1;
+#if DEBUG
+                ConsoleImpl.WriteError(String.Format("{0} ({1})", exception.ToString(), downloadStrategy.Name));
+#else
                 ConsoleImpl.WriteError(String.Format("{0} ({1})", exception.Message, downloadStrategy.Name));
+#endif
             };
             try
             {

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -85,13 +85,21 @@ namespace Paket.Bootstrapper
         {
             Action<Exception> handleException = exception =>
             {
-                if (!fileSystemProxy.FileExists(dlArgs.Target))
-                    Environment.ExitCode = 1;
 #if DEBUG
+                Environment.ExitCode = 1;
                 ConsoleImpl.WriteError(String.Format("{0} ({1})", exception.ToString(), downloadStrategy.Name));
-#else
-                ConsoleImpl.WriteError(String.Format("{0} ({1})", exception.Message, downloadStrategy.Name));
+                return;
 #endif
+                ConsoleImpl.WriteError(String.Format("{0} ({1})", exception.Message, downloadStrategy.Name));
+                if (!fileSystemProxy.FileExists(dlArgs.Target))
+                {
+                    Environment.ExitCode = 1;
+                }
+                else
+                {
+                    fileSystemProxy.WaitForFileFinished(dlArgs.Target);
+                    onSuccess();
+                }
             };
             try
             {

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -114,7 +114,7 @@ namespace Paket.Bootstrapper
                 ConsoleImpl.WriteInfo("Checking Paket version ({0})...", versionRequested);
                 ConsoleImpl.WriteTrace("Target path is {0}", dlArgs.Target);
                 var localVersion = fileSystemProxy.GetLocalFileVersion(dlArgs.Target);
-                ConsoleImpl.WriteTrace("File in target path version: v{0}", localVersion ?? "UNKNOWN");
+                ConsoleImpl.WriteTrace("File in target path version: v{0}", string.IsNullOrEmpty(localVersion) ? "UNKNOWN" : localVersion);
 
                 var specificVersionRequested = true;
                 var latestVersion = dlArgs.LatestVersion;

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -44,7 +44,7 @@ namespace Paket.Bootstrapper.Tests
 
             public Stream CreateFile(string tmpFile)
             {
-                throw new NotImplementedException();
+                return new MemoryStream();
             }
 
             public string GetLocalFileVersion(string filename)
@@ -106,6 +106,15 @@ namespace Paket.Bootstrapper.Tests
                 return Path.Combine(rootDir, "temp");
             }
 
+            public Stream CreateExclusive(string path)
+            {
+                return new MemoryStream();
+            }
+
+            public void WaitForFileFinished(string path)
+            {
+            }
+
             public IEnumerable<string> ReadAllLines(string filename)
             {
                 return Enumerable.Empty<string>();
@@ -113,7 +122,7 @@ namespace Paket.Bootstrapper.Tests
 
             public Stream OpenRead(string filename)
             {
-                return Stream.Null;
+                return new MemoryStream();
             }
 
             public string GetCurrentDirectory()

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using Moq;
 using NUnit.Framework;
@@ -6,6 +7,7 @@ using Paket.Bootstrapper.DownloadStrategies;
 using Paket.Bootstrapper.HelperProxies;
 using System.Security.Cryptography;
 using System.IO;
+using System.Text;
 
 namespace Paket.Bootstrapper.Tests.DownloadStrategies
 {
@@ -20,6 +22,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         public void Setup()
         {
             mockEffectiveStrategy = new Mock<IDownloadStrategy>();
+            mockEffectiveStrategy.SetupGet(s => s.Name).Returns("TestStrategy");
             mockFileProxy = new Mock<IFileSystemProxy>();
             sut = new CacheDownloadStrategy(mockEffectiveStrategy.Object, mockFileProxy.Object);
         }
@@ -133,13 +136,14 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             mockFileProxy.Setup(x => x.FileExists(ItHasFilename("paket.exe"))).Returns(true);
+            MockReadAndCreate();
 
             //act
             sut.DownloadVersion("any", "any", null);
 
             //assert
             mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Never);
-            mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
+            mockFileProxy.Verify(x => x.CreateExclusive("any"));
         }
 
         [Test]
@@ -147,13 +151,21 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
+            mockFileProxy.Setup(x => x.GetTempPath()).Returns("C:\\temp");
+            MockReadAndCreate();
 
             //act
             sut.DownloadVersion("any", "any", null);
 
             //assert
-            mockEffectiveStrategy.Verify(x => x.DownloadVersion("any", "any", null));
-            mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
+            mockEffectiveStrategy.Verify(x => x.DownloadVersion("any", It.IsAny<string>(), null));
+            mockFileProxy.Verify(x => x.CreateExclusive("any"));
+        }
+
+        private void MockReadAndCreate()
+        {
+            mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(() => new MemoryStream());
+            mockFileProxy.Setup(x => x.CreateExclusive(It.IsAny<string>())).Returns(() => new MemoryStream());
         }
 
         [Test]
@@ -170,35 +182,44 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         [Test]
         public void GetLatestVersion_PaketFileCorrupt_DownloadPaketFile()
         {
-            const string hashFile = @"C:\hash.txt";
-
-            //arrange
-            mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Throws<WebException>().Verifiable();
-            mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(new MemoryStream(Guid.NewGuid().ToByteArray()));
-            mockFileProxy.Setup(x => x.ReadAllLines(hashFile)).Returns(new[] { Guid.NewGuid().ToString().Replace("-", String.Empty) + " paket.exe" });
-            mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-
-            //act
-            sut.DownloadVersion("any", "any", hashFile);
-
-            //assert
-            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
-        }
-
-        [Test]
-        public void GetLatestVersion_PaketFileNotCorrupt_DontDownloadPaketFile()
-        {
-            const string hashFile = @"C:\hash.txt";
-
             //arrange
             var content = Guid.NewGuid().ToByteArray();
             var sha = new SHA256Managed();
             var checksum = sha.ComputeHash(new MemoryStream(content));
             var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
+            var hashFile = new PaketHashFile(new List<string> { hash + " paket.exe" });
+
+            var pathInCache = Path.Combine(CacheDownloadStrategy.PaketCacheDir, "any", "paket.exe");
+
             mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Throws<WebException>().Verifiable();
-            mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(new MemoryStream(content));
-            mockFileProxy.Setup(x => x.ReadAllLines(hashFile)).Returns(new[] { hash + " paket.exe" });
+            mockFileProxy.Setup(x => x.OpenRead(pathInCache)).Returns(() => new MemoryStream(Guid.NewGuid().ToByteArray()));
+            mockFileProxy.Setup(x => x.CreateExclusive(It.IsAny<string>())).Returns(() => new MemoryStream());
+            mockFileProxy.Setup(x => x.OpenRead(It.Is<string>(s => s.StartsWith("C:\\temp"))))
+                .Returns(() => new MemoryStream(content));
+            mockFileProxy.Setup(x => x.FileExists(pathInCache)).Returns(true);
+            mockFileProxy.Setup(x => x.GetTempPath()).Returns("C:\\temp");
+
+            //act
+            sut.DownloadVersion("any", "any", hashFile);
+
+            //assert
+            mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PaketHashFile>()), Times.Once);
+            mockFileProxy.Verify(x => x.CreateExclusive("any"));
+        }
+
+        [Test]
+        public void GetLatestVersion_PaketFileNotCorrupt_DontDownloadPaketFile()
+        {
+            //arrange
+            var content = Guid.NewGuid().ToByteArray();
+            var sha = new SHA256Managed();
+            var checksum = sha.ComputeHash(new MemoryStream(content));
+            var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
+            var hashFile = new PaketHashFile(new List<string> { hash + " paket.exe" });
+
+            mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Throws<WebException>().Verifiable();
+            mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(() => new MemoryStream(content));
+            mockFileProxy.Setup(x => x.CreateExclusive(It.IsAny<string>())).Returns(() => new MemoryStream());
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
 
             //act
@@ -206,18 +227,17 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
 
             //assert
             mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Never);
-            mockFileProxy.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()));
+            mockFileProxy.Verify(x => x.CreateExclusive("any"));
         }
 
         [Test]
-        public void GetLatestVersion_PaketHashFileExistsButIsCorrupt_DeleteHashFileAndThrowException()
+        public void GetLatestVersion_PaketHashFileExistsButIsCorrupt_ThrowException()
         {
-            const string hashFile = @"C:\hash.txt";
+            var hashFile = new PaketHashFile(new List<string> { Guid.NewGuid().ToString().Replace("-", String.Empty) + " not-paket.exe" });
 
             //arrange
             mockEffectiveStrategy.Setup(x => x.GetLatestVersion(true)).Throws<WebException>().Verifiable();
             mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(new MemoryStream(Guid.NewGuid().ToByteArray()));
-            mockFileProxy.Setup(x => x.ReadAllLines(hashFile)).Returns(new[] { Guid.NewGuid().ToString().Replace("-", String.Empty) + " not-paket.exe" });
             mockFileProxy.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
 
             //act
@@ -225,7 +245,6 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
 
             //assert
             mockEffectiveStrategy.Verify(x => x.DownloadVersion(It.IsAny<string>(), It.IsAny<string>(), null), Times.Never);
-            mockFileProxy.Verify(x => x.DeleteFile(hashFile));
         }
 
         public string ItHasFilename(string filename)
@@ -247,9 +266,9 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             mockEffectiveStrategy.SetupGet(x => x.CanDownloadHashFile).Returns(false);
 
-            var hashFilePath = sut.DownloadHashFile("42.0");
+            var hashFile = sut.DownloadHashFile("42.0");
 
-            Assert.That(hashFilePath, Is.Null);
+            Assert.That(hashFile, Is.Null);
         }
 
         [Test]
@@ -258,27 +277,29 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockEffectiveStrategy.SetupGet(x => x.CanDownloadHashFile).Returns(true);
             var pathInCache = sut.GetHashFilePathInCache("42.0");
             mockFileProxy.Setup(x => x.FileExists(pathInCache)).Returns(true);
+            mockFileProxy.Setup(x => x.ReadAllLines(pathInCache)).Returns(new[] {"123test"});
 
-            var hashFilePath = sut.DownloadHashFile("42.0");
+            var hashFile = sut.DownloadHashFile("42.0");
 
-            Assert.That(hashFilePath, Is.EqualTo(pathInCache));
+            Assert.That(hashFile.Content, Is.EquivalentTo(new [] { "123test" }));
             mockEffectiveStrategy.Verify(x => x.DownloadHashFile(It.IsAny<string>()), Times.Never);
         }
-
+        
         [Test]
         public void DownloadHashFile_NotInCache()
         {
-            const string pathFromEffectiveStrategy = @"C:\hash.txt";
-            mockEffectiveStrategy.Setup(x => x.DownloadHashFile(It.IsAny<string>())).Returns(pathFromEffectiveStrategy);
+            mockEffectiveStrategy.Setup(x => x.DownloadHashFile(It.IsAny<string>())).Returns(new PaketHashFile(new List<string> { "123test" }));
             mockEffectiveStrategy.SetupGet(x => x.CanDownloadHashFile).Returns(true);
             var pathInCache = sut.GetHashFilePathInCache("42.0");
             mockFileProxy.Setup(x => x.FileExists(pathInCache)).Returns(false);
+            var backingArray = new byte[1024];
+            mockFileProxy.Setup(x => x.CreateExclusive(pathInCache)).Returns(new MemoryStream(backingArray));
 
-            var hashFilePath = sut.DownloadHashFile("42.0");
+            var hashFile = sut.DownloadHashFile("42.0");
 
-            Assert.That(hashFilePath, Is.EqualTo(pathInCache));
+            Assert.That(hashFile.Content, Is.EquivalentTo(new[] { "123test" }));
             mockEffectiveStrategy.Verify(x => x.DownloadHashFile("42.0"), Times.Once);
-            mockFileProxy.Verify(x => x.CopyFile(pathFromEffectiveStrategy, pathInCache, true), Times.Once);
+            Assert.That(Encoding.UTF8.GetString(backingArray), Does.StartWith("123test\r\n"));
         }
     }
 }

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
@@ -318,7 +318,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             mockEffectiveStrategy.Verify(x => x.DownloadHashFile("42.0"), Times.Once);
             backing.Seek(0, SeekOrigin.Begin);
             var reader = new StreamReader(backing);
-            Assert.That(reader.ReadToEnd(), Is.EqualTo("123test\r\n"));
+            Assert.That(reader.ReadToEnd(), Is.EqualTo("123test" + Environment.NewLine));
             backing.ReallyClose();
         }
     }

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/NugetDownloadStrategyTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/NugetDownloadStrategyTests.cs
@@ -317,9 +317,9 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             CreateSystemUnderTestWithDefaultApi();
 
-            var hashFilePath = sut.DownloadHashFile("42.0");
+            var hashFile = sut.DownloadHashFile("42.0");
 
-            Assert.That(hashFilePath, Is.Null);
+            Assert.That(hashFile, Is.Null);
         }
 
         [Test]

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/TemporarilyIgnoreUpdatesDownloadStrategyTest.cs
@@ -180,17 +180,6 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
             _mockEffectiveStrategy.SetupGet(x => x.CanDownloadHashFile).Returns(can);
             Assert.That(_sut.CanDownloadHashFile, Is.EqualTo(can));
         }
-
-        [Test]
-        public void DownloadHashFile()
-        {
-            _mockEffectiveStrategy.Setup(x => x.DownloadHashFile("42.0")).Returns(@"C:\42.txt");
-
-            var hashFilePath = _sut.DownloadHashFile("42.0");
-
-            Assert.That(hashFilePath, Is.EqualTo(@"C:\42.txt"));
-            _mockEffectiveStrategy.Verify(x => x.DownloadHashFile("42.0"), Times.Once);
-        }
     }
 }
 


### PR DESCRIPTION
I still need to fix the tests and clean the code a little but it's starting to take shape.

I have LINQPad scripts to test the behavior running lot of parallel bootstrappers downloading from github (By simulating it) and can't make it crash in it's current state.

I wanted to avoid multiple bootstrapper downloading the same version multiple times but turns out that it's harder to do well and not so important.

The core of the change is in `FileSystemProxy.WaitForFileOpen` that is used instead of the standard primitives that fail in such case.