### PR TITLE
fixing filtered update performance

### DIFF
--- a/src/Paket.Core/Common/Domain.fs
+++ b/src/Paket.Core/Common/Domain.fs
@@ -96,31 +96,26 @@ type QualifiedPackageName =
         let packageName = PackageName packageName
         QualifiedPackageName (groupName, packageName)
 
+type PackageMatch(ex:String) =
+    member this.Expression = Regex("^" + ex + "$", RegexOptions.CultureInvariant ||| RegexOptions.IgnoreCase) 
 
 // Represents a filter of normalized package names
 [<System.Diagnostics.DebuggerDisplay("{ToString()}")>]
 type PackageFilter =
 | PackageName of PackageName
-| PackageFilter of string
+| PackageFilter of PackageMatch
 
     member this.Match (packageName : PackageName) =
         match this with
         | PackageName name -> name = packageName
-        | PackageFilter f ->
-            let regex =
-                Regex("^" + f + "$",
-                    RegexOptions.Compiled 
-                    ||| RegexOptions.CultureInvariant 
-                    ||| RegexOptions.IgnoreCase)
-
-            regex.IsMatch (packageName.CompareString)
+        | PackageFilter f -> f.Expression.IsMatch(packageName.CompareString)
 
     static member ofName name = PackageFilter.PackageName name
 
     override this.ToString() =
         match this with
         | PackageName name -> name.ToString()
-        | PackageFilter filter -> filter
+        | PackageFilter filter -> filter.Expression.ToString()
 
 
 type DomainMessage = 

--- a/src/Paket.Core/Common/Domain.fs
+++ b/src/Paket.Core/Common/Domain.fs
@@ -97,7 +97,7 @@ type QualifiedPackageName =
         QualifiedPackageName (groupName, packageName)
 
 type PackageMatch(ex:String) =
-    member this.Expression = Regex("^" + ex + "$", RegexOptions.CultureInvariant ||| RegexOptions.IgnoreCase) 
+    member val Expression = Regex("^" + ex + "$", RegexOptions.CultureInvariant ||| RegexOptions.IgnoreCase) 
 
 // Represents a filter of normalized package names
 [<System.Diagnostics.DebuggerDisplay("{ToString()}")>]

--- a/src/Paket.Core/Installation/UpdateProcess.fs
+++ b/src/Paket.Core/Installation/UpdateProcess.fs
@@ -272,7 +272,7 @@ let UpdatePackage(dependenciesFileName, groupName, packageName : PackageName, ne
 let UpdateFilteredPackages(dependenciesFileName, groupName, packageName : string, newVersion, options : UpdaterOptions) =
     let dependenciesFile = DependenciesFile.ReadFromFile(dependenciesFileName)
 
-    let filter = PackageFilter.PackageFilter(packageName.ToString())
+    let filter = PackageFilter.PackageFilter(PackageMatch packageName)
 
     let dependenciesFile =
         match newVersion with


### PR DESCRIPTION
- update with regex filter, matching 83 packages of 210, resulted in runtime of about 30 minutes, instead of the expected cca 30 seconds of full update
- most of the time was spent in the filter function, constructing and compiling the regex for each nuget package dependency
- issue was completely fixed by extracting the regex object creation to be done only single time