### PR TITLE
Implement stricter parsing in Requirements.parseRestrictionsLegacy (take 2)

### DIFF
--- a/src/Paket.Core/Dependencies/DependenciesFileParser.fs
+++ b/src/Paket.Core/Dependencies/DependenciesFileParser.fs
@@ -307,6 +307,7 @@ module DependenciesFileParser =
                 | _ -> None
 
             Some (ParserOptions (ParserOption.ResolverStrategyForDirectDependencies setting))
+        | String.RemovePrefix "frameworks" trimmed
         | String.RemovePrefix "framework" trimmed -> 
             let text = trimmed.Replace(":", "").Trim()
             

--- a/src/Paket.Core/PackageManagement/NugetConvert.fs
+++ b/src/Paket.Core/PackageManagement/NugetConvert.fs
@@ -285,8 +285,8 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
                     |> Option.toList 
                     |> List.map (fun fw ->
                         let restrictions, problems = Requirements.parseRestrictionsLegacy false fw
-                        for problem in problems do
-                            Logging.traceErrorfn "Could not detect any platforms from '%s' in %O %O, please tell the package authors" problem.Framework name version
+                        for framework in problems |> Seq.choose (fun x -> x.Framework) do
+                            Logging.traceErrorfn "Could not detect any platforms from '%s' in %O %O, please tell the package authors" framework name version
                         restrictions)
                 | _ -> []
             let restrictions =

--- a/src/Paket.Core/Versioning/Requirements.fs
+++ b/src/Paket.Core/Versioning/Requirements.fs
@@ -583,22 +583,25 @@ type RestrictionParseProblem =
     | ParseFramework of string
     | ParseSecondOperator of string
     | UnsupportedPortable of string
+    | SyntaxError of string
     member x.AsMessage =
         match x with
         | ParseFramework framework ->  sprintf "Could not parse framework '%s'. Try to update or install again or report a paket bug." framework
         | ParseSecondOperator item -> sprintf "Could not parse second framework of between operator '%s'. Try to update or install again or report a paket bug." item
         | UnsupportedPortable item -> sprintf "Profile '%s' is not a supported portable profile" item
+        | SyntaxError msg -> sprintf "Syntax error: %s" msg
     member x.Framework =
         match x with
         | RestrictionParseProblem.UnsupportedPortable fm
         | RestrictionParseProblem.ParseSecondOperator fm
-        | RestrictionParseProblem.ParseFramework fm -> fm
+        | RestrictionParseProblem.ParseFramework fm -> Some fm
+        | SyntaxError _ -> None
     member x.IsCritical =
         match x with
         | RestrictionParseProblem.UnsupportedPortable _ -> false
         | RestrictionParseProblem.ParseSecondOperator _
-        | RestrictionParseProblem.ParseFramework _ -> true
-
+        | RestrictionParseProblem.ParseFramework _
+        | SyntaxError _ -> true
 let parseRestrictionsLegacy failImmediatly (text:string) =
     // older lockfiles to the new "restriction" semantics
     let problems = ResizeArray<_>()
@@ -607,46 +610,91 @@ let parseRestrictionsLegacy failImmediatly (text:string) =
             failwith p.AsMessage
         else
             problems.Add p
-    let text =
-        // workaround missing spaces
-        text.Replace("<=","<= ").Replace(">=",">= ").Replace("=","= ")
-    if text.StartsWith("||") || text.StartsWith("&&") then
-        raise <| InvalidOperationException("&& and || are not allowed in a legacy 'framework' section.")
 
