### PR TITLE
Remove redundant example from binding redirect docs

### DIFF
--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -360,14 +360,6 @@ source https://nuget.org/api/v2
 nuget FSharp.Core redirects: off
 ```
 
-If you want Paket to always create a redirect then use the following:
-
-```paket
-source https://nuget.org/api/v2
-
-nuget FSharp.Core redirects: force
-```
-
 You can also override the redirects settings per project, from its
 [`paket.references` file](references-files.html#Redirects-settings).
 


### PR DESCRIPTION
This section of the page already explains how to use the
'redirects: force' setting, so remove the less descriptive example.