### PR TITLE
Change caching logic to be more suitable for FAKE and in particular the Ionide tooling

### DIFF
--- a/integrationtests/Paket.IntegrationTests/AddGithubSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/AddGithubSpecs.fs
@@ -13,8 +13,8 @@ open Paket.Domain
 [<Test>]
 let ``#3014 paket github add clitool``() =
     let scenario = "i003014-add-github"
-    prepare scenario
-    paket "github add forki/FsUnit" scenario |> ignore
+    use __ = prepare scenario
+    directPaket "github add forki/FsUnit" scenario |> ignore<string>
 
     let depsFile = DependenciesFile.ReadFromFile(Path.Combine(scenarioTempPath scenario,"paket.dependencies"))
     let requirement = depsFile.GetGroup(Constants.MainDependencyGroup).RemoteFiles |> List.exactlyOne

--- a/integrationtests/Paket.IntegrationTests/AddSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/AddSpecs.fs
@@ -13,7 +13,7 @@ open Paket.Domain
 [<Test>]
 let ``#320 paket add clitool``() =
     let scenario = "i000320-add-clitool"
-    paket "add dotnet-fable --version 1.3.7 -t clitool --no-resolve" scenario |> ignore
+    use __ = paket "add dotnet-fable --version 1.3.7 -t clitool --no-resolve" scenario |> fst
 
     let depsFile = DependenciesFile.ReadFromFile(Path.Combine(scenarioTempPath scenario,"paket.dependencies"))
     let requirement = depsFile.GetGroup(Constants.MainDependencyGroup).Packages |> List.exactlyOne
@@ -24,7 +24,7 @@ let ``#320 paket add clitool``() =
 [<Test>]
 let ``#321 paket add nuget is the default``() =
     let scenario = "i000321-add-nuget"
-    paket "add Argu --version 1.2.3 --no-resolve" scenario |> ignore
+    use __ = paket "add Argu --version 1.2.3 --no-resolve" scenario |> fst
 
     let depsFile = DependenciesFile.ReadFromFile(Path.Combine(scenarioTempPath scenario,"paket.dependencies"))
     let requirement = depsFile.GetGroup(Constants.MainDependencyGroup).Packages |> List.exactlyOne
@@ -35,7 +35,7 @@ let ``#321 paket add nuget is the default``() =
 [<Test>]
 let ``#310 paket add nuget should not resolve inconsistent dependency graph``() = 
     try
-        paket "add nuget Castle.Windsor version 3.3.0" "i000310-add-should-not-create-invalid-resolution" |> ignore
+        use __ = paket "add nuget Castle.Windsor version 3.3.0" "i000310-add-should-not-create-invalid-resolution" |> fst
         failwith "resolver error expected"
     with
     | exn when exn.Message.Contains("There was a version conflict during package resolution") -> ()

--- a/integrationtests/Paket.IntegrationTests/BasicResolverSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/BasicResolverSpecs.fs
@@ -22,64 +22,74 @@ open Paket.Domain
 
 [<Test>]
 let ``#49 windsor should resolve correctly``() =
-    let lockFile = update "i000049-resolve-windsor-correctly"
+    let cleanup, lockFile = update "i000049-resolve-windsor-correctly"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor"].Version
     |> shouldEqual (SemVer.Parse "3.2.1")
 
 [<Test>]
 let ``#51 should resolve with pessimistic strategy correctly``() =
     // TODO: change back to i000051-resolve-pessimistic
-    let lockFile = update "i000051"
+    let cleanup, lockFile = update "i000051"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor-log4net"].Version
     |> shouldEqual (SemVer.Parse "3.2.0.1")
 
 [<Test>]
 let ``#55 should resolve with pessimistic strategy correctly``() =
-    let lockFile = update "i000055-resolve-with-pessimistic-strategy"
+    let cleanup, lockFile = update "i000055-resolve-with-pessimistic-strategy"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor"].Version
     |> shouldEqual (SemVer.Parse "3.2.1")
 
 [<Test>]
 let ``#71 should ignore trailing zero during resolve``() =
-    let lockFile = update "i000071-ignore-trailing-zero-during-resolve"
+    let cleanup, lockFile = update "i000071-ignore-trailing-zero-during-resolve"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Newtonsoft.Json"].Version
     |> shouldEqual (SemVer.Parse "6.0.5.0")
 
 [<Test>]
 let ``#108 should resolve jquery case-insensitive``() =
-    let lockFile = update "i000108-case-insensitive-nuget-packages"
+    let cleanup, lockFile = update "i000108-case-insensitive-nuget-packages"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "jQuery"].Version
     |> shouldEqual (SemVer.Parse "1.9.0")
 
 [<Test>]
 let ``#144 should resolve nunit from fsunit``() =
-    let lockFile = update "i000144-resolve-nunit"
+    let cleanup, lockFile = update "i000144-resolve-nunit"
+    use __ = cleanup
     let v = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "NUnit"].Version
     v |> shouldBeGreaterThan (SemVer.Parse "2.6")
     v |> shouldBeSmallerThan (SemVer.Parse "3")
 
 [<Test>]
 let ``#156 should resolve prerelease of logary``() =
-    let lockFile = update "i000156-resolve-prerelease-logary"
+    let cleanup, lockFile = update "i000156-resolve-prerelease-logary"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FSharp.Actor-logary"].Version
     |> shouldEqual (SemVer.Parse "2.0.0-alpha5")
 
 [<Test>]
 let ``#173 should resolve primary dependency optimistic``() =
-    let lockFile = update "i000173-resolve-primary-dependency-optimistic"
+    let cleanup, lockFile = update "i000173-resolve-primary-dependency-optimistic"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FSharp.Formatting"].Version
     |> shouldBeGreaterThan (SemVer.Parse "2.12.0")
 
 [<Test>]
 let ``#220 should respect the == operator``() =
-    let lockFile = update "i000220-use-exactly-this-constraint"
+    let cleanup, lockFile = update "i000220-use-exactly-this-constraint"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Microsoft.AspNet.Razor"].Version
     |> shouldEqual (SemVer.Parse "2.0.30506.0")
 
 
 [<Test>]
 let ``#299 should restore package ending in lib``() =
-    let lockFile = update "i000299-restore-package-that-ends-in-lib"
+    let cleanup, lockFile = update "i000299-restore-package-that-ends-in-lib"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FunScript.TypeScript.Binding.lib"].Version
     |> shouldBeGreaterThan (SemVer.Parse "0")
 
@@ -88,7 +98,8 @@ let ``#299 should restore package ending in lib``() =
     
 [<Test>]
 let ``#359 should restore package with nuget in name``() =
-    let lockFile = update "i000359-packagename-contains-nuget"
+    let cleanup, lockFile = update "i000359-packagename-contains-nuget"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Nuget.CommandLine"].Version
     |> shouldBeGreaterThan (SemVer.Parse "0")
 
@@ -97,31 +108,36 @@ let ``#359 should restore package with nuget in name``() =
 
 [<Test>]
 let ``#1177 should resolve with pessimistic strategy correctly``() =
-    let lockFile = update "i001177-resolve-with-pessimistic-strategy"
+    let cleanup, lockFile = update "i001177-resolve-with-pessimistic-strategy"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Core"].Version
     |> shouldEqual (SemVer.Parse "3.2.0")
 
 [<Test>]
 let ``#1189 should allow # in path``() =
-    let lockFile = update "i001189-allow-#-in-path"
+    let cleanup, lockFile = update "i001189-allow-#-in-path"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FAKE"].Version
     |> shouldBeGreaterThan (SemVer.Parse "4.7.2")
 
 [<Test>]
 let ``#1254 should install unlisted transitive dependencies``() =
-    let lockFile = update "i001254-unlisted"
+    let cleanup, lockFile = update "i001254-unlisted"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "WebActivator"].Version
     |> shouldEqual (SemVer.Parse "1.5.3")
 
 [<Test>]
 let ``#1450 should resolve with twiddle wakka``() =
-    let lockFile = update "i001450-twiddle-wakka"
+    let cleanup, lockFile = update "i001450-twiddle-wakka"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "EnterpriseLibrary.SemanticLogging"].Version
     |> shouldBeSmallerThan (SemVer.Parse "3")
     
 [<Test>]
 let ``#2640 shouldn't try GetDetails if package only exists locally``() =
-    updateEx true "i002640" |> ignore
+    use __ = updateEx true "i002640" |> fst
+    ignore __
 
 #if INTERACTIVE
 ;;

--- a/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
+++ b/integrationtests/Paket.IntegrationTests/BindingRedirect.fs
@@ -9,7 +9,7 @@ open Paket
 
 [<Test>]
 let ``install should redirect required assemblies only``() = 
-    paket "install --redirects --createnewbindingfiles" "i001187-binding-redirect" |> ignore
+    use __ = paket "install --redirects --createnewbindingfiles" "i001187-binding-redirect" |> fst
 
     let path = Path.Combine(scenarioTempPath "i001187-binding-redirect")
     let config1Path = Path.Combine(path, "Project1", "app.config")
@@ -74,7 +74,7 @@ let ``install should redirect required assemblies only``() =
 [<Test>]
 let ``#1195 should report broken app.config``() =
     try
-        paket "install --redirects" "i001195-broken-appconfig" |> ignore
+        use __ = paket "install --redirects" "i001195-broken-appconfig" |> fst
         failwith "paket should fail"
     with
     | exn when exn.Message.Contains("Project1") && exn.Message.Contains("app.config") -> ()
@@ -82,14 +82,14 @@ let ``#1195 should report broken app.config``() =
 [<Test>]
 let ``#2408 should report wrong app.config parsing``() =
     try
-        paket "install --redirects" "i002408-indenting-appconfig" |> ignore
+        use __ = paket "install --redirects" "i002408-indenting-appconfig" |> fst
         failwith "paket should fail"
     with
     | exn when exn.Message.Contains("Project1") && exn.Message.Contains("app.config") -> ()
     
 [<Test>]
 let ``#1218 install should replace paket's binding redirects with required only``() = 
-    paket "install --redirects --createnewbindingfiles" "i001218-binding-redirect" |> ignore
+    use __ = paket "install --redirects --createnewbindingfiles" "i001218-binding-redirect" |> fst
 
     let path = Path.Combine(scenarioTempPath "i001218-binding-redirect")
     let config1Path = Path.Combine(path, "Project1", "app.config")
@@ -167,7 +167,7 @@ let ``#1218 install should replace paket's binding redirects with required only`
 
 [<Test>]
 let ``#1270 force redirects``() = 
-    paket "install --createnewbindingfiles" "i001270-force-redirects" |> ignore
+    use __ = paket "install --createnewbindingfiles" "i001270-force-redirects" |> fst
     let path = Path.Combine(scenarioTempPath "i001270-force-redirects")
     let configPath = Path.Combine(path, "MyClassLibrary", "MyClassLibrary", "app.config")
 
@@ -185,7 +185,7 @@ let ``#1270 force redirects``() =
 
 [<Test>]
 let ``#1270 redirects from references``() = 
-    paket "install --createnewbindingfiles" "i001270-force-redirects" |> ignore
+    use __ = paket "install --createnewbindingfiles" "i001270-force-redirects" |> fst
     let path = Path.Combine(scenarioTempPath "i001270-force-redirects")
     let configPath = Path.Combine(path, "MyClassLibrary", "MyClassLibrary2", "app.config")
 
@@ -203,7 +203,7 @@ let ``#1270 redirects from references``() =
 
 [<Test>]
 let ``#1574 redirects GAC``() = 
-    paket "install --clean-redirects"  "i001574-redirect-gac" |> ignore
+    use __ = paket "install --clean-redirects"  "i001574-redirect-gac" |> fst
     let path = Path.Combine(scenarioTempPath "i001574-redirect-gac")
     let configPath = Path.Combine(path, "BindingRedirectPaketBug", "App.config")
     let originalConfigPath = Path.Combine(path, "BindingRedirectPaketBug", "App.config.expected")
@@ -217,7 +217,7 @@ let ``#1574 redirects GAC``() =
 [<Test>]
 let ``#1621 generates binding redirect when references project with another target profile``() =
     let scenario = "i001621-different-framework"
-    install scenario |> ignore
+    use __ = install scenario |> fst
     let ``NUnit`` = """<assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />"""
     let ``NUnit correct version`` = "newVersion=\"3.0.5813.39031\""
     
