### PR TITLE
BUG: isExtracted function was falsely returning true to comparison of…

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -253,7 +253,7 @@ let inline isExtracted (directory:DirectoryInfo) (packageName:PackageName) (vers
     if not fi.Exists then false else
     if not directory.Exists then false else
     directory.EnumerateFileSystemInfos()
-    |> Seq.exists (fun f -> f.FullName <> fi.FullName && f.FullName <> licenseFile)
+    |> Seq.exists (fun f -> f.FullName.ToLower() <> fi.FullName.ToLower() && f.FullName.ToLower() <> licenseFile.ToLower())
 
 let IsPackageVersionExtracted(config:ResolvedPackagesFolder, packageName:PackageName, version:SemVerInfo) =
     match config.Path with


### PR DESCRIPTION
Re issue #2839,  this patch should rectify. It makes file name comparison lowercase.