### PR TITLE
Fix handling of DotNetCoreAppVersion.V3_0

### DIFF
--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -247,7 +247,7 @@ type DotNetCoreAppVersion =
         | "2" -> Some (DotNetCoreAppVersion.V2_0)
         | "2.1" -> Some (DotNetCoreAppVersion.V2_1)
         | "2.2" -> Some (DotNetCoreAppVersion.V2_2)
-        | "3.0" -> Some (DotNetCoreAppVersion.V3_0)
+        | "3" -> Some (DotNetCoreAppVersion.V3_0)
         | _ -> None
 
 [<RequireQualifiedAccess>]


### PR DESCRIPTION
As input does not contain trailing zeros our map entry must not contain trailing zeros.

This should enable us using/trying paket on .NET core 3.0 projects.