### PR TITLE
Update magic mode file location

### DIFF
--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -277,7 +277,7 @@ namespace Paket.Bootstrapper
             var assemblyLocation = fileSystemProxy.GetExecutingAssemblyPath();
             var targetName = String.Format("paket_{0}.exe",GetHash(assemblyLocation));
             var targetFolder = Path.Combine(fileSystemProxy.GetTempPath(), "paket");            
-            Directory.Create(targetFolder);
+            Directory.CreateDirectory(targetFolder);
             return Path.Combine(targetFolder, targetName);
         }
 

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -276,8 +276,9 @@ namespace Paket.Bootstrapper
             //    accessing the same file as their path depends on the bootstrapper path.
             var assemblyLocation = fileSystemProxy.GetExecutingAssemblyPath();
             var targetName = String.Format("paket_{0}.exe",GetHash(assemblyLocation));
-
-            return Path.Combine(fileSystemProxy.GetTempPath(), targetName);
+            var targetFolder = Path.Combine(fileSystemProxy.GetTempPath(), "paket");            
+            Directory.Create(targetFolder);
+            return Path.Combine(targetFolder, targetName);
         }
 
         private static bool IsTrue(this NameValueCollection appSettings, string key)

--- a/src/Paket.Bootstrapper/ArgumentParser.cs
+++ b/src/Paket.Bootstrapper/ArgumentParser.cs
@@ -277,7 +277,7 @@ namespace Paket.Bootstrapper
             var assemblyLocation = fileSystemProxy.GetExecutingAssemblyPath();
             var targetName = String.Format("paket_{0}.exe",GetHash(assemblyLocation));
             var targetFolder = Path.Combine(fileSystemProxy.GetTempPath(), "paket");            
-            Directory.CreateDirectory(targetFolder);
+            fileSystemProxy.CreateDirectory(targetFolder);
             return Path.Combine(targetFolder, targetName);
         }
 


### PR DESCRIPTION
Some companies (mine included) block the running of exe in any of the app data folders as this is where malware typically embeds itself.
It is possible to put folder exclusions into group policy, but since paket was just going into the root of the temp folder it is not possible to unblock it.
This change will put the downloaded magic paket.exe into a paket folder.