### PR TITLE
add parameter `--type` to `paket add`

### DIFF
--- a/integrationtests/Paket.IntegrationTests/AddSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/AddSpecs.fs
@@ -11,6 +11,28 @@ open Paket
 open Paket.Domain
 
 [<Test>]
+let ``#320 paket add clitool``() =
+    let scenario = "i000320-add-clitool"
+    paket "add dotnet-fable --version 1.3.7 -t clitool --no-resolve" scenario |> ignore
+
+    let depsFile = DependenciesFile.ReadFromFile(Path.Combine(scenarioTempPath scenario,"paket.dependencies"))
+    let requirement = depsFile.GetGroup(Constants.MainDependencyGroup).Packages |> List.exactlyOne
+    requirement.Name |> shouldEqual (PackageName "dotnet-fable")
+    requirement.VersionRequirement.ToString() |> shouldEqual "1.3.7"
+    requirement.Kind |> shouldEqual Paket.Requirements.PackageRequirementKind.DotnetCliTool
+
+[<Test>]
+let ``#321 paket add nuget is the default``() =
+    let scenario = "i000321-add-nuget"
+    paket "add Argu --version 1.2.3 --no-resolve" scenario |> ignore
+
+    let depsFile = DependenciesFile.ReadFromFile(Path.Combine(scenarioTempPath scenario,"paket.dependencies"))
+    let requirement = depsFile.GetGroup(Constants.MainDependencyGroup).Packages |> List.exactlyOne
+    requirement.Name |> shouldEqual (PackageName "Argu")
+    requirement.VersionRequirement.ToString() |> shouldEqual "1.2.3"
+    requirement.Kind |> shouldEqual Paket.Requirements.PackageRequirementKind.Package
+
+[<Test>]
 let ``#310 paket add nuget should not resolve inconsistent dependency graph``() = 
     try
         paket "add nuget Castle.Windsor version 3.3.0" "i000310-add-should-not-create-invalid-resolution" |> ignore

--- a/integrationtests/scenarios/i000320-add-clitool/before/paket.dependencies
+++ b/integrationtests/scenarios/i000320-add-clitool/before/paket.dependencies
@@ -1,0 +1,1 @@
+source http://nuget.org/api/v2

--- a/integrationtests/scenarios/i000321-add-nuget/before/paket.dependencies
+++ b/integrationtests/scenarios/i000321-add-nuget/before/paket.dependencies
@@ -1,0 +1,1 @@
+source http://nuget.org/api/v2

--- a/src/Paket.Core/PackageManagement/AddProcess.fs
+++ b/src/Paket.Core/PackageManagement/AddProcess.fs
@@ -14,7 +14,7 @@ let private addToProject (project : ProjectFile) groupName package =
         .AddNuGetReference(groupName,package)
         .Save()
 
-let private add installToProjects addToProjectsF dependenciesFileName groupName package version options installAfter runResolver =
+let private add installToProjects addToProjectsF dependenciesFileName groupName package version options installAfter runResolver packageKind =
     let existingDependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
     if (not installToProjects) && existingDependenciesFile.HasPackage(groupName,package) && String.IsNullOrWhiteSpace version then
         traceWarnfn "%s contains package %O in group %O already." dependenciesFileName package groupName
@@ -37,7 +37,7 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
                 existingDependenciesFile
             else
                 existingDependenciesFile
-                    .Add(groupName,package,version)
+                    .Add(groupName,package,version, Requirements.InstallSettings.Default, packageKind)
 
         let projects = seq { for p in ProjectFile.FindAllProjects(Path.GetDirectoryName dependenciesFile.FileName) -> p } // lazy sequence in case no project install required
 
@@ -70,7 +70,7 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
                 GarbageCollection.CleanUp(dependenciesFile, lockFile)
 
 // Add a package with the option to add it to a specified project.
-let AddToProject(dependenciesFileName, groupName, package, version, options : InstallerOptions, projectName, installAfter, runResolver) =
+let AddToProject(dependenciesFileName, groupName, package, version, options : InstallerOptions, projectName, installAfter, runResolver, packageKind) =
     let groupName = 
         match groupName with
         | None -> Constants.MainDependencyGroup
