### PR TITLE
No longer search for CredentialProviders on an empty path.

### DIFF
--- a/src/Paket.Core/Versioning/CredentialProviders.fs
+++ b/src/Paket.Core/Versioning/CredentialProviders.fs
@@ -73,7 +73,7 @@ module CredentialProviders =
             |> Seq.filter Directory.Exists
             |> Seq.collect (fun d -> Directory.EnumerateFiles(d, assemblyPattern, SearchOption.AllDirectories))
           let paketDirectory = Path.GetDirectoryName(typeof<CredentialProviderUnknownStatusException>.Assembly.Location)
-          if not (isNull paketDirectory) then
+          if not (String.IsNullOrEmpty paketDirectory) then
             yield! Directory.EnumerateFiles(paketDirectory, paketDirectoryAssemblyPattern)
         ]
     let findPathsFromEnvVar key =


### PR DESCRIPTION
In some unusual scenarios like a paket mkbundle, `Path.GetDirectoryName` on an `Assembly.Location` returns an empty string.  When that happens, `Directory.EnumerateFiles` will eventually call `Path.InsecureGetFullPath` on mono, resulting in this error:

```
System.ArgumentException: The specified path is not of a legal form (empty).
```

coming from [here](https://github.com/mono/mono/blob/master/mcs/class/corlib/System.IO/Path.cs#L367).

Switching to `String.IsNullOrEmpty` addresses that issue.