### PR TITLE
Fix fast restore

### DIFF
--- a/integrationtests/Paket.IntegrationTests/InfoSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InfoSpecs.fs
@@ -17,7 +17,7 @@ let ``#3200 info should locate paket.dependencies``() =
 
     let ``paket info --paket-dependencies-dir`` workingDir =
         directPaketInPathEx "info --paket-dependencies-dir" workingDir
-        |> Seq.map PaketMsg.getMessage
+        |> Seq.map OutputMsg.getMessage
         |> List.ofSeq
 
     // paket.dependencies not exists

--- a/integrationtests/Paket.IntegrationTests/InitSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InitSpecs.fs
@@ -29,7 +29,9 @@ let ``#1743 empty log file``() =
         use __ = paket "init --log-file" "i001040-init-downloads-bootstrapper" |> fst
         failwith "expected error"
     with
-    | exn when exn.Message.Split('\n').[0].Contains "--log-file" -> ()
+    | ProcessFailedWithExitCode(_, _, msgs) ->
+        (msgs.Errors |> Seq.head).Contains "--log-file"
+            |> shouldEqual true
 
 [<Test>]
 #if PAKET_NETCORE

--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -144,7 +144,7 @@ let ``fails on wrong framework given`` () =
 
     use __ = paket "install" scenario |> fst
 
