### PR TITLE
fix for #2755

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -631,6 +631,14 @@ let DownloadAndExtractPackage(alternativeProjectRoot, root, isLocalOverride:bool
     let targetFile = FileInfo targetFileName
     let licenseFileName = getLicenseFile packageName version
 
+    if force then 
+        match configResolved.Path with
+        | Some p ->
+            if verbose then
+                verbosefn "Cleaning %s" p
+            CleanDir p
+        | _ -> ()
+
     let rec getFromCache (caches:Cache list) =
         match caches with
         | cache::rest ->
@@ -670,7 +678,7 @@ let DownloadAndExtractPackage(alternativeProjectRoot, root, isLocalOverride:bool
                     use _ = Profile.startCategory Profile.Category.FileIO
                     let parent = Path.GetDirectoryName targetFileName
                     if not (Directory.Exists parent) then Directory.CreateDirectory parent |> ignore
-                    File.Copy(nupkg.FullName,targetFileName)
+                    File.Copy(nupkg.FullName,targetFileName,true)
                 | _ ->
                 // discover the link on the fly
                 let downloadUrl = ref ""


### PR DESCRIPTION
try to fix #2755 
- add cleaning target folder (packages/groupname/packagename) on "force" restore
this solve two problems: overriding .nupkg on force restore and deal with .nupkg naming problem (normalized name from `~/.nuget` vs "as is" from overrided source)
- add overriding .nupkg file in `~/.nuget` when using `LocalNuGet` source
