### PR TITLE
add types to ambiguous parameters to help overload resolution

### DIFF
--- a/src/Paket.Core/Common/ProcessHelper.fs
+++ b/src/Paket.Core/Common/ProcessHelper.fs
@@ -208,7 +208,7 @@ let ExecProcessAndReturnMessages configProcessStartInfoF timeOut =
     ProcessResult.New exitCode messages errors
 
 /// Converts a sequence of strings to a string with delimiters
-let inline separated delimiter (items : string seq) = String.Join(delimiter, Array.ofSeq items)
+let inline separated (delimiter: string) (items : string seq) = String.Join(delimiter, Array.ofSeq items)
 
 /// Converts a sequence of strings into a string separated with line ends
 let inline toLines text = separated Environment.NewLine text

--- a/src/Paket.Core/Common/Utils.fs
+++ b/src/Paket.Core/Common/Utils.fs
@@ -521,11 +521,11 @@ let RunInLockedAccessMode(lockedFolder,action) =
 module String =
 
     /// Match if 'text' starts with the 'prefix' string case
-    let (|StartsWith|_|) prefix (input: string) =
+    let (|StartsWith|_|) (prefix: string) (input: string) =
         if input.StartsWith prefix then Some () else None
 
     /// Match if 'text' starts with the 'prefix' and return the text with the prefix removed
-    let (|RemovePrefix|_|) prefix (input: string) =
+    let (|RemovePrefix|_|) (prefix: string) (input: string) =
         if input.StartsWith prefix then Some (input.Substring prefix.Length)
         else None
 
@@ -575,8 +575,8 @@ module String =
     let quoted (text:string) = (if text.Contains(" ") then "\"" + text + "\"" else text)
 
     let inline trim (text:string) = text.Trim()
-    let inline trimChars chs (text:string) = text.Trim chs
-    let inline trimStart pre (text:string) = text.TrimStart pre
+    let inline trimChars (chs: char[]) (text:string) = text.Trim chs
+    let inline trimStart (pre: char[]) (text:string) = text.TrimStart pre
     let inline split sep (text:string) = text.Split sep
 
 // MonadPlus - "or else"

--- a/src/Paket.Core/Common/Xml.fs
+++ b/src/Paket.Core/Common/Xml.fs
@@ -36,7 +36,7 @@ let inline withAttributeValue attributeName valueText node =
 
 
 /// [omit]
-let inline withAttributeValueEndsWith attributeName valueText node =
+let inline withAttributeValueEndsWith attributeName (valueText: string) node =
     match getAttribute attributeName node with
     | Some text when text.EndsWith valueText -> true
     | _ -> false

--- a/src/Paket.Core/Dependencies/DependenciesFileParser.fs
+++ b/src/Paket.Core/Dependencies/DependenciesFileParser.fs
@@ -27,7 +27,7 @@ module DependenciesFileParser =
         | NoStrategy -> None
 
     let twiddle (minimum:SemVerInfo) =
-        let inline isNumeric item = 
+        let inline isNumeric (item: string) =
             match BigInteger.TryParse item with
             | true, number -> Some(number)
             | false, _ -> None

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -60,7 +60,7 @@ module NuGetContent =
         | NuGetDirectory (name, contents) -> NuGetDirectory(f name, contents)
         | NuGetFile name -> NuGetFile (f name)
 
-let inline ofGivenList rootName directories files =
+let inline ofGivenList rootName (directories: string seq) (files: string seq) =
     let folders = System.Collections.Generic.Dictionary<_,NuGetContent list>()
     let l = obj()
     let inline getCurrent n = match folders.TryGetValue n with | true, l -> l | _ -> []
