### PR TITLE
Apply paket github api token on github requests

### DIFF
--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -423,8 +423,6 @@ let createWebClient (url,auth:Auth option) =
     client.Headers.Add("User-Agent", "Paket")
     client.Proxy <- getDefaultProxyFor url
 
-    let githubToken = Environment.GetEnvironmentVariable "PAKET_GITHUB_API_TOKEN"
-
     match auth with
     | Some (Credentials({Username = username; Password = password; Type = AuthType.Basic})) ->
         // htttp://stackoverflow.com/questions/16044313/webclient-httpwebrequest-with-basic-authentication-returns-404-not-found-for-v/26016919#26016919
@@ -442,8 +440,6 @@ let createWebClient (url,auth:Auth option) =
         client.Credentials <- cred.GetCredential(new Uri(url), "NTLM")
     | Some (Token token) ->
         client.Headers.[HttpRequestHeader.Authorization] <- sprintf "token %s" token
-    | None when not (isNull githubToken) ->
-        client.Headers.[HttpRequestHeader.Authorization] <- sprintf "token %s" githubToken
     | None ->
         client.UseDefaultCredentials <- true
     client

--- a/src/Paket.Core/PackageManagement/Releases.fs
+++ b/src/Paket.Core/PackageManagement/Releases.fs
@@ -27,7 +27,10 @@ let private doesNotExistsOrIsNewer (file : FileInfo) latest =
 
 /// Downloads the latest version of the given files to the destination dir
 let private downloadLatestVersionOf files destDir =
-    use client = createHttpClient(Constants.GitHubUrl, None)
+    let auth = Environment.GetEnvironmentVariable "PAKET_GITHUB_API_TOKEN"
+               |> fun x -> if isNull(x) then None else Some(Token(x))
+
+    use client = createHttpClient(Constants.GitHubUrl, auth)
 
     trial {
         let latest = "https://github.com/fsprojects/Paket/releases/latest";

--- a/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
@@ -254,8 +254,12 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
             let externalLockDependencies = 
                 group.ExternalLocks
                 |> List.map (fun x ->
-                    if x.StartsWith("http://") || x.StartsWith("https://") then
-                        use client = createHttpClient(x, None)
+                    if x.ToLower().StartsWith("http://") || x.ToLower().StartsWith("https://") then
+                        let auth = if x.ToLower().Contains("://github.com") then
+                                    Environment.GetEnvironmentVariable "PAKET_GITHUB_API_TOKEN" |> fun x -> if isNull(x) then None else Some(Token(x))
+                                   else
+                                    None
+                        use client = createHttpClient(x, auth)
                         let folder = DirectoryInfo(Path.Combine(Path.GetTempPath(),"external_paket",(hash x).ToString()))
                         if not folder.Exists then
                             folder.Create()


### PR DESCRIPTION
Updated version of the reverted #3460 
This uses the already present and supported token authentication and puts the onus on the creator of the client to specify they want the token to be used rather than magicly hiding it away in the net utils