### PR TITLE
Fixes for dotnet SDK fallback folder support

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -760,14 +760,12 @@ let private downloadAndExtractPackage(alternativeProjectRoot, root, isLocalOverr
     let nupkgName = packageName.ToString() + "." + version.ToString() + ".nupkg"
     let normalizedNupkgName = NuGetCache.GetPackageFileName packageName version
     let configResolved = config.Resolve root groupName packageName version includeVersionInPath
-    let targetFileName, isTargetInFallbackFolder =
+    let targetFileName =
         if not isLocalOverride then
-            match NuGetCache.TryGetFallbackNupkg None packageName version with
-            | Some fileName -> fileName, true
-            | None -> NuGetCache.GetTargetUserNupkg packageName version, false
+            NuGetCache.GetTargetUserNupkg packageName version
         else
             match configResolved.Path with
-            | Some p -> Path.Combine(p, nupkgName), false
+            | Some p -> Path.Combine(p, nupkgName)
             | None -> failwithf "paket.local in combination with storage:none is not supported"
 
     if isLocalOverride && not force then
@@ -811,12 +809,22 @@ let private downloadAndExtractPackage(alternativeProjectRoot, root, isLocalOverr
             | _ -> getFromCache rest
         | [] -> false
 
+    let getFromFallbackFolder () =
+        match NuGetCache.TryGetFallbackNupkg packageName version with
+        | Some fileName ->
+            verbosefn "Copying %O %O from SDK cache" packageName version
+            use __ = Profile.startCategory Profile.Category.FileIO
+            ensureDir targetFileName
+            File.Copy(fileName,targetFileName,true)
+            true
+        | None -> false
+
     let rec download authenticated attempt =
         async {
             if not force && targetFile.Exists && targetFile.Length > 0L then
                 if verbose then
                     verbosefn "%O %O already downloaded." packageName version
-            elif not force && getFromCache caches then
+            elif getFromFallbackFolder () || (not force && getFromCache caches) then
                 ()
             else
                 match source with
@@ -986,16 +994,14 @@ let private downloadAndExtractPackage(alternativeProjectRoot, root, isLocalOverr
         | false, otherConfig ->
             otherConfig.Path |> Option.iter SymlinkUtils.delete
 
-            let! extractedFolder = async {
-                if isTargetInFallbackFolder then return Path.GetDirectoryName targetFileName
-                else return! ExtractPackageToUserFolder(targetFile.FullName, packageName, version, kind) }
+            let! extractedUserFolder = ExtractPackageToUserFolder(targetFile.FullName, packageName, version, kind)
 
             let! files = NuGetCache.CopyFromCache(otherConfig, targetFile.FullName, licenseFileName, packageName, version, force, detailed)
 
             let finalFolder =
                 match files with
                 | Some f -> f
-                | None -> extractedFolder
+                | None -> extractedUserFolder
 
             return targetFileName,finalFolder
     }

--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -338,8 +338,8 @@ let TryGetFallbackFolder () =
         let fallbackDir = Path.Combine (dotnetDir, "sdk", "NuGetFallbackFolder")
         if Directory.Exists fallbackDir then Some fallbackDir else None)
 
-let TryGetFallbackNupkg (fallbackFolderOverride:string option) (packageName:PackageName) (version:SemVerInfo) =
-    match fallbackFolderOverride |> Option.orElseWith TryGetFallbackFolder with
+let TryGetFallbackNupkg (packageName:PackageName) (version:SemVerInfo) =
+    match TryGetFallbackFolder() with
     | Some folder ->
         let normalizedNupkgName = GetPackageFileName packageName version
         let fallbackFile = Path.Combine(folder, packageName.CompareString, version.Normalize(), normalizedNupkgName) |> FileInfo


### PR DESCRIPTION
There are two small issues so far.

First, it seems in `NuGet.GetContent` we store a `paket-installmodel.cache` file that has the folder structure for performance reasons. When we try to do this in the fallback folder (which is normally read-only as it's in program files or equivalent), we get an exception. 

All I've come up with is ignoring access exceptions here. Any better ideas, I'm all ears. This fixes #3243.

Second, as part of the install process we copy package 'content' folders. This does [its own search for the package folders](https://github.com/fsprojects/Paket/blob/3d9e4b5110d4baafa2e716b402e6216a2729688f/src/Paket.Core/Installation/InstallProcess.fs#L36) and didn't handle the new fallback location in the case we have `storage:none`. 

The simplest fix was to add a check in that location.. It does occur to me that we could/should know all the package locations when they're extracted earlier in the install process, so it may be better to ensure the path is returned and to use that rather than searching again. I can investigate that.