### PR TITLE
some nuget2 queries fail with normalized filter syntax and should be skipped/blacklisted

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -556,6 +556,8 @@ let tryAndBlacklistUrl doBlackList doWarn (source:NugetSource)
                         | Choice2Of2 except ->  
                             match except with  // but NotFound/404 should allow other query to succeed
                             | RequestStatus HttpStatusCode.NotFound -> false
+                                               // repos may not support full filter syntax (Artifactory)
+                            | RequestStatus HttpStatusCode.MethodNotAllowed -> false
                             | _ -> true        // for any other exceptions, cancel the rest and return                         
                     | _ -> false )
 


### PR DESCRIPTION
nuget2 filter syntax may not be fully supported and `MethodNotAllowed` should be skipped rather than faulting the lookup attempt
e.g. query `/Packages?$filter=(tolower(Id) eq 'my.unique.package.name') and (Version eq '1.2.3.4')'` on Artifactory 5.8.1 consistently fails with 405, but the package may be found via non-normalized query