@@ -232,7 +232,7 @@ let ``#1621 generates binding redirect when references project with another targ
 [<Test>]
 let ``#1783 generates binding redirect when assembly with different version of main group``() =
     let scenario = "i001783-different-versions"
-    install scenario |> ignore
+    use __ = install scenario |> fst
     let ``FSharp.Core`` = """<assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />"""
     let ``Newtonsoft.Json`` = """<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />"""
     

--- a/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ConvertFromNuGetSpecs.fs
@@ -13,7 +13,7 @@ open Paket.Requirements
 
 [<Test>]
 let ``#1217 should convert simple C# project``() = 
-    paket "convert-from-nuget" "i001217-convert-simple-project" |> ignore
+    use __ = paket "convert-from-nuget" "i001217-convert-simple-project" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001217-convert-simple-project","paket.lock"))
     let v = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Newtonsoft.Json"].Version
     v.Major |> shouldEqual 7u
@@ -27,7 +27,7 @@ let ``#1217 should convert simple C# project``() =
 
 [<Test>]
 let ``#1225 should convert simple C# project with non-matching framework restrictions``() = 
-    paket "convert-from-nuget" "i001225-convert-simple-project-non-matching-restrictions" |> ignore
+    use __ = paket "convert-from-nuget" "i001225-convert-simple-project-non-matching-restrictions" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001225-convert-simple-project-non-matching-restrictions","paket.lock"))
     let v = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Newtonsoft.Json"].Version
     v.Major |> shouldEqual 7u
@@ -58,7 +58,7 @@ let ``#1217 should replace packages.config files in project``() =
     originalProjectFile.Document.OuterXml.Contains("packages.config") |> shouldEqual true
     originalProjectFile.Document.OuterXml.Contains("paket.references") |> shouldEqual false
 
-    paket "convert-from-nuget" "i001217-convert-simple-project" |> ignore
+    use __ = paket "convert-from-nuget" "i001217-convert-simple-project" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001217-convert-simple-project","paket.lock"))
     let projectFile = ProjectFile.loadFromFile(Path.Combine(scenarioTempPath "i001217-convert-simple-project", "ClassLibrary1", "ClassLibrary1.csproj"))
     projectFile.Document.OuterXml.Contains("packages.config") |> shouldEqual false
@@ -66,7 +66,7 @@ let ``#1217 should replace packages.config files in project``() =
 
 [<Test>]
 let ``#1591 should convert denormalized versions``() = 
-    paket "convert-from-nuget" "i001591-convert-denormalized" |> ignore
+    use __ = paket "convert-from-nuget" "i001591-convert-denormalized" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001591-convert-denormalized","paket.lock"))
     let v = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "EntityFramework"].Version
     v.Major |> shouldEqual 6u
@@ -79,7 +79,7 @@ let ``#1591 should convert denormalized versions``() =
 [<Test>]
 let ``#1922 should remove references to moved analyzers``() =
     let scenario = "i001922-convert-nuget-with-analyzers"
-    paket "convert-from-nuget" scenario |> ignore
+    use __ = paket "convert-from-nuget" scenario |> fst
     let projectFile = ProjectFile.loadFromFile(Path.Combine(scenarioTempPath scenario, "ConvertFromNugetWithAnalyzers", "ConvertFromNugetWithAnalyzers.csproj"))
     let projectXml = projectFile.Document.OuterXml
     StringAssert.DoesNotContain(@"<Analyzer Include=""..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll""", projectXml)
@@ -91,7 +91,7 @@ let ``#1922 should remove references to moved analyzers``() =
     StringAssert.Contains(@"<Analyzer Include=""..\packages\StyleCop.Analyzers\analyzers\dotnet\cs\StyleCop.Analyzers.dll"">", projectXml)
 
 let testPaketDependenciesFileInSolution scenario expectedFiles =
-    paket "convert-from-nuget" scenario |> ignore
+    use __ = paket "convert-from-nuget" scenario |> fst
 
     let expectedLines = 
         [ yield "Project\\(\"{2150E333-8FDC-42A3-9474-1A3956D46DE8}\"\\) = \"\\.paket\", \"\\.paket\", \"{[^}]+}\""
@@ -121,7 +121,7 @@ let ``#2512 should put paket.dependencies inside the .paket folder that already 
 [<Test>]
 let ``#2528 sdk-2: convert-from-nuget should add explicit FSharp.Core``() =
     let scenario = "i002528-1"
-    paket "convert-from-nuget" scenario |> ignore
+    use __ = paket "convert-from-nuget" scenario |> fst
     let dependenciesFile = File.ReadAllLines(Path.Combine(scenarioTempPath scenario,"paket.dependencies"))
     dependenciesFile
     |> shouldContain "nuget FSharp.Core"
@@ -132,7 +132,7 @@ let ``#2528 sdk-2: convert-from-nuget should add explicit FSharp.Core``() =
 [<Test>]
 let ``#2528 sdk-2: convert-from-nuget should not add FSharp.Core for csharp``() =
     let scenario = "i002528-2"
-    paket "convert-from-nuget" scenario |> ignore
+    use __ = paket "convert-from-nuget" scenario |> fst
     let dependenciesFile = File.ReadAllLines(Path.Combine(scenarioTempPath scenario,"paket.dependencies"))
     dependenciesFile
     |> shouldNotContain "nuget FSharp.Core"
@@ -143,27 +143,31 @@ let ``#2528 sdk-2: convert-from-nuget should not add FSharp.Core for csharp``() 
 [<Test>]
 let ``#2528 sdk-2: install should not warn without FSharp.Core for csharp``() =
     let scenario = "i002528-3"
-    let messages = paket "install" scenario
+    let cleanup, messages = paket "install" scenario
+    use __ = cleanup
     messages
     |> shouldNotContainText "does not reference FSharp.Core"
 
 [<Test>]
 let ``#2528 sdk-2: install should not warn with FSharp.Core``() =
     let scenario = "i002528-4"
-    let messages = paket "install" scenario
+    let cleanup, messages = paket "install" scenario
+    use __ = cleanup
     messages
     |> shouldNotContainText "does not reference FSharp.Core"
 
 [<Test>]
 let ``#2528 sdk-2: install should warn without FSharp.Core: not in dep, not in ref``() =
     let scenario = "i002528-5"
-    let messages = paket "install" scenario
+    let cleanup, messages = paket "install" scenario
+    use __ = cleanup
     messages
     |> shouldContainText "does not reference FSharp.Core"
 
 [<Test>]
 let ``#2528 sdk-2: install should warn without FSharp.Core: in dep but not in ref``() =
     let scenario = "i002528-6"
-    let messages = paket "install" scenario
+    let cleanup, messages = paket "install" scenario
+    use __ = cleanup
     messages
     |> shouldContainText "does not reference FSharp.Core"

--- a/integrationtests/Paket.IntegrationTests/FrameworkRestrictionsSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/FrameworkRestrictionsSpecs.fs
@@ -12,14 +12,16 @@ open Paket.Requirements
 
 [<Test>]
 let ``#140 windsor should resolve framework dependent dependencies``() =
-    let lockFile = update "i000140-resolve-framework-restrictions"
+    let cleanup, lockFile = update "i000140-resolve-framework-restrictions"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "TaskParallelLibrary"].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Between(DotNetFramework(FrameworkVersion.V3_5), DotNetFramework(FrameworkVersion.V4)))
 
 [<Test; Ignore "slow test">]
 let ``#1182 framework restrictions overwrite each other``() =
-    let lockFile = update "i001182-framework-restrictions"
+    let cleanup, lockFile = update "i001182-framework-restrictions"
+    use __ = cleanup
     let lockFile = lockFile.ToString()
     lockFile.Contains("Microsoft.Data.OData (>= 5.6.2)") |> shouldEqual true
     lockFile.Contains("framework: winv4.5") |> shouldEqual false
@@ -32,7 +34,7 @@ let ``#1182 framework restrictions overwrite each other``() =
 [<Flaky>] // failure on assert
 #endif
 let ``#1190 paket add nuget should handle transitive dependencies``() = 
-    paket "add nuget xunit version 2.1.0" "i001190-transitive-dependencies-with-restr" |> ignore
+    use __ = paket "add nuget xunit version 2.1.0" "i001190-transitive-dependencies-with-restr" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001190-transitive-dependencies-with-restr","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "xunit.abstractions"].Settings.FrameworkRestrictions
     |> getExplicitRestriction
@@ -40,7 +42,7 @@ let ``#1190 paket add nuget should handle transitive dependencies``() =
     
 [<Test>]
 let ``#1190 paket add nuget should handle transitive dependencies with restrictions``() = 
-    paket "add nuget xunit version 2.1.0" "i001190-transitive-deps" |> ignore
+    use __ = paket "add nuget xunit version 2.1.0" "i001190-transitive-deps" |> fst
     
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001190-transitive-deps","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "xunit.abstractions"].Settings.FrameworkRestrictions
@@ -50,7 +52,8 @@ let ``#1190 paket add nuget should handle transitive dependencies with restricti
     
 [<Test>]
 let ``#1197 framework dependencies are not restricting each other``() = 
-    let lockFile = update "i001197-too-strict-frameworks"
+    let cleanup, lockFile = update "i001197-too-strict-frameworks"
+    use __ = cleanup
     
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "log4net"].Version
     |> shouldBeGreaterThan (SemVer.Parse "0")
@@ -58,23 +61,24 @@ let ``#1197 framework dependencies are not restricting each other``() =
     
 [<Test>]
 let ``#1213 framework dependencies propagate``() = 
-    let lockFile = update "i001213-framework-propagation"
-    
+    let cleanup, lockFile = update "i001213-framework-propagation"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Newtonsoft.Json"].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual FrameworkRestriction.NoRestriction
 
 [<Test>]
 let ``#1215 framework dependencies propagate``() = 
-    let lockFile = update "i001215-framework-propagation-no-restriction"
-    
+    let cleanup, lockFile = update "i001215-framework-propagation-no-restriction"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Microsoft.Bcl.Async"].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual FrameworkRestriction.NoRestriction
 
 [<Test>]
 let ``#1232 framework dependencies propagate``() = 
-    let lockFile = update "i001232-sql-lite"
+    let cleanup, lockFile = update "i001232-sql-lite"
+    use __ = cleanup
     let restriction =
         lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "System.Data.SQLite.Core"].Settings.FrameworkRestrictions
         |> getExplicitRestriction
@@ -87,6 +91,6 @@ let ``#1232 framework dependencies propagate``() =
 
 [<Test>]
 let ``#1494 detect platform 5.0``() = 
-    let lockFile = update "i001494-download"
+    use __ = update "i001494-download" |> fst
     
     ()

--- a/integrationtests/Paket.IntegrationTests/HttpSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/HttpSpecs.fs
@@ -11,7 +11,7 @@ open Paket
 
 [<Test>]
 let ``#1341 http dlls``() = 
