### PR TITLE
Add nuget package output details to paket pack output

### DIFF
--- a/src/Paket.Core/Packaging/PackageProcess.fs
+++ b/src/Paket.Core/Packaging/PackageProcess.fs
@@ -239,9 +239,10 @@ let Pack(workingDir,dependenciesFile : DependenciesFile, packageOutputPath, buil
             async { 
                 match templateFile with
                 | CompleteTemplate(core, optional) -> 
-                    NupkgWriter.Write core optional (Path.GetDirectoryName templateFile.FileName) packageOutputPath
-                    |> NuGetCache.fixDatesInArchive 
-                    tracefn "Packed: %s" templateFile.FileName
+                    tracefn "Packaging: %s" templateFile.FileName
+                    let outputPath = NupkgWriter.Write core optional (Path.GetDirectoryName templateFile.FileName) packageOutputPath
+                    NuGetCache.fixDatesInArchive outputPath
+                    tracefn "Wrote: %s" outputPath
                 | IncompleteTemplate -> 
                     failwithf "There was an attempt to pack the incomplete template file %s." templateFile.FileName
             })


### PR DESCRIPTION
It turns out to be useful for certain scenarios in our case, to know the details of the nuget package generated by the `paket pack` in a CI setting. So we propose to add the details to the output.