### PR TITLE
Possible fix for #3186?

### DIFF
--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -383,7 +383,7 @@ let createProjectReferencesFiles (lockFile:LockFile) (projectFile:ProjectFile) (
                     excludes,packages
                 | None -> Set.empty,Set.empty
 
-            for (key,_,_) in hull do
+            for (key,pacakgeSettings,_) in hull do
                 let resolvedPackage = resolved.Force().[key]
                 let _,packageName = key
                 let restore =
@@ -399,10 +399,12 @@ let createProjectReferencesFiles (lockFile:LockFile) (projectFile:ProjectFile) (
                     let direct = allDirectPackages.Contains packageName
                     let package = resolved.Force().[key]
                     let copy_local =
-                        match resolvedPackage.Settings.CopyLocal with
-                        | Some false -> "exclude"
-                        | Some x -> x.ToString()
-                        | None -> "false"
+                        match resolvedPackage.Settings.CopyLocal, pacakgeSettings.Settings.CopyLocal with
+                        | Some false, None
+                        | _, Some false -> "exclude"
+                        | Some true, None
+                        | _, Some true -> "true"
+                        | None, None -> "false"
                     let line =
                         packageName.ToString() + "," +
                         package.Version.ToString() + "," +


### PR DESCRIPTION
Fixes: #3186 

Take into consideration the copy_local settings from the references file for New SDK projects.

I don't know if this is the solution to the problem, but it seems to work for me. Although I'm not exactly sure what the implications of setting this to `true` is, which then sets `PrivateAssets` to `All` in the `paket.Restore.targets` file.