### PR TITLE
Reduce next-link warning to once per method/endpoint, omitting the query, fixes #2848

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -73,7 +73,11 @@ let private followODataLink auth url =
 
             match atLeastOneFailed with
             | Some i ->
-                traceWarnfn "At least one 'next' link (index %d) returned a empty result (noticed on '%O'): ['%s']" i url (System.String.Join("' ; '", linksToFollow))
+                let mutable uri = null // warn once per apecific API endpoint, but try to cut the query
+                let baseUrl = if Uri.TryCreate(url, UriKind.Absolute, &uri) then uri.AbsolutePath else url
+                traceWarnIfNotBefore baseUrl
+                    "At least one 'next' link (index %d) returned a empty result (noticed on '%O'): ['%s']" 
+                    i url (System.String.Join("' ; '", linksToFollow))
             | None -> ()
             return
                 true,


### PR DESCRIPTION
Warnings for empty next-link result are repeated for every single occurrence, which caused console/log flooding when we use Artifactory for all of our internal dependencies (repository behavior fix or replacement does not seem negotiable). 

Reduced the warnings to once per specific API endpoint and shortening the report by trimming the query, which only contains redundant information. 