### PR TITLE
Why - Use HashSet for visited nodes - fixes #3702

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -93,7 +93,7 @@ let stable =
 
 let testSuiteFilterFlakyTests = getEnvironmentVarAsBoolOrDefault "PAKET_TESTSUITE_FLAKYTESTS" false
 
-let genFSAssemblyInfo (projectPath) =
+let genFSAssemblyInfo (projectPath: string) =
     let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)
     let folderName = System.IO.Path.GetFileName(System.IO.Path.GetDirectoryName(projectPath))
     let basePath = "src" @@ folderName
@@ -107,7 +107,7 @@ let genFSAssemblyInfo (projectPath) =
         Attribute.FileVersion release.AssemblyVersion
         Attribute.InformationalVersion release.NugetVersion ]
 
-let genCSAssemblyInfo (projectPath) =
+let genCSAssemblyInfo (projectPath: string) =
     let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)
     let folderName = System.IO.Path.GetDirectoryName(projectPath)
     let basePath = folderName @@ "Properties"


### PR DESCRIPTION
Before we used immutable `Set` which didn't preserve visited nodes when traversing the graph, so we ended up searching same nodes over and over again. Using HashSet in place makes sure the list is preserved. 