### PR TITLE
Do not change the AutoGenerateBindingRedirects for exe output type

### DIFF
--- a/src/Paket.Core/Installation/BindingRedirects.fs
+++ b/src/Paket.Core/Installation/BindingRedirects.fs
@@ -158,9 +158,10 @@ let private applyBindingRedirects isFirstGroup cleanBindingRedirects (allKnownLi
         use f = File.Open(configFilePath, FileMode.Create)
         config.Save(f, SaveOptions.DisableFormatting)
 
-    match projectFile.GetAutoGenerateBindingRedirects() with
-    | Some x when x.ToLower() = "true" -> ignore()
-    | _ -> projectFile.SetOrCreateAutoGenerateBindingRedirects()
+    match projectFile.OutputType, projectFile.GetAutoGenerateBindingRedirects() with
+    | ProjectOutputType.Exe, _ -> ignore()
+    | _, Some x when x.ToLower() = "true" -> ignore()
+    | _, _ -> projectFile.SetOrCreateAutoGenerateBindingRedirects()
 
 let findAllReferencesFiles root =
     let findRefFile (p:ProjectFile) =


### PR DESCRIPTION
This has some weird behavior when you set to true on exe output types.

It's safer to leave them alone and let the user decide to enable if they wish.

Currently, i am having to revert the paket change so as to keep my actual redirects rather than those auto generated.

Stupidly in MSBuild, this switch is ONLY used in exe output types to generate the redirects.
But when set on Library output types, it prevents warnings...slow clap for msbuild using the same property for 2 tasks...