### PR TITLE
Add namespace to load scripts

### DIFF
--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -288,3 +288,13 @@ let ``ignore assemblies that are not expected by the specified framework`` () =
         "nlog.csx", ["Java.Interop"; "Mono.Android"; "System.Xml.Linq"; "System.Net"; "System.Windows"; "System.Windows.Browser"; "Xamarin.iOS" ]
         "nlog.fsx", ["Java.Interop"; "Mono.Android"; "System.Xml.Linq"; "System.Net"; "System.Windows"; "System.Windows.Browser"; "Xamarin.iOS" ]
     ] |> assertExpectations scenario ExpectationType.ShouldNotContain
+
+[<Test; Category("scriptgen")>]
+let ``scripts should contain the paket namespace`` () =
+    let scenario = "add-namespace"
+    paket "install" scenario |> ignore
+    
+    [
+        "nlog.csx", ["namespace PaketLoadScripts" ]
+        "nlog.fsx", ["namespace PaketLoadScripts" ]
+    ] |> assertExpectations scenario ExpectationType.ShouldContain

--- a/integrationtests/scenarios/loading-scripts/add-namespace/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/add-namespace/before/paket.dependencies
@@ -1,0 +1,4 @@
+generate_load_scripts: true
+source https://www.nuget.org/api/v2
+framework: net45
+nuget NLog 4.5.10

--- a/src/Paket.Core/Installation/ScriptGeneration.fs
+++ b/src/Paket.Core/Installation/ScriptGeneration.fs
@@ -114,6 +114,8 @@ module ScriptGeneration =
                     (Uri scriptFile.FullName).MakeRelativeUri(Uri libFile.FullName).ToString()
                 else libFile.FullName
 
+            let paketNamespace = "namespace PaketLoadScripts\n"
+
             // create the approiate load string for the target resource
             let refString (reference:ReferenceType)  =
                 let escapeString (s:string) =
@@ -126,7 +128,7 @@ module ScriptGeneration =
                 | Framework name,_ ->
                      sprintf """#r "%s" """ (escapeString name)
         
-            self.Input |> Seq.map refString |> Seq.distinct |> String.concat "\n"
+            self.Input |> Seq.map refString |> Seq.append [paketNamespace] |> Seq.distinct |> String.concat "\n"
         
         /// use the provided directory to compute the relative paths for the script's contents
         /// and construct the 


### PR DESCRIPTION
The generated load scripts don't have a namespace and this causes issues while importing assemblies that have modules defined with the same name as the assembly as that will be the default namespace.

Example:
Assembly `A.dll` defines module `A`. When this is imported via load script, I get the following error:

```
FS0247 - A namespace and a module named 'A' both occur in two parts of this assembly
```

This PR fixes this issue by adding the namespace `PaketLoadScripts` to all the generated load scripts.
 