-    prepare "i001341-http-dlls"
+    use __ = prepare "i001341-http-dlls"
     let root = scenarioTempPath "i001341-http-dlls"
     let deps = sprintf """group Files
 

--- a/integrationtests/Paket.IntegrationTests/InitSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InitSpecs.fs
@@ -13,7 +13,7 @@ open System.Diagnostics
 [<Ignore(".net core paket doesnt init the boostrapper")>]
 #endif
 let ``#1040 init should download release version of bootstrapper``() = 
-    paket "init" "i001040-init-downloads-bootstrapper" |> ignore
+    use __ = paket "init" "i001040-init-downloads-bootstrapper" |> fst
     let bootstrapperPath = Path.Combine(scenarioTempPath "i001040-init-downloads-bootstrapper",".paket","paket.exe")
    
     let productVersion = FileVersionInfo.GetVersionInfo(bootstrapperPath).ProductVersion
@@ -26,7 +26,7 @@ let ``#1040 init should download release version of bootstrapper``() =
 #endif
 let ``#1743 empty log file``() =
     try
-        paket "init --log-file" "i001040-init-downloads-bootstrapper" |> ignore
+        use __ = paket "init --log-file" "i001040-init-downloads-bootstrapper" |> fst
         failwith "expected error"
     with
     | exn when exn.Message.Split('\n').[0].Contains "--log-file" -> ()

--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -35,7 +35,8 @@ let ``updateBaselines should be false``() =
 
 [<Test>]
 let ``#1135 should keep lockfile stable when using framework restrictions``() =
-    let newLockFile = install "i001135-stable-install-on-framework-restrictions"
+    let cleanup, newLockFile = install "i001135-stable-install-on-framework-restrictions"
+    use __ = cleanup
     let oldLockFile = LockFile.LoadFrom(Path.Combine(originalScenarioPath "i001135-stable-install-on-framework-restrictions","paket.lock"))
     newLockFile.ToString()
     |> shouldEqual (oldLockFile.ToString())

--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -42,7 +42,7 @@ let ``#1135 should keep lockfile stable when using framework restrictions``() =
 
 [<Test>]
 let ``#1219 install props``() =
-    let newLockFile = install "i001219-props-files"
+    use __ = install "i001219-props-files" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001219-props-files","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001219-props-files","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -66,7 +66,7 @@ let ``#1219 install props``() =
 
 [<Test>]
 let ``#1487 install props stays stable``() =
-    let newLockFile = install "i001487-stable-props"
+    use __ = install "i001487-stable-props" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001487-stable-props","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001487-stable-props","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
@@ -75,7 +75,7 @@ let ``#1487 install props stays stable``() =
 
 [<Test>]
 let ``#1585 install props with for websharper``() =
-    let newLockFile = install "i001585-websharper-props"
+    use __ = install "i001585-websharper-props" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001585-websharper-props","xUnitTests","xUnitTests.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001585-websharper-props","xUnitTests","xUnitTests.expected.csprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
@@ -85,14 +85,14 @@ let ``#1585 install props with for websharper``() =
 [<Test>]
 let ``#1256 should report error in lock file``() =
     try
-        install "i001256-wrong-lock" |> ignore
+        use __ = install "i001256-wrong-lock" |> fst
         failwith "error expected"
     with
     | exn when exn.Message.Contains("FAKE") && exn.Message.Contains("paket.lock") -> ()
 
 [<Test>]
 let ``#1260 install wpf\xaml and media files``() =
-    let newLockFile = install "i001260-csharp-wpf-project"
+    use __ = install "i001260-csharp-wpf-project" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001260-csharp-wpf-project","WpfApplication","WpfApplication.csproj")
     let project = ProjectFile.LoadFromFile(newFile)
 
@@ -106,7 +106,7 @@ let ``#1260 install wpf\xaml and media files``() =
 
 [<Test>]
 let ``#1270 install net461``() =
-    let newLockFile = install "i001270-net461"
+    use __ = install "i001270-net461" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001270-net461","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001270-net461","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -117,7 +117,7 @@ let ``#1270 install net461``() =
 
 [<Test>]
 let ``#1427 install content once from dependencies file``() =
-    let newLockFile = install "i001427-content-once"
+    use __ = install "i001427-content-once" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001427-content-once","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001427-content-once","MyClassLibrary","MyClassLibrary","MyClassLibrary.expected")
     if updateBaselines then
@@ -138,7 +138,7 @@ let ``#1427 install content once from dependencies file``() =
 [<Test>]
 let ``#1427 install content once from dependencies file stays stable``() =
     let scenario = "i001427-content-once-stable"
-    let newLockFile = install scenario
+    use __ = install scenario |> fst
 
     let newFile = Path.Combine(scenarioTempPath scenario,"MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath scenario,"MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
@@ -160,7 +160,7 @@ let ``#1427 install content once from dependencies file stays stable``() =
 [<Test>]
 let ``#1427 install content once from dependencies file removes paket tag``() =
     let scenario = "i001427-content-once-remove"
-    let newLockFile = install scenario
+    use __ = install scenario |> fst
 
     let newFile = Path.Combine(scenarioTempPath scenario,"MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath scenario,"MyClassLibrary","MyClassLibrary","MyClassLibrary.expected")
@@ -180,7 +180,7 @@ let ``#1427 install content once from dependencies file removes paket tag``() =
 [<Test>]
 let ``#1427 install content once from dependencies file stays stable 2 installs``() =
     let scenario = "i001427-content-once"
-    let newLockFile = install scenario
+    use __ = install scenario |> fst
 
     directPaket "install" scenario |> ignore
 
@@ -201,7 +201,7 @@ let ``#1427 install content once from dependencies file stays stable 2 installs`
 
 [<Test>]
 let ``#1427 install content once from references file``() =
-    let newLockFile = install "i001427-ref-content-once"
+    use __ = install "i001427-ref-content-once" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001427-ref-content-once","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001427-ref-content-once","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -221,7 +221,7 @@ let ``#1427 install content once from references file``() =
 
 [<Test>]
 let ``#1427 install content``() =
-    let newLockFile = install "i001427-content-true"
+    use __ = install "i001427-content-true" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001427-content-true","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001427-content-true","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -239,7 +239,7 @@ let ``#1427 install content``() =
 
 [<Test>]
 let ``#1427 won't install content when content:none``() =
-    let newLockFile = install "i001427-content-none"
+    use __ = install "i001427-content-none" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001427-content-none","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001427-content-none","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -257,7 +257,7 @@ let ``#1427 won't install content when content:none``() =
 
 [<Test>]
 let ``#1701 won't install content when content:none and --keep-major``() =
-    let newLockFile = paket "update --keep-major" "i001701-keep-major"
+    use __ = paket "update --keep-major" "i001701-keep-major" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001701-keep-major","TestPaket","TestPaket.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001701-keep-major","TestPaket","TestPaket.csprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
@@ -267,7 +267,7 @@ let ``#1701 won't install content when content:none and --keep-major``() =
 
 [<Test>]
 let ``#1522 install content and copy to output dir``() =
-    let newLockFile = install "i001522-copy-content"
+    use __ = install "i001522-copy-content" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001522-copy-content","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001522-copy-content","MyClassLibrary","MyClassLibrary","MyClassLibrary.expected")
     if updateBaselines then
@@ -285,7 +285,7 @@ let ``#1522 install content and copy to output dir``() =
 
 [<Test>]
 let ``#1440 auto-detect framework``() =
-    let newLockFile = install "i001440-auto-detect"
+    use __ = install "i001440-auto-detect" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001440-auto-detect","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001440-auto-detect","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
@@ -294,7 +294,7 @@ let ``#1440 auto-detect framework``() =
 
 [<Test>]
 let ``#1466 install package with dll in name``() =
-    let newLockFile = install "i001466-expressive"
+    use __ = install "i001466-expressive" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001466-expressive","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001466-expressive","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
@@ -303,7 +303,7 @@ let ``#1466 install package with dll in name``() =
 
 [<Test>]
 let ``#1505 should install conditionals``() =
-    install "i001505-conditionals" |> ignore
+    use __ = install "i001505-conditionals" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001505-conditionals","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001505-conditionals","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj.expected")
     if updateBaselines then
@@ -315,19 +315,21 @@ let ``#1505 should install conditionals``() =
 [<Test>]
 let ``#1458 should not install conflicting deps from different groups``() =
     try
-        install "i001458-group-conflict" |> ignore
+        use __ = install "i001458-group-conflict" |> fst
         failwith "error expected"
     with
     | exn when exn.Message.Contains "Package Nancy is referenced in different versions" -> ()
 
 [<Test>]
 let ``#1442 should not warn on SonarLint``() =
-    let result = paket "install" "i001442-dont-warn"
+    let cleanup, result = paket "install" "i001442-dont-warn"
+    use __ = cleanup
     result |> shouldNotContainText "contains libraries, but not for the selected TargetFramework"
 
 [<Test>]
 let ``#1442 should warn on Rx-WinRT``() =
-    let result = paket "install" "i001442-warn-Rx"
+    let cleanup, result = paket "install" "i001442-warn-Rx"
+    use __ = cleanup
     result |> shouldContainText "contains libraries, but not for the selected TargetFramework"
 
 
@@ -336,7 +338,7 @@ let ``#1442 should warn on Rx-WinRT``() =
 let ``#1507 allows to download remote dependencies``() =
     let scenario = "i001507-privateeye"
 
-    install scenario |> ignore
+    use __ = install scenario |> fst
 
     File.Exists (Path.Combine(scenarioTempPath scenario, "paket-files", "forki", "PrivateEye", "privateeye.fsx")) |> shouldEqual true
     File.Exists (Path.Combine(scenarioTempPath scenario, "paket-files", "forki", "PrivateEye", "bin", "PrivateEye.Bridge.dll")) |> shouldEqual true
@@ -344,7 +346,7 @@ let ``#1507 allows to download remote dependencies``() =
 
 [<Test>]
 let ``#1663 should import build targets``() =
-    install "i001663-build-targets" |> ignore
+    use __ = install "i001663-build-targets" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001663-build-targets","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001663-build-targets","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -355,7 +357,7 @@ let ``#1663 should import build targets``() =
 
 [<Test>]
 let ``#1145 don't install excludes``() =
-    let newLockFile = install "i001145-excludes"
+    use __ = install "i001145-excludes" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001145-excludes","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001145-excludes","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -366,7 +368,7 @@ let ``#1145 don't install excludes``() =
 
 [<Test>]
 let ``#346 set aliases``() =
-    let newLockFile = install "i000346-aliases"
+    use __ = install "i000346-aliases" |> fst
     let newFile = Path.Combine(scenarioTempPath "i000346-aliases","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i000346-aliases","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -377,7 +379,7 @@ let ``#346 set aliases``() =
 
 [<Test>]
 let ``#1720 install concrete net45``() =
-    let newLockFile = install "i001720-explicit-net45"
+    use __ = install "i001720-explicit-net45" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001720-explicit-net45","projectA","projectA.fsproj")
     let oldFile = Path.Combine(originalScenarioPath "i001720-explicit-net45","projectA","projectA.fsprojtemplate")
     let s1 = File.ReadAllText oldFile |> normalizeLineEndings
@@ -386,7 +388,7 @@ let ``#1720 install concrete net45``() =
 
 [<Test>]
 let ``#1732 aliases ignore cases``() =
-    let newLockFile = install "i001732-lowercase-aliases"
+    use __ = install "i001732-lowercase-aliases" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001732-lowercase-aliases","MyClassLibrary","MyClassLibrary","MyClassLibrary.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001732-lowercase-aliases","MyClassLibrary","MyClassLibrary","MyClassLibrary.csprojtemplate")
     if updateBaselines then
@@ -397,7 +399,7 @@ let ``#1732 aliases ignore cases``() =
 
 [<Test>]
 let ``#1746 hard should be softer``() =
-    install "i001746-hard-legacy" |> ignore
+    use __ = install "i001746-hard-legacy" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001746-hard-legacy","SilverlightClassLibrary1","SilverlightClassLibrary1.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001746-hard-legacy","SilverlightClassLibrary1","SilverlightClassLibrary1.csprojtemplate")
     if updateBaselines then
@@ -408,7 +410,7 @@ let ``#1746 hard should be softer``() =
 
 [<Test>]
 let ``#1779 net20 only in net461``() =
-    install "i001779-net20-only-in-net461" |> ignore
+    use __ = install "i001779-net20-only-in-net461" |> fst
     let newFile = Path.Combine(scenarioTempPath "i001779-net20-only-in-net461","paket-net20-library-problem","paket-net20-library-problem.csproj")
     let oldFile = Path.Combine(originalScenarioPath "i001779-net20-only-in-net461","paket-net20-library-problem","paket-net20-library-problem.csprojtemplate")
     if updateBaselines then
@@ -419,34 +421,39 @@ let ``#1779 net20 only in net461``() =
 
 [<Test>]
 let ``#1871 should install suave``() =
-    install "i001871-suave" |> ignore
+    use __ = install "i001871-suave" |> fst
+    ignore __
 
 [<Test>]
 let ``#1883 install FSharp.Core from Chessie``() =
-    let newLockFile = install "i001883-chessie"
+    let cleanup, newLockFile = install "i001883-chessie"
+    use __ = cleanup
     newLockFile.Groups.[GroupName "main"].Resolution.[PackageName "FSharp.Core"].Version |> shouldBeGreaterThan (SemVer.Parse "4.1")
 
 [<Test>]
 let ``#1883 should not install .NET Standard``() =
-    let newLockFile = install "i001883-machine"
+    let cleanup, newLockFile = install "i001883-machine"
+    use __ = cleanup
     newLockFile.Groups.[GroupName "main"].Resolution.ContainsKey (PackageName "System.Reflection") |> shouldEqual false
 
 [<Test>]
 let ``#1860 faulty condition was generated`` () =
     let scenario = "i001860-attribute"
-    install scenario |> ignore
+    use __ = install scenario |> fst
     let fsprojFile = (scenarioTempPath scenario) </> "Library1" </> "Library1.fsproj" |> File.ReadAllText
     Assert.IsFalse (fsprojFile.Contains(" And ()"))
 
 
 [<Test>]
 let ``#2777 should not conflict with locked packages``() =
-    let newLockFile = install "i002777"
+    let cleanup, newLockFile = install "i002777"
+    use __ = cleanup
     newLockFile.Groups.[GroupName "main"].Resolution.ContainsKey (PackageName "FsPickler") |> shouldEqual true
 
 [<Test>]
 let ``#3062 install should use external lock file``() =
-    let newLockFile = install "i003062-external-lock"
+    let cleanup, newLockFile = install "i003062-external-lock"
+    use __ = cleanup
     newLockFile.Groups.[GroupName "main"].Resolution.ContainsKey (PackageName "FAKE") |> shouldEqual true
     newLockFile.Groups.[GroupName "main"].Resolution.[PackageName "Machine.Specifications"].Version |> shouldEqual (SemVer.Parse "0.12")
 

--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -66,7 +66,7 @@ let assertExpectations scenario expectationType expectations =
 let ``simple dependencies generates expected scripts``() = 
     let scenario = "simple-dependencies"
     let framework = "net4"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
     directPaket (sprintf "generate-load-scripts framework %s" framework) scenario |> ignore
   
@@ -95,7 +95,7 @@ let ``simple dependencies generates expected scripts``() =
 let ``fslab generates expected load of package loader script``() = 
     let scenario = "fslab"
     let framework = "net4"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
     directPaket (sprintf "generate-load-scripts framework %s" framework) scenario |> ignore
   
@@ -120,9 +120,9 @@ let nHibernate35Expectations =
 [<Test;Category("scriptgen")>]
 let ``framework specified``() = 
     let scenario = "framework-specified"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
-    directPaket "generate-load-scripts" scenario |> ignore
+    directPaket "generate-load-scripts" scenario |> ignore<string>
     
     nHibernate35Expectations |> assertExpectations scenario ExpectationType.ShouldContain
 
@@ -131,9 +131,9 @@ let ``framework specified``() =
 let ``don't generate scripts when no references are found``() = 
     (* The deps file for this scenario just includes FAKE, which has no lib or framework references, so no script should be generated for it. *)
     let scenario = "no-references"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
-    directPaket "generate-load-scripts" scenario |> ignore
+    directPaket "generate-load-scripts" scenario |> ignore<string>
     let scriptRootDir = scriptRoot scenario
     Assert.IsFalse(scriptRootDir.Exists)
 
@@ -142,7 +142,7 @@ let ``don't generate scripts when no references are found``() =
 let ``fails on wrong framework given`` () =
     let scenario = "wrong-args"
 
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
     let failure = Assert.Throws (fun () ->
         let result = directPaket "generate-load-scripts framework foo framework bar framework net45" scenario
@@ -159,7 +159,7 @@ let ``fails on wrong framework given`` () =
 let ``fails on wrong scripttype given`` () =
     let scenario = "wrong-args"
 
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
     let failure = Assert.Throws (fun () ->
         let result = directPaket (sprintf "generate-load-scripts type foo type bar framework net45") scenario
@@ -175,9 +175,9 @@ let ``fails on wrong scripttype given`` () =
 [<Test; Category("scriptgen")>]
 let ``issue 1676 casing`` () =
     let scenario = "issue-1676"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
-    directPaket "generate-load-scripts framework net46" scenario |> ignore
+    directPaket "generate-load-scripts framework net46" scenario |> ignore<string>
 
     let expectations = [
         "entityframework.csx", [
@@ -200,9 +200,9 @@ let ``issue 1676 casing`` () =
 [<Test; Category("scriptgen")>]
 let ``mscorlib excluded from f# script`` () =
     let scenario = "mscorlib"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
-    directPaket "generate-load-scripts framework net46" scenario |> ignore
+    directPaket "generate-load-scripts framework net46" scenario |> ignore<string>
 
     let scriptRootDir = scriptRoot scenario
     let hasFilesWithMsCorlib =
@@ -224,9 +224,9 @@ let ``mscorlib excluded from f# script`` () =
 [<Test; Category("scriptgen")>]
 let ``fsharp.core excluded from f# script`` () =
     let scenario = "fsharpcore"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
 
-    directPaket "generate-load-scripts framework net46" scenario |> ignore
+    directPaket "generate-load-scripts framework net46" scenario |> ignore<string>
 
     let scriptRootDir = scriptRoot scenario
     let hasFilesWithFsharpCore =
@@ -242,25 +242,25 @@ let ``fsharp.core excluded from f# script`` () =
 [<Test; Category("scriptgen dependencies")>]
 let ``generates script on install`` () =
     let scenario = "dependencies-file-flag"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
     
     nHibernate35Expectations |> assertExpectations scenario ExpectationType.ShouldContain
 
 [<Test; Category("scriptgen dependencies")>]
 let ``issue 2156 netstandard`` () =
     let scenario = "issue-2156"
-    paket "install" scenario |> ignore
-    directPaket "generate-load-scripts" scenario |> ignore
+    use __ = paket "install" scenario |> fst
+    directPaket "generate-load-scripts" scenario |> ignore<string>
     // note: no assert for now, I don't know what we are exactly expecting
 
 [<Test; Category("scriptgen")>]
 let ``don't touch file if contents are same`` () =
     let scenario = "issue-2939"
-    paket "install" scenario |> ignore
+    use __ = paket "install" scenario |> fst
     let scriptsFolder = scriptRoot scenario
     let newtonsoftScript = Path.Combine(scriptsFolder.FullName, "Newtonsoft.Json.fsx") |> FileInfo
     let modificationDate = newtonsoftScript.LastWriteTimeUtc
-    directPaket "install" scenario |> ignore
+    directPaket "install" scenario |> ignore<string>
     newtonsoftScript.Refresh()
     Assert.AreEqual(modificationDate, newtonsoftScript.LastWriteTimeUtc)
 

--- a/integrationtests/Paket.IntegrationTests/LocalOverrideSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/LocalOverrideSpecs.fs
@@ -14,7 +14,7 @@ open NUnit.Framework
 let ``#1633 paket.local local source override``() =
     clearPackageAtVersion "NUnit" "2.6.3"
 
-    paketEx true "restore" "i001633-local-source-override" |> ignore
+    use __1 = paketEx true "restore" "i001633-local-source-override" |> fst
     let doc = new XmlDocument()
     Path.Combine(
         scenarioTempPath "i001633-local-source-override",
@@ -35,7 +35,7 @@ let ``#1633 paket.local local source override``() =
     |> shouldEqual []
 
     // Issue #2690
-    paketEx true "restore" "i001633-local-source-override" |> ignore
+    use __2 = paketEx true "restore" "i001633-local-source-override" |> fst
 
     // The package should not be in cache
     isPackageCached "NUnit" "2.6.3"

--- a/integrationtests/Paket.IntegrationTests/NuGetV3Specs.fs
+++ b/integrationtests/Paket.IntegrationTests/NuGetV3Specs.fs
@@ -16,14 +16,14 @@ open Paket.NuGetV3
 
 [<Test>]
 let ``#1387 update package in v3``() =
-    update "i001387-nugetv3" |> ignore
+    use __ = update "i001387-nugetv3" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001387-nugetv3","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Bender"].Version
     |> shouldEqual (SemVer.Parse "3.0.29.0")
 
 [<Test>]
 let ``#2700-1 v3 works properly``() =
-    paketEx true "update" "i002700-1" |> ignore
+    use __ = paketEx true "update" "i002700-1" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i002700-1","paket.lock"))
     let mainGroup = lockFile.Groups.[Constants.MainDependencyGroup]
     mainGroup.Resolution.[PackageName "Microsoft.CSharp"].Source.Url

--- a/integrationtests/Paket.IntegrationTests/OutdatedSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/OutdatedSpecs.fs
@@ -10,7 +10,8 @@ open System.Diagnostics
 
 [<Test>]
 let ``#183 outdated without params``() =
-    let msg = paket "outdated" "i000183-outdated-with-special-parameters"
+    let cleanup, msg = paket "outdated" "i000183-outdated-with-special-parameters"
+    use cleanup = cleanup
     msg |> shouldContainText "Newtonsoft.Json 6.0.7 -> 6.0.8"
     msg |> shouldContainText "FSharp.Formatting 2.4 ->"
 
@@ -21,7 +22,8 @@ let ``#183 outdated without params``() =
 [<Platform "Mono">] // PATH TOO LONG on Windows...
 #endif
 let ``#183 outdated --ignore-constraint``() =
-    let msg = paket "outdated --ignore-constraints" "i000183-outdated-with-special-parameters"
+    let cleanup, msg = paket "outdated --ignore-constraints" "i000183-outdated-with-special-parameters"
+    use cleanup = cleanup
     msg.Contains("Newtonsoft.Json 6.0.7 -> 6.0.8") |> shouldEqual false
 
 
@@ -32,6 +34,7 @@ let ``#183 outdated --ignore-constraint``() =
 [<Platform "Mono">] // PATH TOO LONG on Windows...
 #endif
 let ``#183 outdated --include-prereleases``() =
-    let msg = paket "outdated --include-prereleases" "i000183-outdated-with-special-parameters"
+    let cleanup, msg = paket "outdated --include-prereleases" "i000183-outdated-with-special-parameters"
+    use cleanup = cleanup
     msg |> shouldContainText "Newtonsoft.Json 6.0.7 ->"
     msg.Contains("Newtonsoft.Json 6.0.7 -> 6.0.8") |> shouldEqual false

--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -17,12 +17,12 @@ let getDependencies(x:Paket.NuGet.NuGetPackageCache) = x.GetDependencies()
 let ``#1234 empty assembly name``() = 
     let outPath = Path.Combine(scenarioTempPath "i001234-missing-assemblyname","out")
     try
-        paket ("pack output \"" + outPath + "\"") "i001234-missing-assemblyname" |> ignore
+        use __ = paket ("pack output \"" + outPath + "\"") "i001234-missing-assemblyname" |> fst
         failwith "Expected an exeption"
     with
     | exn when exn.Message.Contains("PaketBug.dll") -> ()
 
-    File.Delete(Path.Combine(scenarioTempPath "i001234-missing-assemblyname","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001234-missing-assemblyname","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1348 npm type folder names`` () =
@@ -30,7 +30,7 @@ let ``#1348 npm type folder names`` () =
     let outPath = Path.Combine(rootPath,"out")
     let package = Path.Combine(outPath, "Paket.Integrations.Npm.1.0.0.nupkg")
     
-    paket ("pack output \"" + outPath + "\"") "i001348-packaging-npm-type-folders" |> ignore 
+    use __ = paket ("pack output \"" + outPath + "\"") "i001348-packaging-npm-type-folders" |> fst 
     ZipFile.ExtractToDirectory(package, outPath)
 
     let desiredFolderName = "font-awesome@4.5.0"
@@ -43,38 +43,36 @@ let ``#1348 npm type folder names`` () =
     
     extractedFolder.Name |> shouldEqual desiredFolderName
 
-    CleanDir rootPath
-
 [<Test>]
 let ``#1375 pack specific dependency``() = 
     let outPath = Path.Combine(scenarioTempPath "i001375-pack-specific","out")
-    paket ("pack output \"" + outPath + "\"") "i001375-pack-specific" |> ignore
-
-    File.Delete(Path.Combine(scenarioTempPath "i001375-pack-specific","PaketBug","paket.template"))
+    use __ = paket ("pack output \"" + outPath + "\"") "i001375-pack-specific" |> fst
+    ignore __
+    //File.Delete(Path.Combine(scenarioTempPath "i001375-pack-specific","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1375 pack with projectUrl commandline``() = 
     let outPath = Path.Combine(scenarioTempPath "i001375-pack-specific","out")
-    paket ("pack output \"" + outPath + "\" project-url \"http://localhost\"") "i001375-pack-specific" |> ignore
-
-    File.Delete(Path.Combine(scenarioTempPath "i001375-pack-specific","PaketBug","paket.template"))
+    use __ = paket ("pack output \"" + outPath + "\" project-url \"http://localhost\"") "i001375-pack-specific" |> fst
+    ignore __
+    //File.Delete(Path.Combine(scenarioTempPath "i001375-pack-specific","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1376 fail template``() = 
     let outPath = Path.Combine(scenarioTempPath "i001376-pack-template","out")
     let templatePath = Path.Combine(scenarioTempPath "i001376-pack-template","PaketBug", "paket.template")
-    paket ("pack output \"" + outPath + "\" templatefile " + templatePath) "i001376-pack-template" |> ignore
+    use __ = paket ("pack output \"" + outPath + "\" templatefile " + templatePath) "i001376-pack-template" |> fst
     let fileInfo = FileInfo(Path.Combine(outPath, "PaketBug.1.0.0.0.nupkg"))
     let (expectedFileSize: int64) = int64(1542)
     fileInfo.Length |> shouldBeGreaterThan expectedFileSize
 
-    File.Delete(Path.Combine(scenarioTempPath "i001376-pack-template","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001376-pack-template","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1376 template with plus``() = 
     let outPath = Path.Combine(scenarioTempPath "i001376-pack-template-plus","out")
     let templatePath = Path.Combine(scenarioTempPath "i001376-pack-template-plus","PaketBug", "paket.template")
-    paket ("pack output \"" + outPath + "\" templatefile " + templatePath) "i001376-pack-template-plus" |> ignore
+    use __ = paket ("pack output \"" + outPath + "\" templatefile " + templatePath) "i001376-pack-template-plus" |> fst
     let fileInfo = FileInfo(Path.Combine(outPath, "PaketBug.1.0.0.0.nupkg"))
     let (expectedFileSize: int64) = int64(1542)
     fileInfo.Length |> shouldBeGreaterThan expectedFileSize
@@ -84,15 +82,15 @@ let ``#1376 template with plus``() =
     let expectedFile = Path.Combine(outPath, "content", "net45+net451", "paket.references")
 
     File.Exists expectedFile |> shouldEqual true
-    File.Delete(templatePath)
+    //File.Delete(templatePath)
 
-    File.Delete(Path.Combine(scenarioTempPath "i001376-pack-template-plus","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001376-pack-template-plus","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1429 pack deps from template``() = 
     let outPath = Path.Combine(scenarioTempPath "i001429-pack-deps","out")
     let templatePath = Path.Combine(scenarioTempPath "i001429-pack-deps","PaketBug", "paket.template")
-    paket ("pack output \"" + outPath + "\" templatefile " + templatePath) "i001429-pack-deps" |> ignore
+    use __ = paket ("pack output \"" + outPath + "\" templatefile " + templatePath) "i001429-pack-deps" |> fst
 
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
@@ -103,13 +101,13 @@ let ``#1429 pack deps from template``() =
     details |> getDependencies |> Seq.map (fun (x,_,_) -> x) |> shouldNotContain (PackageName "PaketBug2") // it's not packed in same round
     details |> getDependencies |> Seq.map (fun (x,_,_) -> x) |> shouldNotContain (PackageName "PaketBug")
 
-    File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1429 pack deps``() = 
     let outPath = Path.Combine(scenarioTempPath "i001429-pack-deps","out")
     let templatePath = Path.Combine(scenarioTempPath "i001429-pack-deps","PaketBug", "paket.template")
-    paket ("pack output \"" + outPath + "\"") "i001429-pack-deps" |> ignore
+    use __ = paket ("pack output \"" + outPath + "\"") "i001429-pack-deps" |> fst
 
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
@@ -120,13 +118,13 @@ let ``#1429 pack deps``() =
     details |> getDependencies |> Seq.map (fun (x,_,_) -> x) |> shouldContain (PackageName "PaketBug2")
     details |> getDependencies |> Seq.map (fun (x,_,_) -> x) |> shouldNotContain (PackageName "PaketBug")
 
-    File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1429 pack deps using minimum-from-lock-file``() = 
     let outPath = Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","out")
     let templatePath = Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","PaketBug", "paket.template")
-    paket ("pack minimum-from-lock-file output \"" + outPath + "\"") "i001429-pack-deps-minimum-from-lock" |> ignore
+    use __ = paket ("pack minimum-from-lock-file output \"" + outPath + "\"") "i001429-pack-deps-minimum-from-lock" |> fst
 
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
@@ -137,13 +135,13 @@ let ``#1429 pack deps using minimum-from-lock-file``() =
     let packageName, versionRequirement, restrictions = details |> getDependencies |> Seq.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> Seq.head 
     versionRequirement |> shouldNotEqual (VersionRequirement.AllReleases)
 
-    File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1429 pack deps without minimum-from-lock-file uses dependencies file range``() = 
     let outPath = Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","out")
     let templatePath = Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","PaketBug", "paket.template")
-    paket ("pack output \"" + outPath + "\"") "i001429-pack-deps-minimum-from-lock" |> ignore
+    use __ = paket ("pack output \"" + outPath + "\"") "i001429-pack-deps-minimum-from-lock" |> fst
 
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
@@ -154,13 +152,13 @@ let ``#1429 pack deps without minimum-from-lock-file uses dependencies file rang
     let packageName, versionRequirement, restrictions = details |> getDependencies |> Seq.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> Seq.head 
     versionRequirement |> shouldEqual (VersionRequirement.Parse "1.2.3")
 
-    File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-minimum-from-lock","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1429 pack deps without minimum-from-lock-file uses specifc dependencies file range``() = 
     let outPath = Path.Combine(scenarioTempPath "i001429-pack-deps-specific","out")
     let templatePath = Path.Combine(scenarioTempPath "i001429-pack-deps-specific","PaketBug", "paket.template")
-    paket ("pack output \"" + outPath + "\"") "i001429-pack-deps-specific" |> ignore
+    use __ = paket ("pack output \"" + outPath + "\"") "i001429-pack-deps-specific" |> fst
 
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
@@ -171,13 +169,13 @@ let ``#1429 pack deps without minimum-from-lock-file uses specifc dependencies f
     let packageName, versionRequirement, restrictions = details |> getDependencies |> Seq.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> Seq.head 
     versionRequirement |> shouldEqual (VersionRequirement.Parse "[2.3.4]")
 
-    File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-specific","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-specific","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1429 pack deps with minimum-from-lock-file uses specifc dependencies file range``() = 
     let outPath = Path.Combine(scenarioTempPath "i001429-pack-deps-specific","out")
     let templatePath = Path.Combine(scenarioTempPath "i001429-pack-deps-specific","PaketBug", "paket.template")
-    paket ("pack minimum-from-lock-file  output \"" + outPath + "\"") "i001429-pack-deps-specific" |> ignore
+    use __ = paket ("pack minimum-from-lock-file  output \"" + outPath + "\"") "i001429-pack-deps-specific" |> fst
 
     let details = 
         NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "PaketBug") (SemVer.Parse "1.0.0.0")
@@ -188,13 +186,13 @@ let ``#1429 pack deps with minimum-from-lock-file uses specifc dependencies file
     let packageName, versionRequirement, restrictions = details |> getDependencies |> Seq.filter (fun (x,_,_) -> x = PackageName "MySql.Data") |> Seq.head 
     versionRequirement |> shouldEqual (VersionRequirement.Parse "[2.3.4]")
 
-    File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-specific","PaketBug","paket.template"))
+    //File.Delete(Path.Combine(scenarioTempPath "i001429-pack-deps-specific","PaketBug","paket.template"))
 
 [<Test>]
 let ``#1473 works in same folder``() =
     let scenario = "i001473-blocking"
 
-    prepare scenario
+    use __ = prepare scenario
     directPaket "pack templatefile paket.template output o" scenario |> ignore
     directPaket "update" scenario|> ignore
 
@@ -204,7 +202,7 @@ let ``#1472 globs correctly``() =
 
     let outPath = Path.Combine(scenarioTempPath scenario,"out")
     let templatePath = Path.Combine(scenarioTempPath scenario,"src", "A.Source", "paket.template")
-    paket ("pack version 1.0.0 output \"" + outPath + "\" -v") scenario |> ignore
+    use __ = paket ("pack version 1.0.0 output \"" + outPath + "\" -v") scenario |> fst
 
     let package = Path.Combine(outPath, "A.Source.1.0.0.nupkg")
  
@@ -220,7 +218,7 @@ let ``#1472 allows to put stuff in root of package``() =
 
     let outPath = Path.Combine(scenarioTempPath scenario,"out")
     let templatePath = Path.Combine(scenarioTempPath scenario,"src", "A.Source", "paket.template")
-    paket ("pack version 1.0.0 output \"" + outPath + "\" -v") scenario |> ignore
+    use __ = paket ("pack version 1.0.0 output \"" + outPath + "\" -v") scenario |> fst
 
     let package = Path.Combine(outPath, "A.Source.1.0.0.nupkg")
  
@@ -229,7 +227,7 @@ let ``#1472 allows to put stuff in root of package``() =
     let expectedFile = Path.Combine(outPath, "Folder", "source.cs")
 
     File.Exists expectedFile |> shouldEqual true
-    File.Delete(templatePath)
+    //File.Delete(templatePath)
 
 [<Test>]
 let ``#1472 allows to put stuff in relative folder``() =
@@ -237,7 +235,7 @@ let ``#1472 allows to put stuff in relative folder``() =
 
     let outPath = Path.Combine(scenarioTempPath scenario,"out")
     let templatePath = Path.Combine(scenarioTempPath scenario,"src", "A.Source", "paket.template")
-    paket ("pack version 1.0.0 output \"" + outPath + "\" -v") scenario |> ignore
+    use __ = paket ("pack version 1.0.0 output \"" + outPath + "\" -v") scenario |> fst
 
     let package = Path.Combine(outPath, "A.Source.1.0.0.nupkg")
  
@@ -246,15 +244,15 @@ let ``#1472 allows to put stuff in relative folder``() =
     let expectedFile = Path.Combine(outPath, "A", "Folder", "source.cs")
 
     File.Exists expectedFile |> shouldEqual true
-    File.Delete(templatePath)
+    //File.Delete(templatePath)
 
 [<Test>]
 let ``#1483 pack deps with locked version from group``() = 
     let outPath = Path.Combine(scenarioTempPath "i001483-group-lock","out")
     let templatePath = Path.Combine(scenarioTempPath "i001483-group-lock","pack", "paket.template")
-    paket ("pack output \"" + outPath + "\"") "i001483-group-lock" |> ignore
-
-    File.Delete(templatePath)
+    use __ = paket ("pack output \"" + outPath + "\"") "i001483-group-lock" |> fst
+    ignore __
+    //File.Delete(templatePath)
 
 [<Test>]
 let ``#1506 allows to pack files without ending``() =
@@ -262,7 +260,7 @@ let ``#1506 allows to pack files without ending``() =
 
     let outPath = Path.Combine(scenarioTempPath scenario,"out")
     let templatePath = Path.Combine(scenarioTempPath scenario, "paket.template")
-    paket ("pack output \"" + outPath + "\" -v") scenario |> ignore
+    use __ = paket ("pack output \"" + outPath + "\" -v") scenario |> fst
 
     let package = Path.Combine(outPath, "Foo.1.0.0.nupkg")
  
@@ -270,7 +268,7 @@ let ``#1506 allows to pack files without ending``() =
     
     File.Exists(Path.Combine(outPath, "tools", "blah.foo")) |> shouldEqual true
     File.Exists(Path.Combine(outPath, "tools", "blah")) |> shouldEqual true
-    File.Delete(templatePath)
+    //File.Delete(templatePath)
 
 [<Test>]
 let ``#1514 invalid pack should give proper warning``() =
@@ -280,12 +278,12 @@ let ``#1514 invalid pack should give proper warning``() =
     let templatePath = Path.Combine(scenarioTempPath scenario, "paket.template")
 
     try
-        paket ("pack buildconfig \"Debug\" buildplatform \"AnyCPU\" output \"" + outPath + "\" -v") scenario |> ignore
+        use __ = paket ("pack buildconfig \"Debug\" buildplatform \"AnyCPU\" output \"" + outPath + "\" -v") scenario |> fst
         failwith ""
     with
     | exn when exn.Message.Contains "No package with id 'PaketDemo.MyLibrary'" -> ()
 
-    File.Delete(templatePath)
+    //File.Delete(templatePath)
 
 [<Test>]
 let ``#1538 symbols src folder structure`` () =
@@ -294,7 +292,7 @@ let ``#1538 symbols src folder structure`` () =
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "PackWithSource.1.0.0.0.symbols.nupkg")
     
-    paket ("pack output \"" + outPath + "\" symbols") scenario |> ignore
+    use __ = paket ("pack output \"" + outPath + "\" symbols") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     Path.Combine(outPath, "lib", "net452", "PackWithSource.pdb") |> checkFileExists
@@ -308,14 +306,14 @@ let ``#1538 symbols src folder structure`` () =
     Path.Combine(srcRoot, "Folder", "NestedFolder", "LinkedInNestedFolder.cs") |> checkFileExists
     Path.Combine(srcRoot, "Properties", "AssemblyInfo.cs") |> checkFileExists
 
-    CleanDir rootPath
+   // CleanDir rootPath
 
 [<Test>]
 [<Ignore("ignore until we hear back")>]
 let ``#1504 unpacking should override``() =
     let scenario = "i001504-override"
 
-    prepare scenario
+    use __ = prepare scenario
     directPaket "pack templatefile paket.B.template version 1.0.0 output bin" scenario |> ignore
     directPaket "pack templatefile paket.A.template version 1.0.0 output bin" scenario |> ignore
     directPaket "update" scenario|> ignore
@@ -324,7 +322,7 @@ let ``#1504 unpacking should override``() =
 let ``#1586 pack dependent projects``() =
     let scenario = "i001586-pack-referenced"
 
-    prepare scenario
+    use __ = prepare scenario
     directPaket "pack output . include-referenced-projects minimum-from-lock-file -v" scenario |> ignore
 
 [<Test>]
@@ -333,14 +331,14 @@ let ``#1594 allows to pack directly``() =
 
     let outPath = Path.Combine(scenarioTempPath scenario,"bin")
     let templatePath = Path.Combine(scenarioTempPath scenario, "paket.template")
-    paket "pack output bin version 1.0.0 templatefile paket.template" scenario |> ignore
+    use __ = paket "pack output bin version 1.0.0 templatefile paket.template" scenario |> fst
 
     let package = Path.Combine(outPath, "ClassLibrary1.1.0.0.nupkg")
  
     ZipFile.ExtractToDirectory(package, outPath)
     
     File.Exists(Path.Combine(outPath, "lib", "net35", "ClassLibrary1.dll")) |> shouldEqual true
-    File.Delete(templatePath)
+    //File.Delete(templatePath)
 
 [<Test>]
 let ``#1596 pack works for reflected definition assemblies``() =
@@ -348,14 +346,15 @@ let ``#1596 pack works for reflected definition assemblies``() =
 
     let outPath = Path.Combine(scenarioTempPath scenario,"bin")
     let templatePath = Path.Combine(scenarioTempPath scenario, "paket.template")
-    let r = paket "pack output bin version 1.0.0 templatefile paket.template" scenario 
+    let (cleanup, r) = paket "pack output bin version 1.0.0 templatefile paket.template" scenario 
+    use __ = cleanup
     printfn "paket.pack said: %A" r
     let package = Path.Combine(outPath, "Project2.1.0.0.nupkg")
  
     ZipFile.ExtractToDirectory(package, outPath)
     
     File.Exists(Path.Combine(outPath, "lib", "net45", "Project2.dll")) |> shouldEqual true
-    File.Delete(templatePath)
+    //File.Delete(templatePath)
 
 [<Test>]
 let ``#1816 pack localized happy path`` () =
@@ -364,14 +363,14 @@ let ``#1816 pack localized happy path`` () =
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "LocalizedLib.1.0.0.0.nupkg")
     
-    paket ("pack -v output \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack -v output \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     Path.Combine(outPath, "lib", "net45", "LocalizedLib.dll") |> checkFileExists
     Path.Combine(outPath, "lib", "net45", "sv", "LocalizedLib.resources.dll") |> checkFileExists
     Path.Combine(outPath, "lib", "net45", "sv-FI", "LocalizedLib.resources.dll") |> checkFileExists
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#1816 pack localized when satellite dll is missing`` () =
@@ -380,7 +379,8 @@ let ``#1816 pack localized when satellite dll is missing`` () =
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "LocalizedLib.1.0.0.0.nupkg")
     
-    let result = paket ("pack -v output \"" + outPath + "\"") scenario
+    let cleanup, result = paket ("pack -v output \"" + outPath + "\"") scenario
+    use __ = cleanup
     let expectedMessage = "Did not find satellite assembly for (sv) try building and running pack again."
     StringAssert.Contains(expectedMessage, result)
     ZipFile.ExtractToDirectory(package, outPath)
@@ -388,7 +388,7 @@ let ``#1816 pack localized when satellite dll is missing`` () =
     Path.Combine(outPath, "lib", "net45", "LocalizedLib.dll") |> checkFileExists
     Path.Combine(outPath, "lib", "net45", "sv-FI", "LocalizedLib.resources.dll") |> checkFileExists
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#3275 netstandard pack localized happy path`` () =
@@ -397,7 +397,7 @@ let ``#3275 netstandard pack localized happy path`` () =
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "LibForTest.1.0.0.nupkg")
 
-    paket ("pack -v output \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack -v output \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     Path.Combine(outPath, "lib", "netstandard2.0", "LibForTest.dll") |> checkFileExists
@@ -405,7 +405,7 @@ let ``#3275 netstandard pack localized happy path`` () =
     Path.Combine(outPath, "lib", "netstandard2.0", "ru", "LibForTest.resources.dll") |> checkFileExists
     Path.Combine(outPath, "lib", "netstandard2.0", "en-US", "LibForTest.resources.dll") |> checkFileExists
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#1848 single template without include-referenced-projects`` () = 
@@ -413,7 +413,7 @@ let ``#1848 single template without include-referenced-projects`` () =
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
     let templatePath = Path.Combine(rootPath, "projectA", "paket.template")
-    paket ("pack --template " + templatePath + " \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --template " + templatePath + " \"" + outPath + "\"") scenario |> fst
 
     NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "projectA") (SemVer.Parse "1.0.0.0")
     |> Async.RunSynchronously
@@ -424,7 +424,7 @@ let ``#1848 single template without include-referenced-projects`` () =
     ZipFile.ExtractToDirectory(Path.Combine(outPath, "projectA.1.0.0.0.nupkg"), outPath)
     Path.Combine(outPath, "lib", "net45", "projectB.dll") |> checkFileExists
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#1848 single template with include-referenced-projects`` () = 
@@ -432,7 +432,7 @@ let ``#1848 single template with include-referenced-projects`` () =
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
     let templatePath = Path.Combine(rootPath, "projectA", "paket.template")
-    paket ("pack --include-referenced-projects --template  " + templatePath + " \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --include-referenced-projects --template  " + templatePath + " \"" + outPath + "\"") scenario |> fst
 
     NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "projectA") (SemVer.Parse "1.0.0.0")
     |> Async.RunSynchronously
@@ -446,14 +446,14 @@ let ``#1848 single template with include-referenced-projects`` () =
 
     File.Exists expectedFile |> shouldEqual false
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#1848 all templates without include-referenced-projects`` () = 
     let scenario = "i001848-pack-all-templates-wo-incl-flag"
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
-    paket ("pack \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack \"" + outPath + "\"") scenario |> fst
 
     NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "projectA") (SemVer.Parse "1.0.0.0")
     |> Async.RunSynchronously
@@ -473,14 +473,14 @@ let ``#1848 all templates without include-referenced-projects`` () =
     let expectedFile = Path.Combine(outPath, "lib", "net45", "projectB.dll")
     File.Exists expectedFile |> shouldEqual false
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#1848 all templates with include-referenced-projects`` () = 
     let scenario = "i001848-pack-all-templates-with-incl-flag"
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
-    paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> fst
 
     NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "projectA") (SemVer.Parse "1.0.0.0")
     |> Async.RunSynchronously
@@ -500,14 +500,14 @@ let ``#1848 all templates with include-referenced-projects`` () =
     let expectedFile = Path.Combine(outPath, "lib", "net45", "projectB.dll")
     File.Exists expectedFile |> shouldEqual false
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#1848 include-referenced-projects with non-packed project dependencies`` () = 
     let scenario = "i001848-pack-with-non-packed-deps"
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
-    paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> fst
 
     NuGetLocal.getDetailsFromLocalNuGetPackage false None outPath "" (PackageName "projectA") (SemVer.Parse "1.0.0.0")
     |> Async.RunSynchronously
@@ -519,7 +519,7 @@ let ``#1848 include-referenced-projects with non-packed project dependencies`` (
     ZipFile.ExtractToDirectory(Path.Combine(outPath, "projectA.1.0.0.0.nupkg"), outPath)
     Path.Combine(outPath, "lib", "net45", "projectB.dll") |> checkFileExists
     
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#2520 interproject-references parameter overide --pin-project-references`` () =
@@ -528,7 +528,7 @@ let ``#2520 interproject-references parameter overide --pin-project-references``
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "A.1.0.0.nupkg")
 
-    paket ("pack --pin-project-references \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --pin-project-references \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     let nuspec = NuGetLocal.getNuSpecFromNupgk package
@@ -542,7 +542,7 @@ let ``#2520 interproject-references parameter overide --pin-project-references``
     name |> shouldEqual (PackageName "B")
     versionRequirement |> shouldEqual (VersionRequirement.Parse "[1.2.3,2.0.0)")
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#2520 --interproject-references cli parameter overide interproject-references template file option`` () =
@@ -551,7 +551,7 @@ let ``#2520 --interproject-references cli parameter overide interproject-referen
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "A.1.0.0.nupkg")
 
-    paket ("pack --interproject-references keep-minor \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --interproject-references keep-minor \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     let nuspec = NuGetLocal.getNuSpecFromNupgk package
@@ -565,13 +565,13 @@ let ``#2520 --interproject-references cli parameter overide interproject-referen
     name |> shouldEqual (PackageName "B")
     versionRequirement |> shouldEqual (VersionRequirement.Parse "[1.2.3,1.3.0)")
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#2694 paket fixnuspec should not remove project references``() = 
     let project = "console"
     let scenario = "i002694"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
 
     let wd = (scenarioTempPath scenario) @@ project
 
@@ -599,8 +599,10 @@ let ``#2765 pack single template does not evaluate other template`` () =
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
     let templatePath = Path.Combine(rootPath, "ProjectA", "paket.template")
-    Assert.DoesNotThrow(fun () -> paket ("pack --template " + templatePath + " \"" + outPath + "\"") scenario |> ignore)
-    CleanDir rootPath    
+    Assert.DoesNotThrow(fun () -> 
+        use __ = paket ("pack --template " + templatePath + " \"" + outPath + "\"") scenario |> fst
+        ignore __)
+    //CleanDir rootPath    
 
 [<Test>]
 let ``#2788 with include-pdbs true`` () = 
@@ -608,33 +610,33 @@ let ``#2788 with include-pdbs true`` () =
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "BuiltWithSymbols.1.0.0.0.nupkg")
-    paket ("pack \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     Path.Combine(outPath, "lib", "net45", "BuiltWithSymbols.dll") |> checkFileExists
     Path.Combine(outPath, "lib", "net45", "BuiltWithSymbols.xml") |> checkFileExists
     Path.Combine(outPath, "lib", "net45", "BuiltWithSymbols.pdb") |> checkFileExists
 
-    CleanDir rootPath
+    //CleanDir rootPath
     
 [<Test>]
 let ``#3164 pack analyzer`` () = 
     let scenario = "i003164-pack-analyzer"
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
-    paket ("pack \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack \"" + outPath + "\"") scenario |> fst
 
     let package = Path.Combine(outPath, "Analyzer.0.2.0.3-dev.nupkg")
     ZipFile.ExtractToDirectory(package, outPath)
     Path.Combine(outPath, "analyzers", "dotnet", "cs", "Analyzer.dll") |> checkFileExists
 
-    CleanDir rootPath    
+    //CleanDir rootPath    
 
     
 [<Test>]
 let ``#3317 pack multitarget with p2p`` () =
     let scenario = "i003317-pack-multitarget-with-p2p"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
     let rootPath = scenarioTempPath scenario
 
     directDotnet true "build MyProj.Main -c Release" rootPath
@@ -664,13 +666,13 @@ let ``#3317 pack multitarget with p2p`` () =
     Path.Combine(unzippedNupkgPath, "lib", "net45", "MyProj.Main.dll") |> checkFileExists
     Path.Combine(unzippedNupkgPath, "lib", "netstandard2.0", "MyProj.Main.dll") |> checkFileExists
 
-    CleanDir rootPath    
+    //CleanDir rootPath    
 
 [<Test>]
 let ``#4002 dotnet pack of a global tool shouldnt contain references``() = 
     let project = "tool1"
     let scenario = "i004002-pack-global-tools"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
 
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
@@ -705,7 +707,7 @@ let ``#4002 dotnet pack of a global tool shouldnt contain references``() =
 let ``#4003 dotnet pack of a global tool with p2p``() = 
     let project = "tool1"
     let scenario = "i004003-pack-global-tools-p2p"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
 
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")
@@ -743,7 +745,7 @@ let ``#4003 dotnet pack of a global tool with p2p``() =
 let ``#4004 dotnet pack using different versions``() = 
     let project = "lib1"
     let scenario = "i004004-pack-version"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
 
     let rootPath = scenarioTempPath scenario
 
@@ -768,7 +770,8 @@ let ``#4010-pack-template-only``() =
     let scenario = "i004010-pack-template-only"
     let outPath = Path.Combine(scenarioTempPath scenario, "out")
     let templatePath = Path.Combine(scenarioTempPath scenario, "PaketBug", "paket.template")
-    paket (sprintf """pack --template "%s" "%s" --version 1.2.3 """ templatePath outPath) scenario |> ignore
+    use __ = paket (sprintf """pack --template "%s" "%s" --version 1.2.3 """ templatePath outPath) scenario |> fst
+    ignore __
 
 [<Test>]
 let ``#2776 transitive project references included`` () =
@@ -777,7 +780,7 @@ let ``#2776 transitive project references included`` () =
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "A.1.0.0.nupkg")
 
-    paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     Path.Combine(outPath, "lib", "netstandard2.0", "A.dll") |> checkFileExists
@@ -789,7 +792,7 @@ let ``#2776 transitive project references included`` () =
     let dependencies = nuspec.Dependencies.Value |> Seq.map (fun (x,_,_) -> x)
     dependencies |> shouldContain (PackageName "nlog")
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#2776 transitive references stops on project with template`` () =
@@ -798,7 +801,7 @@ let ``#2776 transitive references stops on project with template`` () =
     let outPath = Path.Combine(rootPath, "out")
     let package = Path.Combine(outPath, "A.1.0.0.nupkg")
 
-    paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> ignore
+    use __ = paket ("pack --include-referenced-projects \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
     Path.Combine(outPath, "lib", "netstandard2.0", "A.dll") |> checkFileExists
@@ -812,12 +815,12 @@ let ``#2776 transitive references stops on project with template`` () =
     dependencies |> shouldContain (PackageName "C")
     dependencies |> shouldNotContain (PackageName "nlog")
 
-    CleanDir rootPath
+    //CleanDir rootPath
 
 [<Test>]
 let ``#3558 pack multitarget with p2p by tfm`` () =
     let scenario = "i003558-pack-multitarget-with-p2p-by-tfm"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
     let rootPath = scenarioTempPath scenario
 
     directDotnet true "build MyProj.Main -c Release" rootPath
@@ -832,7 +835,7 @@ let ``#3558 pack multitarget with p2p by tfm`` () =
     let tfmNETSTANDARD2_0 = FrameworkIdentifier.DotNetStandard(DotNetStandardVersion.V2_0)
     let ``>= netstandard2.0`` = FrameworkRestriction.And [FrameworkRestriction.NotAtLeast(tfmNET45); FrameworkRestriction.AtLeast(tfmNETSTANDARD2_0)]
 
-    let _checkNupkgCommon =
+    do
 
         let nupkgPath = Path.Combine(outPath, "MyProj.Common.1.0.0.nupkg")
 
@@ -854,7 +857,7 @@ let ``#3558 pack multitarget with p2p by tfm`` () =
         Path.Combine(unzippedNupkgPath, "lib", "net45", "MyProj.Common.dll") |> checkFileExists
         Path.Combine(unzippedNupkgPath, "lib", "netstandard2.0", "MyProj.Common.dll") |> checkFileExists
 
-    let _checkNupkgMain =
+    do
 
         let nupkgPath = Path.Combine(outPath, "MyProj.Main.1.0.0.nupkg")
 
@@ -876,4 +879,4 @@ let ``#3558 pack multitarget with p2p by tfm`` () =
         Path.Combine(unzippedNupkgPath, "lib", "net45", "MyProj.Main.dll") |> checkFileExists
         Path.Combine(unzippedNupkgPath, "lib", "netstandard2.0", "MyProj.Main.dll") |> checkFileExists
 
-    CleanDir rootPath    
+    //CleanDir rootPath    

--- a/integrationtests/Paket.IntegrationTests/PaketCoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PaketCoreSpecs.fs
@@ -15,7 +15,7 @@ let alternativeProjectRoot = None
 
 [<Test>]
 let ``#1251 full installer demo``() = 
-    prepare "i001251-installer-demo"
+    use __ = prepare "i001251-installer-demo"
     let deps = """source https://nuget.org/api/v2
     nuget FAKE
     nuget FSharp.Formatting"""
@@ -34,7 +34,7 @@ let ``#1251 full installer demo``() =
 
 [<Test>]
 let ``#1251 install FSharp.Collections.ParallelSeq``() = 
-    prepare "i001251-installer-demo"
+    use __ = prepare "i001251-installer-demo"
     let deps = """source https://nuget.org/api/v2
     nuget FSharp.Collections.ParallelSeq"""
 
@@ -52,7 +52,7 @@ let ``#1251 install FSharp.Collections.ParallelSeq``() =
 [<Test>]
 let ``#1259 install via script``() =
     Environment.SetEnvironmentVariable ("PAKET_DISABLE_RUNTIME_RESOLUTION", "true")
-    prepare "i001259-install-script"
+    use __ = prepare "i001259-install-script"
 
     Paket.Dependencies
        .Install("""

