### PR TITLE
fixed wrong argument order for "File.WriteAllText" in "installForDotnetSDK"

### DIFF
--- a/src/Paket.Core/Installation/InstallProcess.fs
+++ b/src/Paket.Core/Installation/InstallProcess.fs
@@ -323,7 +323,7 @@ let installForDotnetSDK root (project:ProjectFile) =
     if paketPropsFileName.Exists then
         let old = File.ReadAllText paketPropsFileName.FullName
         let newContent = old.Replace("<!-- <RestoreSuccess>False</RestoreSuccess> -->","<RestoreSuccess>False</RestoreSuccess>")
-        File.WriteAllText(newContent,paketPropsFileName.FullName)
+        File.WriteAllText(paketPropsFileName.FullName, newContent)
 
 /// Installs all packages from the lock file.
 let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile, lockFile : LockFile, projectsAndReferences : (ProjectFile * ReferencesFile) list, updatedGroups) =


### PR DESCRIPTION
Without that fix it crashes with: "ArgumentException: Illegal characters in path."

To reproduce:
* unzip [paket-fail.zip](https://github.com/fsprojects/Paket/files/1360998/paket-fail.zip)
* run:
```
paket install
dotnet restore src
paket install
```

Second 'paket install' (after dotnet restore) will fail.