### PR TITLE
Allow for nuget v3 api to have an url that does not end with /index.json

### DIFF
--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -150,7 +150,7 @@ type PackageSource =
 #endif
                     LocalNuGet(source,None)
                 else 
-                    if Regex("/v3(?:/[-\w]+)?/index.json$").IsMatch source then
+                    if Regex("/v3(?:/[-\w]+)?$").IsMatch source then
                         NuGetV3 { Url = source; Authentication = auth }
                     else
                         NuGetV2 { Url = source; Authentication = auth }


### PR DESCRIPTION
This change also helps to circumvent #3575 by using v3 api