### PR TITLE
extending NuGetV3 source detection with Artifactory feed format

### DIFF
--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -150,7 +150,7 @@ type PackageSource =
 #endif
                     LocalNuGet(source,None)
                 else 
-                    if String.endsWithIgnoreCase "v3/index.json" source then
+                    if Regex("/v3(?:/[-\w]+)?/index.json$").IsMatch source then
                         NuGetV3 { Url = source; Authentication = auth }
                     else
                         NuGetV2 { Url = source; Authentication = auth }

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -76,6 +76,7 @@
       <Paket>True</Paket>
       <Link>FsUnit.fs</Link>
     </Compile>
+    <Compile Include="Versioning\PackageSourceSpecs.fs" />
     <None Include="paket.references" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="TestHelpers.fs" />

--- a/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
@@ -1,0 +1,40 @@
+module Paket.PackageSourceSpecs
+
+open Paket
+open NUnit.Framework
+open FsUnit
+open Paket.Domain
+open Paket.PackageSources 
+
+[<TestCase("https://nuget.org/api/v2")>]
+[<TestCase("https://nuget.org/api/v2/")>]
+[<TestCase("https://www.myget.org/F/roslyn-tools/")>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nugetsource/")>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nuget-local/")>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nuget_proxy/")>]
+let ``should parse known nuget2 source``(feed : string) =
+    let line = sprintf "source %s" feed
+    match PackageSource.Parse(line) with
+    | NuGetV2 { Url = source; Authentication = _ } ->
+        let quoted = sprintf "source  \"%s\"" feed
+        match PackageSource.Parse(quoted) with
+        | NuGetV2 { Url = qsource; Authentication = _ } -> 
+            source |> shouldEqual qsource
+        | _ -> failwith quoted
+    | _ -> failwith feed  
+
+[<TestCase("https://api.nuget.org/v3/index.json")>]
+[<TestCase("https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json")>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nugetsource/index.json")>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nuget-local/index.json")>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nuget_proxy/index.json")>]
+let ``should parse known nuget3 source``(feed : string) =
+    let line = sprintf "source %s" feed
+    match PackageSource.Parse(line) with
+    | NuGetV3 { Url = source; Authentication = _ } ->
+        let quoted = sprintf "source  \"%s\"" feed
+        match PackageSource.Parse(quoted) with
+        | NuGetV3 { Url = qsource; Authentication = _ } -> 
+            source |> shouldEqual qsource
+        | _ -> failwith quoted
+    | _ -> failwith feed  


### PR DESCRIPTION
extending NuGetV3 source detection with Artifactory feed format
[www.jfrog.com/confluence/display/RTF/NuGet+Repositories](https://www.jfrog.com/confluence/display/RTF/NuGet+Repositories#NuGetRepositories-NuGetAPIv3RegistrySupport)