### PR TITLE
Trace not-found and blacklist warnings as actual warnings

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -524,7 +524,7 @@ let tryAndBlacklistUrl doBlackList doWarn (source:NugetSource) (tryAgain : 'a ->
                     let! (isOk, res) = task |> Async.AwaitTask
                     if not isOk then
                         if doWarn then
-                            eprintfn "Possible Performance degradation, blacklist '%s'" url.InstanceUrl
+                            traceWarnIfNotBefore url.InstanceUrl "Possible Performance degradation, blacklist '%s'" url.InstanceUrl
                         return Choice2Of3 res
                     else
                         return Choice1Of3 res

--- a/src/Paket.Core/Dependencies/NuGetV2.fs
+++ b/src/Paket.Core/Dependencies/NuGetV2.fs
@@ -98,7 +98,7 @@ let tryGetAllVersionsFromNugetODataWithFilter (auth, nugetURL, package:PackageNa
                 match tryGetAllVersionsFromNugetODataWithFilterWarnings.TryGetValue nugetURL with
                 | true, true -> ()
                 | _, _ ->
-                    eprintfn "Possible Performance degradation, could not retrieve '%s', ignoring further warnings for this source" url
+                    traceWarnfn "Possible Performance degradation, could not retrieve '%s', ignoring further warnings for this source" url
                     tryGetAllVersionsFromNugetODataWithFilterWarnings.TryAdd(nugetURL, true) |> ignore
                 if verbose then
                     printfn "Error while retrieving data from '%s': %O" url exn

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -478,9 +478,9 @@ let loadFromCacheOrGetDetails (force:bool)
                     return false,ODataSearchResult.Match cachedObject
             with exn ->
                 if verboseWarnings then
-                    eprintfn "Possible Performance degradation, could not retrieve '%O' from cache: %O" packageName exn
+                    traceWarnfn "Possible Performance degradation, could not retrieve '%O' from cache: %O" packageName exn
                 else
-                    eprintfn "Possible Performance degradation, could not retrieve '%O' from cache: %s" packageName exn.Message
+                    traceWarnIfNotBefore ("NuGetV3 n/a", packageName, exn.Message) "Possible Performance degradation, could not retrieve '%O' from cache: %s" packageName exn.Message
                 let! details = getPackageDetails source packageName version
                 return true,details
         else


### PR DESCRIPTION
Specific explicitly handled and repeated "errors" are changed to "warn if not before" to avoid stderr writes and/or console/log flooding when the resolver actually continues and can succeed. 
Trace not-found and blacklist warnings as actual warnings, and only once per query and source combination. 