### PR TITLE
don't not add duplicated references

### DIFF
--- a/integrationtests/scenarios/i001578-transitive-ref/before/TestPaketDotNet/TestPaketDotNet.csprojtemplate
+++ b/integrationtests/scenarios/i001578-transitive-ref/before/TestPaketDotNet/TestPaketDotNet.csprojtemplate
@@ -85,6 +85,11 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
       <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <HintPath>..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
         <Reference Include="System.Net.Http.Extensions">
           <HintPath>..\packages\Microsoft.Net.Http\lib\net40\System.Net.Http.Extensions.dll</HintPath>
           <Private>True</Private>

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -784,7 +784,13 @@ module InstallModel =
 
     let filterReferences (references:string Set) (this:InstallModel) =
         this
-        |> mapCompileLibReferences (Set.filter (fun reference -> Set.contains reference.Name references |> not))
+        // HACK: workaround for https://github.com/fsprojects/Paket/issues/2811
+        //  * DO remove FW-References which are already referenced by the user
+        //  * DO NOT remove package references, where the user already has a reference
+        // Example where this is relevant:
+        // 1) Pre-existing reference to the FW-Assembly System.IO.Compression
+        // 2) user adds nuget package https://www.nuget.org/packages/System.IO.Compression/
+        //|> mapCompileLibReferences (Set.filter (fun reference -> Set.contains reference.Name references |> not))
         |> mapCompileLibFrameworkReferences (Set.filter (fun reference -> Set.contains reference.Name references |> not))
 
     let addLicense url (model: InstallModel) =

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -781,16 +781,13 @@ module InstallModel =
         { this with TargetsFileFolders = targetsFileFolders }
             |> addItem targetsFiles getMsbuildFile (addTargetsFile) (fun i -> i.TargetsFileFolders)
 
-
-    let filterReferences (references:string Set) (this:InstallModel) =
+            
+    let filterNonFrameworkReferences (references:string Set) (this:InstallModel) =
         this
-        // HACK: workaround for https://github.com/fsprojects/Paket/issues/2811
-        //  * DO remove FW-References which are already referenced by the user
-        //  * DO NOT remove package references, where the user already has a reference
-        // Example where this is relevant:
-        // 1) Pre-existing reference to the FW-Assembly System.IO.Compression
-        // 2) user adds nuget package https://www.nuget.org/packages/System.IO.Compression/
-        //|> mapCompileLibReferences (Set.filter (fun reference -> Set.contains reference.Name references |> not))
+        |> mapCompileLibReferences (Set.filter (fun reference -> Set.contains reference.Name references |> not))
+
+    let filterFrameworkReferences (references:string Set) (this:InstallModel) =
+        this
         |> mapCompileLibFrameworkReferences (Set.filter (fun reference -> Set.contains reference.Name references |> not))
 
     let addLicense url (model: InstallModel) =
@@ -926,7 +923,9 @@ type InstallModel with
 
     member this.FilterExcludes excludes = InstallModel.filterExcludes excludes this
 
-    member this.FilterReferences(references) = InstallModel.filterReferences references this
+    member this.FilterNonFrameworkReferences(references) = InstallModel.filterNonFrameworkReferences references this
+
+    member this.FilterFrameworkReferences(references) = InstallModel.filterFrameworkReferences references this
 
     member this.ApplyFrameworkRestrictions restrictions = InstallModel.applyFrameworkRestrictions restrictions this
 

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -728,8 +728,14 @@ module ProjectFile =
             getCustomReferenceAndFrameworkNodes project
             |> List.map (fun node -> node.Attributes.["Include"].InnerText.Split(',').[0])
             |> Set.ofList
+            
+        // workaround for https://github.com/fsprojects/Paket/issues/2811
+        //  * DO remove FW-References which are already referenced by the user
+        //  * DO NOT remove package references, where the user already has a reference
 
-        let model = model.FilterReferences references
+        //let model = model.FilterNonFrameworkReferences references
+        let model = model.FilterFrameworkReferences references
+
         let createItemGroup (targets:TargetProfile Set) (frameworkReferences:FrameworkReference list) (libraries:Library list) = 
             let itemGroup = createNode "ItemGroup" project
 

--- a/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
+++ b/tests/Paket.Tests/InstallModel/Xml/SystemNetHttpWithExistingFrameworkReferences.fs
@@ -26,6 +26,11 @@ let expected = """
         <Private>True</Private>
         <Paket>True</Paket>
       </Reference>
+      <Reference Include="System.Net.Http.WebRequest">
+        <HintPath>..\..\..\Microsoft.Net.Http\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+        <Private>True</Private>
+        <Paket>True</Paket>
+      </Reference>
     </ItemGroup>
   </When>
   <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">


### PR DESCRIPTION
HACK: workaround for https://github.com/fsprojects/Paket/issues/2811
 * DO remove FW-References which are already referenced by the user
 * DO NOT remove package references, where the user already has a reference
Example where this is relevant:
1) Pre-existing reference to the FW-Assembly System.IO.Compression
2) user adds nuget package https://www.nuget.org/packages/System.IO.Compression/

Before:
 * the old reference is kept, the new one not added
 * no feedback during compile, assembly mismatch at runtime

After:
 * new reference is added
 * duplicated reference, warning at compile time
 * msbuild automatically takes the higher version, everything is good
 * user can manually remove old reference to silence warning