### PR TITLE
add roll-forward config to enable running on later major versions of the runtime

### DIFF
--- a/src/Paket.preview3/runtimeconfig.template.json
+++ b/src/Paket.preview3/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
+    // '2' allows for major-version roll-forward
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
partially-addresses #3634 by adding a runtime config file that lets the tool run on 3.0 without having to have the user do anything.  This file is pulled in by the build implicitly without being added to the project.  The final result of the template file being taken into consideration is:

```json
➜  netcoreapp2.1 git:(runtimesetting-rollforward) ✗ cat paket.runtimeconfig.json 
{
  "runtimeOptions": {
    "tfm": "netcoreapp2.1",
    "framework": {
      "name": "Microsoft.NETCore.App",
      "version": "2.1.0"
    },
    "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
    "rollForwardOnNoCandidateFx": 2
  }
```