### PR TITLE
3660: Add PaketCommand contidion for Paket installed as .NET Core 3.0 local tool

### DIFF
--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -55,6 +55,7 @@
     <!-- Paket command -->
     <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
     <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '' ">dotnet "$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(PaketCommand)' == '' ">"$(PaketExePath)"</PaketCommand>
 


### PR DESCRIPTION
Fixes: #3660 