### PR TITLE
Adding PAKET_VERSION posix compliant environment variable for bootstrapper

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -87,8 +87,22 @@ Example:
 
 ### With environment variables
 
-`PAKET.VERSION`: The requested version can also be set using this environment
+`PAKET_VERSION`: The requested version can also be set using this environment
 variable.
+
+* powershell   
+    ```
+    $env:PAKET_VERSION = "5.119.7"
+    ```
+* cmd
+    ```
+    set PAKET_VERSION=5.119.7
+    ```
+* bash
+    ```
+    export PAKET_VERSION="5.119.7"
+    ```
+    
 
 ### In paket.dependencies
 
@@ -146,3 +160,11 @@ A few default settings are applied:
 * The bootstrapper is silenced and only errors are displayed. `-v` can be used
   once to restore normal output or twice to show more details.
 * If no version is specified a default `--max-file-age` of `12` hours is used.
+
+### Setting version in magic mode
+
+You can use the all [settings listed above](#In-application-settings) with two exceptions:
+1. `paket.bootstrapper.exe.config` becomes `paket.exe.config`
+2. you can no longer use the command line to specify
+    
+ 

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -38,6 +38,9 @@ namespace Paket.Bootstrapper
         public static class EnvArgs
         {
             public const string PaketVersionEnv = "PAKET.VERSION";
+            // Posix compliant environment variables [a-zA-Z_]+[a-zA-Z0-9_]*
+            // As to not break backwards compatability just adding a second env var
+            public const string PaketVersionEnvPosix = "PAKET_VERSION";
         }
 
         private static void FillTarget(DownloadArguments downloadArguments, bool magicMode, IFileSystemProxy fileSystem)
@@ -147,7 +150,7 @@ namespace Paket.Bootstrapper
 
         private static void FillOptionsFromEnvVariables(BootstrapperOptions options, IDictionary envVariables)
         {
-            var latestVersion = envVariables.GetKey(EnvArgs.PaketVersionEnv);
+            var latestVersion = envVariables.GetKey(EnvArgs.PaketVersionEnvPosix) ?? envVariables.GetKey(EnvArgs.PaketVersionEnv) ;
             if (latestVersion != null)
             {
                 options.DownloadArguments.LatestVersion = latestVersion;

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -433,6 +433,35 @@ namespace Paket.Bootstrapper.Tests
         }
 
         [Test]
+        public void LatestVersion_FromEnvironmentVariablePosix()
+        {
+            //arrange
+            var envVariables= new Dictionary<string, string>();
+            envVariables.Add(ArgumentParser.EnvArgs.PaketVersionEnvPosix, "1.0");
+
+            //act
+            var result = Parse(new string[] {}, null, envVariables);
+
+            //assert
+            Assert.That(result.DownloadArguments.LatestVersion, Is.EqualTo("1.0"));
+        }
+
+        [Test]
+        public void LatestVersion_Set_Both_FromEnvironmentVariable_Posix_Wins()
+        {
+            //arrange
+            var envVariables= new Dictionary<string, string>();
+            envVariables.Add(ArgumentParser.EnvArgs.PaketVersionEnv, "1.0");
+            envVariables.Add(ArgumentParser.EnvArgs.PaketVersionEnvPosix, "2.0");
+
+            //act
+            var result = Parse(new string[] {}, null, envVariables);
+
+            //assert
+            Assert.That(result.DownloadArguments.LatestVersion, Is.EqualTo("2.0"));
+        }
+
+        [Test]
         public void LeftoverCommandArgs()
         {
             //arrange


### PR DESCRIPTION
What's the issue?
Paket boostrapper supplies a way to use environment variables to instruct it which version of paket to get. 
https://github.com/fsprojects/Paket/blob/master/src/Paket.Bootstrapper/ArgumentParser.cs#L40

However `PAKET.VERSION` is not posix compliant.  Instead of just changing it as it might be a breaking change I've just added a new variable compliant for posix and windows.  

I've also added docs on how to obtain different versions using `paket.exe.config` or environment variables in the docs.