### PR TITLE
extended semver2 support in paket.template files

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -238,6 +238,36 @@ dependencies
   FSharp.Core >= LOCKEDVERSION-NetStandard
 ```
 
+`LOCKEDVERSION` and `CURRENTVERSION` support using partial constraints,
+to allow transitive dependencies on specific SemVer compatibility level.
+This allows to create permissive pessimistic constraints automatically.
+
+Use only `LOCKED` or `CURRENT` and semicolon-delimited name of the latest
+SemVer segment (`Major`, `Minor`, `Patch` or `Build`), or bracketed number
+of segments from the original constraint to be used.
+Negative numbers denote count down from the last non-zero segment.
+
+```text
+dependencies
+  FSharp.Core ~> LOCKED:Minor
+  My.Own.Package ~> CURRENT:[2]
+```
+
+Using `0` or `-4` is not supported; `[4]` or `Build` will result in the original
+version but with any prerelease specifiers and metedata cut off.
+
+Combining with group-binding syntax is supported, in either order;
+assuming group "NetStandard" and 4-segment version, these constraints are equal:
+
+```text
+  LOCKED-NetStandard:Patch
+  LOCKED-NetStandard:[3]
+  LOCKED-NetStandard:[-1]
+  LOCKED:Patch-NetStandard
+  LOCKED:[3]-NetStandard
+  LOCKED:[-1]-NetStandard
+```
+
 It's possible to add a line to constrain the target framework:
 
 ```text
@@ -293,4 +323,5 @@ This only works for `paket.template` files of type `project`.
 ## Comments
 
 A line starting with a `#` or `//` is considered a comment and will be ignored
-by the parser.
+by the parser. 
+Endline comments are only allowed in dependency constraint lines.

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -202,6 +202,7 @@ type TemplateFile =
 [<CompilationRepresentationAttribute(CompilationRepresentationFlags.ModuleSuffix)>]
 module internal TemplateFile =
     open Logging
+    open Utils
 
     let tryGetId (templateFile : TemplateFile) =
         match templateFile.Contents with
@@ -286,49 +287,87 @@ module internal TemplateFile =
         | _ -> None
    
     let private getDependencyByLine (fileName, lockFile:LockFile,currentVersion:SemVerInfo option, specificVersions:Map<string, SemVerInfo>, line:string, framework:FrameworkIdentifier option) =
