### PR TITLE
Limit number of open connections to a server and add `PAKET_DEBUG_REQUESTS` to debug request failures.

### DIFF
--- a/src/Paket.Core.preview3/Paket.Core.fsproj
+++ b/src/Paket.Core.preview3/Paket.Core.fsproj
@@ -7,6 +7,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Version Condition="'$(PAKET_PROJ_VERSION)' != ''">$(PAKET_PROJ_VERSION)</Version>
     <PackageVersion Condition="'$(PAKET_PROJ_VERSION)' != ''">$(PAKET_PROJ_VERSION)</PackageVersion>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\AssemblyReader.fs">
@@ -104,11 +105,5 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);DOTNETCORE;NETSTANDARD1_5;NETSTANDARD1_6;USE_HTTP_CLIENT</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Label="dotnet pack instructions">
-    <Content Include="$(OutputPath)Paket.Core.pdb">
-      <Pack>true</Pack>
-      <PackagePath>lib/netstandard2.0</PackagePath>
-    </Content>
-  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Paket.Core.preview3/Paket.Core.fsproj
+++ b/src/Paket.Core.preview3/Paket.Core.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PaketCoreSourcesDir>..\Paket.Core</PaketCoreSourcesDir>
     <DefineConstants>NO_BOOTSTRAPPER;NO_CONFIGURATIONMANAGER;CUSTOM_WEBPROXY;$(DefineConstants)</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/Paket.Core.preview3/Paket.Core.fsproj
+++ b/src/Paket.Core.preview3/Paket.Core.fsproj
@@ -5,6 +5,7 @@
     <PaketCoreSourcesDir>..\Paket.Core</PaketCoreSourcesDir>
     <DefineConstants>NO_BOOTSTRAPPER;NO_CONFIGURATIONMANAGER;CUSTOM_WEBPROXY;$(DefineConstants)</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Version Condition="'$(PAKET_PROJ_VERSION)' != ''">$(PAKET_PROJ_VERSION)</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\AssemblyReader.fs">

--- a/src/Paket.Core.preview3/Paket.Core.fsproj
+++ b/src/Paket.Core.preview3/Paket.Core.fsproj
@@ -6,6 +6,7 @@
     <DefineConstants>NO_BOOTSTRAPPER;NO_CONFIGURATIONMANAGER;CUSTOM_WEBPROXY;$(DefineConstants)</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Version Condition="'$(PAKET_PROJ_VERSION)' != ''">$(PAKET_PROJ_VERSION)</Version>
+    <PackageVersion Condition="'$(PAKET_PROJ_VERSION)' != ''">$(PAKET_PROJ_VERSION)</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\AssemblyReader.fs">

--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -355,7 +355,7 @@ let useDefaultHandler =
         env = "true" || env = "yes" || env = "y"
 
 
-let createHttpHandlerRaw(url, auth: Auth option) : HttpClientHandler =
+let createHttpHandlerRaw(url, auth: Auth option) : HttpMessageHandler =
     let proxy = getDefaultProxyFor url
 #if !NO_WINCLIENTHANDLER
     if isWindows && not useDefaultHandler then
@@ -380,7 +380,7 @@ let createHttpHandlerRaw(url, auth: Auth option) : HttpClientHandler =
             handler.WindowsProxyUsePolicy <- WindowsProxyUsePolicy.UseWinInetProxy
         else
             handler.WindowsProxyUsePolicy <- WindowsProxyUsePolicy.UseCustomProxy
-        handler
+        handler :> _
     else
 #endif
     let handler =
@@ -403,7 +403,7 @@ let createHttpHandlerRaw(url, auth: Auth option) : HttpClientHandler =
         // handled via defaultrequestheaders
         ()
     handler.UseProxy <- true
-    handler
+    handler :> _
 
 
 let createHttpHandler = memoize createHttpHandlerRaw

--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -354,6 +354,9 @@ let useDefaultHandler =
         let env = env.ToLowerInvariant()
         env = "true" || env = "yes" || env = "y"
 
