### PR TITLE
Adding feature to verify the URL and credential correctness before storing them in paket.config

### DIFF
--- a/docs/content/commands/config.md
+++ b/docs/content/commands/config.md
@@ -13,6 +13,16 @@ The credentials you enter here will then be used for `source`s in the
 [`paket.dependencies` file](nuget-dependencies.html) that match `<source URL>`
 unless they carry a username and password.
 
+### Verifying the source URL and credentials
+
+```sh
+paket config add-credentials <source URL> --verify
+```
+
+Paket will verify that the `<source URL>` and the credentials entered with the given
+authentication type are valid. This feature is useful if you want to avoid storing
+wrong credentials or URL in the Paket configuration file.
+
 ### GitHub credentials
 
 ```sh

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -165,11 +165,17 @@ type Dependencies(dependenciesFileName: string) =
                                               projectName, installAfter, runResolver))
 
     /// Adds credentials for a Nuget feed
+    member this.AddCredentials(source: string, username: string, password : string, authType : string) : unit =
+        RunInLockedAccessMode(
+            this.RootPath,
+            fun () -> ConfigFile.askAndAddAuth source username password authType false |> returnOrFail )
+
+     /// Adds credentials for a Nuget feed
     member this.AddCredentials(source: string, username: string, password : string, authType : string, verify : bool) : unit =
         RunInLockedAccessMode(
             this.RootPath,
             fun () -> ConfigFile.askAndAddAuth source username password authType verify |> returnOrFail )
-  
+
     /// Adds a token for a source
     member this.AddToken(source : string, token : string) : unit =
         RunInLockedAccessMode(this.RootPath, fun () -> ConfigFile.AddToken(source, token) |> returnOrFail)

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -165,10 +165,10 @@ type Dependencies(dependenciesFileName: string) =
                                               projectName, installAfter, runResolver))
 
     /// Adds credentials for a Nuget feed
-    member this.AddCredentials(source: string, username: string, password : string, authType : string) : unit =
+    member this.AddCredentials(source: string, username: string, password : string, authType : string, verify : bool) : unit =
         RunInLockedAccessMode(
             this.RootPath,
-            fun () -> ConfigFile.askAndAddAuth source username password authType |> returnOrFail )
+            fun () -> ConfigFile.askAndAddAuth source username password authType verify |> returnOrFail )
   
     /// Adds a token for a source
     member this.AddToken(source : string, token : string) : unit =

--- a/src/Paket.Core/Versioning/ConfigFile.fs
+++ b/src/Paket.Core/Versioning/ConfigFile.fs
@@ -232,7 +232,7 @@ let askAndAddAuth (source : string) (username : string) (password : string) (aut
 
     let authResult = 
         if verify then 
-            Console.WriteLine "Verifying the source URL and credentials..." 
+            tracef "Verifying the source URL and credentials...\n"
             let cred = Credentials(username, password, parseAuthTypeString authType)
             checkCredentials(source, Some cred) 
         else 

--- a/src/Paket.Core/Versioning/ConfigFile.fs
+++ b/src/Paket.Core/Versioning/ConfigFile.fs
@@ -209,7 +209,7 @@ let AddToken (source, token) =
         | None -> () 
     }
 
-let askAndAddAuth (source : string) (username : string) (password : string) (authType : string) = 
+let askAndAddAuth (source : string) (username : string) (password : string) (authType : string) (verify : bool) = 
     let username =
         if username = "" then
             Console.Write "Username: "
@@ -229,4 +229,15 @@ let askAndAddAuth (source : string) (username : string) (password : string) (aut
             if input = "" then "basic" else input
         else
             authType
+
+    let authResult = 
+        if verify then 
+            Console.WriteLine "Verifying the source URL and credentials..." 
+            let cred = Credentials(username, password, parseAuthTypeString authType)
+            checkCredentials(source, Some cred) 
+        else 
+            true
+    if authResult = false then 
+        raise (System.UnauthorizedAccessException("Credentials or the URL for source " + source + " are invalid"))
+
     AddCredentials (source.TrimEnd [|'/'|], username, password, authType)

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -66,6 +66,7 @@ type ConfigArgs =
     | [<Unique>] Username of username:string
     | [<Unique>] Password of password:string
     | [<Unique>] AuthType of authType:string
+    | [<Unique;AltCommandLine>] Verify
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -75,6 +76,7 @@ with
             | Username(_) -> "provide username"
             | Password(_) -> "provide password"
             | AuthType (_) -> "specify authentication type: basic|ntlm (default: basic)"
+            | Verify (_) -> "specify in case you want to verify the credentials"
 
 type ConvertFromNugetArgs =
     | [<Unique;AltCommandLine("-f")>] Force

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -233,8 +233,9 @@ let config (results : ParseResults<_>) =
       let source = args.Item 0
       let username, password = results.GetResult (<@ ConfigArgs.Username @>, ""), results.GetResult (<@ ConfigArgs.Password @>, "")
       let authType = results.GetResult (<@ ConfigArgs.AuthType @>, "")
+      let verify = results.Contains <@ ConfigArgs.Verify @>
 
-      Dependencies(".").AddCredentials(source, username, password, authType)
+      Dependencies(".").AddCredentials(source, username, password, authType, verify)
     | _, true ->
       let args = results.GetResults <@ ConfigArgs.AddToken @>
       let source, token = args.Item 0


### PR DESCRIPTION
While adding a source and its credentials to paket.config, it often happens that there are typos or the credentials do not authenticate, in that case adding these credentials and sources to paket.config becomes pointless. So we propose to have --verify option to augment the config command. It verifies the URL for the source and the credentials are correct.