### PR TITLE
Improve binding redirects performance

### DIFF
--- a/src/Paket.Core/Installation/BindingRedirects.fs
+++ b/src/Paket.Core/Installation/BindingRedirects.fs
@@ -7,6 +7,7 @@ open System.Xml.Linq
 open System.IO
 open Paket.Xml.Linq
 open System.Xml.XPath
+open System.Reflection
 
 /// Represents a binding redirection
 type BindingRedirect = 
@@ -196,9 +197,8 @@ let applyBindingRedirectsToFolder isFirstGroup createNewBindingFiles cleanBindin
         applyBindingRedirects p
 
 /// Calculates the short form of the public key token for use with binding redirects, if it exists.
-let getPublicKeyToken (assembly:Mono.Cecil.AssemblyDefinition) =
-    ("", assembly.Name.PublicKeyToken)
-    ||> Array.fold(fun state b -> state + b.ToString("X2"))
-    |> function
-    | "" -> None
-    | token -> Some (token.ToLower())
+let getPublicKeyToken (assembly:AssemblyName) =
+    assembly.GetPublicKeyToken()
+    |> Option.ofObj
+    |> Option.map (Array.fold(fun state b -> state + b.ToString("X2")) "")
+    |> Option.bind (function | "" -> None | token -> Some (token.ToLower()))


### PR DESCRIPTION
This PR changes from `Mono.Cecil` to `AssemblyReader` to read the assemblies to find out if binding redirects is needed.

`paket install` results:

|Project Size|Before PR|After PR|
|-----------|-----------|-------|
|Small Solution (4 projects)|1 second|1 second|
|Medium Solution (29 projects)|26 seconds|4 seconds|
|Large Solution (72 projects)|1 minute, 33 seconds|13 seconds|