### PR TITLE
PAKET_DETAILED_ERRORS to print inner stack traces

### DIFF
--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -907,7 +907,7 @@ let main() =
         Environment.ExitCode <- 1
         traceErrorfn "Paket failed with"
         if Environment.GetEnvironmentVariable "PAKET_DETAILED_ERRORS" = "true" then
-            printErrorExt true true false exn
+            printErrorExt true true true exn
         else printError exn
 
 main()


### PR DESCRIPTION
Currently doesn't give the inner stack traces when asking for detailed errors.