### PR TITLE
Adding a link to the clitool information on the paket.dependencies page

### DIFF
--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -51,7 +51,8 @@ dependencies](faq.html#transitive).
 
 Paket supports the following source types:
 
-* [NuGet](nuget-dependencies.html) (with dotnet CLI tools as a [special case](https://fsprojects.github.io/Paket/nuget-dependencies.html#Special-case-CLI-tools))
+* [NuGet](nuget-dependencies.html)
+* [.NET CLI Tools](https://fsprojects.github.io/Paket/nuget-dependencies.html#Special-case-CLI-tools)
 * [Git](git-dependencies.html)
 * [GitHub and Gist](github-dependencies.html)
 * [HTTP](http-dependencies.html) (any single file from any site without version

--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -52,7 +52,7 @@ dependencies](faq.html#transitive).
 Paket supports the following source types:
 
 * [NuGet](nuget-dependencies.html)
-* [.NET CLI Tools](https://fsprojects.github.io/Paket/nuget-dependencies.html#Special-case-CLI-tools)
+* [.NET CLI Tools](nuget-dependencies.html#Special-case-CLI-tools)
 * [Git](git-dependencies.html)
 * [GitHub and Gist](github-dependencies.html)
 * [HTTP](http-dependencies.html) (any single file from any site without version

--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -51,7 +51,7 @@ dependencies](faq.html#transitive).
 
 Paket supports the following source types:
 
-* [NuGet](nuget-dependencies.html)
+* [NuGet](nuget-dependencies.html) (with dotnet CLI tools as a [special case](https://fsprojects.github.io/Paket/nuget-dependencies.html#Special-case-CLI-tools))
 * [Git](git-dependencies.html)
 * [GitHub and Gist](github-dependencies.html)
 * [HTTP](http-dependencies.html) (any single file from any site without version


### PR DESCRIPTION
That's where I looked for it first.