### PR TITLE
Implement binding LOCKEDVERSION to particular group name

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -230,6 +230,14 @@ dependencies
   Other.Dep ~> LOCKEDVERSION
 ```
 
+`LOCKEDVERSION` can be constrained to a particular group by suffixing
+the placeholder with the particular group name.
+
+```text
+dependencies
+  FSharp.Core >= LOCKEDVERSION-NetStandard
+```
+
 It's possible to add a line to constrain the target framework:
 
 ```text

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -296,7 +296,7 @@ module internal TemplateFile =
                         | None -> failwithf "The template file %s contains the placeholder CURRENTVERSION, but no version was given." fileName
 
                 elif s.Contains "LOCKEDVERSION" then
-                    let groupRegex = Regex("LOCKEDVERSION-(?<group>.+)")
+                    let groupRegex = Regex("LOCKEDVERSION-(?<group>\w+)")
                     let replaceGroup (m : Match) =
                         let groupName = GroupName m.Groups.["group"].Value
                         match lockFile.Groups |> Map.tryFind groupName with


### PR DESCRIPTION
This PR extends `LOCKEDVERSION` syntax so that it can be used for pinning to locked versions of individual groups. To my knowledge this shouldn't introduce any regressions to existing template files.

`LOCKEDVERSION` can be constrained to a particular group by suffixing
the placeholder with the particular group name.

```text
dependencies
  FSharp.Core >= LOCKEDVERSION-NetStandard
```