+// TODO:
+// re-use HttpClient instances and 
+// try to use MaxConnectionsPerServer = 4
 let createHttpClient (url,auth:Auth option) =
 #if !NO_WINCLIENTHANDLER
     if isWindows && not useDefaultHandler then

--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -392,7 +392,9 @@ let createHttpClientRaw (url,auth:Auth option) : HttpClient =
                 UseProxy = true,
                 Proxy = getDefaultProxyFor url)
         handler.AutomaticDecompression <- DecompressionMethods.GZip ||| DecompressionMethods.Deflate
+#if !NO_MAXCONNECTIONPERSERVER    
         handler.MaxConnectionsPerServer <- 4
+#endif    
         let client = new HttpClient(handler)
         client.Timeout <- Threading.Timeout.InfiniteTimeSpan
         match auth with

--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -73,7 +73,7 @@ type NuGetRequestGetVersions =
             try
                 return! r.DoRequest()
             with e ->
-                return FailedVersionRequest { Url = r.Url; Error = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture e }
+                return FailedVersionRequest { Url = r.Url; Error = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (exn(sprintf "Unhandled error in request to '%O' in NuGetRequestGetVersions.run" r.Url, e)) }
         }
 
 

--- a/src/Paket.Core/PackageManagement/Releases.fs
+++ b/src/Paket.Core/PackageManagement/Releases.fs
@@ -30,7 +30,7 @@ let private downloadLatestVersionOf files destDir =
     let auth = Environment.GetEnvironmentVariable "PAKET_GITHUB_API_TOKEN"
                |> fun x -> if isNull(x) then None else Some(Token(x))
 
