### PR TITLE
Use package details from extracted files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 5.230.0-alpha001 - 2019-11-04
+* PERFORMANCE: Use package details from extracted files
+
 #### 5.229.0 - 2019-11-04
 * PERFORMANCE: Prefer latest AutoComplete server
 

--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -529,7 +529,7 @@ let ``#2520 interproject-references parameter overide --pin-project-references``
     use __ = paket ("pack --pin-project-references \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
-    let nuspec = NuGetCache.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupkg package
     let dependency =
         match nuspec.Dependencies.Value with
         | [d] -> d
@@ -552,7 +552,7 @@ let ``#2520 --interproject-references cli parameter overide interproject-referen
     use __ = paket ("pack --interproject-references keep-minor \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
-    let nuspec = NuGetCache.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupkg package
     let dependency =
         match nuspec.Dependencies.Value with
         | [d] -> d
@@ -578,7 +578,7 @@ let ``#2694 paket fixnuspec should not remove project references``() =
 
     let nupkgPath = wd @@ "bin" @@ "Debug" @@ project + ".1.0.0.nupkg"
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupkg nupkgPath
     match nuspec.Dependencies.Value |> Seq.tryFind (fun (name,_,_) -> name = PackageName "library") with
     | None -> Assert.Fail("Expected package to still contain the project reference!")
     | Some s -> ignore s
@@ -647,7 +647,7 @@ let ``#3317 pack multitarget with p2p`` () =
     let nupkgPath = Path.Combine(outPath, "MyProj.Main.1.0.0.nupkg")
 
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupkg nupkgPath
     let depsByTfm byTfm = nuspec.Dependencies.Value |> Seq.choose (fun (pkgName,version,tfm) -> if (tfm.GetExplicitRestriction()) = byTfm then Some (pkgName,version) else None) |> Seq.toList
     let pkgVer name version = (PackageName name), (VersionRequirement.Parse version)
 
@@ -683,7 +683,7 @@ let ``#4002 dotnet pack of a global tool shouldnt contain references``() =
 
     let nupkgPath = Path.Combine(outPath, project + ".1.0.0.nupkg")
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupkg nupkgPath
 
     printfn "%A" nuspec
 
@@ -718,7 +718,7 @@ let ``#4003 dotnet pack of a global tool with p2p``() =
 
     let nupkgPath = Path.Combine(outPath, project + ".1.0.0.nupkg")
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupkg nupkgPath
 
     printfn "%A" nuspec
 
@@ -815,7 +815,7 @@ let ``#2776 transitive project references included`` () =
     Path.Combine(outPath, "lib", "netstandard2.0", "C.dll") |> checkFileExists
     Path.Combine(outPath, "lib", "netstandard2.0", "D.dll") |> checkFileExists
 
-    let nuspec = NuGetCache.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupkg package
     let dependencies = nuspec.Dependencies.Value |> Seq.map (fun (x,_,_) -> x)
     dependencies |> shouldContain (PackageName "nlog")
 
@@ -836,7 +836,7 @@ let ``#2776 transitive references stops on project with template`` () =
     File.Exists(Path.Combine(outPath, "lib", "netstandard2.0", "C.dll")) |> shouldEqual false
     File.Exists(Path.Combine(outPath, "lib", "netstandard2.0", "D.dll")) |> shouldEqual false
 
-    let nuspec = NuGetCache.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupkg package
     let dependencies = nuspec.Dependencies.Value |> Seq.map (fun (x,_,_) -> x)
 
     dependencies |> shouldContain (PackageName "C")
@@ -867,7 +867,7 @@ let ``#3558 pack multitarget with p2p by tfm`` () =
         let nupkgPath = Path.Combine(outPath, "MyProj.Common.1.0.0.nupkg")
 
         if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-        let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
+        let nuspec = NuGetCache.getNuSpecFromNupkg nupkgPath
         printfn "%A" nuspec
         printfn "%A" nuspec.Dependencies.Value
         let depsByTfm byTfm = nuspec.Dependencies.Value |> Seq.choose (fun (pkgName,version,tfm) -> if (tfm.GetExplicitRestriction()) = byTfm then Some (pkgName,version) else None) |> Seq.toList
@@ -889,7 +889,7 @@ let ``#3558 pack multitarget with p2p by tfm`` () =
         let nupkgPath = Path.Combine(outPath, "MyProj.Main.1.0.0.nupkg")
 
         if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-        let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
+        let nuspec = NuGetCache.getNuSpecFromNupkg nupkgPath
         printfn "%A" nuspec
         printfn "%A" nuspec.Dependencies.Value
         let depsByTfm byTfm = nuspec.Dependencies.Value |> Seq.choose (fun (pkgName,version,tfm) -> if (tfm.GetExplicitRestriction()) = byTfm then Some (pkgName,version) else None) |> Seq.toList

--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -529,7 +529,7 @@ let ``#2520 interproject-references parameter overide --pin-project-references``
     use __ = paket ("pack --pin-project-references \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
-    let nuspec = NuGetLocal.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupgk package
     let dependency =
         match nuspec.Dependencies.Value with
         | [d] -> d
@@ -552,7 +552,7 @@ let ``#2520 --interproject-references cli parameter overide interproject-referen
     use __ = paket ("pack --interproject-references keep-minor \"" + outPath + "\"") scenario |> fst
     ZipFile.ExtractToDirectory(package, outPath)
 
-    let nuspec = NuGetLocal.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupgk package
     let dependency =
         match nuspec.Dependencies.Value with
         | [d] -> d
@@ -578,7 +578,7 @@ let ``#2694 paket fixnuspec should not remove project references``() =
 
     let nupkgPath = wd @@ "bin" @@ "Debug" @@ project + ".1.0.0.nupkg"
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetLocal.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
     match nuspec.Dependencies.Value |> Seq.tryFind (fun (name,_,_) -> name = PackageName "library") with
     | None -> Assert.Fail("Expected package to still contain the project reference!")
     | Some s -> ignore s
@@ -647,7 +647,7 @@ let ``#3317 pack multitarget with p2p`` () =
     let nupkgPath = Path.Combine(outPath, "MyProj.Main.1.0.0.nupkg")
 
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetLocal.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
     let depsByTfm byTfm = nuspec.Dependencies.Value |> Seq.choose (fun (pkgName,version,tfm) -> if (tfm.GetExplicitRestriction()) = byTfm then Some (pkgName,version) else None) |> Seq.toList
     let pkgVer name version = (PackageName name), (VersionRequirement.Parse version)
 
@@ -683,7 +683,7 @@ let ``#4002 dotnet pack of a global tool shouldnt contain references``() =
 
     let nupkgPath = Path.Combine(outPath, project + ".1.0.0.nupkg")
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetLocal.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
 
     printfn "%A" nuspec
 
@@ -718,7 +718,7 @@ let ``#4003 dotnet pack of a global tool with p2p``() =
 
     let nupkgPath = Path.Combine(outPath, project + ".1.0.0.nupkg")
     if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-    let nuspec = NuGetLocal.getNuSpecFromNupgk nupkgPath
+    let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
 
     printfn "%A" nuspec
 
@@ -815,7 +815,7 @@ let ``#2776 transitive project references included`` () =
     Path.Combine(outPath, "lib", "netstandard2.0", "C.dll") |> checkFileExists
     Path.Combine(outPath, "lib", "netstandard2.0", "D.dll") |> checkFileExists
 
-    let nuspec = NuGetLocal.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupgk package
     let dependencies = nuspec.Dependencies.Value |> Seq.map (fun (x,_,_) -> x)
     dependencies |> shouldContain (PackageName "nlog")
 
@@ -836,7 +836,7 @@ let ``#2776 transitive references stops on project with template`` () =
     File.Exists(Path.Combine(outPath, "lib", "netstandard2.0", "C.dll")) |> shouldEqual false
     File.Exists(Path.Combine(outPath, "lib", "netstandard2.0", "D.dll")) |> shouldEqual false
 
-    let nuspec = NuGetLocal.getNuSpecFromNupgk package
+    let nuspec = NuGetCache.getNuSpecFromNupgk package
     let dependencies = nuspec.Dependencies.Value |> Seq.map (fun (x,_,_) -> x)
 
     dependencies |> shouldContain (PackageName "C")
@@ -867,7 +867,7 @@ let ``#3558 pack multitarget with p2p by tfm`` () =
         let nupkgPath = Path.Combine(outPath, "MyProj.Common.1.0.0.nupkg")
 
         if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-        let nuspec = NuGetLocal.getNuSpecFromNupgk nupkgPath
+        let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
         printfn "%A" nuspec
         printfn "%A" nuspec.Dependencies.Value
         let depsByTfm byTfm = nuspec.Dependencies.Value |> Seq.choose (fun (pkgName,version,tfm) -> if (tfm.GetExplicitRestriction()) = byTfm then Some (pkgName,version) else None) |> Seq.toList
@@ -889,7 +889,7 @@ let ``#3558 pack multitarget with p2p by tfm`` () =
         let nupkgPath = Path.Combine(outPath, "MyProj.Main.1.0.0.nupkg")
 
         if File.Exists nupkgPath |> not then Assert.Fail(sprintf "Expected '%s' to exist" nupkgPath)
-        let nuspec = NuGetLocal.getNuSpecFromNupgk nupkgPath
+        let nuspec = NuGetCache.getNuSpecFromNupgk nupkgPath
         printfn "%A" nuspec
         printfn "%A" nuspec.Dependencies.Value
         let depsByTfm byTfm = nuspec.Dependencies.Value |> Seq.choose (fun (pkgName,version,tfm) -> if (tfm.GetExplicitRestriction()) = byTfm then Some (pkgName,version) else None) |> Seq.toList

--- a/src/LockFileComparer/AssemblyInfo.fs
+++ b/src/LockFileComparer/AssemblyInfo.fs
@@ -6,9 +6,9 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A dependency manager for .NET with support for NuGet packages and git repositories.")>]
-[<assembly: AssemblyVersionAttribute("5.229.0")>]
-[<assembly: AssemblyFileVersionAttribute("5.229.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("5.229.0")>]
+[<assembly: AssemblyVersionAttribute("5.230.0")>]
+[<assembly: AssemblyFileVersionAttribute("5.230.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("5.230.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,6 +16,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyProduct = "Paket"
     let [<Literal>] AssemblyCompany = "Paket team"
     let [<Literal>] AssemblyDescription = "A dependency manager for .NET with support for NuGet packages and git repositories."
-    let [<Literal>] AssemblyVersion = "5.229.0"
-    let [<Literal>] AssemblyFileVersion = "5.229.0"
-    let [<Literal>] AssemblyInformationalVersion = "5.229.0"
+    let [<Literal>] AssemblyVersion = "5.230.0"
+    let [<Literal>] AssemblyFileVersion = "5.230.0"
+    let [<Literal>] AssemblyInformationalVersion = "5.230.0-alpha001"

--- a/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/src/Paket.Bootstrapper/Properties/AssemblyInfo.cs
@@ -4,16 +4,16 @@ using System.Reflection;
 [assembly: AssemblyTitleAttribute("Paket.Bootstrapper")]
 [assembly: AssemblyProductAttribute("Paket")]
 [assembly: AssemblyDescriptionAttribute("A dependency manager for .NET with support for NuGet packages and git repositories.")]
-[assembly: AssemblyVersionAttribute("5.229.0")]
-[assembly: AssemblyFileVersionAttribute("5.229.0")]
-[assembly: AssemblyInformationalVersionAttribute("5.229.0")]
+[assembly: AssemblyVersionAttribute("5.230.0")]
+[assembly: AssemblyFileVersionAttribute("5.230.0")]
+[assembly: AssemblyInformationalVersionAttribute("5.230.0-alpha001")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "Paket.Bootstrapper";
         internal const System.String AssemblyProduct = "Paket";
         internal const System.String AssemblyDescription = "A dependency manager for .NET with support for NuGet packages and git repositories.";
-        internal const System.String AssemblyVersion = "5.229.0";
-        internal const System.String AssemblyFileVersion = "5.229.0";
-        internal const System.String AssemblyInformationalVersion = "5.229.0";
+        internal const System.String AssemblyVersion = "5.230.0";
+        internal const System.String AssemblyFileVersion = "5.230.0";
+        internal const System.String AssemblyInformationalVersion = "5.230.0-alpha001";
     }
 }

--- a/src/Paket.Core/AssemblyInfo.fs
+++ b/src/Paket.Core/AssemblyInfo.fs
@@ -6,9 +6,9 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A dependency manager for .NET with support for NuGet packages and git repositories.")>]
-[<assembly: AssemblyVersionAttribute("5.229.0")>]
-[<assembly: AssemblyFileVersionAttribute("5.229.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("5.229.0")>]
+[<assembly: AssemblyVersionAttribute("5.230.0")>]
+[<assembly: AssemblyFileVersionAttribute("5.230.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("5.230.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,6 +16,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyProduct = "Paket"
     let [<Literal>] AssemblyCompany = "Paket team"
     let [<Literal>] AssemblyDescription = "A dependency manager for .NET with support for NuGet packages and git repositories."
-    let [<Literal>] AssemblyVersion = "5.229.0"
-    let [<Literal>] AssemblyFileVersion = "5.229.0"
-    let [<Literal>] AssemblyInformationalVersion = "5.229.0"
+    let [<Literal>] AssemblyVersion = "5.230.0"
+    let [<Literal>] AssemblyFileVersion = "5.230.0"
+    let [<Literal>] AssemblyInformationalVersion = "5.230.0-alpha001"

--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -382,7 +382,7 @@ let tryFindLocalPackage directory (packageName:PackageName) (version:SemVerInfo)
 
 
 /// Reads nuspec from nupkg
-let getNuSpecFromNupgk (fileName:string) =
+let getNuSpecFromNupkg (fileName:string) =
     use __ = Profile.startCategory Profile.Category.FileIO
     let nuspecFile = FileInfo(fileName.Replace(".nupkg",".nuspec"))
     if nuspecFile.Exists then
@@ -399,7 +399,7 @@ let getCacheDataFromExtractedPackage (packageName:PackageName) (version:SemVerIn
     match TryGetFallbackNupkg packageName version with
     | Some nupkg ->
         let fi = FileInfo nupkg
-        let nuspec = getNuSpecFromNupgk nupkg
+        let nuspec = getNuSpecFromNupkg nupkg
         return
             { PackageName = nuspec.OfficialName
               DownloadUrl = packageName.ToString()
@@ -416,7 +416,7 @@ let getCacheDataFromExtractedPackage (packageName:PackageName) (version:SemVerIn
         let targetFolder = DirectoryInfo(dir)
         match tryFindLocalPackage targetFolder.FullName packageName version with
         | Some nupkg ->
-            let nuspec = getNuSpecFromNupgk nupkg.FullName
+            let nuspec = getNuSpecFromNupkg nupkg.FullName
             return
                 { PackageName = nuspec.OfficialName
                   DownloadUrl = packageName.ToString()

--- a/src/Paket.Core/Dependencies/NuGetLocal.fs
+++ b/src/Paket.Core/Dependencies/NuGetLocal.fs
@@ -30,19 +30,6 @@ let getAllVersionsFromLocalPath (isCache, localNugetPath, package:PackageName, a
             return SuccessResponse(versions)
         })
 
-/// Reads packageName and version from .nupkg file name
-let parsePackageInfoFromFileName fileName : (PackageName * SemVerInfo) option =
-    let regex = Regex ("^(?<name>.*?)\.(?<version>\d.*)\.nupkg$", RegexOptions.IgnoreCase)
-    match regex.Match fileName with
-    | matchResult when matchResult.Success && matchResult.Groups.Count = 3 -> 
-        try
-            let semVer = SemVer.Parse matchResult.Groups.["version"].Value
-            let packageName = PackageName matchResult.Groups.["name"].Value 
-            Some (packageName, semVer)
-        with
-        | _ -> None        
-    | _ -> None
-
 let findLocalPackage directory (packageName:PackageName) (version:SemVerInfo) =
     if not (Directory.Exists directory) then
         failwithf "The package %O %O can't be found in %s. (The directory doesn't exist.)%sPlease check the feed definition in your paket.dependencies file." packageName version directory Environment.NewLine
@@ -52,11 +39,11 @@ let findLocalPackage directory (packageName:PackageName) (version:SemVerInfo) =
     let v2 = FileInfo(Path.Combine(directory, sprintf "%O.%s.nupkg" packageName normalizedVersion))
     if v2.Exists then v2 else
 
-    let condition x = 
+    let condition x =
         match parsePackageInfoFromFileName x with
         | Some (name, ver) -> packageName = name && version = ver
-        | None -> false 
-        
+        | None -> false
+
     let v3 =
         Directory.EnumerateFiles(directory,"*.nupkg",SearchOption.AllDirectories)
         |> Seq.tryFind (Path.GetFileName >> condition)
@@ -64,16 +51,6 @@ let findLocalPackage directory (packageName:PackageName) (version:SemVerInfo) =
     match v3 with
     | None -> failwithf "The package %O %O can't be found in %s.%sPlease check the feed definition in your paket.dependencies file." packageName version directory Environment.NewLine
     | Some x -> FileInfo x
-
-/// Reads nuspec from nupkg
-let getNuSpecFromNupgk fileName =
-    use __ = Profile.startCategory Profile.Category.FileIO
-    fixArchive fileName
-    use zipToCreate = new FileStream(fileName, FileMode.Open, FileAccess.Read)
-    use zip = new ZipArchive(zipToCreate, ZipArchiveMode.Read)
-    let zippedNuspec = zip.Entries |> Seq.find (fun f -> f.FullName.EndsWith ".nuspec")
-    use stream = zippedNuspec.Open()
-    Nuspec.Load(Path.Combine(fileName, Path.GetFileName zippedNuspec.FullName), stream)
 
 /// Reads package name from a nupkg file
 let getPackageNameFromLocalFile fileName =

--- a/src/Paket.Core/Dependencies/NuGetLocal.fs
+++ b/src/Paket.Core/Dependencies/NuGetLocal.fs
@@ -54,7 +54,7 @@ let findLocalPackage directory (packageName:PackageName) (version:SemVerInfo) =
 
 /// Reads package name from a nupkg file
 let getPackageNameFromLocalFile fileName =
-    let nuspec = getNuSpecFromNupgk fileName
+    let nuspec = getNuSpecFromNupkg fileName
     nuspec.OfficialName
 
 /// Reads direct dependencies from a nupkg file
@@ -64,7 +64,7 @@ let getDetailsFromLocalNuGetPackage isCache alternativeProjectRoot root localNuG
         let di = getDirectoryInfoForLocalNuGetFeed localNugetPath alternativeProjectRoot root
         let nupkg = findLocalPackage di.FullName packageName version
 
-        let nuspec = getNuSpecFromNupgk nupkg.FullName
+        let nuspec = getNuSpecFromNupkg nupkg.FullName
 
         return
             { PackageName = nuspec.OfficialName

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -46,6 +46,7 @@ type NugetV3ResourceType =
         | AutoComplete -> "SearchAutoCompleteService"
         | AllVersionsAPI -> "PackageBaseAddress"
         | PackageIndex -> "RegistrationsBaseUrl"
+
     member this.AcceptedVersions =
         match this with
         | AutoComplete -> ([ "3.0.0-rc"; "3.0.0-beta" ] |> List.map (SemVer.Parse >> Some)) @ [None]

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -1301,6 +1301,7 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
                                 let! versions = (requestVersions).Work.Task |> Async.AwaitTask
                                 // Preload the first version in range of this requirement
                                 for ((verToPreload, sources), prio) in selectVersionsToPreload verReq fst versions do
+
                                     let w = startRequestGetPackageDetails (GetPackageDetailsParameters.ofParams sources groupName pack verToPreload)
                                     w.Work.TryReprioritize true prio
                                 return ()

--- a/src/Paket.Core/Dependencies/PackageResolver.fs
+++ b/src/Paket.Core/Dependencies/PackageResolver.fs
@@ -1301,7 +1301,6 @@ let Resolve (getVersionsRaw : PackageVersionsFunc, getPreferredVersionsRaw : Pre
                                 let! versions = (requestVersions).Work.Task |> Async.AwaitTask
                                 // Preload the first version in range of this requirement
                                 for ((verToPreload, sources), prio) in selectVersionsToPreload verReq fst versions do
-
                                     let w = startRequestGetPackageDetails (GetPackageDetailsParameters.ofParams sources groupName pack verToPreload)
                                     w.Work.TryReprioritize true prio
                                 return ()

--- a/src/Paket/AssemblyInfo.fs
+++ b/src/Paket/AssemblyInfo.fs
@@ -6,9 +6,9 @@ open System.Reflection
 [<assembly: AssemblyProductAttribute("Paket")>]
 [<assembly: AssemblyCompanyAttribute("Paket team")>]
 [<assembly: AssemblyDescriptionAttribute("A dependency manager for .NET with support for NuGet packages and git repositories.")>]
-[<assembly: AssemblyVersionAttribute("5.229.0")>]
-[<assembly: AssemblyFileVersionAttribute("5.229.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("5.229.0")>]
+[<assembly: AssemblyVersionAttribute("5.230.0")>]
+[<assembly: AssemblyFileVersionAttribute("5.230.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("5.230.0-alpha001")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,6 +16,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyProduct = "Paket"
     let [<Literal>] AssemblyCompany = "Paket team"
     let [<Literal>] AssemblyDescription = "A dependency manager for .NET with support for NuGet packages and git repositories."
-    let [<Literal>] AssemblyVersion = "5.229.0"
-    let [<Literal>] AssemblyFileVersion = "5.229.0"
-    let [<Literal>] AssemblyInformationalVersion = "5.229.0"
+    let [<Literal>] AssemblyVersion = "5.230.0"
+    let [<Literal>] AssemblyFileVersion = "5.230.0"
+    let [<Literal>] AssemblyInformationalVersion = "5.230.0-alpha001"

--- a/tests/Paket.Tests/NuGetLocal/NuGetLocalSpecs.fs
+++ b/tests/Paket.Tests/NuGetLocal/NuGetLocalSpecs.fs
@@ -4,6 +4,7 @@ open Paket.Domain
 open NUnit.Framework
 open FsUnit
 open Paket.NuGetLocal
+open Paket.NuGetCache
 open System.IO
 
 


### PR DESCRIPTION
two improvements:

1) instead of getting package details (meta data) from NuGet API we first try to look if we already have the package in some local cache. If so then we extract it's nuspec and use the meta data from within. This saves a lot of request in early stages after SDK installation. The main packages of .NET Standard and asp.net are often already in the NuGet Fallback folder.

2) in our lookahead routine we didn't deduplicate requests. We now do that and also we limit to 3 versions lookahead instead of 10.  