### PR TITLE
Clarify how Including referenced projects works

### DIFF
--- a/docs/content/commands/pack.md
+++ b/docs/content/commands/pack.md
@@ -78,7 +78,7 @@ project output to the package for inter-project dependencies that don't have a
 [`paket.template` file][templatefile].
 
 1. It recursively iterates referenced projects and adds their project output to
-   the package
+   the package (as long as the working directory contains the other projects).
 1. When combined with the [symbols switch](#Symbol-Packages), it
    will also include the source code of the referenced projects.  Also
    recursively.


### PR DESCRIPTION
Paket automatically replaces inter-project dependencies with NuGet dependencies if the dependency has its own paket.template. However, if the working directory is the project directory (as opposed to the solution directory) the project dependencies will not be added.