### PR TITLE
Install Content files again.

### DIFF
--- a/src/Paket.Core/Installation/InstallProcess.fs
+++ b/src/Paket.Core/Installation/InstallProcess.fs
@@ -536,10 +536,7 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
                           Link = None }
                 ) |> Seq.toList
            
-            if toolsVersion >= 15.0 then
-                processContentFiles root project Map.empty gitRemoteItems options
-            else
-                processContentFiles root project usedPackages gitRemoteItems options
+            processContentFiles root project usedPackages gitRemoteItems options
             
             project.Save forceTouch
             projectCache.[project.FileName] <- Some project

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1564,7 +1564,9 @@ module ProjectFile =
     let determineBuildAction fileName (project:ProjectFile) =
         match (Path.GetExtension fileName).ToLowerInvariant() with
         | ext when Path.GetExtension project.FileName = ext + "proj"
-            -> BuildAction.Compile
+            -> match getToolsVersion project with
+                | 15.0 -> BuildAction.Content
+                | _ -> BuildAction.Compile
         | ".fsi" -> BuildAction.Compile
         | ".xaml" -> BuildAction.Page
         | ".ttf" | ".png" | ".ico" | ".jpg" | ".jpeg"| ".bmp" | ".gif"


### PR DESCRIPTION
Fix for https://github.com/fsprojects/Paket/issues/3269

This PR allows the usage of nuget packages with Content files, as well as allowing .cs files to be included as Content. Previously they got added as Compile, which caused duplicate errors to prevent the project from compiling.