-    use client = createHttpClient(Constants.GitHubUrl, auth)
+    let client = createHttpClient(Constants.GitHubUrl, auth)
 
     trial {
         let latest = "https://github.com/fsprojects/Paket/releases/latest";

--- a/src/Paket.Core/Paket.Core.fsproj
+++ b/src/Paket.Core/Paket.Core.fsproj
@@ -22,7 +22,7 @@
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <OutputPath>..\..\bin</OutputPath>
-    <DefineConstants>TRACE;DEBUG;USE_WEB_CLIENT_FOR_UPLOAD;NO_WINCLIENTHANDLER</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;USE_WEB_CLIENT_FOR_UPLOAD;NO_WINCLIENTHANDLER;NO_MAXCONNECTIONPERSERVER</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <StartArguments>update</StartArguments>
     <StartAction>Project</StartAction>

--- a/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
@@ -259,7 +259,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
                                     Environment.GetEnvironmentVariable "PAKET_GITHUB_API_TOKEN" |> fun x -> if isNull(x) then None else Some(Token(x))
                                    else
                                     None
-                        use client = createHttpClient(x, auth)
+                        let client = createHttpClient(x, auth)
                         let folder = DirectoryInfo(Path.Combine(Path.GetTempPath(),"external_paket",(hash x).ToString()))
                         if not folder.Exists then
                             folder.Create()

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -182,7 +182,7 @@ type PackageSource =
 
     static member WarnIfNoConnection (source,_) = 
         let n url (auth:AuthProvider) =
-            use client = NetUtils.createHttpClient(url, auth.Retrieve true)
+            let client = NetUtils.createHttpClient(url, auth.Retrieve true)
             try 
                 client.DownloadData url |> ignore 
             with _ ->


### PR DESCRIPTION
seeing in Azure DevOps FAKE Build, see https://github.com/fsharp/FAKE/pull/2384 

```
Standard Error Output should contain 'runtime error', but was: 'There was a problem while setting up the environment:
-> Unable to retrieve package versions for 'System.Security.AccessControl'
   -- CLOSED --
      Fake.Runtime  (from d:\a\1\s\integrationtests\core-simple-runtime-error\temp\.fake\runtime-error.fsx\paket.dependencies)
      FSharp.Core  (from d:\a\1\s\integrationtests\core-simple-runtime-error\temp\.fake\runtime-error.fsx\paket.dependencies)
      FSharp.Compiler.Service >= 31.0 (from Fake.Runtime 5.16.2-alpha.1275)
      Paket.Core >= 5.216 (from Fake.Runtime 5.16.2-alpha.1275)
      Fake.Core.Context >= 5.16.2-alpha.1275 (from Fake.Runtime 5.16.2-alpha.1275)
      FSharp.Core >= 4.7 (from Fake.Runtime 5.16.2-alpha.1275)
      System.Runtime.Loader >= 4.3 (from Fake.Runtime 5.16.2-alpha.1275)
      Microsoft.DotNet.PlatformAbstractions >= 2.1 (from Fake.Runtime 5.16.2-alpha.1275)
      Mono.Cecil >= 0.11 (from Fake.Runtime 5.16.2-alpha.1275)
      Newtonsoft.Json >= 10.0.3 (from Paket.Core 5.223.0)
      System.Net.Http.WinHttpHandler >= 4.5 (from Paket.Core 5.223.0)
      System.Security.Cryptography.ProtectedData >= 4.4 (from Paket.Core 5.223.0)
      System.Reflection.Emit >= 4.3 (from FSharp.Compiler.Service 32.0.0)
      System.Reflection.TypeExtensions >= 4.3 (from FSharp.Compiler.Service 32.0.0)
      System.Security.Cryptography.Algorithms >= 4.3 (from FSharp.Compiler.Service 32.0.0)
      System.IO >= 4.3 (from System.Runtime.Loader 4.3.0)
      System.Reflection >= 4.3 (from System.Runtime.Loader 4.3.0)
      System.Runtime >= 4.3 (from System.Runtime.Loader 4.3.0)
      System.Diagnostics.Process >= 4.1 (from FSharp.Compiler.Service 32.0.0)
      System.Diagnostics.TraceSource >= 4.0 (from FSharp.Compiler.Service 32.0.0)
      System.Reflection.Metadata >= 1.6 (from FSharp.Compiler.Service 32.0.0)
      Chessie >= 0.6 (from Paket.Core 5.223.0)
      System.Reflection.Emit.ILGeneration >= 4.6 (from System.Reflection.Emit 4.6.0)
      System.Memory >= 4.5.3 (from System.Net.Http.WinHttpHandler 4.6.0)
      System.Buffers >= 4.5 (from System.Net.Http.WinHttpHandler 4.6.0)
      runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.2 (from System.Security.Cryptography.Algorithms 4.3.1)
      runtime.native.System.Security.Cryptography.Apple >= 4.3.1 (from System.Security.Cryptography.Algorithms 4.3.1)
      Microsoft.Win32.Primitives >= 4.3 (from System.Diagnostics.Process 4.3.0)
      Microsoft.Win32.Registry >= 4.3 (from System.Diagnostics.Process 4.3.0)
      runtime.native.System >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.Diagnostics.Debug >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.Globalization >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.IO.FileSystem >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.IO.FileSystem.Primitives >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.Text.Encoding.Extensions >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.Threading >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.Threading.Thread >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.Threading.ThreadPool >= 4.3 (from System.Diagnostics.Process 4.3.0)
      System.Threading.Tasks >= 4.3 (from System.IO 4.3.0)
      System.Reflection.Primitives >= 4.3 (from System.Reflection 4.3.0)
      System.Collections >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Resources.ResourceManager >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Runtime.Extensions >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Runtime.Handles >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Runtime.InteropServices >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Runtime.Numerics >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Security.Cryptography.Encoding >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Security.Cryptography.Primitives >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      System.Text.Encoding >= 4.3 (from System.Security.Cryptography.Algorithms 4.3.1)
      NETStandard.Library >= 1.6 (from Chessie 0.6.0)
      System.Collections.Immutable >= 1.6 (from System.Reflection.Metadata 1.7.0)
      Microsoft.NETCore.Targets >= 1.1.3 (from System.Runtime 4.3.1)
      Microsoft.NETCore.Platforms >= 1.1.1 (from System.Runtime 4.3.1)
   -- OPEN ----
      System.Security.AccessControl >= 4.6 (from Microsoft.Win32.Registry 4.6.0)
      System.Security.Principal.Windows >= 4.6 (from Microsoft.Win32.Registry 4.6.0)
      System.Runtime.CompilerServices.Unsafe >= 4.5.2 (from System.Memory 4.5.3)
      System.Numerics.Vectors >= 4.4 (from System.Memory 4.5.3)
      runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl >= 4.3.3 (from runtime.native.System.Security.Cryptography.OpenSsl 4.3.3)
      runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple >= 4.3.1 (from runtime.native.System.Security.Cryptography.Apple 4.3.1)
      System.Runtime >= 4.3.1 (from System.Runtime.Extensions 4.3.1)
      System.Collections.Concurrent >= 4.3 (from System.Security.Cryptography.Encoding 4.3.0)
      System.Linq >= 4.3 (from System.Security.Cryptography.Encoding 4.3.0)
   StackTrace:
        at Paket.PackageResolver.getVersionsBlock@1057-1.GenerateNext(IEnumerable`1& next)
        at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1.MoveNextImpl() in E:\A\_work\130\s\src\fsharp\FSharp.Core\seqcore.fs:line 371
        at Microsoft.FSharp.Collections.SeqModule.oneStepTo@985[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 994
        at Microsoft.FSharp.Collections.SeqModule.action@4126-1[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i, Unit unitVar0) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 1009
        at Microsoft.FSharp.Collections.SeqModule.result@1001.Invoke(Int32 i)
        at Microsoft.FSharp.Collections.Internal.IEnumerator.unfold@205.DoMoveNext(b& curr) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 207
        at Microsoft.FSharp.Collections.Internal.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext() in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 64
        at Microsoft.FSharp.Collections.Internal.IEnumerator.map@75.DoMoveNext(b& curr) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 77
        at Microsoft.FSharp.Collections.Internal.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext() in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 64
        at Microsoft.FSharp.Collections.Internal.IEnumerator.next@193[T](FSharpFunc`2 f, IEnumerator`1 e, FSharpRef`1 started, Unit unitVar0) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 194
        at Microsoft.FSharp.Collections.Internal.IEnumerator.filter@188.System-Collections-IEnumerator-MoveNext() in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 196
        at Microsoft.FSharp.Collections.SeqModule.oneStepTo@985[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 994
        at Microsoft.FSharp.Collections.SeqModule.action@4126-1[T](IEnumerable`1 source, List`1 prefix, FSharpRef`1 enumeratorR, Int32 i, Unit unitVar0) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 1009
        at Microsoft.FSharp.Collections.SeqModule.result@1001.Invoke(Int32 i)
        at Microsoft.FSharp.Collections.Internal.IEnumerator.unfold@205.DoMoveNext(b& curr) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 207
        at Microsoft.FSharp.Collections.Internal.IEnumerator.MapEnumerator`1.System-Collections-IEnumerator-MoveNext() in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 64
        at Microsoft.FSharp.Collections.SeqModule.IsEmpty[T](IEnumerable`1 source) in E:\A\_work\130\s\src\fsharp\FSharp.Core\seq.fs:line 700
        at Paket.PackageResolver.getCompatibleVersions(ResolverStep currentStep, GroupName groupName, PackageRequirement currentRequirement, IDictionary`2 rootDependencies, FSharpFunc`2 getVersionsF, Boolean globalOverride, FSharpOption`1 globalStrategyForDirectDependencies, FSharpOption`1 globalStrategyForTransitives)
        at Paket.PackageResolver.step@1113(UpdateMode updateMode, GroupName groupName, FSharpOption`1 globalStrategyForTransitives, FSharpOption`1 globalStrategyForDirectDependencies, FrameworkRestrictions globalFrameworkRestrictions, FSharpFunc`2 getVersionsRaw, FSharpFunc`2 getPreferredVersionsRaw, FSharpFunc`2 getPackageDetailsRaw, FSharpSet`1 cliToolSettings, ResolverRequestQueue workerQueue, Int32 taskTimeout, TimeSpan loopTimeout, ConcurrentDictionary`2 startedGetPackageDetailsRequests, FSharpFunc`2 getPackageDetailsBlock, ConcurrentDictionary`2 startedGetVersionsRequests, FSharpOption`1 packageFilter, IDictionary`2 rootDependenciesDict, FSharpSet`1 lockedPackages, DateTime loopTime, Stage stage, StackPack stackpack, IEnumerable`1 compatibleVersions, StepFlags flags)
        at Paket.PackageResolver.Resolve(FSharpFunc`2 getVersionsRaw, FSharpFunc`2 getPreferredVersionsRaw, FSharpFunc`2 getPackageDetailsRaw, GroupName groupName, FSharpOption`1 globalStrategyForDirectDependencies, FSharpOption`1 globalStrategyForTransitives, FrameworkRestrictions globalFrameworkRestrictions, FSharpSet`1 rootDependencies, UpdateMode updateMode)
        at <StartupCode$Paket-Core>.$DependenciesFile.resolveGroup@222-1.Invoke(GroupName groupName, b _arg1)
        at Microsoft.FSharp.Collections.MapTreeModule.mapiOpt[a,b,c](FSharpFunc`3 f, MapTree`2 m) in E:\A\_work\130\s\src\fsharp\FSharp.Core\map.fs:line 285
        at Microsoft.FSharp.Collections.FSharpMap`2.Map[b](FSharpFunc`2 f) in E:\A\_work\130\s\src\fsharp\FSharp.Core\map.fs:line 552
        at Paket.UpdateProcess.selectiveUpdate(Boolean force, FSharpFunc`2 getSha1, FSharpFunc`2 getVersionsF, FSharpFunc`2 getPackageDetailsF, FSharpFunc`2 getRuntimeGraphFromPackage, LockFile lockFile, DependenciesFile dependenciesFile, UpdateMode updateMode, SemVerUpdateMode semVerUpdateMode)
        at Paket.UpdateProcess.SelectiveUpdate(DependenciesFile dependenciesFile, FSharpOption`1 alternativeProjectRoot, UpdateMode updateMode, SemVerUpdateMode semVerUpdateMode, Boolean force)
        at Paket.UpdateProcess.SmartInstall(DependenciesFile dependenciesFile, UpdateMode updateMode, UpdaterOptions options)
        at Paket.UpdateProcess.UpdateGroup(String dependenciesFileName, GroupName groupName, UpdaterOptions options)
        at <StartupCode$Paket-Core>.$PublicAPI.UpdateGroup@336-3.Invoke(Unit unitVar0)
        at Paket.Utils.RunInLockedAccessMode[a](String lockedFolder, FSharpFunc`2 action)
        at Fake.Runtime.FakeRuntime.restoreOrUpdate@242(FakeConfig config, String cacheDir, Dependencies paketApi, FSharpOption`1 group, VerboseLevel logLevel, String script, String groupStr, FileInfo lockFilePath, Unit unitVar0) in d:\a\1\s\src\app\Fake.Runtime\FakeRuntime.fs:line 243
        at Fake.Runtime.FakeRuntime.paketCachingProvider(FakeConfig config, String cacheDir, Dependencies paketApi, Lazy`1 paketDependenciesFile, FSharpOption`1 group) in d:\a\1\s\src\app\Fake.Runtime\FakeRuntime.fs:line 345
        at Fake.Runtime.FakeRuntime.runScript(PrepareInfo preparedScript) in d:\a\1\s\src\app\Fake.Runtime\FakeRuntime.fs:line 596
        at Program.runOrBuild(RunArguments args) in d:\a\1\s\src\app\Fake.netcore\Program.fs:line 156
-> One or more errors occurred. (One or more errors occurred. (Could not find versions for package System.Security.AccessControl on any of ["https://api.nuget.org/v3/index.json"; "..\..\../../../release/dotnetcore"]. (Source 'https://api.nuget.org/v3/index.json' yielded no results (Request 'https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/index.json?semVerLevel=2.0.0' finished with error)) (Source '..\..\../../../release/dotnetcore' yielded (0): [] (Request 'd:\a\1\s\release\dotnetcore' finished with: []))))
   StackTrace:
        at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
        at Paket.PackageResolver.ResolverTaskMemory`1.Wait(Int32 timeout)
        at Paket.PackageResolver.getAndReport@994[a](Int32 taskTimeout, FSharpList`1 sources, BlockReason blockReason, ResolverTaskMemory`1 mem)
        at Paket.PackageResolver.getVersionsBlock@1057-1.GenerateNext(IEnumerable`1& next)
