### PR TITLE
consider dependencies target framework restrictions in paket pack

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -277,7 +277,7 @@ Target "RunIntegrationTestsNetCore" (fun _ ->
             AdditionalArgs =
               [ "--filter"; (if testSuiteFilterFlakyTests then "TestCategory=Flaky" else "TestCategory!=Flaky")
                 sprintf "--logger:trx;LogFileName=%s" ("tests_result/netcore/Paket.IntegrationTests/TestResult.trx" |> Path.GetFullPath) ]
-            TimeOut = TimeSpan.FromMinutes 50.
+            TimeOut = TimeSpan.FromMinutes 60.
         })
 )
 "Clean" ==> "DotnetPublish" ==> "RunIntegrationTestsNetCore" 

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/Class1.cs
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MyProj.Common
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/MyProj.Common.csproj
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/MyProj.Common.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+  </PropertyGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/paket.references
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/paket.references
@@ -1,0 +1,3 @@
+FSharp.Core
+Suave framework: net45
+Argu framework: netstandard2.0

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/paket.template
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Common/paket.template
@@ -1,0 +1,7 @@
+type project
+dependencies
+  framework: net45
+  framework: netstandard2.0
+files
+    bin/Release/net45/MyProj.Common.dll ==> lib/net45
+    bin/Release/netstandard2.0/MyProj.Common.dll ==> lib/netstandard2.0

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/Class1.cs
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MyProj.Main
+{
+    public class Class1
+    {
+    }
+}

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/MyProj.Main.csproj
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/MyProj.Main.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MyProj.Common\MyProj.Common.csproj" />
+  </ItemGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/paket.references
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/paket.references
@@ -1,0 +1,3 @@
+FSharp.Core
+Suave
+Argu

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/paket.template
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/MyProj.Main/paket.template
@@ -1,0 +1,7 @@
+type project
+dependencies
+  framework: net45
+  framework: netstandard2.0
+files
+    bin/Release/net45/MyProj.Main.dll ==> lib/net45
+    bin/Release/netstandard2.0/MyProj.Main.dll ==> lib/netstandard2.0

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/paket.dependencies
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/paket.dependencies
@@ -1,0 +1,6 @@
+source https://www.nuget.org/api/v2
+framework: net45, netstandard2.0
+
+nuget FSharp.Core >= 3.1.2.5 lowest_matching: true
+nuget Suave 1.1.3 framework: net45
+nuget Argu 5.2.0 framework: netstandard2.0

--- a/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/paket.lock
+++ b/integrationtests/scenarios/i003166-pack-multitarget-with-p2p-by-tfm/before/paket.lock
@@ -1,0 +1,26 @@
+RESTRICTION: || (== net45) (== netstandard2.0)
+NUGET
+  remote: https://www.nuget.org/api/v2
+    Argu (5.2) - restriction: == netstandard2.0
+      FSharp.Core (>= 4.3.2) - restriction: == netstandard2.0
+      System.Configuration.ConfigurationManager (>= 4.4) - restriction: == netstandard2.0
+    FSharp.Core (4.3.2)
+    Suave (1.1.3) - restriction: == net45
+      FSharp.Core (>= 3.1.2.5)
+    System.Buffers (4.5) - restriction: == netstandard2.0
+    System.Configuration.ConfigurationManager (4.5) - restriction: == netstandard2.0
+      System.Security.Cryptography.ProtectedData (>= 4.5) - restriction: || (&& (== net45) (>= netstandard2.0)) (== netstandard2.0)
+      System.Security.Permissions (>= 4.5) - restriction: || (&& (== net45) (>= monoandroid)) (&& (== net45) (>= monotouch)) (&& (== net45) (>= net461)) (&& (== net45) (>= netstandard2.0)) (&& (== net45) (>= xamarintvos)) (&& (== net45) (>= xamarinwatchos)) (== netstandard2.0)
+    System.Memory (4.5.2) - restriction: == netstandard2.0
+      System.Buffers (>= 4.4)
+      System.Numerics.Vectors (>= 4.4) - restriction: || (&& (== net45) (>= net461)) (== netstandard2.0)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
+    System.Numerics.Vectors (4.5) - restriction: == netstandard2.0
+    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: == netstandard2.0
+    System.Security.AccessControl (4.5) - restriction: == netstandard2.0
+      System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (== net45) (>= net461)) (&& (== net45) (>= netcoreapp2.0)) (&& (== net45) (>= netstandard2.0)) (== netstandard2.0)
+    System.Security.Cryptography.ProtectedData (4.5) - restriction: == netstandard2.0
+      System.Memory (>= 4.5) - restriction: || (&& (== net45) (>= netstandard2.0)) (== netstandard2.0)
+    System.Security.Permissions (4.5) - restriction: == netstandard2.0
+      System.Security.AccessControl (>= 4.5) - restriction: || (&& (== net45) (>= net461)) (&& (== net45) (>= netstandard2.0)) (== netstandard2.0)
+    System.Security.Principal.Windows (4.5.1) - restriction: == netstandard2.0


### PR DESCRIPTION
Scenario: there are framework restrictions (like `framework: net461`) in paket.dependencies or paket.references

The `paket pack` should consider these and filter dependencies for the nuspec target framework groups

Before, all packages where added in all target framework groups