### PR TITLE
do not export the MSBuild env-var to the outer shell

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -5,6 +5,10 @@ if errorlevel 1 (
   exit /b %errorlevel%
 )
 
+setlocal
+
 set MSBuild=packages\build\RoslynTools.MSBuild\tools\msbuild
 
 packages\build\FAKE\tools\FAKE.exe build.fsx %*
+
+endlocal

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,7 @@ then
   if [ $exit_code -ne 0 ]; then
   	exit $exit_code
   fi
-  # export MSBuild=packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe
-  packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
+  MSBuild=packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
 else
   mono .paket/paket.exe restore
   exit_code=$?

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ then
   if [ $exit_code -ne 0 ]; then
   	exit $exit_code
   fi
-  export MSBuild=packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe
+  # export MSBuild=packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe
   packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx 
 else
   mono .paket/paket.exe restore


### PR DESCRIPTION
fixes https://github.com/fsprojects/Paket/issues/2751

/cc @vbfox, sorry about that.

Please review by someone who knows more about batch than me.