-        let reg = Regex(@"(?<id>\S+)(?<version>.*)").Match line
-        let name = PackageName reg.Groups.["id"].Value
-        let versionRequirement =
-            let versionString =
-                let s = reg.Groups.["version"].Value.Trim()
-                if s.Contains "CURRENTVERSION" then
-                    match specificVersions.TryFind (string name) with
-                    | Some v -> s.Replace("CURRENTVERSION", string v)
-                    | None ->
-                        match currentVersion with
-                        | Some v -> s.Replace("CURRENTVERSION", string v)
-                        | None -> failwithf "The template file %s contains the placeholder CURRENTVERSION, but no version was given." fileName
-
-                elif s.Contains "LOCKEDVERSION" then
-                    let groupRegex = Regex("LOCKEDVERSION-(?<group>\w+)")
-                    let replaceGroup (m : Match) =
-                        let groupName = GroupName m.Groups.["group"].Value
-                        match lockFile.Groups |> Map.tryFind groupName with
-                        | None -> failwithf "The template file %s contains the placeholder LOCKEDVERSION-%O, but no group %O was found in paket.lock" fileName groupName groupName
-                        | Some gp ->
-                            match gp.Resolution |> Map.tryFind name with
-                            | None -> failwithf "The template file %s contains the placeholder LOCKEDVERSION-%O, but no version was given for package %O in group %O in paket.lock" fileName groupName name groupName
-                            | Some p -> string p.Version
-
-                    let s = groupRegex.Replace(s, replaceGroup)
-
-                    match lockFile.Groups.[Constants.MainDependencyGroup].Resolution |> Map.tryFind name with
-                    | Some p -> s.Replace("LOCKEDVERSION", string p.Version)
-                    | None ->
-                        let packages = 
-                            lockFile.GetGroupedResolution()
-                            |> Seq.filter (fun kv -> snd kv.Key = name)
-                            |> Seq.toList
-
-                        match packages with
-                        | [] -> failwithf "The template file %s contains the placeholder LOCKEDVERSION, but no version was given for package %O in paket.lock." fileName name
-                        | [kv] -> s.Replace("LOCKEDVERSION", string kv.Value.Version)
-                        | _ -> failwithf "The template file %s contains the placeholder LOCKEDVERSION, but more than one group contains package %O in paket.lock." fileName name
-
-                else s
-                                
-            DependenciesFileParser.parseVersionRequirement versionString
-        name, versionRequirement
+        let item = line.Split([|"//"; "#"|], 2, StringSplitOptions.None).[0].Trim()
+        if item |> String.IsNullOrWhiteSpace then
+            None // skip comment lines, allowing paket.dependencies-like formatting
+        else
+        
+        let reg = Regex(@"(?in)^(?<id>[^\s@!~>\<\=]+)(?<version>.*)?").Match item
+        let packageName = PackageName reg.Groups.["id"].Value
+        
+        let rawRequirement = reg.Groups.["version"].Value.Trim()
+        let regVersion = Regex(@"(?in)(?<repl>(?<what>(LOCKED|CURRENT))((?<=\k<what>)VERSION|:(?<spec>(Major|Minor|Patch|Build|\[-?[1-4]\]))|-(?<group>[\w-]+)){1,3})")
+        
+        let rec versionReplace requireText =
+            match regVersion.Match requireText with
+            | m when m.Success ->
+                let sourceVersion : SemVerInfo =
+                    match m.Groups.["what"].Value with
+                    | String.EqualsIC "LOCKED" ->
+                        match m.Groups.["group"] with
+                        | g when g.Success -> // this may as well include Main
+                        
+                            let groupName = GroupName g.Value
+                            match lockFile.Groups |> Map.tryFind groupName with
+                            | Some group -> 
+                                match group.Resolution |> Map.tryFind packageName with
+                                | Some resolvedPackage -> resolvedPackage.Version
+                                | None -> failwithf "The template file %s contains the placeholder %A, but no version was given for package %O in group %O in paket.lock" fileName requireText packageName groupName
+                            | None -> failwithf "The template file %s contains the placeholder %A, but group %O was not found in paket.lock" fileName requireText groupName
+                                      
+                        | _ -> // default to Main, _or_ any other group with warning
+                            let mainGroup = lockFile.Groups.[Constants.MainDependencyGroup] 
+                            match mainGroup.TryFind packageName with
+                            | Some resolvedPackage -> resolvedPackage.Resolved.Version
+                            | None ->
+                                let packages = lockFile.GetGroupedResolution() |> Seq.filter (fun kv -> snd kv.Key = packageName) |> Seq.toList                
+                                match packages with
+                                | [] -> failwithf "The template file %s contains the placeholder %A, but no version was given for package %O in paket.lock." fileName requireText packageName
+                                | [groupAndPackage] ->
+                                    traceWarnfn "The template file %s contains the placeholder %A, but version for package %O was found in group %A." fileName requireText packageName (fst groupAndPackage.Key)
+                                    groupAndPackage.Value.Version
+                                | _ -> failwithf "The template file %s contains the placeholder %A, but more than one group contains package %O in paket.lock." fileName requireText packageName                                
+                        
+                    | String.EqualsIC "CURRENT" -> 
+                        match specificVersions.TryFind (string packageName) with
+                        | Some excplicitVersion -> excplicitVersion
+                        | None ->
+                            match currentVersion with
+                            | Some thisVersion -> thisVersion
+                            | None -> failwithf "The template file %s contains the placeholder %A, but no version was given." fileName requireText
+                                                    
+                    | _ -> failwithf "The template file %s contains invalid placeholder %A" fileName line
+            
+                let versionParts = (sourceVersion.AsString |> String.split [|'-'; '+'|]).[0] |> String.split [|'.'|]
+                let segmentCount = 
+                    match m.Groups.["spec"] with
+                    | spec when spec.Success ->
+                        match spec.Value with
+                        | "[1]" | "Major" -> 1
+                        | "[2]" | "Minor" -> 2
+                        | "[3]" | "Patch" -> 3 
+                        | "[4]" | "Build" -> 4 // do not normalize zero builds away, if explicitly requested
+                        | "[-1]" | "[-2]" | "[-3]" ->
+                            let versionLength = 
+                                versionParts |> Seq.rev // count non-zero segments, from original, NOT-normalized source 
+                                |> Seq.takeWhile (fun i -> match bigint.TryParse i with | true, n -> n > 0I | _ -> false) 
+                                |> Seq.length
+                            versionLength + (int (spec.Value.Trim([|'['; ']'|])))
+                        | _ -> failwithf "The template file %s contains invalid specification %s" fileName line
+                    | _ -> 0
+                    
+                let targetVersion = 
+                    match segmentCount with
+                    | 1 | 2 | 3 | 4 -> String.Join(".", versionParts, 0, Math.Min(versionParts.Length, Math.Max(0, segmentCount)))
+                    | _ -> sourceVersion.AsString
+                
+                versionReplace (m.Result(targetVersion)) 
+                 
+            | _ -> requireText
+                
+        let versionString = versionReplace rawRequirement                
+        let versionRequirement = DependenciesFileParser.parseVersionRequirement versionString
+        Some (packageName, versionRequirement)
 
     let private getDependenciesByTargetFramework fileName lockFile currentVersion  specificVersions (lineNo, state: OptionalDependencyGroup list) line =
         let lineNo = lineNo + 1
