### PR TITLE
Lowercase package names in package cache (resolves #2676)

### DIFF
--- a/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
@@ -97,19 +97,19 @@
     </Compile>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="TestHelper.fs" />
-    <!-- <Compile Include="InitSpecs.fs" />
+    <Compile Include="InitSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="FullGitSpecs.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />
     <Compile Include="NuGetV3Specs.fs" />
-    <Compile Include="UpdatePackageSpecs.fs" /> 
+    <Compile Include="UpdatePackageSpecs.fs" />
     <Compile Include="UpdateGroupsSpecs.fs" />
     <Compile Include="AddSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="PackSpecs.fs" />
-    <Compile Include="InstallSpecs.fs" /> -->
+    <Compile Include="InstallSpecs.fs" />
     <Compile Include="RestoreSpecs.fs" />
-    <!-- <Compile Include="AutoRestoreSpec.fs" />
+    <Compile Include="AutoRestoreSpec.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />
     <Compile Include="HttpSpecs.fs" />
     <Compile Include="PaketCoreSpecs.fs" />
@@ -121,7 +121,7 @@
     <Compile Include="BindingRedirect.fs" />
     <Compile Include="LoadingScriptGenerationTests.fs" />
     <Compile Include="LocalOverrideSpecs.fs" />
-    <Compile Include="SimplifierSpecs.fs" /> -->
+    <Compile Include="SimplifierSpecs.fs" />
     <None Include="paket.references" />
     <Content Include="App.config" />
   </ItemGroup>

--- a/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
@@ -107,8 +107,8 @@
     <Compile Include="AddSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="PackSpecs.fs" />
-    <Compile Include="InstallSpecs.fs" />
-    <Compile Include="RestoreSpecs.fs" /> -->
+    <Compile Include="InstallSpecs.fs" /> -->
+    <Compile Include="RestoreSpecs.fs" />
     <!-- <Compile Include="AutoRestoreSpec.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />
     <Compile Include="HttpSpecs.fs" />

--- a/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
@@ -95,9 +95,9 @@
       <Paket>True</Paket>
       <Link>FsUnit.fs</Link>
     </Compile>
-    <!-- <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="TestHelper.fs" />
-    <Compile Include="InitSpecs.fs" />
+    <!-- <Compile Include="InitSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="FullGitSpecs.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />
@@ -107,8 +107,8 @@
     <Compile Include="AddSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="PackSpecs.fs" />
-    <Compile Include="InstallSpecs.fs" /> -->
-    <Compile Include="RestoreSpecs.fs" />
+    <Compile Include="InstallSpecs.fs" />
+    <Compile Include="RestoreSpecs.fs" /> -->
     <!-- <Compile Include="AutoRestoreSpec.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />
     <Compile Include="HttpSpecs.fs" />

--- a/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
@@ -95,21 +95,21 @@
       <Paket>True</Paket>
       <Link>FsUnit.fs</Link>
     </Compile>
-    <Compile Include="AssemblyInfo.fs" />
+    <!-- <Compile Include="AssemblyInfo.fs" />
     <Compile Include="TestHelper.fs" />
     <Compile Include="InitSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="FullGitSpecs.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />
     <Compile Include="NuGetV3Specs.fs" />
-    <Compile Include="UpdatePackageSpecs.fs" />
+    <Compile Include="UpdatePackageSpecs.fs" /> 
     <Compile Include="UpdateGroupsSpecs.fs" />
     <Compile Include="AddSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="PackSpecs.fs" />
-    <Compile Include="InstallSpecs.fs" />
+    <Compile Include="InstallSpecs.fs" /> -->
     <Compile Include="RestoreSpecs.fs" />
-    <Compile Include="AutoRestoreSpec.fs" />
+    <!-- <Compile Include="AutoRestoreSpec.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />
     <Compile Include="HttpSpecs.fs" />
     <Compile Include="PaketCoreSpecs.fs" />
@@ -121,7 +121,7 @@
     <Compile Include="BindingRedirect.fs" />
     <Compile Include="LoadingScriptGenerationTests.fs" />
     <Compile Include="LocalOverrideSpecs.fs" />
-    <Compile Include="SimplifierSpecs.fs" />
+    <Compile Include="SimplifierSpecs.fs" /> -->
     <None Include="paket.references" />
     <Content Include="App.config" />
   </ItemGroup>

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -15,3 +15,7 @@ let ``#2496 Paket fails on projects that target multiple frameworks``() =
     let wd = (scenarioTempPath scenario) @@ project
     directDotnet true (sprintf "restore %s.csproj" project) wd
         |> ignore
+
+[<Test>]
+let ``#2676 Real test failure on mono: file not found, probably incorrect casing``() = 
+    ()

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -6,6 +6,7 @@ open Fake
 open NUnit.Framework
 open FsUnit
 open Paket
+open Paket.Utils
 
 [<Test>]
 let ``#2496 Paket fails on projects that target multiple frameworks``() = 
@@ -24,8 +25,11 @@ let ``#2812 Lowercase package names in package cache``() =
 
     let shouldContainExactlyOneCasingVariant (str: string) (sequence: string seq) = 
         let matchingStrings = getCasingVariantsOf str sequence |> List.ofSeq
-        if not (matchingStrings |> Seq.tryExactlyOne |> Option.exists ((=) str))
-        then failwithf "Expected \"%s\" but got %A" str matchingStrings
+        shouldEqual [ str ] matchingStrings
+
+    let fileNamesInDir (dir: string) = dir |> directoryInfo |> filesInDir |> Seq.map (fun x -> x.Name)
+    let subDirectoryNames (dir: string) = dir |> directoryInfo |> subDirectories |> Seq.map (fun x -> x.Name)    
+    let matchingFileNamesInDir (filter: string -> bool) (dir: string) = fileNamesInDir dir |> Seq.filter filter
 
     let scenario = "i002812"
     let packageName = "AutoMapper"
@@ -36,15 +40,23 @@ let ``#2812 Lowercase package names in package cache``() =
     [ packageName; packageNameLowercase ] |> Seq.iter clearPackage
     directPaket "restore" scenario |> ignore
     
-    let packageCacheDirectory = Constants.UserNuGetPackagesFolder |> directoryInfo
-    let packageFolderNames = packageCacheDirectory |> subDirectories |> Array.map (fun x -> x.Name)
-    packageFolderNames |> shouldContainExactlyOneCasingVariant packageNameLowercase
+    // check if packages stored in cache are properly lowercased
+    Constants.UserNuGetPackagesFolder
+        |> subDirectoryNames
+        |> shouldContainExactlyOneCasingVariant packageNameLowercase
+    Constants.UserNuGetPackagesFolder @@ packageNameLowercase @@ packageVersion
+        |> matchingFileNamesInDir (String.startsWithIgnoreCase (sprintf "%s." packageName))
+        |> Seq.map (fun x -> x.Substring(0, packageName.Length))
+        |> Seq.distinct
+        |> shouldContainExactlyOneCasingVariant packageNameLowercase
 
-    let packageContentFolder = packageCacheDirectory.FullName @@ packageNameLowercase @@ packageVersion
-    let packageFiles = packageContentFolder |> directoryInfo |> filesInDir |> Array.map (fun x -> x.Name)
-
-    let filesToFind = [ sprintf ".%s.nupkg" packageVersion
-                        sprintf ".%s.nupkg.sha512" packageVersion
-                        ".nuspec" ]
-                      |> List.map (sprintf "%s%s" packageNameLowercase)
-    filesToFind |> Seq.iter (fun x -> packageFiles |> shouldContainExactlyOneCasingVariant x)
+    // check if packages stored in solution package folder are left unchanged
+    let packagesDirectory = (scenarioTempPath scenario) @@ "packages"
+    packagesDirectory
+        |> subDirectoryNames
+        |> shouldContainExactlyOneCasingVariant packageName
+    packagesDirectory @@ packageName
+        |> matchingFileNamesInDir (String.startsWithIgnoreCase (sprintf "%s." packageName))
+        |> Seq.map (fun x -> x.Substring(0, packageName.Length))
+        |> Seq.distinct
+        |> shouldContainExactlyOneCasingVariant packageName

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -5,6 +5,7 @@ open System.IO
 open Fake
 open NUnit.Framework
 open FsUnit
+open Paket
 
 [<Test>]
 let ``#2496 Paket fails on projects that target multiple frameworks``() = 
@@ -17,5 +18,33 @@ let ``#2496 Paket fails on projects that target multiple frameworks``() =
         |> ignore
 
 [<Test>]
-let ``#2812 Lowercase package names in package cache``() = 
-    ()
+let ``#2812 Lowercase package names in package cache``() =
+    let getCasingVariantsOf (str: string) (sequence: string seq) =
+        sequence |> Seq.filter (fun x -> x.Equals(str, StringComparison.InvariantCultureIgnoreCase))
+
+    let shouldContainExactlyOneCasingVariant (str: string) (sequence: string seq) = 
+        let matchingStrings = getCasingVariantsOf str sequence |> List.ofSeq
+        if not (matchingStrings |> Seq.tryExactlyOne |> Option.exists ((=) str))
+        then failwithf "Expected \"%s\" but got %A" str matchingStrings
+
+    let scenario = "i002812"
+    let packageName = "AutoMapper"
+    let packageNameLowercase = packageName.ToLower()
+    let packageVersion = "6.1.1"
+
+    prepareSdk scenario
+    [ packageName; packageNameLowercase ] |> Seq.iter clearPackage
+    directPaket "restore" scenario |> ignore
+    
+    let packageCacheDirectory = Constants.UserNuGetPackagesFolder |> directoryInfo
+    let packageFolderNames = packageCacheDirectory |> subDirectories |> Array.map (fun x -> x.Name)
+    packageFolderNames |> shouldContainExactlyOneCasingVariant packageNameLowercase
+
+    let packageContentFolder = packageCacheDirectory.FullName @@ packageNameLowercase @@ packageVersion
+    let packageFiles = packageContentFolder |> directoryInfo |> filesInDir |> Array.map (fun x -> x.Name)
+
+    let filesToFind = [ sprintf ".%s.nupkg" packageVersion
+                        sprintf ".%s.nupkg.sha512" packageVersion
+                        ".nuspec" ]
+                      |> List.map (sprintf "%s%s" packageNameLowercase)
+    filesToFind |> Seq.iter (fun x -> packageFiles |> shouldContainExactlyOneCasingVariant x)

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -19,44 +19,63 @@ let ``#2496 Paket fails on projects that target multiple frameworks``() =
         |> ignore
 
 [<Test>]
-let ``#2812 Lowercase package names in package cache``() =
-    let getCasingVariantsOf (str: string) (sequence: string seq) =
-        sequence |> Seq.filter (fun x -> x.Equals(str, StringComparison.InvariantCultureIgnoreCase))
-
-    let shouldContainExactlyOneCasingVariant (str: string) (sequence: string seq) = 
-        let matchingStrings = getCasingVariantsOf str sequence |> List.ofSeq
-        shouldEqual [ str ] matchingStrings
-
-    let fileNamesInDir (dir: string) = dir |> directoryInfo |> filesInDir |> Seq.map (fun x -> x.Name)
-    let subDirectoryNames (dir: string) = dir |> directoryInfo |> subDirectories |> Seq.map (fun x -> x.Name)    
-    let matchingFileNamesInDir (filter: string -> bool) (dir: string) = fileNamesInDir dir |> Seq.filter filter
-
-    let scenario = "i002812"
+let ``#2812 Lowercase package names in package cache: old csproj, packages folder enabled``() =
+    let scenario = "i002812-old-csproj-storage-default"
+    let projectName = "project"
     let packageName = "AutoMapper"
     let packageNameLowercase = packageName.ToLower()
-    let packageVersion = "6.1.1"
+    let workingDir = scenarioTempPath scenario
+    let csprojFile = workingDir @@ projectName @@ sprintf "%s.csproj" projectName
+    let packagesDir = workingDir @@ "packages" 
 
-    prepareSdk scenario
     [ packageName; packageNameLowercase ] |> Seq.iter clearPackage
-    directPaket "restore" scenario |> ignore
     
-    // check if packages stored in cache are properly lowercased
-    Constants.UserNuGetPackagesFolder
-        |> subDirectoryNames
-        |> shouldContainExactlyOneCasingVariant packageNameLowercase
-    Constants.UserNuGetPackagesFolder @@ packageNameLowercase @@ packageVersion
-        |> matchingFileNamesInDir (String.startsWithIgnoreCase (sprintf "%s." packageName))
-        |> Seq.map (fun x -> x.Substring(0, packageName.Length))
-        |> Seq.distinct
-        |> shouldContainExactlyOneCasingVariant packageNameLowercase
+    prepareSdk scenario
+    directPaket "restore" scenario |> ignore
+    isPackageCachedWithOnlyLowercaseNames packageName |> shouldEqual true
+    packagesDir
+        |> Directory.GetDirectories 
+        |> Array.map Path.GetFileName
+        |> shouldEqual [| packageName |]
+    MSBuildRelease "" "Build" [ csprojFile ] |> ignore
 
-    // check if packages stored in solution package folder are left unchanged
-    let packagesDirectory = (scenarioTempPath scenario) @@ "packages"
-    packagesDirectory
-        |> subDirectoryNames
-        |> shouldContainExactlyOneCasingVariant packageName
-    packagesDirectory @@ packageName
-        |> matchingFileNamesInDir (String.startsWithIgnoreCase (sprintf "%s." packageName))
-        |> Seq.map (fun x -> x.Substring(0, packageName.Length))
-        |> Seq.distinct
-        |> shouldContainExactlyOneCasingVariant packageName
+[<Test>]
+let ``#2812 Lowercase package names in package cache: new csproj, packages folder enabled``() =
+    let scenario = "i002812-new-csproj-storage-default"
+    let projectName = "project"
+    let packageName = "AutoMapper"
+    let packageNameLowercase = packageName.ToLower()
+    let workingDir = scenarioTempPath scenario
+    let projectDir = workingDir @@ projectName
+    let emptyFeedPath = workingDir @@ "emptyFeed"
+    let packagesDir = workingDir @@ "packages" 
+
+    [ packageName; packageNameLowercase ] |> Seq.iter clearPackage
+    
+    prepareSdk scenario
+    directPaket "restore" scenario |> ignore
+    isPackageCachedWithOnlyLowercaseNames packageName |> shouldEqual true
+    packagesDir
+        |> Directory.GetDirectories 
+        |> Array.map Path.GetFileName
+        |> shouldEqual [| packageName |]
+    directDotnet false (sprintf "restore --source \"%s\"" emptyFeedPath) projectDir |> ignore
+    directDotnet false "build --no-restore" projectDir |> ignore
+
+[<Test>]
+let ``#2812 Lowercase package names in package cache: new csproj, packages folder disabled``() =
+    let scenario = "i002812-new-csproj-storage-default"
+    let projectName = "project"
+    let packageName = "AutoMapper"
+    let packageNameLowercase = packageName.ToLower()
+    let workingDir = scenarioTempPath scenario
+    let projectDir = workingDir @@ projectName
+    let emptyFeedPath = workingDir @@ "emptyFeed"
+
+    [ packageName; packageNameLowercase ] |> Seq.iter clearPackage
+    
+    prepareSdk scenario
+    directPaket "restore" scenario |> ignore
+    isPackageCachedWithOnlyLowercaseNames packageName |> shouldEqual true
+    directDotnet false (sprintf "restore --source \"%s\"" emptyFeedPath) projectDir |> ignore
+    directDotnet false "build --no-restore" projectDir |> ignore

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -17,5 +17,5 @@ let ``#2496 Paket fails on projects that target multiple frameworks``() =
         |> ignore
 
 [<Test>]
-let ``#2676 Real test failure on mono: file not found, probably incorrect casing``() = 
+let ``#2812 Lowercase package names in package cache``() = 
     ()

--- a/integrationtests/scenarios/i002812-new-csproj-storage-default/before/paket.dependencies
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-default/before/paket.dependencies
@@ -1,0 +1,4 @@
+source https://api.nuget.org/v3/index.json
+framework: net45
+references: strict
+nuget AutoMapper == 6.1.1

--- a/integrationtests/scenarios/i002812-new-csproj-storage-default/before/paket.lock
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-default/before/paket.lock
@@ -1,0 +1,5 @@
+REFERENCES: STRICT
+RESTRICTION: == net45
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    AutoMapper (6.1.1)

--- a/integrationtests/scenarios/i002812-new-csproj-storage-default/before/project/paket.references
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-default/before/project/paket.references
@@ -1,0 +1,1 @@
+AutoMapper

--- a/integrationtests/scenarios/i002812-new-csproj-storage-default/before/project/project.csproj
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-default/before/project/project.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i002812-new-csproj-storage-none/before/paket.dependencies
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-none/before/paket.dependencies
@@ -1,0 +1,5 @@
+source https://api.nuget.org/v3/index.json
+framework: net45
+references: strict
+storage: none
+nuget AutoMapper == 6.1.1

--- a/integrationtests/scenarios/i002812-new-csproj-storage-none/before/paket.lock
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-none/before/paket.lock
@@ -1,0 +1,6 @@
+REFERENCES: STRICT
+STORAGE: NONE
+RESTRICTION: == net45
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    AutoMapper (6.1.1)

--- a/integrationtests/scenarios/i002812-new-csproj-storage-none/before/project/paket.references
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-none/before/project/paket.references
@@ -1,0 +1,1 @@
+AutoMapper

--- a/integrationtests/scenarios/i002812-new-csproj-storage-none/before/project/project.csproj
+++ b/integrationtests/scenarios/i002812-new-csproj-storage-none/before/project/project.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i002812-old-csproj-storage-default/before/paket.dependencies
+++ b/integrationtests/scenarios/i002812-old-csproj-storage-default/before/paket.dependencies
@@ -1,0 +1,4 @@
+source https://api.nuget.org/v3/index.json
+framework: net45
+references: strict
+nuget AutoMapper == 6.1.1

--- a/integrationtests/scenarios/i002812-old-csproj-storage-default/before/paket.lock
+++ b/integrationtests/scenarios/i002812-old-csproj-storage-default/before/paket.lock
@@ -1,0 +1,5 @@
+REFERENCES: STRICT
+RESTRICTION: == net45
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    AutoMapper (6.1.1)

--- a/integrationtests/scenarios/i002812-old-csproj-storage-default/before/project/paket.references
+++ b/integrationtests/scenarios/i002812-old-csproj-storage-default/before/project/paket.references
@@ -1,0 +1,1 @@
+AutoMapper

--- a/integrationtests/scenarios/i002812-old-csproj-storage-default/before/project/project.csproj
+++ b/integrationtests/scenarios/i002812-old-csproj-storage-default/before/project/project.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1782EFD0-F1D8-4640-A11D-1F3A8A39CBF7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>project</RootNamespace>
+    <AssemblyName>project</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
+        <Reference Include="AutoMapper">
+          <HintPath>..\packages\AutoMapper\lib\net45\AutoMapper.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/integrationtests/scenarios/i002812/before/paket.dependencies
+++ b/integrationtests/scenarios/i002812/before/paket.dependencies
@@ -1,0 +1,3 @@
+source https://api.nuget.org/v3/index.json
+framework: net45
+nuget AutoMapper == 6.1.1

--- a/integrationtests/scenarios/i002812/before/paket.dependencies
+++ b/integrationtests/scenarios/i002812/before/paket.dependencies
@@ -1,3 +1,0 @@
-source https://api.nuget.org/v3/index.json
-framework: net45
-nuget AutoMapper == 6.1.1

--- a/integrationtests/scenarios/i002812/before/paket.lock
+++ b/integrationtests/scenarios/i002812/before/paket.lock
@@ -1,0 +1,4 @@
+RESTRICTION: == net45
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    AutoMapper (6.1.1)

--- a/integrationtests/scenarios/i002812/before/paket.lock
+++ b/integrationtests/scenarios/i002812/before/paket.lock
@@ -1,4 +1,0 @@
-RESTRICTION: == net45
-NUGET
-  remote: https://api.nuget.org/v3/index.json
-    AutoMapper (6.1.1)

--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -240,8 +240,8 @@ let fixArchive fileName =
     if isMonoRuntime then
         fixDatesInArchive fileName
 
-let GetLicenseFileName (packageName:PackageName) (version:SemVerInfo) = packageName.ToString() + "." + version.Normalize() + ".license.html"
-let GetPackageFileName (packageName:PackageName) (version:SemVerInfo) = packageName.ToString() + "." + version.Normalize() + ".nupkg"
+let GetLicenseFileName (packageName:PackageName) (version:SemVerInfo) = packageName.ToString().ToLower() + "." + version.Normalize() + ".license.html"
+let GetPackageFileName (packageName:PackageName) (version:SemVerInfo) = packageName.ToString().ToLower() + "." + version.Normalize() + ".nupkg"
 
 let inline isExtracted (directory:DirectoryInfo) (packageName:PackageName) (version:SemVerInfo) =
     let inDir f = Path.Combine(directory.FullName, f)
@@ -294,16 +294,16 @@ let rec private cleanup (dir : DirectoryInfo) =
             File.Move(file.FullName, newFullName)
 
 
-let GetTargetUserFolder packageName (version:SemVerInfo) =
-    DirectoryInfo(Path.Combine(Constants.UserNuGetPackagesFolder,packageName.ToString(),version.Normalize())).FullName
+let GetTargetUserFolder (packageName:PackageName) (version:SemVerInfo) =
+    DirectoryInfo(Path.Combine(Constants.UserNuGetPackagesFolder,packageName.CompareString,version.Normalize())).FullName
 
-let GetTargetUserNupkg packageName (version:SemVerInfo) =
+let GetTargetUserNupkg (packageName:PackageName) (version:SemVerInfo) =
     let normalizedNupkgName = GetPackageFileName packageName version
     let path = GetTargetUserFolder packageName version
     Path.Combine(path, normalizedNupkgName)
 
-let GetTargetUserToolsFolder packageName (version:SemVerInfo) =
-    DirectoryInfo(Path.Combine(Constants.UserNuGetPackagesFolder,".tools",packageName.ToString(),version.Normalize())).FullName
+let GetTargetUserToolsFolder (packageName:PackageName) (version:SemVerInfo) =
+    DirectoryInfo(Path.Combine(Constants.UserNuGetPackagesFolder,".tools",packageName.CompareString,version.Normalize())).FullName
 
 /// Extracts the given package to the user folder
 let rec ExtractPackageToUserFolder(fileName:string, packageName:PackageName, version:SemVerInfo, isCliTool) =
@@ -327,7 +327,9 @@ let rec ExtractPackageToUserFolder(fileName:string, packageName:PackageName, ver
                 File.Copy(fileName,targetPackageFileName,true)
 
             ZipFile.ExtractToDirectory(fileName, targetFolder.FullName)
-
+            // lowercase the .nuspec file to mimic NuGet behavior
+            let nuspecFileName = sprintf "%s.nuspec" (packageName.ToString())
+            File.Move(Path.Combine(targetFolder.FullName, nuspecFileName), Path.Combine(targetFolder.FullName, nuspecFileName.ToLowerInvariant()))
             let cachedHashFile = Path.Combine(Constants.NuGetCacheFolder,fi.Name + ".sha512")
             if not <| File.Exists cachedHashFile then
                 let packageHash = getSha512File fileName


### PR DESCRIPTION
NuGet client used by `dotnet` CLI lowercases package names when saving them to `packages` folder and to the cache, while Paket doesn't touch the casing. On case-sensitive filesystems (i.e. on Mono under Linux) this causes `dotnet restore` to download the referenced packages again.

### Repro steps (Windows + Docker)
1. Checkout https://github.com/julkwiec/paket-dotnet-docker-test
2. Open powershell, run `run.ps1`
3. In the container, run `dotnet restore --source /empty` - it will fail since the package source directory is empty and AutoMapper is not yet present in the cache.
4. Run `mono paket.exe restore`
5. Run `dotnet restore --source /empty` again - dotnet still doesn't find the package in cache
6. Lowercase the names of AutoMapper files and directories:
  - `cd ~/.nuget/packages`
  - `mv AutoMapper automapper`
  - `cd automapper/6.1.1/`
  - `mv AutoMapper.6.1.1.nupkg automapper.6.1.1.nupkg`
  - `mv AutoMapper.6.1.1.nupkg.sha512 automapper.6.1.1.nupkg.sha512`
  - `mv AutoMapper.nuspec automapper.nuspec`
7. Run `cd /test`
8. Run `dotnet restore --source /empty`. No failure this time - package was found in cache.

@forki sorry, I screwed up the previous PR.