### PR TITLE
Fix license_download docs

### DIFF
--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -314,13 +314,13 @@ The global option may be
 
 ### License download
 
-If you want paket to download licenses automatically you can use the `download_license` modifier. It is disabled by default.
+If you want paket to download licenses automatically you can use the `license_download` modifier. It is disabled by default.
 
 ```paket
 source https://nuget.org/api/v2
-download_license: true
+license_download: true
 
-nuget suave 
+nuget suave
 ```
 
 The global option may be

--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -322,12 +322,12 @@ nuget Microsoft.Bcl.Build import_targets: false // Do not import *.targets and *
 
 ### License download
 
-If you want paket to download licenses automatically you can use the `download_license` modifier. It is disabled by default.
+If you want paket to download licenses automatically you can use the `license_download` modifier. It is disabled by default.
 
 ```paket
 source https://nuget.org/api/v2
 
-nuget suave download_license: true
+nuget suave license_download: true
 ```
 
 

--- a/integrationtests/Paket.IntegrationTests/InitSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InitSpecs.fs
@@ -63,7 +63,7 @@ let ``#1041 init api``() =
     let url = "http://my.test/api"
     let source = Paket.PackageSources.PackageSource.NuGetV2Source(url)
 
-    Paket.Dependencies.Init(tempScenarioDir, [source], [ "download_license: true" ], false)
+    Paket.Dependencies.Init(tempScenarioDir, [source], [ "license_download: true" ], false)
 
     let depsPath = tempScenarioDir </> "paket.dependencies"
     File.Exists(depsPath) |> shouldEqual true
@@ -71,4 +71,4 @@ let ``#1041 init api``() =
     let lines = File.ReadAllText(depsPath)
 
     StringAssert.Contains(url, lines);
-    StringAssert.Contains("download_license: true", lines);
+    StringAssert.Contains("license_download: true", lines);

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -269,7 +269,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read download_license config``() = 
+let ``should read license_download config``() =
     let cfg = DependenciesFile.FromSource(downloadLicenseConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.LicenseDownload |> shouldEqual (Some true)
 


### PR DESCRIPTION
The wrong flag was also used in some tests.

Fixes #3148.