@@ -340,15 +379,17 @@ module internal TemplateFile =
                 lineNo, groups
             | Empty  _ -> lineNo, current::other
             | _ -> 
-                let dependency = getDependencyByLine(fileName, lockFile, currentVersion, specificVersions, line, current.Framework)
-                lineNo, { current with Dependencies = current.Dependencies @ [dependency] }::other
+                match getDependencyByLine(fileName, lockFile, currentVersion, specificVersions, line, current.Framework) with
+                | Some dependency -> lineNo, { current with Dependencies = current.Dependencies @ [dependency] }::other
+                | None -> lineNo, current::other
         | [] ->
             match line with
             | Framework framework -> lineNo, [OptionalDependencyGroup.ForFramework framework]
             | Empty  _ -> lineNo, []
             | _ ->
-                let dependency = getDependencyByLine(fileName, lockFile, currentVersion, specificVersions, line, None)
-                lineNo, [{ Framework = None; Dependencies = [dependency] }]
+                match getDependencyByLine(fileName, lockFile, currentVersion, specificVersions, line, None) with
+                | Some dependency -> lineNo, [{ Framework = None; Dependencies = [dependency] }]
+                | None -> lineNo, []
             
    
     let private getDependencyGroups (fileName, lockFile:LockFile, info : Map<string, string>,currentVersion:SemVerInfo option, specificVersions:Map<string, SemVerInfo>) =

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -1,6 +1,7 @@
 ﻿module Paket.TemplateFile.Test
 
 open System.IO
+open System.IO
 open Paket
 open Chessie.ErrorHandling
 open FsUnit
@@ -320,8 +321,37 @@ dependencies
         |> ignore
     )
 
