### PR TITLE
Allow addition of <EmbedInteropTypes> for Nuget packages

### DIFF
--- a/docs/content/references-files.md
+++ b/docs/content/references-files.md
@@ -79,6 +79,11 @@ DotNetZip framework: >= net45
 FSharp.Core redirects: on
 ```
 
+## Adding support for COM interop DLL
+Follows the same syntax as the previous one:
+`PkgName embed_interop_types: true`
+In case it is not enabled, the default behavior is to drop `<EmbedInteropTypes>` from the project file.
+
 ## Excluding libraries
 
 This option allows you to exclude libraries from being referenced in project files:

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -723,7 +723,7 @@ module ProjectFile =
         AnalyzersNode : XmlElement
     }
 
-    let generateXml (model:InstallModel) (usedFrameworkLibs:HashSet<TargetProfile*string>) (aliases:Map<string,string>) (copyLocal:bool option) (specificVersion:bool option) (importTargets:bool) (referenceCondition:string option) (allTargetProfiles:Set<TargetProfile>) (project:ProjectFile) : XmlContext =
+    let generateXml (model:InstallModel) (usedFrameworkLibs:HashSet<TargetProfile*string>) (aliases:Map<string,string>) (embedInteropTypes:bool option) (copyLocal:bool option) (specificVersion:bool option) (importTargets:bool) (referenceCondition:string option) (allTargetProfiles:Set<TargetProfile>) (project:ProjectFile) : XmlContext =
         let references = 
             getCustomReferenceAndFrameworkNodes project
             |> List.map (fun node -> node.Attributes.["Include"].InnerText.Split(',').[0])
@@ -767,6 +767,10 @@ module ProjectFile =
                     | None -> n
                     | Some(bool) -> addChild (createNodeSet "SpecificVersion" specificVersionSettings project) n
                 |> addChild (createNodeSet "Paket" "True" project)
+                |> fun n ->
+                    match embedInteropTypes with
+                    | None -> n
+                    | _ -> addChild (createNodeSet "EmbedInteropTypes" "True" project) n
                 |> fun n ->
                     match aliases with
                     | None -> n
@@ -1237,7 +1241,7 @@ module ProjectFile =
                 let importTargets = defaultArg installSettings.ImportTargets true
             
                 let allFrameworks = applyRestrictionsToTargets restrictionList KnownTargetProfiles.AllProfiles
-                generateXml projectModel usedFrameworkLibs installSettings.Aliases installSettings.CopyLocal installSettings.SpecificVersion importTargets installSettings.ReferenceCondition (set allFrameworks) project)
+                generateXml projectModel usedFrameworkLibs installSettings.Aliases installSettings.EmbedInteropTypes installSettings.CopyLocal installSettings.SpecificVersion importTargets installSettings.ReferenceCondition (set allFrameworks) project)
 
         for ctx in contexts do
             for chooseNode in ctx.ChooseNodes do
@@ -1726,7 +1730,7 @@ type ProjectFile with
 
     member this.DeleteCustomModelNodes(model:InstallModel) = ProjectFile.deleteCustomModelNodes model this
 
-    member this.GenerateXml(model, usedFrameworkLibs:HashSet<TargetProfile*string>, aliases, copyLocal, specificVersion, importTargets, allTargetProfiles:#seq<TargetProfile>, referenceCondition) = ProjectFile.generateXml model usedFrameworkLibs aliases copyLocal specificVersion importTargets referenceCondition (set allTargetProfiles) this
+    member this.GenerateXml(model, usedFrameworkLibs:HashSet<TargetProfile*string>, aliases, embedInteropTypes, copyLocal, specificVersion, importTargets, allTargetProfiles:#seq<TargetProfile>, referenceCondition) = ProjectFile.generateXml model usedFrameworkLibs aliases embedInteropTypes copyLocal specificVersion importTargets referenceCondition (set allTargetProfiles) this
 
     member this.RemovePaketNodes () = ProjectFile.removePaketNodes this 
 

--- a/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
@@ -128,11 +128,12 @@ type ReferencesFile =
             { ReferencesFile.FromLines lines with FileName = fileName }
         with e -> raise (new Exception(sprintf "Could not parse reference file '%s': %s" fileName e.Message, e))
 
-    member this.AddNuGetReference(groupName, packageName : PackageName, copyLocal: bool, specificVersion: bool, importTargets: bool, frameworkRestrictions, includeVersionInPath, downloadLicense, omitContent : bool, createBindingRedirects, referenceCondition) =
+    member this.AddNuGetReference(groupName, packageName : PackageName, embedInteropTypes: bool, copyLocal: bool, specificVersion: bool, importTargets: bool, frameworkRestrictions, includeVersionInPath, downloadLicense, omitContent : bool, createBindingRedirects, referenceCondition) =
         let package: PackageInstallSettings =
             { Name = packageName
               Settings = 
-                  { CopyLocal = if not copyLocal then Some copyLocal else None
+                  { EmbedInteropTypes = if embedInteropTypes then Some embedInteropTypes else None
+                    CopyLocal = if not copyLocal then Some copyLocal else None
                     SpecificVersion = if not specificVersion then Some specificVersion else None
                     CopyContentToOutputDirectory = None
                     StorageConfig = None
@@ -172,7 +173,7 @@ type ReferencesFile =
                 { this with Groups = newGroups }
 
     member this.AddNuGetReference(groupName, packageName : PackageName) = 
-        this.AddNuGetReference(groupName, packageName, true, true, true, ExplicitRestriction FrameworkRestriction.NoRestriction, false, false, false, None, null)
+        this.AddNuGetReference(groupName, packageName, false, true, true, true, ExplicitRestriction FrameworkRestriction.NoRestriction, false, false, false, None, null)
 
     member this.RemoveNuGetReference(groupName, packageName : PackageName) =
         let group = this.Groups.[groupName]

--- a/src/Paket.Core/Versioning/Requirements.fs
+++ b/src/Paket.Core/Versioning/Requirements.fs
@@ -883,6 +883,7 @@ type InstallSettings =
       LicenseDownload: bool option
       ReferenceCondition : string option
       CreateBindingRedirects : BindingRedirectsSettings option
+      EmbedInteropTypes : bool option
       CopyLocal : bool option
       SpecificVersion : bool option
       StorageConfig : PackagesFolderGroupConfig option
@@ -892,7 +893,8 @@ type InstallSettings =
       GenerateLoadScripts : bool option }
 
     static member Default =
-        { CopyLocal = None
+        { EmbedInteropTypes = None
+          CopyLocal = None
           SpecificVersion = None
           StorageConfig = None
           ImportTargets = None
@@ -1046,6 +1048,10 @@ type InstallSettings =
                 | x -> failwithf "Unknown copy_content_to_output_dir settings: %A" x
               Excludes = []
               Aliases = Map.empty
+              EmbedInteropTypes =
+                match getPair "embed_interop_types" with
+                | Some "true" -> Some true
+                | _ -> None
               CopyLocal =
                 match getPair "copy_local" with
                 | Some "false" -> Some false 


### PR DESCRIPTION
- Problem
NuGet package reference with a COM interop DLL, `<EmbedInteropTypes>True</EmbedInteropTypes>` needs to be managed manually and `paket update` removes the flag.

- Solution
Provide a way to express this through existing `paket.references` syntax
`PkgName embed_interop_types: true`

- Related Issues
https://github.com/fsprojects/Paket/issues/910

There might be some failing testcases but adding the PR to open up the discussion.