--- a/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/ResolverSkipsConflictsFastSpecs.fs
@@ -23,13 +23,15 @@ open System
 
 [<Test>]
 let ``#1166 Should resolve Nancy without timeout``() =
-    let lockFile = update "i001166-resolve-nancy-fast"
+    let cleanup, lockFile = update "i001166-resolve-nancy-fast"
+    use __ = cleanup
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Nancy"].Version
     |> shouldBeGreaterThan (SemVer.Parse "1.1")
 
 [<Test>]
 let ``#2289 Paket 4.x install command takes hours to complete``() =
-    let lockFile = install "i002289-resolve-nunit-timeout"
+    let cleanup, lockFile = install "i002289-resolve-nunit-timeout"
+    use __ = cleanup
     let nunitVersion =
         lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "NUnit"].Version
 

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -12,7 +12,7 @@ open Paket.Utils
 let ``#2496 Paket fails on projects that target multiple frameworks``() = 
     let project = "EmptyTarget"
     let scenario = "i002496"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
 
     let wd = (scenarioTempPath scenario) @@ project
     directDotnet true (sprintf "restore %s.csproj" project) wd
@@ -22,7 +22,7 @@ let ``#2496 Paket fails on projects that target multiple frameworks``() =
 let ``#3527 BaseIntermediateOutputPath``() =
     let project = "project"
     let scenario = "i003527"
