### PR TITLE
[API] add overload for Dependencies.Init

### DIFF
--- a/integrationtests/Paket.IntegrationTests/InitSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InitSpecs.fs
@@ -55,3 +55,20 @@ let ``#1240 current bootstrapper should work``() =
 
     File.Exists(scenarioTempPath "i001240-bootstrapper" </> "paket.exe")
     |> shouldEqual true
+
+[<Test>]
+let ``#1041 init api``() = 
+    let tempScenarioDir = scenarioTempPath "i001041-init-api"
+
+    let url = "http://my.test/api"
+    let source = Paket.PackageSources.PackageSource.NuGetV2Source(url)
+
+    Paket.Dependencies.Init(tempScenarioDir, [source], [ "download_license: true" ], false)
+
+    let depsPath = tempScenarioDir </> "paket.dependencies"
+    File.Exists(depsPath) |> shouldEqual true
+
+    let lines = File.ReadAllText(depsPath)
+
+    StringAssert.Contains(url, lines);
+    StringAssert.Contains("download_license: true", lines);

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -87,6 +87,25 @@ type Dependencies(dependenciesFileName: string) =
         deps.DownloadLatestBootstrapper()
 #endif
 
+    /// Initialize paket.dependencies file in the given directory
+    static member Init(directory, sources, additional, downloadBootstrapper) =
+        let directory = DirectoryInfo(directory)
+
+        RunInLockedAccessMode(
+            directory.FullName,
+            fun () ->
+                PaketEnv.initWithContent sources additional directory
+                |> returnOrFail
+        )
+
+#if !NO_BOOTSTRAPPER
+        if downloadBootstrapper then
+            let deps = Dependencies.Locate(directory.FullName)
+            deps.DownloadLatestBootstrapper()
+#else
+        ignore downloadBootstrapper
+#endif
+
     /// Converts the solution from NuGet to Paket.
     static member ConvertFromNuget(force: bool,installAfter: bool, initAutoRestore: bool,credsMigrationMode: string option, ?directory: DirectoryInfo) : unit =
         let dir = defaultArg directory (DirectoryInfo(Directory.GetCurrentDirectory()))


### PR DESCRIPTION
add overload to `Dependencies.Init` to:

- specify sources
- choose if download bootstrapper
- additional global config in deps