### PR TITLE
Update getResolverStrategy for rootRequirements

### DIFF
--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -382,7 +382,7 @@ type Resolved = {
 
 let getResolverStrategy globalStrategyForDirectDependencies globalStrategyForTransitives (rootDependencies:IDictionary<PackageName,PackageRequirement>) (allRequirementsOfCurrentPackage:Set<PackageRequirement>) (currentRequirement:PackageRequirement) =
     let strategy =
-        if currentRequirement.Parent.IsRootRequirement() && Set.count allRequirementsOfCurrentPackage = 1 then
+        if currentRequirement.Parent.IsRootRequirement() then
             currentRequirement.ResolverStrategyForDirectDependencies ++ globalStrategyForDirectDependencies
         else
             match rootDependencies.TryGetValue currentRequirement.Name with

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -207,6 +207,8 @@ module ResolutionRaw =
                 let pr = formatPR req.VersionRequirement
                 let tp = if req.TransitivePrereleases then "*" else ""
                 match req.Parent with
+                | RuntimeDependency ->
+                    sprintf "   - Runtime Dependency requested package %O: %s%s%s" req.Name vr pr tp
                 | DependenciesFile _ ->
                     sprintf "   - Dependencies file requested package %O: %s%s%s" req.Name vr pr tp
                 | DependenciesLock(_,path) ->
@@ -483,7 +485,7 @@ let private explorePackageConfig (getPackageDetailsBlock:PackageDetailsSyncFunc)
 
         let settings =
             match dependency.Parent with
-            | DependenciesFile _ | DependenciesLock _ -> dependency.Settings
+            | DependenciesFile _ | DependenciesLock _ | RuntimeDependency -> dependency.Settings
             | Package _ ->
                 match pkgConfig.RootDependencies.TryGetValue packageDetails.Name with
                 | true, r -> r.Settings + dependency.Settings

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -384,7 +384,9 @@ type Resolved = {
 
 let getResolverStrategy globalStrategyForDirectDependencies globalStrategyForTransitives (rootDependencies:IDictionary<PackageName,PackageRequirement>) (allRequirementsOfCurrentPackage:Set<PackageRequirement>) (currentRequirement:PackageRequirement) =
     let strategy =
-        if currentRequirement.Parent.IsRootRequirement() then
+        if (currentRequirement.Parent.IsRootRequirement()) then
+            currentRequirement.ResolverStrategyForDirectDependencies ++ globalStrategyForDirectDependencies
+        elif (currentRequirement.Parent.IsRuntimeRequirement() && Set.count allRequirementsOfCurrentPackage = 1) then
             currentRequirement.ResolverStrategyForDirectDependencies ++ globalStrategyForDirectDependencies
         else
             match rootDependencies.TryGetValue currentRequirement.Name with

--- a/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
@@ -336,7 +336,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
                               VersionRequirement = versionReq
                               ResolverStrategyForDirectDependencies = group.Options.ResolverStrategyForDirectDependencies
                               ResolverStrategyForTransitives = group.Options.ResolverStrategyForTransitives
-                              Parent = PackageRequirementSource.DependenciesFile("runtimeresolution.dependencies",0)
+                              Parent = PackageRequirementSource.RuntimeDependency
                               Graph = Set.empty
                               Sources = group.Sources
                               Kind = PackageRequirementKind.Package
@@ -363,7 +363,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
                                 match oldDepsInfo with
                                 | Some d -> d.ResolverStrategyForTransitives
                                 | None -> group.Options.ResolverStrategyForTransitives
-                              Parent = PackageRequirementSource.DependenciesFile("runtimeresolution.dependencies",0)
+                              Parent = PackageRequirementSource.RuntimeDependency
                               Graph = Set.empty
                               Sources = group.Sources
                               Kind = PackageRequirementKind.Package

--- a/src/Paket.Core/Versioning/Requirements.fs
+++ b/src/Paket.Core/Versioning/Requirements.fs
@@ -1162,9 +1162,15 @@ type PackageRequirementSource =
 | DependenciesFile of string * int
 | DependenciesLock of string * string
 | Package of PackageName * SemVerInfo * PackageSource
+
     member this.IsRootRequirement() =
         match this with
         | DependenciesFile _ | DependenciesLock _ -> true
+        | _ -> false
+
+    member this.IsRuntimeRequirement() =
+        match this with
+        | RuntimeDependency -> true
         | _ -> false
 
     override this.ToString() =

--- a/src/Paket.Core/Versioning/Requirements.fs
+++ b/src/Paket.Core/Versioning/Requirements.fs
@@ -1158,6 +1158,7 @@ type RemoteFileInstallSettings =
             | _ -> None }
 
 type PackageRequirementSource =
+| RuntimeDependency
 | DependenciesFile of string * int
 | DependenciesLock of string * string
 | Package of PackageName * SemVerInfo * PackageSource
@@ -1168,6 +1169,7 @@ type PackageRequirementSource =
 
     override this.ToString() =
         match this with
+        | RuntimeDependency -> "Runtime Dependency"
         | DependenciesFile(x,_) -> x
         | DependenciesLock(_,x) -> x
         | Package(name,version,_) ->

--- a/tests/Paket.Tests/Resolver/GlobalOptimisticStrategySpecs.fs
+++ b/tests/Paket.Tests/Resolver/GlobalOptimisticStrategySpecs.fs
@@ -140,7 +140,7 @@ let ``should favor strategy from parent when it overrides``() =
     let resolved =
         DependenciesFile.FromSource(config)
         |> resolve graph2 UpdateMode.UpdateAll
-    getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.2.1"
+    getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.1"
@@ -159,7 +159,7 @@ let ``should favor strategy from parent that overrides strategy``() =
     let resolved =
         DependenciesFile.FromSource(config)
         |> resolve graph2 UpdateMode.UpdateAll
-    getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.2.1"
+    getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.0"

--- a/tests/Paket.Tests/Resolver/GlobalPessimisticStrategySpecs.fs
+++ b/tests/Paket.Tests/Resolver/GlobalPessimisticStrategySpecs.fs
@@ -130,7 +130,7 @@ let ``should favor strategy override when updating all``() =
         DependenciesFile.FromSource(config6)
         |> resolve graph2 UpdateMode.UpdateAll
     getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
-    getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.1"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.1"
 
 [<Test>]
@@ -139,7 +139,7 @@ let ``should respect overrides when updating single package``() =
         DependenciesFile.FromSource(config6)
         |> resolve graph2 (UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Windsor-NLog" |> PackageFilter.ofName))
     getVersion resolved.[PackageName "Castle.Windsor-NLog"] |> shouldEqual "3.3.0"
-    getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.0"
+    getVersion resolved.[PackageName "Castle.Core-NLog"] |> shouldEqual "3.3.1"
     getVersion resolved.[PackageName "Castle.Core"] |> shouldEqual "3.3.1"
 
 [<Test>]


### PR DESCRIPTION
When root requirement, us the resolver strategy for direct dependencies.
Even if it also has other requirements

Attempted fix for #3669 

And meaning that the statement `that all direct dependencies will still get their latest matching versions, no matter the value of the strategy option. If you want to influence the resolution of direct dependencies then read about the lowest_matching option.` in the docs is actually correct