### PR TITLE
add `paket info --paket-dependencies-dir` to locate repo root

### DIFF
--- a/integrationtests/Paket.IntegrationTests.preview3/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests.preview3/Paket.IntegrationTests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="$(PaketTestsSourcesDir)\AssemblyInfo.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\TestHelper.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\InitSpecs.fs" />
+    <Compile Include="$(PaketTestsSourcesDir)\InfoSpecs.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\OutdatedSpecs.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\FullGitSpecs.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\FrameworkRestrictionsSpecs.fs" />

--- a/integrationtests/Paket.IntegrationTests/InfoSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InfoSpecs.fs
@@ -1,0 +1,33 @@
+﻿module Paket.IntegrationTests.InfoSpecs
+
+open Fake
+open System
+open NUnit.Framework
+open FsUnit
+open System
+open System.IO
+open System.Diagnostics
+
+[<Test>]
+let ``#3200 info should locate paket.dependencies``() = 
+    let repoDir = scenarioTempPath "i003200-info-paketdeps-dir"
+
+    let subDir = repoDir </> "src" </> "app"
+    Directory.CreateDirectory(subDir) |> ignore
+
+    let ``paket info --paket-dependencies-dir`` workingDir =
+        directPaketInPathEx "info --paket-dependencies-dir" workingDir
+        |> Seq.map PaketMsg.getMessage
+        |> List.ofSeq
+
+    // paket.dependencies not exists
+    
+    CollectionAssert.DoesNotContain(``paket info --paket-dependencies-dir`` repoDir, repoDir)
+    CollectionAssert.DoesNotContain(``paket info --paket-dependencies-dir`` subDir, repoDir)
+
+    // empty paket.dependencies
+    File.WriteAllText(repoDir </> "paket.dependencies", "")
+
+    CollectionAssert.Contains(``paket info --paket-dependencies-dir`` repoDir, repoDir)
+    CollectionAssert.Contains(``paket info --paket-dependencies-dir`` subDir, repoDir)
+

--- a/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
@@ -98,6 +98,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="TestHelper.fs" />
     <Compile Include="InitSpecs.fs" />
+    <Compile Include="InfoSpecs.fs" />
     <Compile Include="OutdatedSpecs.fs" />
     <Compile Include="FullGitSpecs.fs" />
     <Compile Include="FrameworkRestrictionsSpecs.fs" />

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -429,6 +429,14 @@ with
             | Max_Results(_) -> "limit maximum number of results"
             | Max_Results_Legacy(_) -> "[obsolete]"
 
+type InfoArgs =
+    | [<Unique>] Paket_Dependencies_Dir
+with
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Paket_Dependencies_Dir -> "absolute path of paket.dependencies directory, if exists"
+
 type PackArgs =
     | [<ExactlyOnce;MainCommand>] Output of path:string
     | [<Hidden;ExactlyOnce;CustomCommandLine("output")>] Output_Legacy of path:string
@@ -620,6 +628,7 @@ type Command =
     | [<Hidden;CustomCommandLine("generate-include-scripts")>] GenerateIncludeScripts of ParseResults<GenerateLoadScriptsArgs>
     | [<CustomCommandLine("generate-load-scripts")>]    GenerateLoadScripts of ParseResults<GenerateLoadScriptsArgs>
     | [<CustomCommandLine("why")>]                      Why of ParseResults<WhyArgs>
+    | [<CustomCommandLine("info")>]                     Info of ParseResults<InfoArgs>
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -649,6 +658,7 @@ with
             | GenerateIncludeScripts _ -> "[obsolete]"
             | GenerateLoadScripts _ -> "generate F# and C# include scripts that reference installed packages in a interactive environment like F# Interactive or ScriptCS"
             | Why _ -> "determine why a dependency is required"
+            | Info _ -> "info"
             | Log_File _ -> "print output to a file"
             | Silent -> "suppress console output"
             | Verbose -> "print detailed information to the console"

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -699,6 +699,12 @@ let generateLoadScripts (results : ParseResults<GenerateLoadScriptsArgs>) =
 
     Dependencies.Locate().GenerateLoadScripts providedGroups providedFrameworks providedScriptTypes
 
+let info (results : ParseResults<InfoArgs>) =
+    if results.Contains <@ InfoArgs.Paket_Dependencies_Dir @> then
+        match Dependencies.TryLocate() with
+        | None -> ()
+        | Some deps -> tracefn "%s" deps.RootPath
+
 let generateNuspec (results:ParseResults<GenerateNuspecArgs>) =
     let projectFile = results.GetResult <@ GenerateNuspecArgs.Project @>
     let dependenciesPath = results.GetResult <@ GenerateNuspecArgs.DependenciesFile @>
@@ -769,6 +775,7 @@ let handleCommand silent command =
     | GenerateLoadScripts r -> processCommand silent generateLoadScripts r
     | GenerateNuspec r -> processCommand silent generateNuspec r
     | Why r -> processCommand silent why r
+    | Info r -> processCommand silent info r
     // global options; list here in order to maintain compiler warnings
     // in case of new subcommands added
     | Verbose


### PR DESCRIPTION
the command does a `DependenciesFile.TryLocate` to find in the directory hierarchy the `paket.dependencies` file.
if found, print the path of dir

Useful to ask paket where is the repo root, when in a subdir

