### PR TITLE
Reproduce i3103

### DIFF
--- a/tests/Paket.Tests.preview3/Paket.Tests.fsproj
+++ b/tests/Paket.Tests.preview3/Paket.Tests.fsproj
@@ -103,6 +103,7 @@
     <Compile Include="$(PaketTestsSourcesDir)\Resolver\PropertyTests.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\Resolver\DependencyGroupsAndRestrictions.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\Resolver\ResolverErrorSituationTests.fs" />
+    <Compile Include="$(PaketTestsSourcesDir)\Resolver\DowngradeIssue3103.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\Resolver\PrereleaseSpecs.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\Lockfile\GeneratorSpecs.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\Lockfile\GenerateWithOptionsSpecs.fs" />

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -216,6 +216,7 @@
     <Compile Include="Resolver\PropertyTests.fs" />
     <Compile Include="Resolver\DependencyGroupsAndRestrictions.fs" />
     <Compile Include="Resolver\ResolverErrorSituationTests.fs" />
+    <Compile Include="Resolver\DowngradeIssue3103.fs" />
     <Compile Include="Resolver\PrereleaseSpecs.fs" />
     <Compile Include="Lockfile\GeneratorSpecs.fs" />
     <Compile Include="Lockfile\GenerateWithOptionsSpecs.fs" />

--- a/tests/Paket.Tests/Resolver/DowngradeIssue3103.fs
+++ b/tests/Paket.Tests/Resolver/DowngradeIssue3103.fs
@@ -1,0 +1,29 @@
+﻿module Paket.DowngradeIssue3103
+
+open Paket
+open NUnit.Framework
+open FsUnit
+open TestHelpers
+open Paket.Domain
+
+let graph = 
+  OfSimpleGraph [
+    "delphi-tf-latest-convert ","0.0.75",["delphi-TaxDoc", VersionRequirement(VersionRange.AtLeast "0",PreReleaseStatus.No)]
+    "delphi-tf-latest-convert ","0.0.74",["delphi-TaxDoc", VersionRequirement(VersionRange.AtLeast "0",PreReleaseStatus.No)]
+    "delphi-TaxDoc","17.4.0.16",[]
+    "delphi-TaxDoc","17.3.0.41",[]
+    "delphi-tf-latest-calc,","1.0.127",[]
+  ]
+
+let config = """
+source "https://www.nuget.org/api/v2"
+
+nuget delphi-tf-latest-convert
+"""
+
+
+[<Test>]
+let ``should resolve config``() = 
+    let cfg = DependenciesFile.FromSource(config)
+    let resolved = ResolveWithGraph(cfg,noSha1, VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
+    getVersion resolved.[PackageName "delphi-tf-latest-convert"] |> shouldEqual "0.0.75"

--- a/tests/Paket.Tests/Resolver/DowngradeIssue3103.fs
+++ b/tests/Paket.Tests/Resolver/DowngradeIssue3103.fs
@@ -6,13 +6,22 @@ open FsUnit
 open TestHelpers
 open Paket.Domain
 
+let exactVersion s =
+    let info = SemVer.Parse s |> VersionRange.Specific
+    VersionRequirement(info, PreReleaseStatus.No)
+
+let anyVersion = VersionRequirement(VersionRange.AtLeast "0",PreReleaseStatus.No)
+
 let graph = 
   OfSimpleGraph [
-    "delphi-tf-latest-convert ","0.0.75",["delphi-TaxDoc", VersionRequirement(VersionRange.AtLeast "0",PreReleaseStatus.No)]
-    "delphi-tf-latest-convert ","0.0.74",["delphi-TaxDoc", VersionRequirement(VersionRange.AtLeast "0",PreReleaseStatus.No)]
-    "delphi-TaxDoc","17.4.0.16",[]
-    "delphi-TaxDoc","17.3.0.41",[]
-    "delphi-tf-latest-calc,","1.0.127",[]
+    "delphi-tf-latest-convert ","0.0.75",[("delphi-TaxDoc", anyVersion); ("delphi-tf-latest-calc", anyVersion)]
+    "delphi-tf-latest-convert ","0.0.74",[("delphi-TaxDoc", anyVersion); ("delphi-tf-latest-calc", anyVersion)]
+    "delphi-TaxDoc","17.4.0.16",["dummy", (exactVersion "17.4.0.16")]
+    "delphi-TaxDoc","17.3.0.41",["dummy", (exactVersion "17.3.0.41")]
+    "delphi-tf-latest-calc","1.0.127",["delphi-CchData", (exactVersion "17.3.0.41")]
+    "delphi-CchData","17.3.0.41",["dummy", (exactVersion "17.3.0.41")]
+    "dummy","17.4.0.16",[]
+    "dummy","17.3.0.41",[]
   ]
 
 let config = """


### PR DESCRIPTION
See https://github.com/fsprojects/Paket/issues/3103.

Test failure reproduces issue:

```
Errors, Failures and Warnings
1) Failed : Paket.DowngradeIssue3103.should resolve config
Expected: "0.0.75"  Actual: "0.0.74" 
String lengths are both 6. Strings differ at index 5.
Expected: "0.0.75"                                                                                                      
But was:  "0.0.74"
----------------^
at FsUnit.Extensions.shouldEqual[a](a expected, a actual) in D:\Projets\Paket\paket-files\forki\FsUnit\FsUnit.fs:line 10
```