### PR TITLE
Paket template packagetypes

### DIFF
--- a/src/Paket.Core/Packaging/NupkgWriter.fs
+++ b/src/Paket.Core/Packaging/NupkgWriter.fs
@@ -142,6 +142,18 @@ module internal NupkgWriter =
                 d.Add(buildReferenceNode r)
             metadataNode.Add d
 
+        let buildPackageTypesNode (name) =
+            let dep = XElement(ns + "packageType")
+            dep.SetAttributeValue(XName.Get "name", name)
+            dep
+
+        let buildPackageTypesNode packageTypesList =
+            if List.isEmpty packageTypesList then () else
+            let d = XElement(ns + "packageTypes")
+            for r in packageTypesList do
+                d.Add(buildPackageTypesNode r)
+            metadataNode.Add d
+
         !! "id" core.Id
         match core.Version with
         | Some v -> !! "version" (v.ToString())
@@ -163,6 +175,7 @@ module internal NupkgWriter =
         if optional.DevelopmentDependency  then
             !! "developmentDependency" "true"
 
+        optional.PackageTypes |> buildPackageTypesNode
         optional.References |> buildReferencesNode
         optional.FrameworkAssemblyReferences |> buildFrameworkReferencesNode
         optional.DependencyGroups |> buildDependenciesNode optional.ExcludedDependencies

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -2096,6 +2096,7 @@ type ProjectFile with
             FrameworkAssemblyReferences = [] //propOr "FrameworkAssemblyReferences" []
             Files = [] //propMap "Files" [] splitString
             FilesExcluded = [] //propMap  "FilesExcluded" [] splitString
+            PackageTypes = []
             IncludePdbs = propMap "IncludePdbs" true tryBool
             IncludeReferencedProjects = propMap "IncludeReferencedProjects" true tryBool
         }

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -157,6 +157,7 @@ type OptionalPackagingInfo =
       /// (src * target) list
       Files : (string * string) list
       FilesExcluded : string list 
+      PackageTypes : string list
       IncludePdbs : bool 
       IncludeReferencedProjects : bool
       }
@@ -180,6 +181,7 @@ type OptionalPackagingInfo =
           FrameworkAssemblyReferences = []
           Files = []
           FilesExcluded = [] 
+          PackageTypes = []
           IncludeReferencedProjects = false
           IncludePdbs = false }
 
@@ -451,6 +453,9 @@ module internal TemplateFile =
 
         let excludedDependencies = map |> getExcludedDependencies
         let excludedGroups = map |> getExcludedGroups
+
+        let packageTypes =
+            []
         
         let includePdbs = 
             match get "include-pdbs" with
@@ -481,6 +486,7 @@ module internal TemplateFile =
           FrameworkAssemblyReferences = getFrameworkReferences map
           Files = getFiles map
           FilesExcluded = getFileExcludes map
+          PackageTypes = packageTypes
           IncludeReferencedProjects = includeReferencedProjects 
           IncludePdbs = includePdbs }
 

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -455,7 +455,10 @@ module internal TemplateFile =
         let excludedGroups = map |> getExcludedGroups
 
         let packageTypes =
-            []
+            match Map.tryFind "packagetypes" map with
+            | None -> []
+            | Some o ->
+                o.Split ',' |> Array.map String.trim |> Array.toList
         
         let includePdbs = 
             match get "include-pdbs" with

--- a/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
+++ b/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
@@ -322,6 +322,38 @@ let ``should not serialize files``() =
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings result)
 
+
+[<Test>]
+let ``should serialize packageTypes``() = 
+    let result = """<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata>
+    <id>Paket.Core</id>
+    <version>4.2</version>
+    <authors>Michael, Steffen</authors>
+    <description>A description</description>
+    <packageTypes>
+      <packageType name="DotnetTool" />
+      <packageType name="DotnetCliTool" />
+    </packageTypes>
+  </metadata>
+</package>"""
+
+    let core : CompleteCoreInfo =
+        { Id = "Paket.Core"
+          Version = SemVer.Parse "4.2" |> Some
+          Authors = [ "Michael"; "Steffen" ]
+          Description = "A description"
+          Symbols = false }
+    
+    let optional = 
+        { OptionalPackagingInfo.Empty with 
+            PackageTypes = [ "DotnetTool"; "DotnetCliTool" ]  }
+                       
+    let doc = NupkgWriter.nuspecDoc (core, optional)
+    doc.ToString()
+    |> normalizeLineEndings
+    |> shouldEqual (normalizeLineEndings result)
+
 [<Test>]
 let ``should not serialize all properties``() = 
     let result = """<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -163,6 +163,8 @@ LANGUAGE
     en-gb
 tags
     rop, fsharp F#
+packageTypes
+    DotnetTool, Template
 summary
     Railway-oriented programming for .NET
 dependencies
@@ -203,6 +205,7 @@ let ``Optional fields are read`` (fileContent : string) =
     sut.RequireLicenseAcceptance |> shouldEqual false
     sut.DevelopmentDependency |> shouldEqual false
     sut.Language |> shouldEqual (Some "en-gb")
+    sut.PackageTypes |> shouldEqual ["DotnetTool"; "Template"]
     sut.DependencyGroups |> shouldContain ({ Framework = None;
                                              Dependencies =
                                                 [PackageName "FSharp.Core",VersionRequirement.Parse("[4.3.1]")


### PR DESCRIPTION
add `packageTypes` to `paket.template`

used by newer nuspec schema for types like `Template`, `DotnetTool`, `DotnetCliTool`

is optional, and default is not set
