### PR TITLE
Fixes a few things when framework: lines are parsed in template

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -271,7 +271,11 @@ module internal TemplateFile =
 
     let private (|Framework|_|) (line:string) =        
         match line.Trim()  with
-        | String.RemovePrefix "framework:" _ as trimmed -> Some (FrameworkDetection.Extract(trimmed.Replace("framework: ","")))
+        | String.RemovePrefix "framework:" trimmed ->
+            match FrameworkDetection.Extract trimmed with
+            | Some _ as fw -> Some fw
+            | None ->
+                failwithf "Unable to identify a framework from '%s'" trimmed
         | _ -> None
 
     let private (|Empty|_|) (line:string) =

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -303,6 +303,12 @@ dependencies
 let ``Fail on invalid targetFramework for dependencies`` () =
     let fileContent = """type file
 id My.Thing
+authors Bob McBob
+description
+    A longer description
+    on two lines.
+version
+    1.0
 dependencies
     framework: AnswerIs42
 """

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -254,7 +254,7 @@ version
     1.0
 dependencies
     xunit 2.0.0
-    framework: net461
+    framework:net461
     framework: net45
         FSharp.Core 4.3.1
         My.OtherThing
@@ -299,6 +299,19 @@ dependencies
         | _ -> Assert.Fail()
     | _ -> Assert.Fail()
 
+[<Test>]
+let ``Fail on invalid targetFramework for dependencies`` () =
+    let fileContent = """type file
+id My.Thing
+dependencies
+    framework: AnswerIs42
+"""
+
+    shouldFail (fun _ ->
+        TemplateFile.Parse("file1.template", LockFile.Parse("",[||]), None, Map.empty, strToStream fileContent)
+        |> returnOrFail
+        |> ignore
+    )
 
 [<Test>]
 let ``Detect dependencies with CURRENTVERSION correctly`` () =


### PR DESCRIPTION
Had to hunt some oddities due to that today 😉 

* Accept the `framework:foo` format (without a space after ":")
* Fail on unknown frameworks instead of silently ignoring the framework and continuing as if nothing was specified

Note: I choose to fail hard using failwith instead of wiring the `Choice<,>` around as dependency parsing in `getDependencyByLine` already does that.