### PR TITLE
Add PaketRestoreDisabled when NCrunch enabled in targets

### DIFF
--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -62,6 +62,9 @@
     <!-- see https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1032-fsharp-in-dotnet-sdk.md -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+
+    <!-- Disable Paket restore under NCrunch build -->
+    <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
   </PropertyGroup>
 
   <Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">


### PR DESCRIPTION
As suggested here:
https://forum.ncrunch.net/yaf_postst2467_F---net-core-projects-doesn-t-build-in-after-upgrade-to-VS-2017-15-7-0.aspx
When running new style project files & using NCrunch
The paket restore will fail (as its not got everything it needs)
So prevent the restore from running.
NCrunch will still work as expected as it will use the restored files

The Caveat is that a user will have to build manually in order to
1st create the restore files.  But at least this way NCrunch will work!