### PR TITLE
Support wildcards in MSBuild Compile Includes using the MSBuild API

### DIFF
--- a/src/Paket.Core.preview3/Paket.Core.fsproj
+++ b/src/Paket.Core.preview3/Paket.Core.fsproj
@@ -97,5 +97,9 @@
       <PackagePath>lib/netstandard1.6</PackagePath>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="15.3.409" />
+	<PackageReference Include="Microsoft.Build.Framework" Version="15.1.548" />
+  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -144,6 +144,9 @@
     <None Include="Prototypes\script-generation.fsx" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1957,7 +1957,7 @@ type ProjectFile with
                 let linkNodes = [for i in metaData do if i.Name = "Link" then yield i.EvaluatedValue]
                 match linkNodes with
                     | [] -> createRelativePath (projectFolder + string Path.DirectorySeparatorChar) sourceFile
-                    | nodes -> List.head nodes
+                    | nodes -> List.head nodes |> normalizePath |> Path.GetDirectoryName
 
             let rec evaluateCompileItems items =
                 match items with


### PR DESCRIPTION
Fixes issue #2889 

- Use MSBuild Evaluation API to evaluate the `include` inside the `Compile` node.  Enables support for diverse project files and better maintainability.
