### PR TITLE
Fix for #2573

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1671,6 +1671,21 @@ module ProjectFile =
               Kind = NugetPackageKind.DotnetCliTool
               TargetFramework = None })
 
+    let getAutoGenerateBindingRedirects (project:ProjectFile) = getProperty "AutoGenerateBindingRedirects" project
+    let setOrCreateAutoGenerateBindingRedirects (project:ProjectFile) =
+        if (getAutoGenerateBindingRedirects project).IsSome then
+            project.Document
+            |> getDescendants "AutoGenerateBindingRedirects"
+            |> List.iter(fun x -> x.InnerText <- "true")
+        else
+            project.Document
+            |> getDescendants "PropertyGroup"
+            |> List.head
+            |> fun x -> x.AppendChild (createNodeSet "AutoGenerateBindingRedirects" "true" project)
+            |> ignore
+
+        save false project
+
 type ProjectFile with
 
     member this.GetPropertyWithDefaults propertyName defaultProperties = ProjectFile.getPropertyWithDefaults propertyName defaultProperties this
@@ -1753,7 +1768,11 @@ type ProjectFile with
 
     member this.GetAssemblyName () = ProjectFile.getAssemblyName this
 
-    static member LoadFromStream(fullName:string, stream:Stream) = ProjectFile.loadFromStream fullName stream 
+    member this.GetAutoGenerateBindingRedirects() = ProjectFile.getAutoGenerateBindingRedirects this
+
+    member this.SetOrCreateAutoGenerateBindingRedirects() = ProjectFile.setOrCreateAutoGenerateBindingRedirects this
+
+    static member LoadFromStream(fullName:string, stream:Stream) = ProjectFile.loadFromStream fullName stream
 
     static member LoadFromFile(fileName:string) =  ProjectFile.loadFromFile fileName
 

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1673,17 +1673,13 @@ module ProjectFile =
 
     let getAutoGenerateBindingRedirects (project:ProjectFile) = getProperty "AutoGenerateBindingRedirects" project
     let setOrCreateAutoGenerateBindingRedirects (project:ProjectFile) =
-        if (getAutoGenerateBindingRedirects project).IsSome then
-            project.Document
-            |> getDescendants "AutoGenerateBindingRedirects"
-            |> List.iter(fun x -> x.InnerText <- "true")
-        else
-            let propertyGroups = project.Document |> getDescendants "PropertyGroup"
-            if propertyGroups.IsEmpty |> not then
-                propertyGroups
-                |> List.head
-                |> fun x -> x.AppendChild (createNodeSet "AutoGenerateBindingRedirects" "true" project)
-                |> ignore
+        match getAutoGenerateBindingRedirects project with
+        | Some _ -> project.Document
+                    |> getDescendants "AutoGenerateBindingRedirects"
+                    |> List.iter(fun x -> x.InnerText <- "true")
+        | _ -> match project.Document |> getDescendants "PropertyGroup" with
+               | x :: _ -> x.AppendChild (createNodeSet "AutoGenerateBindingRedirects" "true" project) |> ignore
+               | _ -> ()
 
         save false project
 

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1678,11 +1678,12 @@ module ProjectFile =
             |> getDescendants "AutoGenerateBindingRedirects"
             |> List.iter(fun x -> x.InnerText <- "true")
         else
-            project.Document
-            |> getDescendants "PropertyGroup"
-            |> List.head
-            |> fun x -> x.AppendChild (createNodeSet "AutoGenerateBindingRedirects" "true" project)
-            |> ignore
+            let propertyGroups = project.Document |> getDescendants "PropertyGroup"
+            if propertyGroups.IsEmpty |> not then
+                propertyGroups
+                |> List.head
+                |> fun x -> x.AppendChild (createNodeSet "AutoGenerateBindingRedirects" "true" project)
+                |> ignore
 
         save false project
 


### PR DESCRIPTION
Fixes #2573 by adding AutoGenerateBindingRedirects automatically when BindingRedirects are added to a config file.

This change is documented here: https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection
By enabling the setting it prevents MSBuild trying to do a unification.