### PR TITLE
fix potential race condition when redirecting output.

### DIFF
--- a/src/Paket.Core/Common/ProcessHelper.fs
+++ b/src/Paket.Core/Common/ProcessHelper.fs
@@ -181,6 +181,8 @@ let ExecProcessWithLambdas configProcessStartInfoF (timeOut : TimeSpan) silent e
                     null
                 with exn -> exn
             raise (Exception(sprintf "Process %s %s timed out." proc.StartInfo.FileName proc.StartInfo.Arguments, inner))
+    // See http://stackoverflow.com/a/16095658/1149924 why WaitForExit must be called twice.
+    proc.WaitForExit()
     proc.ExitCode
 
 /// A process result including error code, message log and errors.


### PR DESCRIPTION
That this happens in real world can be seen [here](https://dev.azure.com/fakebuild/FSProjects/_build/results?buildId=475&view=logs):

```
2018-09-13T15:05:42.6262273Z Paket failed with
2018-09-13T15:05:42.6348151Z -> Unable to retrieve package versions for 'matthid_test_auth_custom_nuget_package'
2018-09-13T15:05:42.6349188Z    -- CLOSED --
2018-09-13T15:05:42.6349593Z       
2018-09-13T15:05:42.6349763Z    -- OPEN ----
2018-09-13T15:05:42.6349954Z       matthid_test_auth_custom_nuget_package  (from D:\a\1\s\paket_cred\paket.dependencies)
2018-09-13T15:05:42.6376020Z    StackTrace:
2018-09-13T15:05:42.6400785Z         at Paket.PackageResolver.getVersionsBlock@1057-1.GenerateNext(IEnumerable`1& next)
2018-09-13T15:05:42.6401355Z         at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1.MoveNextImpl()
2018-09-13T15:05:42.6401667Z         at Microsoft.FSharp.Collections.SeqModule.oneStepTo@984[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i)
2018-09-13T15:05:42.6401930Z         at Microsoft.FSharp.Collections.SeqModule.action@4236-1[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i, Unit unitVar0)
2018-09-13T15:05:42.6402948Z         at Microsoft.FSharp.Collections.SeqModule.result@1000.Invoke(Int32 i)
2018-09-13T15:05:42.6403142Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.unfold@199.DoMoveNext(b& curr)
2018-09-13T15:05:42.6403374Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext()
2018-09-13T15:05:42.6403580Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.map@74.DoMoveNext(b& curr)
2018-09-13T15:05:42.6403997Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext()
2018-09-13T15:05:42.6404368Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.next@187[T](FSharpFunc`2 f, IEnumerator`1 e, FSharpRef`1 started, Unit unitVar0)
2018-09-13T15:05:42.6404570Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.filter@182.System-Collections-IEnumerator-MoveNext()
2018-09-13T15:05:42.6405049Z         at Microsoft.FSharp.Collections.SeqModule.oneStepTo@984[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i)
2018-09-13T15:05:42.6405253Z         at Microsoft.FSharp.Collections.SeqModule.action@4236-1[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i, Unit unitVar0)
2018-09-13T15:05:42.6405434Z         at Microsoft.FSharp.Collections.SeqModule.result@1000.Invoke(Int32 i)
2018-09-13T15:05:42.6405611Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.unfold@199.DoMoveNext(b& curr)
2018-09-13T15:05:42.6406036Z         at Microsoft.FSharp.Collections.Internal.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext()
2018-09-13T15:05:42.6406197Z         at Microsoft.FSharp.Collections.SeqModule.IsEmpty[T](IEnumerable`1 source)
2018-09-13T15:05:42.6406473Z         at Paket.PackageResolver.getCompatibleVersions(ResolverStep currentStep, GroupName groupName, PackageRequirement currentRequirement, IDictionary`2 rootDependencies, FSharpFunc`2 getVersionsF, Boolean globalOverride, FSharpOption`1 globalStrategyForDirectDependencies, FSharpOption`1 globalStrategyForTransitives)
2018-09-13T15:05:42.6407048Z         at Paket.PackageResolver.step@1113(UpdateMode updateMode, GroupName groupName, FSharpOption`1 globalStrategyForTransitives, FSharpOption`1 globalStrategyForDirectDependencies, FrameworkRestrictions globalFrameworkRestrictions, FSharpFunc`2 getVersionsRaw, FSharpFunc`2 getPreferredVersionsRaw, FSharpFunc`2 getPackageDetailsRaw, FSharpSet`1 cliToolSettings, ResolverRequestQueue workerQueue, Int32 taskTimeout, TimeSpan loopTimeout, ConcurrentDictionary`2 startedGetPackageDetailsRequests, FSharpFunc`2 getPackageDetailsBlock, ConcurrentDictionary`2 startedGetVersionsRequests, FSharpOption`1 packageFilter, IDictionary`2 rootDependenciesDict, FSharpSet`1 lockedPackages, DateTime loopTime, Stage stage, StackPack stackpack, IEnumerable`1 compatibleVersions, StepFlags flags)
2018-09-13T15:05:42.6407635Z         at Paket.PackageResolver.Resolve(FSharpFunc`2 getVersionsRaw, FSharpFunc`2 getPreferredVersionsRaw, FSharpFunc`2 getPackageDetailsRaw, GroupName groupName, FSharpOption`1 globalStrategyForDirectDependencies, FSharpOption`1 globalStrategyForTransitives, FrameworkRestrictions globalFrameworkRestrictions, FSharpSet`1 rootDependencies, UpdateMode updateMode)
2018-09-13T15:05:42.6407934Z         at <StartupCode$Paket-Core>.$DependenciesFile.resolveGroup@222-1.Invoke(GroupName groupName, b _arg1)
2018-09-13T15:05:42.6408121Z         at Microsoft.FSharp.Collections.MapTreeModule.mapiOpt[a,b,c](FSharpFunc`3 f, MapTree`2 m)
2018-09-13T15:05:42.6408286Z         at Microsoft.FSharp.Collections.FSharpMap`2.Map[b](FSharpFunc`2 f)
2018-09-13T15:05:42.6408535Z         at Paket.UpdateProcess.selectiveUpdate(Boolean force, FSharpFunc`2 getSha1, FSharpFunc`2 getVersionsF, FSharpFunc`2 getPackageDetailsF, FSharpFunc`2 getRuntimeGraphFromPackage, LockFile lockFile, DependenciesFile dependenciesFile, UpdateMode updateMode, SemVerUpdateMode semVerUpdateMode)
2018-09-13T15:05:42.6408906Z         at Paket.UpdateProcess.SelectiveUpdate(DependenciesFile dependenciesFile, FSharpOption`1 alternativeProjectRoot, UpdateMode updateMode, SemVerUpdateMode semVerUpdateMode, Boolean force)
2018-09-13T15:05:42.6409124Z         at Paket.UpdateProcess.SmartInstall(DependenciesFile dependenciesFile, UpdateMode updateMode, UpdaterOptions options)
2018-09-13T15:05:42.6409348Z         at <StartupCode$Paket-Core>.$PublicAPI.Update@320.Invoke(Unit unitVar0)
2018-09-13T15:05:42.6409502Z         at Paket.Utils.RunInLockedAccessMode[a](String lockedFolder, FSharpFunc`2 action)
2018-09-13T15:05:42.6409663Z         at Paket.Program.handleCommand@827-16.Invoke(ParseResults`1 results)
2018-09-13T15:05:42.6409849Z         at Paket.Program.processWithValidationEx$cont@42[a](Boolean silent, FSharpFunc`2 commandF, a result, Unit unitVar)
2018-09-13T15:05:42.6410042Z         at Paket.Program.processWithValidation[T](Boolean silent, FSharpFunc`2 validateF, FSharpFunc`2 commandF, ParseResults`1 result)
2018-09-13T15:05:42.6410664Z         at Paket.Program.handleCommand(Boolean silent, Command command)
2018-09-13T15:05:42.6410849Z         at Paket.Program.main()
2018-09-13T15:05:42.6411228Z -> Credential provider returned an invalid result (0): 
2018-09-13T15:05:42.6411362Z     Standard Error: 
```

This fix is already part of FAKE quite some time. Maybe we should depend on fake.core.process :)
