### PR TITLE
Fixed confusing instruction for paket.dependencies location

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -39,7 +39,7 @@ This guide will show you
 
 ### Specifying dependencies
 
-Create a [`paket.dependencies` file](dependencies-file.html) in your project's
+Create a [`paket.dependencies` file](dependencies-file.html) in your solution's
 root and specify all your dependencies in it. You can use
 [NuGet packages](nuget-dependencies.html),
 [Git repos](git-dependencies.html),


### PR DESCRIPTION
paket.dependencies should be created in the solution root, not in the project directory.
Other steps in Getting started guide refer to the Solutions directory correctly, which makes this mistake even more confusing (for example, step 1: Create a .paket directory in the root of your solution), especially for people who are just starting out with Paket.