-    let failure = Assert.Throws (fun () ->
+    let failure = Assert.Throws<ProcessFailedWithExitCode> (fun () ->
         let result = directPaket "generate-load-scripts framework foo framework bar framework net45" scenario
         printf "%s" result
     )
@@ -161,7 +161,7 @@ let ``fails on wrong scripttype given`` () =
 
     use __ = paket "install" scenario |> fst
 
-    let failure = Assert.Throws (fun () ->
+    let failure = Assert.Throws<ProcessFailedWithExitCode> (fun () ->
         let result = directPaket (sprintf "generate-load-scripts type foo type bar framework net45") scenario
         printf "%s" result
     )

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -9,6 +9,17 @@ open Paket
 open Paket.Utils
 
 [<Test>]
+let ``#3608 dotnet build should work with unparsable cache``() = 
+    let project = "console"
+    let scenario = "i003608-invalid-cache"
+    use __ = prepareSdk scenario
+
+    let wd = (scenarioTempPath scenario) @@ project
+    // Build should work immediately (and call 'paket restore')
+    directDotnet true (sprintf "build %s.fsproj" project) wd
+        |> ignore
+
+[<Test>]
 let ``#2684 Paket should not be called the second time in msbuild (Restore Performance)``() = 
     let project = "console"
     let scenario = "i002684-fast-restore"
@@ -23,7 +34,6 @@ let ``#2684 Paket should not be called the second time in msbuild (Restore Perfo
     // make sure it builds as well (checks if restore-targets contains syntax errors)
     directDotnet true (sprintf "build %s.fsproj" project) wd
         |> ignore
-
 
 [<Test>]
 let ``#2496 Paket fails on projects that target multiple frameworks``() = 

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -13,7 +13,6 @@ let ``#3608 dotnet build should work with unparsable cache``() =
     let project = "console"
     let scenario = "i003608-invalid-cache"
     use __ = prepareSdk scenario
-
     let wd = (scenarioTempPath scenario) @@ project
     // Build should work immediately (and call 'paket restore')
     directDotnet true (sprintf "build %s.fsproj" project) wd

--- a/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/RestoreSpecs.fs
@@ -20,7 +20,8 @@ let ``#3608 dotnet build should work with unparsable cache``() =
         |> ignore
 
 [<Test>]
-let ``#2684 Paket should not be called the second time in msbuild (Restore Performance)``() = 
+let ``#2684 Paket should not be called the second time in msbuild (Restore Performance)``() =
+    // NOTE: This test also ensure that FAKE can be used without paket on the CI server, see https://github.com/fsharp/FAKE/issues/2348
     let project = "console"
     let scenario = "i002684-fast-restore"
     use __ = prepareSdk scenario

--- a/integrationtests/scenarios/i002684-fast-restore/before/console/Program.fs
+++ b/integrationtests/scenarios/i002684-fast-restore/before/console/Program.fs
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv =
+    printfn "Hello World from F#!"
+    0 // return an integer exit code

--- a/integrationtests/scenarios/i002684-fast-restore/before/console/console.fsproj
+++ b/integrationtests/scenarios/i002684-fast-restore/before/console/console.fsproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i002684-fast-restore/before/console/paket.references
+++ b/integrationtests/scenarios/i002684-fast-restore/before/console/paket.references
@@ -1,0 +1,1 @@
+FSharp.Core

--- a/integrationtests/scenarios/i002684-fast-restore/before/paket.dependencies
+++ b/integrationtests/scenarios/i002684-fast-restore/before/paket.dependencies
@@ -1,0 +1,4 @@
+source https://api.nuget.org/v3/index.json
+restriction: || (==netstandard20) (== netcoreapp21)
+storage: none
+nuget FSharp.Core

--- a/integrationtests/scenarios/i002684-fast-restore/before/paket.lock
+++ b/integrationtests/scenarios/i002684-fast-restore/before/paket.lock
@@ -1,0 +1,5 @@
+STORAGE: NONE
+RESTRICTION: || (== netcoreapp2.1) (== netstandard2.0)
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    FSharp.Core (4.6.2)

--- a/integrationtests/scenarios/i003608-invalid-cache/before/console/Program.fs
+++ b/integrationtests/scenarios/i003608-invalid-cache/before/console/Program.fs
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv =
+    printfn "Hello World from F#!"
+    0 // return an integer exit code

--- a/integrationtests/scenarios/i003608-invalid-cache/before/console/console.fsproj
+++ b/integrationtests/scenarios/i003608-invalid-cache/before/console/console.fsproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i003608-invalid-cache/before/console/paket.references
+++ b/integrationtests/scenarios/i003608-invalid-cache/before/console/paket.references
@@ -1,0 +1,1 @@
+FSharp.Core

--- a/integrationtests/scenarios/i003608-invalid-cache/before/paket-files/paket.restore.cached
+++ b/integrationtests/scenarios/i003608-invalid-cache/before/paket-files/paket.restore.cached
@@ -1,0 +1,1 @@
+Some not parsable File

--- a/integrationtests/scenarios/i003608-invalid-cache/before/paket.dependencies
+++ b/integrationtests/scenarios/i003608-invalid-cache/before/paket.dependencies
@@ -1,0 +1,4 @@
+source https://api.nuget.org/v3/index.json
+restriction: || (==netstandard20) (== netcoreapp21)
+storage: none
+nuget FSharp.Core

--- a/integrationtests/scenarios/i003608-invalid-cache/before/paket.lock
+++ b/integrationtests/scenarios/i003608-invalid-cache/before/paket.lock
@@ -1,0 +1,5 @@
+STORAGE: NONE
+RESTRICTION: || (== netcoreapp2.1) (== netstandard2.0)
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    FSharp.Core (4.6.2)

--- a/src/Paket.Core/Installation/InstallProcess.fs
+++ b/src/Paket.Core/Installation/InstallProcess.fs
@@ -585,7 +585,10 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
                 first := false
 
     let restoreCacheFile = Path.Combine(root, Constants.PaketRestoreHashFilePath)
-    Paket.RestoreProcess.saveToFile (lockFile.ToString()) (FileInfo restoreCacheFile) |> ignore
+    let hash = Paket.RestoreProcess.getLockFileHashFromContent (lockFile.ToString())
+    // NIT: We probably need to check if we have really fully restored (could be partial install)
+    // Lets see if users report issues
+    Paket.RestoreProcess.writeRestoreCache restoreCacheFile { PackagesDownloadedHash = hash; ProjectsRestoredHash = hash }
     Paket.RestoreProcess.WriteGitignore restoreCacheFile
 
     for project, _ in projectsAndReferences do

--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -95,9 +95,6 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
     </Exec>
 
-    <!-- Debug whats going on -->
-    <Message Importance="low" Text="calling paket restore with targetframework=$(TargetFramework) targetframeworks=$(TargetFrameworks)" />
-
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
       <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
       <PaketRestoreCachedHash Condition=" '$(PaketRestoreCachedHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
@@ -116,7 +113,9 @@
     </PropertyGroup>
 
     <!-- Do a global restore if required -->
+    <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we always call the bootstrapper" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" />
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
+    <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
     
     <!-- Step 2 Detect project specific changes -->
@@ -126,7 +125,7 @@
       <MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
       <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
     </ItemGroup>
-    <Message Importance="low" Text="MyTargetFrameworks=@(MyTargetFrameworks) PaketResolvedFilePaths=@(PaketResolvedFilePaths)" />
+
     <PropertyGroup>
       <PaketReferencesCachedFilePath>$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
       <!-- MyProject.fsproj.paket.references has the highest precedence -->
@@ -163,6 +162,7 @@
 
     <!-- Step 3 Restore project specific stuff if required -->
     <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
+    <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)'" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' " />
     <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
     <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
@@ -255,6 +255,7 @@
       <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.$(PackageVersion.Split(`+`)[0]).nuspec"/>
     </ItemGroup>
 
+    <Error Text="Error Because of PAKET_ERROR_ON_MSBUILD_EXEC (not calling fix-nuspecs)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' " />
     <Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' />
     <Error Condition="@(_NuspecFiles) == ''" Text='Could not find nuspec files in "$(AdjustedNuspecOutputPath)" (Version: "$(PackageVersion)"), therefore we cannot call "paket fix-nuspecs" and have to error out!' />
 

--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -82,32 +82,35 @@
     <PropertyGroup>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
+      <CacheFilesExist>false</CacheFilesExist>
+      <CacheFilesExist Condition=" Exists('$(PaketRestoreCacheFile)') And Exists('$(PaketLockFilePath)') ">true</CacheFilesExist>
     </PropertyGroup>
 
     <!-- Read the hash of the lockfile -->
-    <GetFileHash Files="$(PaketLockFilePath)" Algorithm="SHA256" HashEncoding="hex" >
+    <GetFileHash Condition=" '$(CacheFilesExist)' == 'true' " Files="$(PaketLockFilePath)" Algorithm="SHA256" HashEncoding="hex" >
       <Output TaskParameter="Hash" PropertyName="PaketRestoreLockFileHash" />
     </GetFileHash>
     <!-- Read the hash of the cache, which is json, but a very simple key value object -->
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(CacheFilesExist)' == 'true' ">
         <PaketRestoreCachedContents>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedContents>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition=" '$(CacheFilesExist)' == 'true' ">
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)">
-            <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
-            <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
+            Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
+          <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
+          <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
         </PaketRestoreCachedKeyValue>
     </ItemGroup>
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(CacheFilesExist)' == 'true' ">
         <!-- Retrieve the hashes we are interested in -->
         <PackagesDownloadedHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'packagesDownloadedHash' ">%(PaketRestoreCachedKeyValue.Value)</PackagesDownloadedHash>
         <ProjectsRestoredHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'projectsRestoredHash' ">%(PaketRestoreCachedKeyValue.Value)</ProjectsRestoredHash>
     </PropertyGroup>
 
