### PR TITLE
paket pack with p2p dependencies and multitargeting

### DIFF
--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -9,6 +9,7 @@ open System.IO.Compression
 open Paket.Domain
 open Paket
 open Paket.NuGetCache
+open Paket.Requirements
 
 let getDependencies(x:Paket.NuGet.NuGetPackageCache) = x.GetDependencies()
 
@@ -583,6 +584,41 @@ let ``#3164 pack analyzer`` () =
 
     CleanDir rootPath    
 
+    
+[<Test>]
+let ``#3165 pack multitarget with p2p`` () = 
+    let scenario = "i003165-pack-multitarget-with-p2p"
+    prepareSdk scenario
+    let rootPath = scenarioTempPath scenario
+
+    directDotnet true "build MyProj.Main -c Release" rootPath
+    |> Seq.iter (printfn "%A")
+
+    let outPath = Path.Combine(rootPath, "out")
+    directPaket (sprintf """pack "%s" """ outPath) scenario
+    |> Seq.iter (printfn "%A")
+
+    let nupkgPath = Path.Combine(outPath, "MyProj.Main.1.0.0.nupkg")
+
+    if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
+    let nuspec = NuGetLocal.getNuSpecFromNupgk nupkgPath
+    let depsByTfm byTfm = nuspec.Dependencies.Value |> Seq.choose (fun (pkgName,version,tfm) -> if (tfm.GetExplicitRestriction()) = byTfm then Some (pkgName,version) else None) |> Seq.toList
+    let pkgVer name version = (PackageName name), (VersionRequirement.Parse version)
+
+    let tfmNET45 = FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4_5)
+    CollectionAssert.AreEquivalent([ pkgVer "FSharp.Core" "3.1.2.5"; pkgVer "Argu" "4.2.1" ], depsByTfm (FrameworkRestriction.AtLeast(tfmNET45)))
+
+    let tfmNETSTANDARD2_0 = FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V2_0)
+    CollectionAssert.AreEquivalent([ pkgVer "FSharp.Core" "4.5.1"; pkgVer "Argu" "5.1.0" ], depsByTfm (FrameworkRestriction.And [FrameworkRestriction.NotAtLeast(tfmNET45); FrameworkRestriction.AtLeast(tfmNETSTANDARD2_0)]))
+
+    CollectionAssert.AreEquivalent([ pkgVer "MyProj.Common" "1.0.0" ], depsByTfm (FrameworkRestriction.Or [FrameworkRestriction.AtLeast(tfmNET45); FrameworkRestriction.AtLeast(tfmNETSTANDARD2_0)]))
+
+    let unzippedNupkgPath = Path.Combine(outPath, "MyProj.Main")
+    ZipFile.ExtractToDirectory(nupkgPath, unzippedNupkgPath)
+    Path.Combine(unzippedNupkgPath, "lib", "net45", "MyProj.Main.dll") |> checkFileExists
+    Path.Combine(unzippedNupkgPath, "lib", "netstandard2.0", "MyProj.Main.dll") |> checkFileExists
+
+    CleanDir rootPath    
 
 [<Test>]
 [<Ignore("disabled for now, because require .net core 2.1.300")>]

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/Class1.cs
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MyProj.Common
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/MyProj.Common.csproj
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/MyProj.Common.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+  </PropertyGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/paket.references
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/paket.references
@@ -1,0 +1,6 @@
+FSharp.Core
+Suave
+
+group NetStandard
+  FSharp.Core
+  Suave

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/paket.template
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Common/paket.template
@@ -1,0 +1,11 @@
+type project
+dependencies
+  framework: net45
+    FSharp.Core >= LOCKEDVERSION
+    Suave >= LOCKEDVERSION
+  framework: netstandard2.0
+    FSharp.Core >= LOCKEDVERSION-NetStandard
+    Suave >= LOCKEDVERSION-NetStandard
+files
+    bin/Release/net45/MyProj.Common.dll ==> lib/net45
+    bin/Release/netstandard2.0/MyProj.Common.dll ==> lib/netstandard2.0

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/Class1.cs
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MyProj.Main
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/MyProj.Main.csproj
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/MyProj.Main.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MyProj.Common\MyProj.Common.csproj" />
+  </ItemGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/paket.references
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/paket.references
@@ -1,0 +1,6 @@
+FSharp.Core
+Argu
+
+group NetStandard
+  FSharp.Core
+  Argu

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/paket.template
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/MyProj.Main/paket.template
@@ -1,0 +1,11 @@
+type project
+dependencies
+  framework: net45
+    FSharp.Core >= LOCKEDVERSION
+    Argu >= LOCKEDVERSION
+  framework: netstandard2.0
+    FSharp.Core >= LOCKEDVERSION-NetStandard
+    Argu >= LOCKEDVERSION-NetStandard
+files
+    bin/Release/net45/MyProj.Main.dll ==> lib/net45
+    bin/Release/netstandard2.0/MyProj.Main.dll ==> lib/netstandard2.0

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/paket.dependencies
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/paket.dependencies
@@ -1,0 +1,14 @@
+source https://www.nuget.org/api/v2
+framework: >= net45
+
+nuget FSharp.Core >= 3.1.2.5 lowest_matching: true
+nuget Suave
+nuget Argu
+
+group NetStandard
+source https://www.nuget.org/api/v2
+framework: netstandard2.0
+
+nuget Suave
+nuget FSharp.Core
+nuget Argu

