### PR TITLE
Avoid duplicates in package source cache

### DIFF
--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -91,7 +91,7 @@ type PackageResolution = Map<PackageName, ResolvedPackage>
 type VersionCache =
   { Version : SemVerInfo; Sources : PackageSource list; AssumedVersion : bool }
     static member ofParams version sources isAssumed =
-        { Version = version; Sources = sources; AssumedVersion = isAssumed }
+        { Version = version; Sources = sources |> List.distinctBy (fun s -> s.Url); AssumedVersion = isAssumed }
 
 type ResolverStep = {
     Relax: bool


### PR DESCRIPTION
Package sources ended up multiplied in the internal version cache, causing unnecessary operations -- this looks like a good place to deduplicate them, 