### PR TITLE
new appveyor account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Travis build status](https://api.travis-ci.org/fsprojects/Paket.svg)](https://travis-ci.org/fsprojects/Paket)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/aqs8eux16x4g5p47/branch/master?svg=true)](https://ci.appveyor.com/project/SteffenForkmann/paket/branch/master)
+[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/f77ejdp6mtkris2u/branch/master?svg=true)](https://ci.appveyor.com/project/paket/paket/branch/master)
 [![NuGet Status](https://img.shields.io/nuget/v/Paket.svg?style=flat)](https://www.nuget.org/packages/Paket/)
 [![Join the chat at https://gitter.im/fsprojects/Paket](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fsprojects/Paket?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Twitter](https://img.shields.io/badge/Twitter-PaketManager-blue.svg)](https://twitter.com/PaketManager)


### PR DESCRIPTION
to @fsprojects/paket-owners

- created a new organizational appveyor account https://ci.appveyor.com/project/paket/
- added @fsprojects/paket-owners as admin
    - you can login in appveyor with github credential and selecting `paket`  as account
    - with that, you can manage buils (stop unneeded)
- fixed README badge
- enabled https://ci.appveyor.com/project/paket/paket as appveyor webhook to build PR/commit
- disabled others webhooks (@cloudRoutine @matthid @forki ) , so all build use only https://ci.appveyor.com/project/paket/paket (before was random)