-[<Test>]
-let ``Detect dependencies with CURRENTVERSION correctly`` () =
+[<TestCase("CURRENTVERSION", "2.1", "2.1")>]
+[<TestCase("CURRENTVERSION", "2.1.0", "2.1.0")>]
+[<TestCase("CURRENTVERSION", "2.1.0.0", "2.1.0.0")>]
+[<TestCase("CURRENTVERSION", "2.1.0.1", "2.1.0.1")>]
+[<TestCase("CURRENTVERSION", "2.1.0-pre.3", "2.1.0-pre.3")>]
+[<TestCase("CURRENTVERSION", "2.1.0.1-pre.3", "2.1.0.1-pre.3")>]
+[<TestCase("CURRENT:Major", "2.1", "2")>]
+[<TestCase("CURRENT:Major", "2.1.0", "2")>]
+[<TestCase("CURRENT:Major", "2.1.0.0", "2")>]
+[<TestCase("CURRENT:Major", "2.1.0.1", "2")>]
+[<TestCase("CURRENT:Major", "2.1.0-pre.3", "2")>]
+[<TestCase("CURRENT:Major", "2.1.0.1-pre.3", "2")>]
+[<TestCase("CURRENT:Minor", "2.1", "2.1")>]
+[<TestCase("CURRENT:Minor", "2.1.0", "2.1")>]
+[<TestCase("CURRENT:Minor", "2.1.0.0", "2.1")>]
+[<TestCase("CURRENT:Minor", "2.1.0.1", "2.1")>]
+[<TestCase("CURRENT:Minor", "2.1.0-pre.3", "2.1")>]
+[<TestCase("CURRENT:Minor", "2.1.0.1-pre.3", "2.1")>]
+[<TestCase("CURRENT:Patch", "2.1", "2.1")>]
+[<TestCase("CURRENT:Patch", "2.1.0", "2.1.0")>]
+[<TestCase("CURRENT:Patch", "2.1.0.0", "2.1.0")>]
+[<TestCase("CURRENT:Patch", "2.1.0.1", "2.1.0")>]
+[<TestCase("CURRENT:Patch", "2.1.0-pre.3", "2.1.0")>]
+[<TestCase("CURRENT:Patch", "2.1.0.1-pre.3", "2.1.0")>]
+[<TestCase("CURRENT:Build", "2.1", "2.1")>]
+[<TestCase("CURRENT:Build", "2.1.0", "2.1.0")>]
+[<TestCase("CURRENT:Build", "2.1.0.0", "2.1.0.0")>]
+[<TestCase("CURRENT:Build", "2.1.0.1", "2.1.0.1")>]
+[<TestCase("CURRENT:Build", "2.1.0-pre.3", "2.1.0")>]
+[<TestCase("CURRENT:Build", "2.1.0.1-pre.3", "2.1.0.1")>]
+let ``Detect dependencies with CURRENTVERSION correctly`` placeholder source target =
     let fileContent = """type file
 id My.Thing
 authors Bob McBob
@@ -333,10 +363,10 @@ version
 dependencies
      FSharp.Core 4.3.1
      My.OtherThing CURRENTVERSION
-"""
-
+""" 
+    let content = fileContent.Replace("CURRENTVERSION", placeholder)
     let sut =
-        TemplateFile.Parse("file1.template", LockFile.Parse("",[||]), Some(SemVer.Parse "2.1"), Map.empty, strToStream fileContent)
+        TemplateFile.Parse("file1.template", LockFile.Parse("",[||]), Some(SemVer.Parse source), Map.empty, strToStream content)
         |> returnOrFail
         |> function
            | CompleteInfo (_, opt)
@@ -346,7 +376,7 @@ dependencies
         name1 |> shouldEqual (PackageName "FSharp.Core")
         range1.Range |> shouldEqual (Specific (SemVer.Parse "4.3.1"))
         name2 |> shouldEqual (PackageName "My.OtherThing")
-        range2.Range |> shouldEqual (Specific (SemVer.Parse "2.1"))
+        range2.Range |> shouldEqual (Specific (SemVer.Parse target))
     | _ -> Assert.Fail()
 
 [<Test>]
@@ -387,8 +417,38 @@ dependencies
         range3.Range |> shouldEqual (Specific specificVersion)
     | _ -> Assert.Fail()
 
-[<Test>]
-let ``Detect dependencies with LOCKEDVERSION correctly`` () =
+/// source replaces locked version of My.OtherThing (1.2.3.0)
+[<TestCase("LOCKEDVERSION", "1.2", "1.2.0")>]
+[<TestCase("LOCKEDVERSION", "1.2.3", "1.2.3")>]
+[<TestCase("LOCKEDVERSION", "1.2.3.0", "1.2.3.0")>]
+[<TestCase("LOCKEDVERSION", "1.2.3.1", "1.2.3.1")>]
+[<TestCase("LOCKEDVERSION", "1.2.3-pre.3", "1.2.3-pre.3")>]
+[<TestCase("LOCKEDVERSION", "1.2.3.1-pre.3", "1.2.3.1-pre.3")>]
+[<TestCase("LOCKED:Major", "1.2", "1.0.0")>]
+[<TestCase("LOCKED:Major", "1.2.3", "1.0.0")>]
+[<TestCase("LOCKED:Major", "1.2.3.0", "1.0.0")>]
+[<TestCase("LOCKED:Major", "1.2.3.1", "1.0.0")>]
+[<TestCase("LOCKED:Major", "1.2.3-pre.3", "1.0.0")>]
+[<TestCase("LOCKED:Major", "1.2.3.1-pre.3", "1.0.0")>]
+[<TestCase("LOCKED:Minor", "1.2", "1.2.0")>]
+[<TestCase("LOCKED:Minor", "1.2.3", "1.2.0")>]
+[<TestCase("LOCKED:Minor", "1.2.3.0", "1.2.0")>]
+[<TestCase("LOCKED:Minor", "1.2.3.1", "1.2.0")>]
+[<TestCase("LOCKED:Minor", "1.2.3-pre.3", "1.2.0")>]
+[<TestCase("LOCKED:Minor", "1.2.3.1-pre.3", "1.2.0")>]
+[<TestCase("LOCKED:Patch", "1.2", "1.2.0")>]
+[<TestCase("LOCKED:Patch", "1.2.3", "1.2.3")>]
+[<TestCase("LOCKED:Patch", "1.2.3.0", "1.2.3")>]
+[<TestCase("LOCKED:Patch", "1.2.3.1", "1.2.3")>]
+[<TestCase("LOCKED:Patch", "1.2.3-pre.3", "1.2.3")>]
+[<TestCase("LOCKED:Patch", "1.2.3.1-pre.3", "1.2.3")>]
+[<TestCase("LOCKED:Build", "1.2", "1.2.0")>]
+[<TestCase("LOCKED:Build", "1.2.3", "1.2.3")>]
+[<TestCase("LOCKED:Build", "1.2.3.0", "1.2.3.0")>]
+[<TestCase("LOCKED:Build", "1.2.3.1", "1.2.3.1")>]
+[<TestCase("LOCKED:Build", "1.2.3-pre.3", "1.2.3")>]
+[<TestCase("LOCKED:Build", "1.2.3.1-pre.3", "1.2.3.1")>]
+let ``Detect dependencies with LOCKEDVERSION correctly`` placeholder source target =
     let fileContent = """type file
 id My.Thing
 authors Bob McBob