@@ -792,7 +792,7 @@ let private downloadAndExtractPackage(alternativeProjectRoot, root, isLocalOverr
             CleanDir p
         | _ -> ()
 
-    let ensureDir fileName =
+    let ensureDir (fileName: string) =
         let parent = Path.GetDirectoryName fileName
         if not (Directory.Exists parent) then Directory.CreateDirectory parent |> ignore
 

--- a/src/Paket.Core/PackageManagement/RemoveProcess.fs
+++ b/src/Paket.Core/PackageManagement/RemoveProcess.fs
@@ -12,7 +12,7 @@ let private removePackageFromProject (project : ProjectFile) groupName package =
         .RemoveNuGetReference(groupName,package)
         .Save()
 
-let private remove removeFromProjects dependenciesFileName alternativeProjectRoot groupName (package: PackageName) force installAfter = 
+let private remove removeFromProjects (dependenciesFileName: string) alternativeProjectRoot groupName (package: PackageName) force installAfter =
     let root = Path.GetDirectoryName dependenciesFileName
     let allProjects = ProjectFile.FindAllProjects root
     

--- a/src/Paket.Core/Packaging/PackageProcess.fs
+++ b/src/Paket.Core/Packaging/PackageProcess.fs
@@ -111,7 +111,7 @@ let private convertToSymbols (projectFile:ProjectFile) includeReferencedProjects
         let augmentedFiles = optional.Files |> List.append sourceFiles
         { templateFile with Contents = ProjectInfo({ core with Symbols = true }, { optional with Files = augmentedFiles }) }
 
-let Pack(workingDir,dependenciesFile : DependenciesFile, packageOutputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, minimumFromLockFile, pinProjectReferences, interprojectReferencesConstraint, symbols, includeReferencedProjects, projectUrl) =
+let Pack(workingDir: string, dependenciesFile : DependenciesFile, packageOutputPath: string, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile: string option, excludedTemplates, lockDependencies, minimumFromLockFile, pinProjectReferences, interprojectReferencesConstraint, symbols, includeReferencedProjects, projectUrl) =
     let buildConfig = defaultArg buildConfig "Release"
     let buildPlatform = defaultArg buildPlatform ""
     let packageOutputPath = if Path.IsPathRooted(packageOutputPath) then packageOutputPath else Path.Combine(workingDir,packageOutputPath)

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -628,7 +628,7 @@ module LockFileParser =
 type LockFile (fileName:string, groups: Map<GroupName,LockFileGroup>) =
     let fileName = if isNull fileName then String.Empty else fileName
     
-    let tryFindRemoteFile (remoteFiles:ResolvedSourceFile list) name =
+    let tryFindRemoteFile (remoteFiles:ResolvedSourceFile list) (name: string) =
         remoteFiles |> List.tryFind (fun x -> x.Name.EndsWith(name))
     let findRemoteFile referencesFile remoteFiles name =
         match tryFindRemoteFile remoteFiles name with

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1377,7 +1377,7 @@ module ProjectFile =
                 | Some n -> n.InnerText.ToLower() = "true"
                 | None -> true
 
-            let makePathNode path =
+            let makePathNode (path: string) =
                 { Path =
                     if Path.IsPathRooted path then Path.GetFullPath path else 
                     let di = FileInfo(normalizePath project.FileName).Directory
@@ -2052,7 +2052,7 @@ type ProjectFile with
         let propMap name value fn =
             defaultArg (self.GetProperty name|>Option.map fn) value
         
-        let tryBool = Boolean.TryParse>>function true, value-> value| _ -> false
+        let tryBool (s: string) = Boolean.TryParse s |> function true, value -> value | _ -> false
         
         let splitString = String.split[|';'|] >> Array.map (fun x -> x.Trim()) >> List.ofArray
 

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -723,14 +723,14 @@ module FrameworkDetection =
                         Some (v.ToString() |> simplify)
                 else None
 
-            let (|MatchTfm|_|) tfmStart tryParseVersion (s:string) =
+            let (|MatchTfm|_|) (tfmStart: string) tryParseVersion (s:string) =
                 if s.StartsWith tfmStart then
                     let versionPart = s.Substring (tfmStart.Length)
                     tryNormalizeVersion versionPart
                     |> Option.bind tryParseVersion
                 else
                     None
-            let (|MatchTfms|_|) tfmStarts tryParseVersion (s:string) =
+            let (|MatchTfms|_|) (tfmStarts: string seq) tryParseVersion (s:string) =
                 tfmStarts
                 |> Seq.tryPick (fun tfmStart ->
                     match s with


### PR DESCRIPTION
While working through #3550 I had a devil of a time building with more recent Mono versions than are used in the CI pipeline. This PR fixes the type-based mono failures which have arisen due to mono incorporating span overloads for certain members.