@@ -86,10 +86,10 @@ let AddToProject(dependenciesFileName, groupName, package, version, options : In
         | None ->
             traceErrorfn "Could not install package in specified project %s. Project not found" projectName
 
-    add true addToSpecifiedProject dependenciesFileName groupName package version options installAfter runResolver
+    add true addToSpecifiedProject dependenciesFileName groupName package version options installAfter runResolver packageKind
 
 // Add a package with the option to interactively add it to multiple projects.
-let Add(dependenciesFileName, groupName, package, version, options : InstallerOptions, interactive, installAfter, runResolver) =
+let Add(dependenciesFileName, groupName, package, version, options : InstallerOptions, interactive, installAfter, runResolver, packageKind) =
     let groupName = 
         match groupName with
         | None -> Constants.MainDependencyGroup
@@ -101,4 +101,4 @@ let Add(dependenciesFileName, groupName, package, version, options : InstallerOp
                 if package |> notInstalled project groupName && Utils.askYesNo(sprintf "  Install to %s into group %O?" project.FileName groupName) then
                     addToProject project groupName package
 
-    add interactive addToProjects dependenciesFileName groupName package version options installAfter runResolver
+    add interactive addToProjects dependenciesFileName groupName package version options installAfter runResolver packageKind

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -145,13 +145,17 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Adds the given package with the given version to the dependencies file.
     member this.Add(groupName: string option, package: string,version: string,force: bool, withBindingRedirects: bool, cleanBindingRedirects: bool,  createNewBindingFiles:bool, interactive: bool, installAfter: bool, semVerUpdateMode, touchAffectedRefs, runResolver:bool): unit =
+        this.Add(groupName, package,version,force, withBindingRedirects, cleanBindingRedirects,  createNewBindingFiles, interactive, installAfter, semVerUpdateMode, touchAffectedRefs, runResolver, Requirements.PackageRequirementKind.Package)
+
+    /// Adds the given package with the given version to the dependencies file.
+    member this.Add(groupName: string option, package: string,version: string,force: bool, withBindingRedirects: bool, cleanBindingRedirects: bool,  createNewBindingFiles:bool, interactive: bool, installAfter: bool, semVerUpdateMode, touchAffectedRefs, runResolver:bool, packageKind:Requirements.PackageRequirementKind): unit =
         let withBindingRedirects = if withBindingRedirects then BindingRedirectsSettings.On else BindingRedirectsSettings.Off
         RunInLockedAccessMode(
             this.RootPath,
             fun () -> 
                     AddProcess.Add(dependenciesFileName, groupName, PackageName(package.Trim()), version,
                                      InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, semVerUpdateMode, touchAffectedRefs, false, [], [], None),
-                                     interactive, installAfter, runResolver, Requirements.PackageRequirementKind.Package))
+                                     interactive, installAfter, runResolver, packageKind))
 
    /// Adds the given package with the given version to the dependencies file.
     member this.AddToProject(groupName, package: string,version: string,force: bool, withBindingRedirects: bool, cleanBindingRedirects: bool, createNewBindingFiles:bool, projectName: string, installAfter: bool, semVerUpdateMode, touchAffectedRefs): unit =
@@ -159,12 +163,16 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Adds the given package with the given version to the dependencies file.
     member this.AddToProject(groupName, package: string,version: string,force: bool, withBindingRedirects: bool, cleanBindingRedirects: bool, createNewBindingFiles:bool, projectName: string, installAfter: bool, semVerUpdateMode, touchAffectedRefs, runResolver:bool): unit =
+        this.AddToProject(groupName, package,version,force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, projectName, installAfter, semVerUpdateMode, touchAffectedRefs, runResolver, Requirements.PackageRequirementKind.Package)
+
+    /// Adds the given package with the given version to the dependencies file.
+    member this.AddToProject(groupName, package: string,version: string,force: bool, withBindingRedirects: bool, cleanBindingRedirects: bool, createNewBindingFiles:bool, projectName: string, installAfter: bool, semVerUpdateMode, touchAffectedRefs, runResolver:bool, packageKind:Requirements.PackageRequirementKind): unit =
         let withBindingRedirects = if withBindingRedirects then BindingRedirectsSettings.On else BindingRedirectsSettings.Off
         RunInLockedAccessMode(
             this.RootPath,
             fun () -> AddProcess.AddToProject(dependenciesFileName, groupName, PackageName package, version,
                                               InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, semVerUpdateMode, touchAffectedRefs, false, [], [], None),
-                                              projectName, installAfter, runResolver, Requirements.PackageRequirementKind.Package))
+                                              projectName, installAfter, runResolver, packageKind))
 
     /// Adds credentials for a Nuget feed
     member this.AddCredentials(source: string, username: string, password : string, authType : string) : unit =

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -151,7 +151,7 @@ type Dependencies(dependenciesFileName: string) =
             fun () -> 
                     AddProcess.Add(dependenciesFileName, groupName, PackageName(package.Trim()), version,
                                      InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, semVerUpdateMode, touchAffectedRefs, false, [], [], None),