--- a/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/paket.lock
+++ b/integrationtests/scenarios/i003165-pack-multitarget-with-p2p/before/paket.lock
@@ -1,0 +1,36 @@
+RESTRICTION: >= net45
+NUGET
+  remote: https://www.nuget.org/api/v2
+    Argu (4.2.1)
+      FSharp.Core (>= 3.1.2)
+    FSharp.Core (3.1.2.5)
+    Suave (1.1.3)
+      FSharp.Core (>= 3.1.2.5)
+
+GROUP NetStandard
+RESTRICTION: == netstandard2.0
+NUGET
+  remote: https://www.nuget.org/api/v2
+    Argu (5.1)
+      FSharp.Core (>= 4.3.2)
+      System.Configuration.ConfigurationManager (>= 4.4)
+    FSharp.Core (4.5.1)
+    Suave (2.4.3)
+      FSharp.Core (>= 4.0 < 5.0)
+    System.Buffers (4.5)
+    System.Configuration.ConfigurationManager (4.5)
+      System.Security.Cryptography.ProtectedData (>= 4.5)
+      System.Security.Permissions (>= 4.5)
+    System.Memory (4.5.1)
+      System.Buffers (>= 4.4)
+      System.Numerics.Vectors (>= 4.4)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5)
+    System.Numerics.Vectors (4.5)
+    System.Runtime.CompilerServices.Unsafe (4.5.1)
+    System.Security.AccessControl (4.5)
+      System.Security.Principal.Windows (>= 4.5)
+    System.Security.Cryptography.ProtectedData (4.5)
+      System.Memory (>= 4.5)
+    System.Security.Permissions (4.5)
+      System.Security.AccessControl (>= 4.5)
+    System.Security.Principal.Windows (4.5)

--- a/src/Paket.Core/Packaging/PackageMetaData.fs
+++ b/src/Paket.Core/Packaging/PackageMetaData.fs
@@ -131,8 +131,14 @@ let addDependency (templateFile : TemplateFile) (dependency : PackageName * Vers
                 |> Option.isSome)
             |> function
             | Some _ -> opt.DependencyGroups
-            | None -> dependency |> addDependencyToFrameworkGroup None opt.DependencyGroups
-
+            | None ->
+                match opt.DependencyGroups |> List.map (fun { Framework = tfm } -> tfm) with
+                | [] ->
+                    dependency |> addDependencyToFrameworkGroup None opt.DependencyGroups
+                | tfms ->
+                    // add to all dependency groups
+                    (opt.DependencyGroups, tfms)
+                    ||> List.fold (fun groups tfm -> dependency |> addDependencyToFrameworkGroup tfm groups)
 
         { FileName = templateFile.FileName
           Contents = CompleteInfo(core, { opt with DependencyGroups = newDeps }) }


### PR DESCRIPTION
When creating the package with `paket pack` of a multitargeting projects with projectreferences (`MyCommon`), the generated nuspec was:

```xml
      <group>
        <dependency id="MyCommon" version="4.5.0.0" />
      </group>
      <group targetFramework="net45">
        <dependency id="FSharp.Core" version="3.1.2.5" />
      </group>
      <group targetFramework="netstandard2.0">
        <dependency id="FSharp.Core" version="4.3.4" />
      </group>
```

But that doesnt add `MyCommon` to depencies for `net45` or `netstandard2.0`, that is instead added to fallback group (when the tfm is not compatibile with `net45` or `netstandard2.0`)

This PR fix it, adding the p2p deps to each dependency group

```xml
      <group targetFramework="net45">
        <dependency id="MyCommon" version="4.5.0.0" />
        <dependency id="FSharp.Core" version="3.1.2.5" />
      </group>
      <group targetFramework="netstandard2.0">
        <dependency id="MyCommon" version="4.5.0.0" />
        <dependency id="FSharp.Core" version="4.3.4" />
      </group>
```

/cc @eiriktsarpalis 