### PR TITLE
Set AllowExplicitVersion to true for PackageReference in Paket.Restore.targets

### DIFF
--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -183,6 +183,7 @@
         <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' == '6' And %(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
         <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '6' And %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
         <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
+        <AllowExplicitVersion>true</AllowExplicitVersion>
       </PackageReference>
     </ItemGroup>
 


### PR DESCRIPTION
This resolves https://github.com/fsprojects/Paket/issues/3481

It suppresses the SDK warning `NETSDK1071` for implicit references that was introduced in SDK 2.2.x, by allowing an explicit version to be specified.
This allows you to control/upgrade implicit meta package references from paket without a warning.

The warnings can break builds if you use `/warnaserror`

https://github.com/dotnet/sdk/issues/2602
https://github.com/aspnet/Docs/issues/6430