-                                     interactive, installAfter, runResolver))
+                                     interactive, installAfter, runResolver, Requirements.PackageRequirementKind.Package))
 
    /// Adds the given package with the given version to the dependencies file.
     member this.AddToProject(groupName, package: string,version: string,force: bool, withBindingRedirects: bool, cleanBindingRedirects: bool, createNewBindingFiles:bool, projectName: string, installAfter: bool, semVerUpdateMode, touchAffectedRefs): unit =
@@ -164,7 +164,7 @@ type Dependencies(dependenciesFileName: string) =
             this.RootPath,
             fun () -> AddProcess.AddToProject(dependenciesFileName, groupName, PackageName package, version,
                                               InstallerOptions.CreateLegacyOptions(force, withBindingRedirects, cleanBindingRedirects, createNewBindingFiles, semVerUpdateMode, touchAffectedRefs, false, [], [], None),
-                                              projectName, installAfter, runResolver))
+                                              projectName, installAfter, runResolver, Requirements.PackageRequirementKind.Package))
 
     /// Adds credentials for a Nuget feed
     member this.AddCredentials(source: string, username: string, password : string, authType : string) : unit =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -30,6 +30,7 @@ type AddArgs =
     | [<Unique>] Keep_Minor
     | [<Unique>] Keep_Patch
     | [<Unique>] Touch_Affected_Refs
+    | [<Unique;AltCommandLine("-t")>] Type of packageType:AddArgsDependencyType
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -59,6 +60,10 @@ with
             | Keep_Minor -> "only allow updates that preserve the minor version"
             | Keep_Patch -> "only allow updates that preserve the patch version"
             | Touch_Affected_Refs -> "touch project files referencing affected dependencies to help incremental build tools detecting the change"
+            | Type _ -> "the type of dependency: nuget|clitool (default: nuget)"
+and [<RequireQualifiedAccess>] AddArgsDependencyType =
+    | Nuget
+    | Clitool
 
 type ConfigArgs =
     | [<Unique;CustomCommandLine("add-credentials")>] AddCredentials of key_or_URL:string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -208,17 +208,21 @@ let add (results : ParseResults<_>) =
         (results.TryGetResult <@ AddArgs.Project @>,
          results.TryGetResult <@ AddArgs.Project_Legacy @>)
         |> legacyOption results (ReplaceArgument("--project", "project"))
+    let packageKind = 
+        match results.GetResult (<@ AddArgs.Type @>, defaultValue = AddArgsDependencyType.Nuget) with
+        | AddArgsDependencyType.Nuget -> Requirements.PackageRequirementKind.Package
+        | AddArgsDependencyType.Clitool -> Requirements.PackageRequirementKind.DotnetCliTool
 
     match project with
     | Some projectName ->
         Dependencies
             .Locate()
-            .AddToProject(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not)
+            .AddToProject(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not, packageKind)
     | None ->
         let interactive = results.Contains <@ AddArgs.Interactive @>
         Dependencies
             .Locate()
-            .Add(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not)
+            .Add(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not, packageKind)
 
 let validateConfig (results : ParseResults<_>) =
     let credential = results.Contains <@ ConfigArgs.AddCredentials @>

--- a/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
@@ -877,3 +877,25 @@ nuget FAKE @~> 1.2
 
     cfg.ToString()
     |> shouldEqual (normalizeLineEndings expected)
+
+[<Test>]
+let ``should add clitool packages``() = 
+    let config = """source http://www.nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2
+nuget Rx-Main ~> 2.0
+nuget FAKE = 1.1
+nuget SignalR = 3.3.2"""
+
+    let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "dotnet-fable","1.3.7", InstallSettings.Default, PackageRequirementKind.DotnetCliTool)
+    
+    let expected = """source http://www.nuget.org/api/v2
+
+nuget Castle.Windsor-log4net ~> 3.2
+clitool dotnet-fable 1.3.7
+nuget Rx-Main ~> 2.0
+nuget FAKE = 1.1
+nuget SignalR = 3.3.2"""
+
+    cfg.ToString()
+    |> shouldEqual (normalizeLineEndings expected)


### PR DESCRIPTION
enable `paket add dotnet-fable --type clitool` or `paket add dotnet-fable -t clitool`

default is `nuget`, so `paket add Argu` is the same as `paket add Argu -t nuget`