-    prepareSdk scenario
+    use __ = prepareSdk scenario
 
     let wd = (scenarioTempPath scenario) @@ project
     directDotnet true (sprintf "restore %s.fsproj" project) wd
@@ -44,7 +44,7 @@ let ``#3000-a dotnet restore``() =
 
     [ packageName; (packageName.ToLower()) ] |> Seq.iter clearPackage
     
-    prepareSdk scenario
+    use __ = prepareSdk scenario
     directDotnet false "restore" projectDir |> ignore
     directDotnet false "build --no-restore" projectDir |> ignore
 
@@ -58,6 +58,6 @@ let ``#3012 Paket restore silently fails when TargetFramework(s) are specified i
 
     [ packageName; (packageName.ToLower()) ] |> Seq.iter clearPackage
     
-    prepareSdk scenario
+    use __ = prepareSdk scenario
     directPaket "install" scenario |> ignore
     directDotnet false "build" projectDir |> ignore

--- a/integrationtests/Paket.IntegrationTests/SemVerUpdateSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/SemVerUpdateSpecs.fs
@@ -11,7 +11,7 @@ open Paket.Domain
 
 [<Test>]
 let ``#1125 Should keep minor versions``() =
-    paket "update --keep-minor" "i001125-update-and-keep-minor" |> ignore
+    use __ = paket "update --keep-minor" "i001125-update-and-keep-minor" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001125-update-and-keep-minor","paket.lock"))
     let v = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FSharp.Formatting"].Version
     v.Major |> shouldEqual 2u
