### PR TITLE
fix integration test

### DIFF
--- a/integrationtests/Paket.IntegrationTests/InfoSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InfoSpecs.fs
@@ -10,7 +10,7 @@ open System.Diagnostics
 
 [<Test>]
 let ``#3200 info should locate paket.dependencies``() = 
-    let repoDir = scenarioTempPath "i003200-info-paketdeps-dir"
+    let repoDir = createScenarioDir "i003200-info-paketdeps-dir"
 
     let subDir = repoDir </> "src" </> "app"
     Directory.CreateDirectory(subDir) |> ignore

--- a/integrationtests/Paket.IntegrationTests/TestHelper.fs
+++ b/integrationtests/Paket.IntegrationTests/TestHelper.fs
@@ -42,6 +42,10 @@ let cleanupAllScenarios() =
         cleanup scenario
     scenarios.Clear()
 
+let createScenarioDir scenario =
+    let scenarioPath = scenarioTempPath scenario
+    CleanDir scenarioPath
+    scenarioPath
 
 let prepare scenario =
     if isLiveUnitTesting then Assert.Inconclusive("Integration tests are disabled when in a Live-Unit-Session")
@@ -50,8 +54,7 @@ let prepare scenario =
 
     scenarios.Add scenario
     let originalScenarioPath = originalScenarioPath scenario
-    let scenarioPath = scenarioTempPath scenario
-    CleanDir scenarioPath
+    let scenarioPath = createScenarioDir scenario
     CopyDir scenarioPath originalScenarioPath (fun _ -> true)
 
     for ext in ["fsproj";"csproj";"vcxproj";"template";"json"] do


### PR DESCRIPTION
use `createScenarioDir` to create a clean `temp` dir for integration tests

fix integration test `#3200 info should locate paket.dependencies`.
now test can be run multiple times, temp dir is cleaned up correctly