### PR TITLE
Allow for nuget v3 api to have an url that does not end with /index.json - third try

### DIFF
--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -150,7 +150,7 @@ type PackageSource =
 #endif
                     LocalNuGet(source,None)
                 else 
-                    if Regex("/v3(?:/[-\w]+)?/index.json$").IsMatch source then
+                    if source.Contains("/v3/") then
                         NuGetV3 { Url = source; Authentication = auth }
                     else
                         NuGetV2 { Url = source; Authentication = auth }


### PR DESCRIPTION
Reduce the check for v3 api to searching the string "/v3/" in the url

This change also helps to circumvent #3575 by using v3 api