### PR TITLE
Fix path to fsc.exe in mono build

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -161,6 +161,7 @@ Target "Build" (fun _ ->
         |> MSBuildReleaseExt "" [
                 "VisualStudioVersion", "14.0"
                 "ToolsVersion"       , "14.0"
+                "FscToolPath"        , "$(MSBuildThisFileDirectory)"
         ] "Rebuild"
         |> ignore
     else


### PR DESCRIPTION
Fixes linux build using mono by overriding `FscToolPath` and setting it to "$(MSBuildThisFileDirectory)"

Before adding this I was getting: 
```
Target CoreCompile:
./Paket/packages/FSharp.Compiler.Tools/tools/Microsoft.FSharp.Targets: error : Tool executable './Paket/src/Paket.Core/../tools/fsc.exe' could not be found
			Task "Fsc" execution -- FAILED
			Done building target "CoreCompile" in project "./Paket/src/Paket.Core/Paket.Core.fsproj".-- FAILED
		Done building project "./Paket/src/Paket.Core/Paket.Core.fsproj".-- FAILED
	Task "MSBuild" execution -- FAILED
	Done building target "Rebuild" in project "./Paket/Paket.sln".-- FAILED
Done building project "./Paket/Paket.sln".-- FAILED

Build FAILED.

Warnings:

./Paket/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj:  warning : Could not find project file //.paket/paket.targets, to import. Ignoring.
./Paket/Paket.sln:  warning : Don't know how to handle GlobalSection ExtensibilityGlobals, Ignoring.
./Paket/Paket.sln:  warning : Don't know how to handle GlobalSection Performance, Ignoring.
./Paket/Paket.sln:  warning : Don't know how to handle GlobalSection Performance, Ignoring.
./Paket/Paket.sln:  warning : Don't know how to handle GlobalSection Performance, Ignoring.
./Paket/Paket.sln:  warning : Don't know how to handle GlobalSection Performance, Ignoring.

Errors:

./Paket/Paket.sln (Rebuild) ->
(Rebuild target) ->
./Paket/src/Paket.Core/Paket.Core.fsproj (Rebuild) ->
./Paket/packages/FSharp.Compiler.Tools/tools/Microsoft.FSharp.Targets (CoreCompile target) ->

	./Paket/packages/FSharp.Compiler.Tools/tools/Microsoft.FSharp.Targets: error : Tool executable './Paket/src/Paket.Core/../tools/fsc.exe' could not be found

	 6 Warning(s)
	 1 Error(s)

```

Apologies if this isn't the correct way to fix this.  I wasn't sure if it was an issue with the FSharp.Compiler.Tools or with the Paket build on mono.