### PR TITLE
Defect #2902, removing paket.exe from list of files not added to version control.

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -159,10 +159,6 @@ The following files can be committed, but are not essential:
 The following files should *not* be committed to your version control system,
 and should be added to any ignore files:
 
-* `.paket/paket.exe`, the main Paket executable, downloaded by
-  [`.paket/paket.bootstrapper.exe`](bootstrapper.html). It should not be
-  committed, as it is a binary file which can unnecessarily bloat repositories,
-  and because it is likely to be updated on a regular basis.
 * `paket-files` directory, as [`paket install`](paket-install.html) will restore
   this.
 * Same applies to the `packages` directory.


### PR DESCRIPTION
My first commit to this project. Based on discussion [here](https://github.com/fsprojects/Paket/issues/2902) it seemed like I should remove the reference to paket.exe because that is a file that is needed into source control. 

I'm not sure what your current branching strategy is, if you want me to change which branch to merge into let me know.

Let me know if you have any questions, comments or suggestions.