-    <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
+    <PropertyGroup Condition=" '$(CacheFilesExist)' == 'true' ">
       <!-- If the restire file doesn't exist we need to restore, otherwise only if hashes don't match -->
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(ProjectsRestoredHash)' ">false</PaketRestoreRequired>

--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -73,34 +73,44 @@
     <MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
   </Target>
 
+  <!-- Official workaround for https://docs.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 -->
+  <UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildVersion)' &lt; '16.0.360' " />
+  <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildVersion)' &lt; '16.0.360' " />
   <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="PaketBootstrapping">
 
-    <!-- Step 1 Check if lockfile is properly restored -->
+    <!-- Step 1 Check if lockfile is properly restored (if the hash of the lockfile and the cache-file match) -->
     <PropertyGroup>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
     </PropertyGroup>
 
-    <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
+    <!-- Read the hash of the lockfile -->
+    <GetFileHash Files="$(PaketLockFilePath)" Algorithm="SHA256" HashEncoding="hex" >
+      <Output TaskParameter="Hash" PropertyName="PaketRestoreLockFileHash" />
+    </GetFileHash>
+    <!-- Read the hash of the cache, which is json, but a very simple key value object -->
     <PropertyGroup>
-      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketRestoreCacheFile)" | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
-      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketLockFilePath)" | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+        <PaketRestoreCachedContents>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedContents>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- Parse our simple 'paket.restore.cached' json ...-->
+        <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
+        <!-- Keep Key, Value ItemGroup-->
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)">
+            <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
+            <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
+        </PaketRestoreCachedKeyValue>
+    </ItemGroup>
+    <PropertyGroup>
+        <!-- Retrieve the hashes we are interested in -->
+        <PackagesDownloadedHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'packagesDownloadedHash' ">%(PaketRestoreCachedKeyValue.Value)</PackagesDownloadedHash>
+        <ProjectsRestoredHash Condition=" '%(PaketRestoreCachedKeyValue.Key)' == 'projectsRestoredHash' ">%(PaketRestoreCachedKeyValue.Value)</ProjectsRestoredHash>
     </PropertyGroup>
 
-    <!-- If shasum and awk exist get the hashes -->
-    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
-    </Exec>
-    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
-    </Exec>
-
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
-      <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
-      <PaketRestoreCachedHash Condition=" '$(PaketRestoreCachedHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
-      <PaketRestoreLockFileHash Condition=" '$(PaketRestoreLockFileHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
+      <!-- If the restire file doesn't exist we need to restore, otherwise only if hashes don't match -->
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(ProjectsRestoredHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
 


### PR DESCRIPTION
This has regressed countless times:
- (recently) https://github.com/fsprojects/Paket/pull/3598
- https://github.com/fsprojects/Paket/pull/3013
- https://github.com/fsprojects/Paket/pull/3200
- https://github.com/fsprojects/Paket/pull/3201
- https://github.com/fsprojects/Paket/pull/3206

The last regression was due to the change of the caching file to only contain hashes. This is tricky to fix in msbuild, but there is https://docs.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 which seems to produce the exact same hash we already generate in C# (when using SHA256 in hex format).
I guess this also replaces https://github.com/fsprojects/Paket/pull/2870, lets see if this actually works for everyone, if not we are doomed ;)

Therefore we:
- [x] Add (failing) integration test for #2684.
- [x] Fix the issue at hand