### PR TITLE
Fix the optimization for restore bypassing argu

### DIFF
--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -204,7 +204,7 @@ let add (results : ParseResults<_>) =
         (results.TryGetResult <@ AddArgs.Project @>,
          results.TryGetResult <@ AddArgs.Project_Legacy @>)
         |> legacyOption results (ReplaceArgument("--project", "project"))
-    let packageKind = 
+    let packageKind =
         match results.GetResult (<@ AddArgs.Type @>, defaultValue = AddArgsDependencyType.Nuget) with
         | AddArgsDependencyType.Nuget -> Requirements.PackageRequirementKind.Package
         | AddArgsDependencyType.Clitool -> Requirements.PackageRequirementKind.DotnetCliTool
@@ -222,7 +222,7 @@ let add (results : ParseResults<_>) =
 
 let github (results : ParseResults<_>) =
     match results.GetResult <@ GithubArgs.Add @> with
-    | add -> 
+    | add ->
         let group =
             add.TryGetResult <@ AddGithubArgs.Group @>
         let repository =
@@ -235,11 +235,11 @@ let github (results : ParseResults<_>) =
             match add.TryGetResult <@ AddGithubArgs.Version @> with
             | Some v -> v
             | None -> ""
-    
+
         Dependencies
             .Locate()
             .AddGithub(group, repository, file, version)
-    
+
 let validateConfig (results : ParseResults<_>) =
     let credential = results.Contains <@ ConfigArgs.AddCredentials @>
     let token = results.Contains <@ ConfigArgs.AddToken @>
@@ -766,10 +766,10 @@ let why (results: ParseResults<WhyArgs>) =
 let restriction (results: ParseResults<RestrictionArgs>) =
     let restrictionRaw = results.GetResult <@ RestrictionArgs.Restriction @>
     let restriction, parseProblems = Requirements.parseRestrictions restrictionRaw
-    
+
     for problem in parseProblems |> Seq.map (fun x -> x.AsMessage) do
         Logging.traceWarnfn "Problem: %s" problem
-        
+
     Logging.tracefn "Restriction: %s" restrictionRaw
     Logging.tracefn "Simplified: %s" (restriction.ToString())
     Logging.tracefn "Frameworks: [ "
@@ -840,9 +840,20 @@ let main() =
     try
     let args = Environment.GetCommandLineArgs()
     match args with
-    | [| "restore" |] | [| "--from-bootstrapper"; "restore" |] ->
-        // fast restore route, see https://github.com/fsprojects/Argu/issues/90
-        processWithValidationEx ignore false (fun _ -> true) (fun _ -> Dependencies.Locate().Restore()) ()
+    | [| _; "restore" |] | [| _; "--from-bootstrapper"; "restore" |] ->
+        // Global restore fast route, see https://github.com/fsprojects/Argu/issues/90
+        processWithValidationEx
+            ignore
+            false
+            (fun _ -> true)
+            (fun _ -> Dependencies.Locate().Restore()) ()
+    | [| _; "restore"; "--project"; project |] | [| _; "--from-bootstrapper"; "restore"; "--project"; project |] ->
+        // Project restore fast route, see https://github.com/fsprojects/Argu/issues/90
+        processWithValidationEx
+            ignore
+            false
+            (fun _ -> true)
+            (fun _ -> Dependencies.Locate().Restore(false, None, project, false, false, false, None)) ()
     | _ ->
         let parser = ArgumentParser.Create<Command>(programName = "paket",
                                                     helpTextMessage = sprintf "Paket version %s%sHelp was requested:" paketVersion Environment.NewLine,

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -854,6 +854,13 @@ let main() =
             false
             (fun _ -> true)
             (fun _ -> Dependencies.Locate().Restore(false, None, project, false, false, false, None)) ()
+    | [| _; "install" |] | [| _; "--from-bootstrapper"; "install" |] ->
+        // Global restore fast route, see https://github.com/fsprojects/Argu/issues/90
+        processWithValidationEx
+            ignore
+            false
+            (fun _ -> true)
+            (fun _ -> Dependencies.Locate().Install(false, false, false, false, false, SemVerUpdateMode.NoRestriction, false, false, [], [], None)) ()
     | _ ->
         let parser = ArgumentParser.Create<Command>(programName = "paket",
                                                     helpTextMessage = sprintf "Paket version %s%sHelp was requested:" paketVersion Environment.NewLine,


### PR DESCRIPTION
The current optimization to bypass argu doesn't work because the first element in the arguments is the current executable path.

So I fixed it and also added support for `restore --project` that the SDK projects target uses, and for `install` as it's one of the most used command