### PR TITLE
Use nuget.org's V3 service index

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -49,7 +49,7 @@ root and specify all your dependencies in it. You can use
 The file might look like this:
 
 ```paket
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Castle.Windsor-log4net >= 3.2
 nuget NUnit


### PR DESCRIPTION
The NuGet team advocates the V3 API over the V2 API. I realize Paket can map between the two, but we should prefer the V3 service index if possible.