### PR TITLE
various fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "FSharp.excludeProjectDirectories": [
+        ".git",
+        "paket-files",
+        "integrationtests/scenarios",
+        "packages"
+    ]
+}

--- a/integrationtests/Paket.IntegrationTests/LocalOverrideSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/LocalOverrideSpecs.fs
@@ -12,7 +12,7 @@ open NUnit.Framework
 
 [<Test>]
 let ``#1633 paket.local local source override``() =
-    clearPackage "NUnit"
+    clearPackageAtVersion "NUnit" "2.6.3"
 
     paketEx true "restore" "i001633-local-source-override" |> ignore
     let doc = new XmlDocument()
@@ -31,14 +31,14 @@ let ``#1633 paket.local local source override``() =
     |> shouldEqual (Some "true")
 
     // The package should not be in cache
-    isPackageCached "NUnit"
+    isPackageCached "NUnit" "2.6.3"
     |> shouldEqual []
 
     // Issue #2690
     paketEx true "restore" "i001633-local-source-override" |> ignore
 
     // The package should not be in cache
-    isPackageCached "NUnit"
+    isPackageCached "NUnit" "2.6.3"
     |> shouldEqual []
 
 let replaceInFile filePath (searchText: string) replaceText =

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -730,6 +730,10 @@ let why (results: ParseResults<WhyArgs>) =
 
     Why.ohWhy(packageName, directDeps, lockFile, groupName, results.Parser.PrintUsage(), options)
 
+let waitForDebugger () =
+    while not(System.Diagnostics.Debugger.IsAttached) do
+      System.Threading.Thread.Sleep(100)
+
 let handleCommand silent command =
     match command with
     | Add r -> processCommand silent add r
@@ -770,6 +774,10 @@ let handleCommand silent command =
     | Log_File _ -> failwithf "internal error: this code should never be reached."
 
 let main() =
+    let waitDebuggerEnvVar = Environment.GetEnvironmentVariable ("PAKET_WAIT_DEBUGGER")
+    if waitDebuggerEnvVar = "1" then
+        waitForDebugger()
+
     let resolution = Environment.GetEnvironmentVariable ("PAKET_DISABLE_RUNTIME_RESOLUTION")
     Logging.verboseWarnings <- Environment.GetEnvironmentVariable "PAKET_DETAILED_WARNINGS" = "true"
     if System.String.IsNullOrEmpty resolution then

--- a/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
+++ b/tests/Paket.Tests/NuGetOData/ODataSpecs.fs
@@ -16,12 +16,12 @@ open System.Xml
 let fakeUrl = "http://doesntmatter"
 
 let parseList fileName =
-    System.Environment.CurrentDirectory <- Path.GetDirectoryName __SOURCE_DIRECTORY__
+    use _cd = TestHelpers.changeWorkingDir (Path.GetDirectoryName __SOURCE_DIRECTORY__)
     let doc = XmlDocument()
     doc.Load (fileName:string)
     parseODataListDetails("tenp",fakeUrl,PackageName "package",SemVer.Parse "0",doc)
 let parseEntry fileName =
-    System.Environment.CurrentDirectory <- Path.GetDirectoryName __SOURCE_DIRECTORY__
+    use _cd = TestHelpers.changeWorkingDir (Path.GetDirectoryName __SOURCE_DIRECTORY__)
     let doc = XmlDocument()
     doc.Load (fileName:string)
     parseODataEntryDetails("tenp",fakeUrl,PackageName "package",SemVer.Parse "0",doc)

--- a/tests/Paket.Tests/Packaging/PackageProcessSpecs.fs
+++ b/tests/Paket.Tests/Packaging/PackageProcessSpecs.fs
@@ -17,7 +17,8 @@ let ``Loading assembly metadata works``() =
         if curDir.ToLowerInvariant().Contains "system32" then
             Path.GetDirectoryName (assemblyLocation)
         else curDir
-    System.Environment.CurrentDirectory <- workingDir
+
+    use _cd = TestHelpers.changeWorkingDir workingDir
 
     let fileName =
         if File.Exists(Path.Combine(workingDir, "Paket.Tests.fsproj")) then

--- a/tests/Paket.Tests/TestHelpers.fs
+++ b/tests/Paket.Tests/TestHelpers.fs
@@ -144,3 +144,11 @@ let toPath elems = System.IO.Path.Combine(elems |> Seq.toArray)
 let ensureDir () = System.Environment.CurrentDirectory <-  NUnit.Framework.TestContext.CurrentContext.TestDirectory
 
 let printSqs sqs = sqs |> Seq.iter (printfn "%A")
+
+let changeWorkingDir newPath =
+    let oldPath = System.Environment.CurrentDirectory
+    System.Environment.CurrentDirectory <- newPath
+    { new IDisposable with
+        member x.Dispose() = 
+            System.Environment.CurrentDirectory <- oldPath
+    }


### PR DESCRIPTION
FIX

- fix test
    - was removing other package, like nunit.console
    - was removing other package version (one was in use by dotnet test )
- if test need to change working dir, should restore previous when done

NEW

- add vscode workspace settings
- add `PAKET_WAIT_DEBUGGER` env var to wait for debugger
    if `PAKET_WAIT_DEBUGGER` is `1`, paket will wait at start to a debugger to attach

partial code extracted from #2918 
