### PR TITLE
Added nugetV3 detection for index.json

### DIFF
--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -150,7 +150,7 @@ type PackageSource =
 #endif
                     LocalNuGet(source,None)
                 else 
-                    if source.Contains("/v3/") then
+                    if source.Contains("/v3/") || source.EndsWith("index.json") then
                         NuGetV3 { Url = source; Authentication = auth }
                     else
                         NuGetV2 { Url = source; Authentication = auth }


### PR DESCRIPTION
Currently Paket can't pull packages from github registry as the registry is Nuget V3 only and has the structure `https://nuget.pkg.github.com/{user}/index.json`

This PR aims to fix that