### PR TITLE
One-liner paket installation script

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -25,12 +25,8 @@ This guide will show you
 
 ### Downloading Paket's Bootstrapper
 
-1. Create a `.paket` directory in the root of your solution.
-1. Download the latest
-   [`paket.bootstrapper.exe`](https://github.com/fsprojects/Paket/releases/latest)
-   into that directory.
-1. Rename `.paket/paket.bootstrapper.exe` to `.paket/paket.exe`.
-   [Read more about "magic mode"](bootstrapper.html#Magic-mode).
+1. In the root directory of your solution, execute `curl -fsSL https://raw.githubusercontent.com/fsprojects/Paket/web-install/install/web-install.fsx | fsharpi --quiet --readline-`
+   * This will execute a script that downloads the latest `paket.bootstrapper.exe` and save it to `.paket/paket.exe`. [Read more about "magic mode"](bootstrapper.html#magic-mode).
 1. Commit `.paket/paket.exe` to your repository.
 1. After the first `.paket/paket.exe` invocation Paket will create a couple of
    files in `.paket` — commit those as well.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -25,7 +25,7 @@ This guide will show you
 
 ### Downloading Paket's Bootstrapper
 
-1. In the root directory of your solution, execute `curl -fsSL https://raw.githubusercontent.com/fsprojects/Paket/web-install/install/web-install.fsx | fsharpi --quiet --readline-`
+1. In the root directory of your solution, execute `curl -fsSL https://raw.githubusercontent.com/fsprojects/Paket/master/install/web-install.fsx | fsharpi --quiet --readline-`
    * This will execute a script that downloads the latest `paket.bootstrapper.exe` and save it to `.paket/paket.exe`. [Read more about "magic mode"](bootstrapper.html#magic-mode).
 1. Commit `.paket/paket.exe` to your repository.
 1. After the first `.paket/paket.exe` invocation Paket will create a couple of

--- a/install/web-install.fsx
+++ b/install/web-install.fsx
@@ -1,0 +1,26 @@
+// This script downloades and saves the latest paket bootstrapper (in magic mode) into ./.paket/ . 
+
+open System
+open System.IO
+open System.Net
+open System.Text.RegularExpressions
+
+let paketDir = Path.Combine [|Environment.CurrentDirectory; ".paket"|]
+let paketExe = Path.Combine [|paketDir; "paket.exe"|]
+let bootstrapperExeRegex = new Regex(@"""browser_download_url"":\s*""(?<url>[^""]*/paket.bootstrapper.exe)""")
+
+let latestBootstrapperUrl (wc: WebClient) =
+    wc.Headers.Add ("user-agent", "fsharp-script")
+    let json = wc.DownloadString "https://api.github.com/repos/fsprojects/Paket/releases/latest"
+    (bootstrapperExeRegex.Match json).Groups.["url"].Value
+
+let main () =
+    use wc = new WebClient ()
+    printfn "Fetching latest paket release..."
+    let url = latestBootstrapperUrl wc
+    printfn "Saving paket bootstrapper as paket.exe (magic mode) in %s..." paketDir
+    Directory.CreateDirectory paketDir |> ignore
+    wc.DownloadFile (url, paketExe)
+    printfn "Done. Paket should now be working."
+
+main ()

--- a/install/web-install.fsx
+++ b/install/web-install.fsx
@@ -1,5 +1,5 @@
 // This script downloades and saves the latest paket bootstrapper (in magic mode) into ./.paket/ .
-// curl -fsSL https://raw.githubusercontent.com/fsprojects/Paket/web-install/install/web-install.fsx | fsharpi --quiet --readline-
+// curl -fsSL https://raw.githubusercontent.com/fsprojects/Paket/master/install/web-install.fsx | fsharpi --quiet --readline-
 
 open System
 open System.IO

--- a/install/web-install.fsx
+++ b/install/web-install.fsx
@@ -1,4 +1,5 @@
-// This script downloades and saves the latest paket bootstrapper (in magic mode) into ./.paket/ . 
+// This script downloades and saves the latest paket bootstrapper (in magic mode) into ./.paket/ .
+// curl -fsSL https://raw.githubusercontent.com/fsprojects/Paket/web-install/install/web-install.fsx | fsharpi --quiet --readline-
 
 open System
 open System.IO


### PR DESCRIPTION
I've added a handy script and documentation changes that replaces some manual steps for adding the paket bootstrapper to a project. Now, instead of using the pesky mouse & GUI to download and rename `paket.boostrapper.exe` to `.paket/paket.exe`, just copy-paste this into the terminal: `curl -fsSL https://raw.githubusercontent.com/fsprojects/Paket/web-install/install/web-install.fsx | fsharpi --quiet --readline-`.

This is such a common task for me that I've already been using a version of this script for my own use,  and I think a lot of people could benefit from it.