### PR TITLE
Safeguards loading of assemblies during load script generation. 

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/DependencyCache.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependencyCache.fs
@@ -99,13 +99,12 @@ type DependencyCache (lockFile:LockFile) =
             installModel
             |> InstallModel.getLegacyReferences (TargetProfile.SinglePlatform framework)
             |> Seq.map (fun l -> l.Path)
-            |> Seq.map (fun path -> 
+            |> Seq.choose (fun path -> 
                 try 
                     (AssemblyDefinition.ReadAssembly path, FileInfo(path)) |> Some
                 with
                 | :? BadImageFormatException -> None
             )
-            |> Seq.choose id
             |> dict
 
         getDllOrder (dllFiles.Keys |> Seq.toList)
@@ -127,12 +126,11 @@ type DependencyCache (lockFile:LockFile) =
                         sysLibs.Add sysLib |> ignore
 
             let assemblyFilePerAssemblyDef = 
-                libs |> Seq.map (fun (f:FileInfo) -> 
+                libs |> Seq.choose (fun (f:FileInfo) -> 
                     try
                         (AssemblyDefinition.ReadAssembly (f.FullName:string), f) |> Some
                     with
                     | :? BadImageFormatException -> None)
-                |> Seq.choose id
                 |> dict
 
             let assemblies = 

--- a/src/Paket.Core/PaketConfigFiles/DependencyCache.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependencyCache.fs
@@ -98,7 +98,13 @@ type DependencyCache (lockFile:LockFile) =
             installModel
             |> InstallModel.getLegacyReferences (TargetProfile.SinglePlatform framework)
             |> Seq.map (fun l -> l.Path)
-            |> Seq.map (fun path -> AssemblyDefinition.ReadAssembly path, FileInfo(path))
+            |> Seq.map (fun path -> 
+                try 
+                    (AssemblyDefinition.ReadAssembly path, FileInfo(path)) |> Some
+                with
+                | _ -> None
+            )
+            |> Seq.choose id
             |> dict
 
         getDllOrder (dllFiles.Keys |> Seq.toList)
@@ -121,7 +127,11 @@ type DependencyCache (lockFile:LockFile) =
 
             let assemblyFilePerAssemblyDef = 
                 libs |> Seq.map (fun (f:FileInfo) -> 
-                    AssemblyDefinition.ReadAssembly (f.FullName:string), f)
+                    try
+                        (AssemblyDefinition.ReadAssembly (f.FullName:string), f) |> Some
+                    with
+                    | _ -> None)
+                |> Seq.choose id
                 |> dict
 
             let assemblies = 

--- a/src/Paket.Core/PaketConfigFiles/DependencyCache.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependencyCache.fs
@@ -8,6 +8,7 @@ open Mono.Cecil
 open System.Collections.Generic
 open Logging
 open ProviderImplementation.AssemblyReader.Utils.SHA1
+open System
 
 // Needs an update so that all work is not done at once
 // computation should be done on a per group/per framework basis
@@ -102,7 +103,7 @@ type DependencyCache (lockFile:LockFile) =
                 try 
                     (AssemblyDefinition.ReadAssembly path, FileInfo(path)) |> Some
                 with
-                | _ -> None
+                | :? BadImageFormatException -> None
             )
             |> Seq.choose id
             |> dict
@@ -130,7 +131,7 @@ type DependencyCache (lockFile:LockFile) =
                     try
                         (AssemblyDefinition.ReadAssembly (f.FullName:string), f) |> Some
                     with
-                    | _ -> None)
+                    | :? BadImageFormatException -> None)
                 |> Seq.choose id
                 |> dict
 


### PR DESCRIPTION
This is a super naive approach to the problem of loading native assembies that will fail with a `BadImageFormatException`.

Fixes #3097 .
I confirmed, that this fixes the error for https://github.com/ChrSteinert/Paket-3097 