@@ -401,7 +461,8 @@ dependencies
      FSharp.Core 4.3.1
      My.OtherThing LOCKEDVERSION
 """
-
+    let content = fileContent.Replace("LOCKEDVERSION", placeholder)
+    
     let lockFile = """NUGET
   remote: https://www.nuget.org/api/v2
   specs:
@@ -441,9 +502,11 @@ GITHUB
   specs:
     modules/Octokit/Octokit.fsx (494c549c61dc15ab798b7b92cb4ac6e981267f49)
       Octokit"""
+      
+    let lockLines = lockFile.Replace("My.OtherThing (1.2.3.0) - redirects: on", sprintf "My.OtherThing (%s) - redirects: on" source)
 
     let sut =
-        TemplateFile.Parse("file1.template", LockFile.Parse("",toLines lockFile), Some(SemVer.Parse "2.1"), Map.empty, strToStream fileContent)
+        TemplateFile.Parse("file1.template", LockFile.Parse("",toLines lockLines), Some(SemVer.Parse "2.1"), Map.empty, strToStream content)
         |> returnOrFail
         |> function
            | CompleteInfo (_, opt)
@@ -453,14 +516,19 @@ GITHUB
         name1 |> shouldEqual (PackageName "FSharp.Core")
         range1.Range |> shouldEqual (Specific (SemVer.Parse "4.3.1"))
         name2 |> shouldEqual (PackageName "My.OtherThing")
-        range2.Range.ToString() |> shouldEqual "1.2.3"
-        range2.FormatInNuGetSyntax() |> shouldEqual "[1.2.3.0]"
+        let semVerTarget = SemVer.Parse target
+        range2.Range.ToString() |> shouldEqual (semVerTarget.NormalizeToShorter())
+        range2.FormatInNuGetSyntax() |> shouldEqual (sprintf "[%s]" target)
 
     | _ -> Assert.Fail()
 
 
-[<Test>]
-let ``Detect Group-bound LOCKEDVERSION declarations correctly`` () =
+[<TestCase("LOCKEDVERSION-Build")>]
+[<TestCase("LOCKEDVERSION-Build:Build")>]
+[<TestCase("LOCKEDVERSION:Build-Build")>]
+[<TestCase("LOCKEDVERSION-Build:[4]")>]
+[<TestCase("LOCKEDVERSION:[4]-Build")>]
+let ``Detect Group-bound LOCKEDVERSION declarations correctly`` placeholder =
     let fileContent = """type file
 id My.Thing
 authors Bob McBob
