### PR TITLE
Resolve home folder in paket.dependencies (cache) correctly

### DIFF
--- a/src/Paket.Core/Versioning/Cache.fs
+++ b/src/Paket.Core/Versioning/Cache.fs
@@ -19,17 +19,23 @@ type Cache = {
             { this with Location = Path.Combine(root,this.Location) |> normalizePath }
 
     static member Parse(line : string) =
+        let normalizeHomeDirectory (fileName : string) =
+            let homeDirectory = "~"
+            fileName.Replace(homeDirectory, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))
+
+        let normalizedLine = normalizeHomeDirectory line
+
         let sourceRegex = Regex("cache[ ]*[\"]([^\"]*)[\"]", RegexOptions.IgnoreCase)
-        let parts = line.Split ' '
+        let parts = normalizedLine.Split ' '
         let source = 
-            if sourceRegex.IsMatch line then
-                sourceRegex.Match(line).Groups.[1].Value.TrimEnd([| '/' |])
+            if sourceRegex.IsMatch normalizedLine then
+                sourceRegex.Match(normalizedLine).Groups.[1].Value.TrimEnd([| '/' |])
             else
                 parts.[1].Replace("\"","").TrimEnd([| '/' |])
 
         let rest =
-            let start = line.IndexOf source + source.Length
-            line.Substring(start)
+            let start = normalizedLine.IndexOf source + source.Length
+            normalizedLine.Substring(start)
 
         let kvPairs = parseKeyValuePairs (rest.ToLower())
 

--- a/src/Paket.Core/Versioning/Cache.fs
+++ b/src/Paket.Core/Versioning/Cache.fs
@@ -19,9 +19,9 @@ type Cache = {
             { this with Location = Path.Combine(root,this.Location) |> normalizePath }
 
     static member Parse(line : string) =
-        let normalizeHomeDirectory (fileName : string) =
+        let normalizeHomeDirectory (line : string) =
             let homeDirectory = "~"
-            fileName.Replace(homeDirectory, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))
+            line.Replace(homeDirectory, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))
 
         let normalizedLine = normalizeHomeDirectory line
 

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -1613,3 +1613,15 @@ let ``should read config with cli tool``() =
     let nuget = cfg.Groups.[Constants.MainDependencyGroup].Packages.Tail.Head
     tool.Kind |> shouldEqual PackageRequirementKind.DotnetCliTool
     nuget.Kind |> shouldEqual PackageRequirementKind.Package
+
+let paketCacheTestPath = System.IO.Path.Combine("~", ".paket-cache")
+let configWithHomePathInCache = String.Concat("""
+source https://www.nuget.org/api/v2
+
+cache """, paketCacheTestPath)
+
+[<Test>]
+let ``should parse config with home path in cache``() =
+    let cfg = DependenciesFile.FromSource(configWithHomePathInCache)
+    let expected = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".paket-cache")
+    cfg.Groups.[Constants.MainDependencyGroup].Caches.[0].Location |> shouldEqual expected


### PR DESCRIPTION
This should solve issue https://github.com/fsprojects/Paket/issues/3072.
The commit itself is simple enough: The parsed line is being normalized by replacing the tilde with `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)`.
I also added a small test. On my machines (Windows and Ubuntu) everything worked as expected.
If you have any suggestions to improve my changes, please let me know.