### PR TITLE
fix design time (VS) when framework restriction exists

### DIFF
--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -272,8 +272,14 @@ let createPaketPropsFile (lockFile:LockFile) (cliTools:ResolvedPackage seq) (pac
         else
             packages
             |> Seq.map (fun ((groupName,packageName),_,_) -> 
-                let p = lockFile.Groups.[groupName].Resolution.[packageName]
-                let condition = Paket.Requirements.getExplicitRestriction p.Settings.FrameworkRestrictions      
+                let group = lockFile.Groups.[groupName]
+                let p = group.Resolution.[packageName]
+                let restrictions =
+                    match p.Settings.FrameworkRestrictions with
+                    | FrameworkRestrictions.ExplicitRestriction FrameworkRestriction.HasNoRestriction -> group.Options.Settings.FrameworkRestrictions
+                    | FrameworkRestrictions.ExplicitRestriction fw -> FrameworkRestrictions.ExplicitRestriction fw
+                    | _ -> group.Options.Settings.FrameworkRestrictions
+                let condition = restrictions |> getExplicitRestriction
                 p,condition)
             |> Seq.groupBy snd
             |> Seq.collect (fun (condition,packages) -> 

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -283,7 +283,10 @@ let createPaketPropsFile (lockFile:LockFile) (cliTools:ResolvedPackage seq) (pac
                 p,condition)
             |> Seq.groupBy snd
             |> Seq.collect (fun (condition,packages) -> 
-                let condition = condition.ToMSBuildCondition()
+                let condition =
+                    match condition with
+                    | FrameworkRestriction.HasNoRestriction -> ""
+                    | restrictions -> restrictions.ToMSBuildCondition()
                 let condition =
                     if condition = "" || condition = "true" then "" else
                     sprintf " AND (%s)" condition

--- a/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
+++ b/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
@@ -48,7 +48,7 @@ let checkContainsPackageRefs pkgRefs (group: XElement) =
 
 
 [<Test>]
-let ``should create props file for design mode``() = 
+let ``should create props file for design mode with group restrictions``() = 
 
     let lockFile = """RESTRICTION: && (>= net461) (< net47)
 NUGET

--- a/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
+++ b/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
@@ -149,14 +149,20 @@ group Other2
     let itemGroups = doc.Root.Elements (xname "ItemGroup") |> Seq.toList
             
     match itemGroups with
-    | [groupMain; otherGroup] ->
+    | [groupMain; otherGroup20And21; otherGroupOnly21] ->
         groupMain
         |> checkTargetFrameworkRestriction (lockFile.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions)
         groupMain
         |> checkContainsPackageRefs [ "FSharp.Core","3.1.2.5"; "Argu","4.2.1" ] 
-        otherGroup
-        |> checkTargetFrameworkRestriction (lockFile.Groups.[Domain.GroupName "Other1"].Options.Settings.FrameworkRestrictions)
-        otherGroup
-        |> checkContainsPackageRefs [ "FSharp.Core","4.3.4"; "FsCheck","2.8.2" ] 
+
+        otherGroup20And21
+        |> checkTargetFrameworkRestriction (lockFile.Groups.[Domain.GroupName "Other2"].Options.Settings.FrameworkRestrictions)
+        otherGroup20And21
+        |> checkContainsPackageRefs [ "FSharp.Core","4.3.4" ] 
+
+        otherGroupOnly21
+        |> checkTargetFrameworkRestriction (lockFile.Groups.[Domain.GroupName "Other2"].Resolution.[Domain.PackageName "FsCheck"].Settings.FrameworkRestrictions)
+        otherGroupOnly21
+        |> checkContainsPackageRefs [ "FsCheck","2.8.2" ] 
     | l ->
         Assert.Fail(sprintf "expected two ItemGroup but was '%A'" l)

--- a/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
+++ b/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
@@ -160,7 +160,7 @@ group Other1
         Assert.Fail(sprintf "expected two ItemGroup but was '%A'" l)
 
 [<Test>]
-let ``should create props file for design mode with single package restriction``() = 
+let ``should create props file for design mode with group and package restriction``() = 
 
     let lockFile = """RESTRICTION: && (>= net461) (< net47)
 NUGET

--- a/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
+++ b/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
@@ -1,0 +1,92 @@
+﻿module Paket.InstallModel.PaketPropsTests
+
+open Paket
+open NUnit.Framework
+open FsUnit
+open TestHelpers
+open System.Xml.Linq
+
+let ns = "http://schemas.microsoft.com/developer/msbuild/2003"
+let xname name = XName.Get(name, ns)
+
+let checkContainsPackageRefs pkgRefs (group: XElement) =
+
+    let isPackageReference name (x: XElement) =
+        if x.Name = (xname "PackageReference") then
+            match x.Attribute(XName.Get "Include") with
+            | null -> false
+            | v -> v.Value = name
+        else
+            false
+
+    let hasVersion version (x: XElement) =
+        x.Elements(xname "Version")
+        |> Seq.tryHead
+        |> Option.map (fun x -> x.ToString() = version)
+        |> function Some true -> true | _ -> false
+
+    let packageRefs = group.Elements(xname "PackageReference") |> Seq.toList
+    Assert.AreEqual(pkgRefs |> List.length, packageRefs |> Seq.length, (sprintf "%A" group))
+    for (pkgName, pkgVersion) in pkgRefs do
+        let pkg =
+            packageRefs
+            |> List.filter (isPackageReference pkgName)
+            |> List.filter (hasVersion pkgVersion)
+            |> List.tryHead
+        match pkg with
+        | Some p -> ()
+        | None ->
+            Assert.Fail("expected package '%s' with version '%s' not found in '%A' group")
+
+
+[<Test>]
+let ``should create props file for design mode``() = 
+
+    let lockFile = """RESTRICTION: && (>= net461) (< net47)
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    Argu (4.2.1)
+      FSharp.Core (>= 3.1.2)
+    FSharp.Core (3.1.2.5)
+
+GROUP Other1
+RESTRICTION: == netstandard2.0
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    FsCheck (2.8.2)
+      FSharp.Core (>= 3.1.2.5)
+    FSharp.Core (4.3.4)"""
+
+    let refFileContent = """
+FSharp.Core
+Argu
+
+group Other1
+  FSharp.Core
+  FsCheck
+"""
+
+    let lockFile = LockFile.Parse("", toLines lockFile)
+
+    let refFile = ReferencesFile.FromLines(toLines refFileContent) // .Groups.[Constants.MainDependencyGroup]
+
+    let packages =
+        [ for kv in refFile.Groups do
+            let packagesInGroup,_ = lockFile.GetOrderedPackageHull(kv.Key, refFile)
+            yield! packagesInGroup ]
+
+    let outPath = System.IO.Path.GetTempFileName()
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty packages (FileInfo outPath)
+
+    let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
+
+    let itemGroups = doc.Root.Elements (xname "ItemGroup") |> Seq.toList
+            
+    match itemGroups with
+    | [groupMain; otherGroup] ->
+        groupMain
+        |> checkContainsPackageRefs [ "FSharp.Core","1"; "Argu","2" ] 
+        otherGroup
+        |> checkContainsPackageRefs [ "FSharp.Core","1"; "Argu","2" ] 
+    | l ->
+        Assert.Fail(sprintf "expected two ItemGroup but was '%A'" l)

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -353,6 +353,7 @@
     <Compile Include="InstallModel\BindingRedirect.fs" />
     <Compile Include="InstallModel\RuntimeGraphTests.fs" />
     <Compile Include="InstallModel\InstallNuGetContentsTests.fs" />
+    <Compile Include="InstallModel\PaketPropsTests.fs" />
     <Compile Include="Packaging\PackageProcessSpecs.fs" />
     <Compile Include="Packaging\NuspecWriterSpecs.fs" />
     <Compile Include="Packaging\TemplateFileParsing.fs" />


### PR DESCRIPTION
fix #3334

This generate the correct msbuild condtion based on group and packages framework restrictions.

It also cleanup the condition (just checking is DesignMode), if there are no framework restrictions (instead of create a really big condition with all the target framework)