@@ -20,7 +20,7 @@ let ``#1125 Should keep minor versions``() =
 
 [<Test>]
 let ``#1125 Should keep major versions``() =
-    paket "update --keep-major" "i001125-update-and-keep-minor" |> ignore
+    use __ = paket "update --keep-major" "i001125-update-and-keep-minor" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001125-update-and-keep-minor","paket.lock"))
     let v = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FSharp.Formatting"].Version
     v.Major |> shouldEqual 2u
@@ -28,7 +28,7 @@ let ``#1125 Should keep major versions``() =
 
 [<Test>]
 let ``#1125 Should keep patch versions``() =
-    paket "update --keep-patch" "i001125-update-and-keep-minor" |> ignore
+    use __ = paket "update --keep-patch" "i001125-update-and-keep-minor" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001125-update-and-keep-minor","paket.lock"))
     let v = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "FSharp.Formatting"].Version
     v.Major |> shouldEqual 2u

--- a/integrationtests/Paket.IntegrationTests/SimplifierSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/SimplifierSpecs.fs
@@ -3,12 +3,13 @@
 open NUnit.Framework
 open Fake
 open FsUnit
+open Paket
 
 [<Test>]
 let ``#1737 simplify should handle auto-detected framework``() =
     let scenario = "i001737-simplify-with-auto-framework"
