### PR TITLE
Avoid replacing load script files if the contents are the same

### DIFF
--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -233,3 +233,14 @@ let ``issue 2156 netstandard`` () =
     paket "install" scenario |> ignore
     directPaket "generate-load-scripts" scenario |> ignore
     // note: no assert for now, I don't know what we are exactly expecting
+
+[<Test; Category("scriptgen")>]
+let ``don't touch file if contents are same`` () =
+    let scenario = "issue-2939"
+    paket "install" scenario |> ignore
+    let scriptsFolder = scriptRoot scenario
+    let newtonsoftScript = Path.Combine(scriptsFolder.FullName, "Newtonsoft.Json.fsx") |> FileInfo
+    let modificationDate = newtonsoftScript.LastWriteTimeUtc
+    directPaket "install" scenario |> ignore
+    newtonsoftScript.Refresh()
+    Assert.AreEqual(modificationDate, newtonsoftScript.LastWriteTimeUtc)

--- a/integrationtests/scenarios/loading-scripts/issue-2939/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/issue-2939/before/paket.dependencies
@@ -1,0 +1,4 @@
+source https://nuget.org/api/v2
+framework: net45
+generate_load_scripts: true
+nuget Newtonsoft.Json

--- a/src/Paket.Core/Installation/ScriptGeneration.fs
+++ b/src/Paket.Core/Installation/ScriptGeneration.fs
@@ -134,7 +134,19 @@ module ScriptGeneration =
                 verbosefn "generating script - %s" scriptFile.FullName
             scriptFile.Directory.Create()
             let text = self.Render rootPath
-            File.WriteAllText (scriptFile.FullName, text)
+            
+            let existingFileContents =
+                if scriptFile.Exists then 
+                    Some (File.ReadAllText scriptFile.FullName)
+                else
+                    None
+
+            match existingFileContents with
+            | Some contents when contents = text ->
+                if verbose then
+                    verbosefn "script contents hasn't changed - %s" scriptFile.FullName
+            | None | Some _ ->
+                File.WriteAllText (scriptFile.FullName, text)
 
 
     type PaketContext = {


### PR DESCRIPTION
This fixes #2939.