### PR TITLE
Fix invalid syntax in packages config

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/PackagesConfigFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/PackagesConfigFile.fs
@@ -30,7 +30,8 @@ let Serialize (packages: NugetPackage seq) =
         packages 
         |> Seq.choose (fun p -> 
             match p.VersionRequirement.Range with
-            | VersionRange.Specific v ->
+            | VersionRange.Specific v
+            | VersionRange.Minimum v ->
                 let framework = 
                     match p.TargetFramework with
                     | Some tf -> sprintf "targetFramework=\"%s\" " (tf.Replace(">= ",""))

--- a/src/Paket.Core/PaketConfigFiles/PackagesConfigFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/PackagesConfigFile.fs
@@ -36,13 +36,6 @@ let Serialize (packages: NugetPackage seq) =
                     | Some tf -> sprintf "targetFramework=\"%s\" " (tf.Replace(">= ",""))
                     | _ -> ""
 
-                Some (sprintf """  <package id="%s" version="[%O]" %s/>""" p.Id v framework)
-            | VersionRange.Minimum v ->
-                let framework = 
-                    match p.TargetFramework with
-                    | Some tf -> sprintf "targetFramework=\"%s\" " (tf.Replace(">= ",""))
-                    | _ -> ""
-
                 Some (sprintf """  <package id="%s" version="%O" %s/>""" p.Id v framework)
             | _ -> None)
 

--- a/tests/Paket.Tests.preview3/Paket.Tests.fsproj
+++ b/tests/Paket.Tests.preview3/Paket.Tests.fsproj
@@ -58,7 +58,6 @@
     <TestAsset Include="NuGetLocal\case2\package.name.1.2.0.0.nupkg" />
     <TestAsset Include="NuGetLocal\case3\netstedFolder\package.in.nested.folder.1.0.0.nupkg" />
     <TestAsset Include="PackagesConfig\xunit.visualstudio.packages.config" />
-    <TestAsset Include="PackagesConfig\xunit.visualstudio.packages2.config" />
     <TestAsset Include="PackagesConfig\asp.net.packages.config" />
     <Compile Include="$(PaketTestsSourcesDir)\PackagesConfig\ReadConfig.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\PackagesConfig\WriteConfig.fs" />

--- a/tests/Paket.Tests/PackagesConfig/ReadConfig.fs
+++ b/tests/Paket.Tests/PackagesConfig/ReadConfig.fs
@@ -12,11 +12,3 @@ let ``can read xunit.visualstudio.packages.config``() =
     config.Id |> shouldEqual "xunit.runner.visualstudio"
     config.TargetFramework |> shouldEqual None
     config.VersionRequirement.Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "2.0.1"))
-
-[<Test>]
-let ``can read xunit.visualstudio.packages2.config``() = 
-    let config = Read("PackagesConfig/xunit.visualstudio.packages2.config") |> List.head
-
-    config.Id |> shouldEqual "xunit.runner.visualstudio"
-    config.TargetFramework |> shouldEqual None
-    config.VersionRequirement.Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "2.0.1"))

--- a/tests/Paket.Tests/PackagesConfig/WriteConfig.fs
+++ b/tests/Paket.Tests/PackagesConfig/WriteConfig.fs
@@ -15,13 +15,6 @@ let ``can write xunit.visualstudio.packages.config``() =
     Serialize config |> normalizeLineEndings |> shouldEqual expected
 
 [<Test>]
-let ``can write xunit.visualstudio.package2s.config``() = 
-    let fileName = "PackagesConfig/xunit.visualstudio.packages2.config"
-    let config = Read fileName
-    let expected = File.ReadAllText fileName |> normalizeLineEndings
-    Serialize config |> normalizeLineEndings |> shouldEqual expected
-
-[<Test>]
 let ``can write asp.net.packages.config``() = 
     let fileName = "PackagesConfig/asp.net.packages.config"
     let config = Read fileName

--- a/tests/Paket.Tests/PackagesConfig/xunit.visualstudio.packages2.config
+++ b/tests/Paket.Tests/PackagesConfig/xunit.visualstudio.packages2.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="xunit.runner.visualstudio" version="[2.0.1]" />
-</packages>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -138,9 +138,6 @@
     <Content Include="PackagesConfig\xunit.visualstudio.packages.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="PackagesConfig\xunit.visualstudio.packages2.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="PackagesConfig\asp.net.packages.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fixes #3231.

Is there a reason why we only use `VersionRange.Specific` and `VersionRange.Minimum`?