### PR TITLE
Trace detailed messages for missing package errors

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -580,7 +580,8 @@ let GetVersions force alternativeProjectRoot root (parameters:GetPackageVersions
         | _ when Array.isEmpty trial1.Versions |> not ->
             return trial1.Requests
         | _ ->
-            traceWarn "Trial1 (NuGet.GetVersions) did not yield any results, trying again."
+            let requested = trial1.Requests |> Seq.collect (fun i -> i.Requests) |> Seq.map (fun r -> "   " + r.Request.Url)
+            traceWarnfn "Trial1 (NuGet.GetVersions) did not yield any results, trying again.%s%O" Environment.NewLine (String.Join(Environment.NewLine, requested)) 
             let! trial2 = trial true
             match trial2 with
             | _ when Array.isEmpty trial2.Versions |> not ->

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -1000,7 +1000,7 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
                 |> fun a -> Async.StartAsTaskProperCancel(a, cancellationToken = ct))
             |> ResolverTaskMemory.ofWork)
 
-    let getVersionsBlock resolverStrategy versionParams =
+    let getVersionsBlock resolverStrategy versionParams (currentStep:ResolverStep) =
         seq {
             let preferred = getPreferredVersionsRaw resolverStrategy versionParams
             yield! preferred
@@ -1011,7 +1011,12 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
                     getAndReport versionParams.Package.Sources Profile.BlockReason.GetVersion workHandle 
                     |> Seq.toList
                 with e ->
-                    raise (Exception (sprintf "Unable to retrieve package versions for '%O'" versionParams.Package.PackageName, e))
+                    let newline = Environment.NewLine
+                    let opened = String.Join(newline + "   ", currentStep.OpenRequirements |> Seq.sort)
+                    let closed = String.Join(newline + "   ", currentStep.ClosedRequirements |> Seq.sort)
+                    let requirements = sprintf "-- CLOSED --%s   %s%s-- OPEN ----%s   %s" newline closed newline newline opened
+                    let message = sprintf "Unable to retrieve package versions for '%O'%s%s" versionParams.Package.PackageName Environment.NewLine requirements
+                    raise (Exception (message, e))
             let sorted =
                 match resolverStrategy with
                 | ResolverStrategy.Max -> List.sortDescending versions
@@ -1129,7 +1134,7 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
 
                 let currentConflict =
                     let getVersionsF packName =
-                        getVersionsBlock ResolverStrategy.Max (GetPackageVersionsParameters.ofParams currentRequirement.Sources groupName packName)
+                        getVersionsBlock ResolverStrategy.Max (GetPackageVersionsParameters.ofParams currentRequirement.Sources groupName packName) currentStep
 
                     if Seq.isEmpty conflicts then
                         { currentConflict with
@@ -1150,8 +1155,9 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
                 if not (Seq.isEmpty conflicts) then
                     fuseConflicts currentRequirement currentStep.FilteredVersions currentConflict priorConflictSteps conflicts
                 else
+                    let getCurrentVersionBlock = fun strategy args -> getVersionsBlock strategy args currentStep
                     let compatibleVersions,globalOverride,tryRelaxed =
-                        getCompatibleVersions currentStep groupName currentRequirement getVersionsBlock
+                        getCompatibleVersions currentStep groupName currentRequirement getCurrentVersionBlock
                                 currentConflict.GlobalOverride
                                 globalStrategyForDirectDependencies
                                 globalStrategyForTransitives
@@ -1303,7 +1309,7 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
                             step (Step((currentConflict,nextStep,currentRequirement), (currentConflict,currentStep,currentRequirement,compatibleVersions,flags)::priorConflictSteps)) stackpack currentConflict.VersionsToExplore flags
                         else
                             let getVersionsF packName =
-                                getVersionsBlock ResolverStrategy.Max (GetPackageVersionsParameters.ofParams currentRequirement.Sources groupName packName)
+                                getVersionsBlock ResolverStrategy.Max (GetPackageVersionsParameters.ofParams currentRequirement.Sources groupName packName) currentStep
 
                             let conflictingPackageName,vr = 
                                 match Seq.tryHead conflictingResolvedPackages with
@@ -1339,7 +1345,7 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
     let currentRequirement = getCurrentRequirement packageFilter startingStep.OpenRequirements (Dictionary())
 
     let status =
-        let getVersionsF packName = getVersionsBlock ResolverStrategy.Max (GetPackageVersionsParameters.ofParams currentRequirement.Sources groupName packName)
+        let getVersionsF packName = getVersionsBlock ResolverStrategy.Max (GetPackageVersionsParameters.ofParams currentRequirement.Sources groupName packName) startingStep 
         ResolutionRaw.ConflictRaw { ResolveStep = startingStep; RequirementSet = Set.empty; Requirement = currentRequirement; GetPackageVersions = getVersionsF }
 
 


### PR DESCRIPTION
If the resolver goes to a retry, or fails completely, trace a more detailed message which can be usable for immediate investigation
1/ Warning "Trial1 (NuGet.GetVersions) did not yield any results" did not contain any exact information -- added the failing request/s
2/ Failure "Unable to retrieve package versions" did not contain information needed to discover how the missing package was requested at all -- added readable open/closed requirement report
This seems to be enough to see the issue at hand without resorting to verbose and lengthy analysis in many cases