### PR TITLE
Don't lock files in the bootstrapper that we are only reading

### DIFF
--- a/src/Paket.Bootstrapper/HelperProxies/FileSystemProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/FileSystemProxy.cs
@@ -46,7 +46,8 @@ namespace Paket.Bootstrapper.HelperProxies
             {
                 try
                 {
-                    return File.Open(path, filemode, fileAccess, FileShare.None);
+                    var readOnly = fileAccess == FileAccess.Read;
+                    return File.Open(path, filemode, fileAccess, readOnly ? FileShare.Read : FileShare.None);
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
Create lot of bugs when the bootstrapper is executed in parallel
(like for dotnet restore)