-    let commaSplit = text.Trim().Split(',')
-    [for p in commaSplit do
-        let operatorSplit = p.Trim().Split([|' '|],StringSplitOptions.RemoveEmptyEntries)
-        let framework =
-            if operatorSplit.Length < 2 then 
-                operatorSplit.[0] 
-            else 
-                operatorSplit.[1]
+    let extractFw = FrameworkDetection.Extract
 
+    let extractProfile framework =
+        PlatformMatching.extractPlatforms false framework |> Option.bind (fun pp ->
+            let prof = pp.ToTargetProfile false
+            if prof.IsSome && prof.Value.IsUnsupportedPortable then
+                handleError <| (RestrictionParseProblem.UnsupportedPortable framework)
+            prof)
 
-        match FrameworkDetection.Extract(framework) with
+    let frameworkToken (str : string) =
+        let withoutLeading = str.TrimStart()
+        match withoutLeading.IndexOfAny([|' ';'=';'<';'>'|]) with
+        | -1 -> withoutLeading, ""
+        | i ->
+            let startIndex = str.Length - withoutLeading.Length
+            let remaining = str.Substring(startIndex + i).Trim()
+            withoutLeading.Substring (0, i), remaining
+
+    let tryParseFramework handlers (token : string) =
+        match handlers |> Seq.choose (fun f -> f token) |> Seq.tryHead with
+        | Some fw -> Some fw
         | None ->
-            match PlatformMatching.extractPlatforms false framework |> Option.bind (fun pp -> 
-                let prof = pp.ToTargetProfile false
-                if prof.IsSome && prof.Value.IsUnsupportedPortable then
-                    handleError <| (RestrictionParseProblem.UnsupportedPortable framework)
-                prof) with
-            | Some profile ->
-                yield FrameworkRestriction.AtLeastPlatform profile
-            | None ->
-                handleError <| (RestrictionParseProblem.ParseFramework framework)
-        | Some x -> 
-            if operatorSplit.[0] = ">=" then
-                if operatorSplit.Length < 4 then
-                    yield FrameworkRestriction.AtLeast x
-                else
-                    let item = operatorSplit.[3]
-                    match FrameworkDetection.Extract(item) with
+            handleError <| (RestrictionParseProblem.ParseFramework token)
+            None
+
+    let parseExpr (str : string) =
+        let restriction, remaining =
+            match str.Trim() with
+            | x when x.StartsWith ">=" ->
+                let fw1, remaining = frameworkToken (x.Substring 2)
+
+                let fw2, remaining =
+                    let p str =
+                        let token, remaining = frameworkToken str
+                        Some token, remaining
+                    match remaining with
+                    | x when x.StartsWith "<=" -> p (x.Substring 2)
+                    | x when x.StartsWith "<"  -> p (x.Substring 1)
+                    | x -> None, x
+
+                let restriction =
+                    match fw2 with
                     | None ->
-                        handleError <| (RestrictionParseProblem.ParseSecondOperator item)
-                    | Some y -> yield FrameworkRestriction.Between(x, y)
-            else
-                yield FrameworkRestriction.Exactly x]
-    |> List.fold (fun state item -> FrameworkRestriction.combineRestrictionsWithOr state item) FrameworkRestriction.EmptySet,
+                        let handlers =
+                            [ extractFw >> Option.map FrameworkRestriction.AtLeast
+                              extractProfile >> Option.map FrameworkRestriction.AtLeastPlatform ]
+
+                        tryParseFramework handlers fw1
+
+                    | Some fw2 ->
+                        let tryParse = tryParseFramework [extractFw]
+
+                        match tryParse fw1, tryParse fw2 with
+                        | Some x, Some y -> Some (FrameworkRestriction.Between (x, y))
+                        | _ -> None
+
+                restriction, remaining
+
+            | x when x.StartsWith "=" ->
+                let fw, remaining = frameworkToken (x.Substring 1)
+
+                let handlers =
+                    [ extractFw >> Option.map FrameworkRestriction.Exactly ]
+
+                tryParseFramework handlers fw, remaining
+
+            | x ->
+                let fw, remaining = frameworkToken x
+
+                let handlers =
+                    [ extractFw >> Option.map FrameworkRestriction.Exactly
+                      extractProfile >> Option.map FrameworkRestriction.AtLeastPlatform ]
+
+                tryParseFramework handlers fw, remaining
+
+        match remaining with
+        | "" -> restriction
+        | x ->
+            handleError (SyntaxError (sprintf "Expected end of input, got '%s'." x))
+            None
+
+    text.Trim().Split(',')
+    |> Seq.choose parseExpr
+    |> Seq.fold (fun state item -> FrameworkRestriction.combineRestrictionsWithOr state item) FrameworkRestriction.EmptySet,
     problems.ToArray()
 
 let private parseRestrictionsRaw skipSimplify (text:string) =

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -1200,6 +1200,9 @@ let validFrameworks =
     let any = Seq.fold FrameworkRestriction.combineRestrictionsWithOr FrameworkRestriction.EmptySet
 
     [ TestCaseData("framework: net40").Returns(exactly net40)
+      TestCaseData("frameworks: net40").Returns(exactly net40)
+      TestCaseData("framework net40").Returns(exactly net40)
+      TestCaseData("frameworks net40").Returns(exactly net40)
       TestCaseData("framework: = net40").Returns(exactly net40)
       TestCaseData("framework: =net40").Returns(exactly net40)
       TestCaseData("framework: portable-windows8+net45+wp8").Returns(minPlatform profile78)

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -222,7 +222,7 @@ let ``should read content none config``() =
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NuGetV2Source "http://www.nuget.org/api/v2"]
 
 let specificFrameworkConfig = """
-framework net40 net35
+framework net40, net35
 source "http://www.nuget.org/api/v2" // first source
 
 nuget "Microsoft.SqlServer.Types"
@@ -1187,6 +1187,52 @@ let ``should read config with target framework``() =
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4)))
+
+
+let validFrameworks =
+    let net40 = DotNetFramework(FrameworkVersion.V4)
+    let net45 = DotNetFramework(FrameworkVersion.V4_5)
+    let profile78 = TargetProfile.PortableProfile (PortableProfileType.Profile78)
+    let exactly  = FrameworkRestriction.Exactly
+    let min  = FrameworkRestriction.AtLeast
+    let minPlatform = FrameworkRestriction.AtLeastPlatform
+    let between x y  = FrameworkRestriction.Between(x, y)
+    let any = Seq.fold FrameworkRestriction.combineRestrictionsWithOr FrameworkRestriction.EmptySet
+
+    [ TestCaseData("framework: net40").Returns(exactly net40)
+      TestCaseData("framework: = net40").Returns(exactly net40)
+      TestCaseData("framework: =net40").Returns(exactly net40)
+      TestCaseData("framework: portable-windows8+net45+wp8").Returns(minPlatform profile78)
+      TestCaseData("framework: >= portable-windows8+net45+wp8").Returns(minPlatform profile78)
+      TestCaseData("framework: >=portable-windows8+net45+wp8").Returns(minPlatform profile78)
+      TestCaseData("framework: net40,net45").Returns(any [exactly net40; exactly net45])
+      TestCaseData("framework: net40, net45").Returns(any [exactly net40; exactly net45])
+      TestCaseData("framework: net40, >= net45").Returns(any [exactly net40; min net45])
+      TestCaseData("framework: net40,>=net45").Returns(any [exactly net40; min net45])
+      TestCaseData("framework: >= net40 <= net45").Returns(between net40 net45)
+      TestCaseData("framework: >=net40<=net45").Returns(between net40 net45)
+      TestCaseData("framework: >= net40 < net45").Returns(between net40 net45)
+      TestCaseData("framework: >=net40<net45").Returns(between net40 net45)]
+
+[<Test>]
+[<TestCaseSource("validFrameworks")>]
+let ``should read config with valid target framework`` config =
+    let cfg = DependenciesFile.FromSource(config)
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions |> getExplicitRestriction
+
+[<TestCase("framework: netstandard 2.0")>]
+[<TestCase("framework: = foo")>]
+[<TestCase("framework: == net40")>]
+[<TestCase("framework: > net40")>]
+[<TestCase("framework: <= net40")>]
+[<TestCase("framework: >= net40 = net45")>]
+[<TestCase("framework: > net40 <= net45")>]
+[<TestCase("framework: = net40 <= net45")>]
+[<TestCase("framework: = portable-windows8+net45+wp8")>]
+[<TestCase("framework: >= portable-windows8+net45+wp8 <= net45")>]
+[<TestCase("framework: net40 net45")>]
+let ``should throw on config with invalid target framework`` config =
+    shouldFail<Exception> (fun () -> DependenciesFile.FromSource(config) |> ignore)
 
 [<Test>]
 let ``should read packages with redirects``() = 


### PR DESCRIPTION
This supersedes reverted PR #2816, which caused issue #2822 

It seems some existing files in the wild incorrectly used e.g. `frameworks: net40` instead of `framework: net40`, and the previous 'loose' parsing would parse the resulting expression `s net40` as `= net40`. The stricter version previously merged would bail as `s` isn't a valid framework.

This PR changes to first check for `frameworks` and then `framework` meaning the two are now interchangeable and existing files such as those described in #2822 will continue to work.