### PR TITLE
Fix zsh completer for clear-cache

### DIFF
--- a/completion/paket-completion.zsh
+++ b/completion/paket-completion.zsh
@@ -442,7 +442,7 @@ _paket-clear-cache() {
   local -a args
   args=(
     $global_options
-    '(--clear-local)'{--clear-local}"[also clear local packages and paket-files directory]"
+    '(--clear-local)'--clear-local"[also clear local packages and paket-files directory]"
   )
 
   _arguments -C \


### PR DESCRIPTION
The `paket clear-cache` completer is broken. This fixes it.