-> One or more errors occurred. (Could not find versions for package System.Security.AccessControl on any of ["https://api.nuget.org/v3/index.json"; "..\..\../../../release/dotnetcore"]. (Source 'https://api.nuget.org/v3/index.json' yielded no results (Request 'https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/index.json?semVerLevel=2.0.0' finished with error)) (Source '..\..\../../../release/dotnetcore' yielded (0): [] (Request 'd:\a\1\s\release\dotnetcore' finished with: [])))
-> Could not find versions for package System.Security.AccessControl on any of ["https://api.nuget.org/v3/index.json"; "..\..\../../../release/dotnetcore"]. (Source 'https://api.nuget.org/v3/index.json' yielded no results (Request 'https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/index.json?semVerLevel=2.0.0' finished with error)) (Source '..\..\../../../release/dotnetcore' yielded (0): [] (Request 'd:\a\1\s\release\dotnetcore' finished with: []))
   StackTrace:
        at Paket.NuGet.GetVersions@749-7.Invoke(GetVersionRequestResult _arg6)
        at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck[a,b](AsyncActivation`1 ctxt, FSharpFunc`2 userCode, b result1) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 417
        at <StartupCode$FSharp-Core>.$Async.Return@1066.Invoke(AsyncActivation`1 ctxt) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 1066
        at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 109
	-  Source 'https://api.nuget.org/v3/index.json' yielded no results (Request 'https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/index.json?semVerLevel=2.0.0' finished with error)
	-> Request 'https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/index.json?semVerLevel=2.0.0' finished with error
	-> HttpRequestException: An error occurred while sending the request.
	   StackTrace:
	        at Paket.NetUtils._safeGetFromUrl@573-9.Invoke(Exception _arg5)
	        at <StartupCode$FSharp-Core>.$Async.TryWith@1082-1.Invoke(Exception exn) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 1082
	        at Microsoft.FSharp.Control.AsyncPrimitives.CallFilterThenInvoke[T](AsyncActivation`1 ctxt, FSharpFunc`2 catchFilter, ExceptionDispatchInfo edi) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 436
	        at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 109
	-> WinHttpException: Error 12002 calling WINHTTP_CALLBACK_STATUS_REQUEST_ERROR, 'The operation timed out'.
	   StackTrace:
	        at System.Threading.Tasks.RendezvousAwaitable`1.GetResult()
	        at System.Net.Http.WinHttpHandler.StartRequest(WinHttpRequestState state)
	-  Source '..\..\../../../release/dotnetcore' yielded (0): [] (Request 'd:\a\1\s\release\dotnetcore' finished with: [])
	-> Request 'd:\a\1\s\release\dotnetcore' finished with: []', Out: 'Hint: If you just upgraded the fake-runner you can try to remove the .fake directory and try again.'. Actual value was false but had expected it to be true.
   at Fake.Core.IntegrationTests.SimpleHelloWorldTests.tests@66-40.Invoke(Unit _arg5) in d:\a\1\s\src\test\Fake.Core.IntegrationTests\SimpleHelloWorldTests.fs:line 73
   at Expecto.Impl.execTestAsync@960-1.Invoke(Unit unitVar) in C:\Users\Anthony Lloyd\src\expecto\Expecto\Expecto.fs:line 964
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 398
   at <StartupCode$FSharp-Core>.$Async.StartChild@1650-5.Invoke(AsyncActivation`1 ctxt) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 1650
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in E:\A\_work\130\s\src\fsharp\FSharp.Core\async.fs:line 109‌ ‌&lt;‌Expecto‌&gt;‌
00D‌5hd:\a\1\s\integrationtests\core-reference-fake-runtime\temp&gt; &quot;d:\a\1\s\release\dotnetcore\Fake.netcore\current\fake.exe&quot; --silent run reference_fake-runtime.fsx (In: false, Out: true, Err: true)‌

```

I see various Integration tests failing and this basically blocks me from releasing FAKE.