@@ -474,7 +542,9 @@ dependencies
      My.OtherThing LOCKEDVERSION
      My.OtherThing LOCKEDVERSION-Build
 """
-
+    
+    let content = fileContent.Replace("LOCKEDVERSION-Build", placeholder)
+    
     let lockFile = """NUGET
   remote: https://www.nuget.org/api/v2
   specs:
@@ -517,7 +587,7 @@ GITHUB
       Octokit"""
 
     let sut =
-        TemplateFile.Parse("file1.template", LockFile.Parse("",toLines lockFile), Some(SemVer.Parse "2.1"), Map.empty, strToStream fileContent)
+        TemplateFile.Parse("file1.template", LockFile.Parse("",toLines lockFile), Some(SemVer.Parse "2.1"), Map.empty, strToStream content)
         |> returnOrFail
         |> function
            | CompleteInfo (_, opt)
@@ -874,7 +944,7 @@ files
 
 [<Test>]
 let ``parse real world template``() =
-    let text = """﻿
+    let text = """
 type project
 title Gu.SiemensCommunication
 


### PR DESCRIPTION
Attempt at supporting half-open dependency constraints with minimum from current or locked version, but open to semver-declared compatibility. 

Example of intended usage would be `My.Package ~> LOCKED:Minor >= LOCKEDVERSION`. 

- Numeric syntax is "number of segments used", negative counts non-zero segments from end. 
- Unit-testing is done by extending existing scenarios via TestCase, further may be added. 
- Combining with group-binding syntax is expected and supported, like: 

>`LOCKED-NetCore:Patch` -or- `LOCKED:Patch-NetCore`
>`LOCKED-NetCore:[3]` -or- `LOCKED:[3]-NetCore`
>`LOCKED-NetCore:[-1]` -or- `LOCKED:[-1]-NetCore`

As side effect, `paket.template` dependencies can now support inline and full-line comments.
Locked-version dependencies without group bind are assumed to be "Main" and print warnings when resolved from different group. 