### PR TITLE
paket.targets -> Paket.Restore.targets

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -137,8 +137,9 @@ committed to source control:
 
 The following files can be committed, but are not essential:
 
-* [`.paket/paket.targets`](paket-folder.html) allows you to enable automatic
-  package restore in Visual Studio.
+* [`.paket/Paket.Restore.targets`](paket-folder.html) allows you to enable automatic
+  package restore in Visual Studio. If not commited then if using Visual Studio you 
+  will need to run `dotnet restore` manually. 
 * [`.paket/paket.bootstrapper.exe`](bootstrapper.html) is a small,
   rarely updated executable that will download the latest version of the main
   `paket.exe`. It is not necessary, but can be very useful for other developers


### PR DESCRIPTION
I believe the docs are out of date on this file. I don't have a paket.targets file, only a Packet.Restore.targets file. Updated the docs on the assumption Paket.Restore.targets is the new name.

Pls review my comment on the implications of not committing this file as I'm not sure that is correct.