### PR TITLE
Fix DebuggerDisplay-Attribute of GroupName

### DIFF
--- a/src/Paket.Core/Common/Domain.fs
+++ b/src/Paket.Core/Common/Domain.fs
@@ -42,7 +42,7 @@ let PackageName(name:string) =
 
 
 /// Represents a normalized group name
-[<System.Diagnostics.DebuggerDisplay("{Item2}")>]
+[<System.Diagnostics.DebuggerDisplay("{compareString}")>]
 [<CustomEquality; CustomComparison>]
 type GroupName =
    | GroupName of name:string * compareString:string


### PR DESCRIPTION
This makes the debugger display the `compareString` as intended, instead of this error message:

``` text
error CS0103: The name 'Item2' does not exist in the current context
```