-    prepare scenario
-    paket "install" scenario |> ignore
+    use __ = prepare scenario
+    directPaket "install" scenario |> ignore<string>
 
     let deps = Paket.Dependencies(scenarioTempPath scenario </> "paket.dependencies")
     deps.Simplify(false)

--- a/integrationtests/Paket.IntegrationTests/SymbolicLinkSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/SymbolicLinkSpecs.fs
@@ -10,7 +10,7 @@ let ``#3127 symlink enabled on all dependencies and empty paket.lock``() =
     clearPackageAtVersion "NUnit" "2.6.3"
     let scenario = "i003127-storage-symlink"
     let workingDir = scenarioTempPath scenario
-    paketEx true "update" scenario |> ignore
+    use __ = paketEx true "update" scenario |> fst
     
     workingDir </> "packages" </> "NUnit" 
     |> SymlinkUtils.isDirectoryLink 
@@ -32,7 +32,7 @@ let ``#3127 symlink enabled -> disabled on all dependencies on existing paket.lo
     
     let packagesDir = workingDir </> "packages"    
     
-    paketEx true "install" scenario |> ignore
+    use __ = paketEx true "install" scenario |> fst
     
     workingDir </> "paket.dependencies" |> Paket.DependenciesFile.ReadFromFile     
     |> storageConfig
@@ -50,7 +50,7 @@ nuget NUnit < 3.0.0"""
     |> storageConfig
     |> shouldEqual None
 
-    directPaketEx "update" scenario |> ignore
+    directPaketEx "update" scenario |> ignore<ResizeArray<_>>
 
     packagesDir </> "NUnit" 
     |> SymlinkUtils.isDirectoryLink 
@@ -61,7 +61,7 @@ let ``#3127 symlink disabled -> enabled on all dependencies on existing paket.lo
     clearPackageAtVersion "NUnit" "2.6.3"
     
     let scenario = "i003127-storage-symlink"
-    prepare scenario
+    use __ = prepare scenario
     let workingDir = scenarioTempPath scenario
     let packagesDir = workingDir </> "packages"
     
@@ -73,7 +73,7 @@ nuget NUnit < 3.0.0"""
     |> storageConfig
     |> shouldEqual None
 
