### PR TITLE
[DON'T MERGE] Add getting started section to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@
 
 A dependency manager for .NET with support for NuGet packages and git repositories.
 
+## Getting started
+
+Detailed "Getting started" guide: https://fsprojects.github.io/Paket/getting-started.html
+
+This will use the bootstrapper in [magic mode](https://fsprojects.github.io/Paket/bootstrapper.html#Magic-mode):
+
+### Windows
+
+1) Open powershell and navigate to your project directory.
+2) Execute ``[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri "https://get-paket.azurewebsites.net/api/bootstrapper" -OutFile ".\paket.exe"`` (the first part is required because github disabled support for older ssl versions)
+3) Run either ``.\paket init`` or ``.\paket convert-from-nuget``, depending on whether you already have an existing project.
+
+### Linux
+
+1) Open a terminal and navigate to your project directory.
+2) Execute ``wget ‐‐output-document=paket.exe https://get-paket.azurewebsites.net/api/bootstrapper``
+3) Run either ``mono paket init`` or ``mono paket convert-from-nuget``, depending on whether you already have an existing project.
+
+### Manual
+
+The latest paket.exe can be downloaded from https://get-paket.azurewebsites.net/api/paket.  
+The latest paket.bootstrapper.exe can be downloaded from https://get-paket.azurewebsites.net/api/bootstrapper.
+
 ## Why Paket?
 
 NuGet does not separate out the concept of transitive dependencies.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will use the bootstrapper in [magic mode](https://fsprojects.github.io/Pake
 ### Windows
 
 1) Open powershell and navigate to your project directory.
-2) Execute ``[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri "https://get-paket.azurewebsites.net/api/bootstrapper" -OutFile ".\paket.exe"`` (the first part is required because github disabled support for older ssl versions)
+2) Execute ``[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri "https://get-paket.azurewebsites.net/api/bootstrapper" -OutFile ".\paket.exe"`` (the first part is required because [github disabled support for older ssl versions](https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/))
 3) Run either ``.\paket init`` or ``.\paket convert-from-nuget``, depending on whether you already have an existing project.
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will use the bootstrapper in [magic mode](https://fsprojects.github.io/Pake
 ### Windows
 
 1) Open powershell and navigate to your project directory.
-2) Execute ``[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri "https://get-paket.azurewebsites.net/api/bootstrapper" -OutFile ".\paket.exe"`` (the first part is required because [github disabled support for older ssl versions](https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/))
+2) Execute ``[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;(New-Object System.Net.WebClient).DownloadFile("https://get-paket.azurewebsites.net/api/bootstrapper", [io.path]::Combine($pwd, "paket.exe"))`` (the first part is required because [github disabled support for older ssl versions](https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/))
 3) Run either ``.\paket init`` or ``.\paket convert-from-nuget``, depending on whether you already have an existing project.
 
 ### Linux


### PR DESCRIPTION
Whenever I _paketize_ a new project, I am always slightly annoyed that I need to either copy-paste a paket.exe from another project, or got to github, go to paket, go to releases, download bootstrapper, move from download directory to project directory ...


I have created two azure functions which provide stable download URLs to the latest versions:

* https://get-paket.azurewebsites.net/api/paket
* https://get-paket.azurewebsites.net/api/bootstrapper

I added shell-commands to the README, which download the bootstrapper and rename it to paket.exe.

This should make it a little bit simpler to get started.

__What do you think?__
