### PR TITLE
Fix "Incorrect time metrics" (#2510)

### DIFF
--- a/src/Paket.Core/Common/Profile.fs
+++ b/src/Paket.Core/Common/Profile.fs
@@ -24,17 +24,20 @@ type EventBoundary =
             match b with
             | Start(dt) -> dt
             | End(dt) -> dt
+        static member IsEndBoundary(b: EventBoundary) = 
+            match b with
+            | End(_) -> true
+            | _ -> false
+        static member IsStartBoundary(b: EventBoundary) = 
+            match b with
+            | Start(_) -> true
+            | _ -> false
 
 type Event = { Category: Category; Start: EventBoundary; End: EventBoundary }
 
-let private isEnd eb = 
-    match eb with
-    | EventBoundary.End(_) -> true
-    | _ -> false
-
 let private getNextSpan(startIndex: int, boundaries: EventBoundary array): (TimeSpan * (int * EventBoundary array)) option = 
     let mutable i = startIndex
-    while (i < boundaries.Length) && isEnd(boundaries.[i]) do
+    while (i < boundaries.Length) && EventBoundary.IsEndBoundary(boundaries.[i]) do
         i <- i + 1
 
     if i >= boundaries.Length then

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -45,7 +45,11 @@ let processWithValidationEx printUsage silent validateF commandF result =
                     |> Seq.groupBy (fun (ev) -> ev.Category)
                     |> Seq.map (fun (cat, group) ->
                         let l = group |> Seq.toList
-                        cat, l.Length, l |> Seq.map (fun ev -> ev.Duration) |> Seq.fold (+) (TimeSpan()))
+                        let eventBoundaries = l |> List.collect(fun ev -> [ev.Start; ev.End])
+                        let mergedSpans = Profile.getCoalescedEventTimeSpans(eventBoundaries |> List.toArray)
+                        let mergedSpanLengths = mergedSpans |> Array.fold (+) (TimeSpan())
+
+                        cat, l.Length, mergedSpanLengths)
                     |> Seq.toList
                 let blockedRaw =
                     groupedResults

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -350,6 +350,7 @@
     <Compile Include="Packaging\TemplateFileParsing.fs" />
     <Compile Include="Packaging\RemotePushUrlSpecs.fs" />
     <Compile Include="ScriptGeneration\LoadingScriptTests.fs" />
+    <Compile Include="Performance\EventBoundarySpecs.fs" />
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Paket.Tests/Performance/EventBoundarySpecs.fs
+++ b/tests/Paket.Tests/Performance/EventBoundarySpecs.fs
@@ -1,0 +1,64 @@
+module Performance.EventBoundarySpecs
+
+open Paket.Profile
+
+open FsCheck
+open NUnit.Framework
+open System
+
+[<Test>]
+let ``simple event boundaries work``() = 
+    let boundaries = 
+        [|
+            Start(new DateTime(2017, 12, 23, 19, 7, 0))
+            End(new DateTime(2017, 12, 23, 19, 15, 0))
+        |]
+
+    let results = getCoalescedEventTimeSpans(boundaries)
+    let expected = [| new TimeSpan(0, 8, 0) |]
+    Assert.AreEqual(expected, results)
+
+[<Test>]
+let ``coalescing event boundaries works``() = 
+    let boundaries = 
+        [|
+            Start(new DateTime(2017, 12, 23, 19, 7, 0))
+            Start(new DateTime(2017, 12, 23, 19, 14, 0))
+            End(new DateTime(2017, 12, 23, 19, 15, 0))
+            End(new DateTime(2017, 12, 23, 19, 16, 0))
+        |]
+
+    let results = getCoalescedEventTimeSpans(boundaries)
+    let expected = [| new TimeSpan(0, 9, 0) |]
+    Assert.AreEqual(expected, results)
+
+[<Test>]
+let ``skip mismatched event end boundaries``() = 
+    let boundaries = 
+        [|
+            End(new DateTime(2017, 12, 23, 19, 6, 0))
+            Start(new DateTime(2017, 12, 23, 19, 7, 0))
+            Start(new DateTime(2017, 12, 23, 19, 14, 0))
+            End(new DateTime(2017, 12, 23, 19, 15, 0))
+            End(new DateTime(2017, 12, 23, 19, 16, 0))
+            End(new DateTime(2017, 12, 23, 19, 17, 0))
+        |]
+
+    let results = getCoalescedEventTimeSpans(boundaries)
+    let expected = [| new TimeSpan(0, 9, 0) |]
+    Assert.AreEqual(expected, results)
+
+[<Test>]
+let ``arbitrary event boundaries produce at least one time span``() = 
+    let hasBeginBeforeEnd(bounds: EventBoundary array) = 
+        let firstStart = bounds |> Array.tryFindIndex EventBoundary.IsStartBoundary
+        let firstEnd = bounds |> Array.tryFindIndex EventBoundary.IsEndBoundary
+
+        match (firstStart, firstEnd) with
+        | (Some(fs), Some(fe)) when fs < fe -> true
+        | _ -> false
+
+    let boundariesCoalesceToAtLeastOneTimeSpan(bounds: EventBoundary array) = 
+        not(hasBeginBeforeEnd(bounds)) || not(getCoalescedEventTimeSpans(bounds) |> Array.isEmpty)
+
+    Check.QuickThrowOnFailure boundariesCoalesceToAtLeastOneTimeSpan


### PR DESCRIPTION
This is a fix for https://github.com/fsprojects/Paket/issues/2510 . It tracks the start and end times of operations, and then coalesces overlapping operations until only discontiguous spans remain. The durations of these spans are then used to calculate the overall time spent per category.