### PR TITLE
Delete assets file on install

### DIFF
--- a/src/Paket.Core/Installation/InstallProcess.fs
+++ b/src/Paket.Core/Installation/InstallProcess.fs
@@ -324,6 +324,9 @@ let invalidateRestoreCachesForDotnetSdk (projectFileInfo:FileInfo) =
         let old = File.ReadAllText paketPropsFile.FullName
         let newContent = old.Replace("<!-- <RestoreSuccess>False</RestoreSuccess> -->","<RestoreSuccess>False</RestoreSuccess>")
         File.WriteAllText(paketPropsFile.FullName, newContent)
+    let assetsFile = ProjectFile.getAssetsFileInfo projectFileInfo
+    if assetsFile.Exists then
+        try assetsFile.Delete() with | _ -> ()
 
 let installForDotnetSDK root (project:ProjectFile) =
     let paketTargetsPath = RestoreProcess.extractRestoreTargets root

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1528,6 +1528,9 @@ module ProjectFile =
     let getPaketPropsFileInfo (projectFileInfo:FileInfo) =
         FileInfo(Path.Combine(projectFileInfo.Directory.FullName,"obj",projectFileInfo.Name + ".paket.props"))
 
+    let getAssetsFileInfo (projectFileInfo:FileInfo) =
+        FileInfo(Path.Combine(projectFileInfo.Directory.FullName,"obj","project.assets"))
+
     let getOutputDirectory buildConfiguration buildPlatform (project:ProjectFile) =
         let targetFramework = 
             match getTargetFramework project with


### PR DESCRIPTION
//cc @Krzysztof-Cieslak @enricosada 

Guys what do you think? This would invalidate the nuget cache on paket install. Can you make the ionide track this file and call dotnet restore?