### PR TITLE
Add support for dotnet SDK fallback folder

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -331,6 +331,21 @@ let GetTargetUserNupkg (packageName:PackageName) (version:SemVerInfo) =
 let GetTargetUserToolsFolder (packageName:PackageName) (version:SemVerInfo) =
     DirectoryInfo(Path.Combine(Constants.UserNuGetPackagesFolder,".tools",packageName.CompareString,version.Normalize())).FullName
 
+let TryGetFallbackFolder () =
+    let dotnet = if isUnix then "dotnet" else "dotnet.exe"
+    ProcessHelper.tryFindFileOnPath dotnet |> Option.bind (fun fileName ->
+        let dotnetDir = Path.GetDirectoryName fileName
+        let fallbackDir = Path.Combine (dotnetDir, "sdk", "NuGetFallbackFolder")
+        if Directory.Exists fallbackDir then Some fallbackDir else None)
+
+let TryGetFallbackNupkg (fallbackFolderOverride:string option) (packageName:PackageName) (version:SemVerInfo) =
+    match fallbackFolderOverride |> Option.orElseWith TryGetFallbackFolder with
+    | Some folder ->
+        let normalizedNupkgName = GetPackageFileName packageName version
+        let fallbackFile = Path.Combine(folder, packageName.CompareString, version.Normalize(), normalizedNupkgName) |> FileInfo
+        if fallbackFile.Exists && fallbackFile.Length > 0L then Some fallbackFile.FullName else None
+    | None -> None
+
 /// Extracts the given package to the user folder
 let rec ExtractPackageToUserFolder(fileName:string, packageName:PackageName, version:SemVerInfo, kind:PackageResolver.ResolvedPackageKind) =
     async {


### PR DESCRIPTION
The dotnet SDK ships with various .NET Core and ASP.NET Core nuget packages in a NuGetFallbackFolder.

This changes to try to find packages in that folder before looking in other caches or downloading from source. In the event the package is found here, the contents are copied or linked directly from that folder
instead of the user's cache.

Paket resolves a few packages with higher versions than the ones that ship, so this doesn't eliminate all downloads, but it makes a very significant dent. A before/after when starting with an empty cache for a project referencing `Microsoft.AspNetCore.App`:

#### Before
```
Performance:
 - Disk IO: 46 seconds
 - Average Download Time: 173 milliseconds
 - Number of downloads: 273
 - Average Request Time: 177 milliseconds
 - Number of Requests: 276
 - Runtime: 1 minute, 6 seconds
```
#### After
```
Performance:
 - Disk IO: 5 seconds
 - Average Download Time: 125 milliseconds
 - Number of downloads: 34
 - Average Request Time: 218 milliseconds
 - Number of Requests: 36
 - Runtime: 12 seconds

```

We could go further: I'd guess this won't work when e.g. FAKE does a local install of the dotnet SDK as that folder won't be on the path. It seems that there's an MSBuild property available during restore (as I mentioned in https://github.com/fsprojects/Paket/issues/2827#issuecomment-394189748) that we could pass to `paket.exe` when called in `Paket.Restore.targets`.

Fixes #2827