-    directPaketEx "install" scenario |> ignore
+    directPaketEx "install" scenario |> ignore<ResizeArray<_>>
 
     packagesDir </> "NUnit" 
     |> SymlinkUtils.isDirectoryLink 
@@ -88,7 +88,7 @@ nuget NUnit < 3.0.0"""
     |> storageConfig
     |> shouldEqual (Some PackagesFolderGroupConfig.SymbolicLink)
 
-    directPaketEx "update" scenario |> ignore
+    directPaketEx "update" scenario |> ignore<ResizeArray<_>>
 
     packagesDir </> "NUnit" 
     |> SymlinkUtils.isDirectoryLink 

--- a/integrationtests/Paket.IntegrationTests/UpdateGroupsSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/UpdateGroupsSpecs.fs
@@ -12,7 +12,7 @@ open Paket.Domain
 
 [<Test>]
 let ``#1711 update main group with correct source``() =
-    update "i001711-wrong-source" |> ignore
+    use __ = update "i001711-wrong-source" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001711-wrong-source","paket.lock"))
     let p1 = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Test"]
     p1.Version |> shouldEqual (SemVer.Parse "0.0.1")
@@ -20,7 +20,7 @@ let ``#1711 update main group with correct source``() =
 
 [<Test>]
 let ``#1711 update main group with correct source with multiple groups``() =
-    update "i001711-wrong-groupsource" |> ignore
+    use __ = update "i001711-wrong-groupsource" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001711-wrong-groupsource","paket.lock"))
     let p1 = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Test"]
     p1.Version |> shouldEqual (SemVer.Parse "0.0.1")

--- a/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/UpdatePackageSpecs.fs
@@ -23,7 +23,7 @@ open Paket.Requirements
 
 [<Test>]
 let ``#1178 update specific package``() =
-    paket "update nuget NUnit" "i001178-update-with-regex" |> ignore
+    use __ = paket "update nuget NUnit" "i001178-update-with-regex" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001178-update-with-regex","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor"].Version
     |> shouldEqual (SemVer.Parse "2.5.1")
@@ -34,14 +34,14 @@ let ``#1178 update specific package``() =
 
 [<Test>]
 let ``#1469 update package in main group``() =
-    update "i001469-darkseid" |> ignore
+    use __ = update "i001469-darkseid" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001469-darkseid","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Darkseid"].Version
     |> shouldBeGreaterThan (SemVer.Parse "0.2.1")
 
 [<Test>]
 let ``#1178 update with Mircosoft.* filter``() =
-    paket "update nuget Microsoft.* --filter" "i001178-update-with-regex" |> ignore
+    use __ = paket "update nuget Microsoft.* --filter" "i001178-update-with-regex" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001178-update-with-regex","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor"].Version
     |> shouldEqual (SemVer.Parse "2.5.1")
@@ -52,7 +52,7 @@ let ``#1178 update with Mircosoft.* filter``() =
 
 [<Test>]
 let ``#1178 update with [MN].* --filter``() =
-    paket "update nuget [MN].* --filter" "i001178-update-with-regex" |> ignore
+    use __ = paket "update nuget [MN].* --filter" "i001178-update-with-regex" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001178-update-with-regex","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor"].Version
     |> shouldEqual (SemVer.Parse "2.5.1")
@@ -64,14 +64,14 @@ let ``#1178 update with [MN].* --filter``() =
 [<Test>]
 let ``#1178 update with [MN].* and without filter should fail``() =
     try
-        paket "update nuget [MN].*" "i001178-update-with-regex" |> ignore
+        use __ = paket "update nuget [MN].*" "i001178-update-with-regex" |> fst
         failwithf "Paket command expected to fail"
     with
     | exn when exn.Message.Contains "Package [MN].* was not found in paket.dependencies in group Main" -> ()
 
 [<Test>]
 let ``#1178 update with NUn.* filter to specific version``() =
-    paket "update nuget NUn.* --filter version 2.6.2" "i001178-update-with-regex" |> ignore
+    use __ = paket "update nuget NUn.* --filter version 2.6.2" "i001178-update-with-regex" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001178-update-with-regex","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Castle.Windsor"].Version
     |> shouldEqual (SemVer.Parse "2.5.1")
@@ -83,7 +83,7 @@ let ``#1178 update with NUn.* filter to specific version``() =
 
 [<Test>]
 let ``#1117 can understand portable``() =
-    update "i001117-aws" |> ignore
+    use __ = update "i001117-aws" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001117-aws","paket.lock"))
     let restrictions = lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "PCLStorage"].Settings.FrameworkRestrictions
     match restrictions with
@@ -102,7 +102,7 @@ let ``#1117 can understand portable``() =
 
 [<Test>]
 let ``#1413 doesn't take symbols``() =
-    update "i001413-symbols" |> ignore
+    use __ = update "i001413-symbols" |> fst
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i001413-symbols","paket.lock"))
     lockFile.Groups.[Constants.MainDependencyGroup].Resolution.[PackageName "Composable.Core"].Version
     |> shouldEqual (SemVer.Parse "3.4.0")
@@ -111,7 +111,7 @@ let ``#1413 doesn't take symbols``() =
 let ``#1432 update doesn't throw Stackoverflow``() =
     let scenario = "i001432-stackoverflow"
 
-    prepare scenario
+    use __ = prepare scenario
     directPaket "pack templatefile paket.A.template version 1.0.0-prerelease output bin" scenario |> ignore
     directPaket "pack templatefile paket.A.template version 1.0.0 output bin" scenario |> ignore
     directPaket "pack templatefile paket.A.template version 1.1.0-prerelease output bin" scenario |> ignore
@@ -124,27 +124,29 @@ let ``#1432 update doesn't throw Stackoverflow``() =
 let ``#1579 update allows unpinned``() =
     let scenario = "i001579-unlisted"
 
-    prepare scenario
+    use __ = prepare scenario
     directPaket "pack templatefile paket.A.template version 1.0.0-prerelease output bin" scenario |> ignore
     directPaket "update" scenario|> ignore
 
 [<Test;Ignore "slow test">]
 let ``#1501 download succeeds``() =
-    update "i001510-download" |> ignore
+    use __ = update "i001510-download" |> fst
+    ignore __
 
 [<Test>]
 let ``#1520 update with pinned dependency succeeds``() =
-    update "i001520-pinned-error" |> ignore
+    use __ = update "i001520-pinned-error" |> fst
+    ignore __
 
 [<Test>]
 let ``#1703 resolves locally``() =
-    update "i001703-local" |> ignore
-
+    use __ = update "i001703-local" |> fst
+    ignore __
 
 [<Test>]
 let ``#1635 should tell about auth issue``() =
     try
-        update "i001635-wrong-pw" |> ignore
+        use __ = update "i001635-wrong-pw" |> fst
         failwith "error expected"
     with
     | exn when exn.Message.Contains("Unable to retrieve package versions for 'Argu'") -> 
@@ -156,7 +158,7 @@ let ``#1635 should tell about auth issue``() =
 [<Test>]
 let ``#2572 should tell about late resolver issue``() =
     try
-        update "i002572-pinned-error" |> ignore
+        use __ = update "i002572-pinned-error" |> fst
         failwith "error expected"
     with
     | exn when exn.Message.Contains("xunit.core 2.3.0-beta3-build3705 requested package xunit.extensibility.core: 2.3.0-beta3-build3705") ->

--- a/src/Paket.Core/Common/Utils.fs
+++ b/src/Paket.Core/Common/Utils.fs
@@ -197,7 +197,7 @@ let CleanDir path =
         try
             emptyDir di
         with
-        | exn -> failwithf "Error during cleaning of %s%s  - %s" di.FullName Environment.NewLine exn.Message
+        | e -> raise <| exn(sprintf "Error during cleaning of %s%s  - %s" di.FullName Environment.NewLine e.Message, e)
     else
         Directory.CreateDirectory path |> ignore
     // set writeable

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -235,13 +235,16 @@ let extractElement root name =
     saveToFile newContent targetFile
 
 let extractRestoreTargets root =
-    if !copiedElements then
-        Path.Combine(root,".paket","Paket.Restore.targets")
-    else
-        let (fileWritten, path) = extractElement root "Paket.Restore.targets"
-        copiedElements := true
-        if fileWritten then tracefn "Extracted Paket.Restore.targets to: %s" path
-        path
+    let path = Path.Combine(root,".paket","Paket.Restore.targets")
+    if Environment.GetEnvironmentVariable "PAKET_SKIP_RESTORE_TARGETS" <> "true" then
+        // allow to be more clever than paket
+        if !copiedElements then path
+        else
+            let (fileWritten, path) = extractElement root "Paket.Restore.targets"
+            copiedElements := true
+            if fileWritten then tracefn "Extracted Paket.Restore.targets to: %s (Can be disabled with PAKET_SKIP_RESTORE_TARGETS=true)" path
+            path
+    else path
 
 let CreateInstallModel(alternativeProjectRoot, root, groupName, sources, caches, force, package) =
     async {

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -379,6 +379,11 @@ type Dependencies(dependenciesFileName: string) =
 
     /// Restores all dependencies.
     member this.Restore(): unit = this.Restore(false,None,[],false,false,false,None,None)
+    /// Simple packages restore: 
+    /// - Doesn't restore projects
+    /// - Doesn't write targets file
+    member this.SimplePackagesRestore(): unit = 
+        RestoreProcess.Restore(dependenciesFileName,RestoreProcess.RestoreProjectOptions.NoProjects,false,None,true,false,None,None,true)
 
     /// Restores the given paket.references files.
     member this.Restore(group: string option, files: string list, ignoreChecks): unit = this.Restore(false, group, files, false, ignoreChecks,false,None,None)
@@ -391,14 +396,16 @@ type Dependencies(dependenciesFileName: string) =
         if touchAffectedRefs then
             let packagesToTouch = RestoreProcess.FindPackagesNotExtractedYet(dependenciesFileName)
             this.Process (FindReferences.TouchReferencesOfPackages packagesToTouch)
-        RestoreProcess.Restore(dependenciesFileName,None,force,Option.map GroupName group,files,ignoreChecks, failOnChecks, targetFramework, outputPath)
+        let restoreOpts =
+            if files = [] then RestoreProcess.RestoreProjectOptions.AllProjects else RestoreProcess.RestoreProjectOptions.ReferenceFileList files
+        RestoreProcess.Restore(dependenciesFileName,restoreOpts,force,Option.map GroupName group,ignoreChecks, failOnChecks, targetFramework, outputPath, false)
 
     /// Restores the given paket.references files.
     member this.Restore(force: bool, group: string option, project: string, touchAffectedRefs: bool, ignoreChecks, failOnChecks, targetFramework, outputPath) : unit =
         if touchAffectedRefs then
             let packagesToTouch = RestoreProcess.FindPackagesNotExtractedYet(dependenciesFileName)
             this.Process (FindReferences.TouchReferencesOfPackages packagesToTouch)
-        RestoreProcess.Restore(dependenciesFileName,Some project,force,Option.map GroupName group,[],ignoreChecks, failOnChecks, targetFramework, outputPath)
+        RestoreProcess.Restore(dependenciesFileName,RestoreProcess.RestoreProjectOptions.SingleProject project,force,Option.map GroupName group,ignoreChecks, failOnChecks, targetFramework, outputPath, false)
 
     /// Restores packages for all available paket.references files
     /// (or all packages if onlyReferenced is false)


### PR DESCRIPTION
This changes some internals with (hopefully) minimal observable impact. The cache now supports multiple different "caching scenarios". This means that we can no detect if the .nuget/packages folder is up to date separately from if we have written new SDK restore files.
I left it the same single file because otherwise, we would have problems with `.gitignore` and user education again :). But the format changed now to a JSON file and we only store the hash within.

#### Why?

After adding FAKE support into Ionide I noticed `paket.restore.targets` is written by paket.core (which is used by the Fake.Runtime, which is used to provide Ionide support).
To solve this (and potentially some reported issues in FAKE as well). I refactored the restore process to allow a `SimpleRestore` (new public API), all this does is restoring packages into the NuGet cache. 
I could have tried to no use the cache when in Ionide or FAKE. But then the performance could be a problem. Hence this PR.