### PR TITLE
Use TLS 1.2 for WebProxyRequests

### DIFF
--- a/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
@@ -7,6 +7,7 @@ namespace Paket.Bootstrapper.HelperProxies
     {
         public WebRequestProxy()
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             Client = new WebClient();
         }
 

--- a/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
@@ -7,7 +7,6 @@ namespace Paket.Bootstrapper.HelperProxies
     {
         public WebRequestProxy()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             Client = new WebClient();
         }
 

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -13,12 +13,17 @@ using Paket.Bootstrapper.HelperProxies;
 
 namespace Paket.Bootstrapper
 {
+
     static class Program
     {
         private static readonly Stopwatch executionWatch = new Stopwatch();
 
         static void Main(string[] args)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
+                                         | SecurityProtocolType.Tls11
+                                         | SecurityProtocolType.Tls
+                                         | SecurityProtocolType.Ssl3;
             executionWatch.Start();
             Console.CancelKeyPress += CancelKeyPressed;
 


### PR DESCRIPTION
This fixes the issue caused by Github removing support for weak cryptographic standards. https://githubengineering.com/crypto-removal-notice/

Fixes issue #3065 