### PR TITLE
Added BootstrapperOutputDir to config

### DIFF
--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -88,7 +88,7 @@ Example:
 * `ForceNuget`: Same as `--force-nuget` option.
 * `Prerelease`: Same as `prerelease` option.
 * `PaketVersion`: Same as `<version>` option.
-* `BootstrapperOuputDir`: Same as `--output-dir=` option.
+* `BootstrapperOutputDir`: Same as `--output-dir=` option.
 
 ### With environment variables
 
@@ -174,9 +174,9 @@ A few default settings are applied:
   once to restore normal output or twice to show more details.
 * If no version is specified a default `--max-file-age` of `12` hours is used.
 
-**IMPORTANT PERFOMANCE NOTE:**
+**Note about anti virus and magic mode:**
 
-If you have aggresive Anti Virus monitoring, but have your development folder
-excluded, then be aware that the temp folder will be impacted in Magic Mode.
-To work around this, change the `BoostrapperOutputDir` to a folder that uses
-a path inside the repo, and exclude that folder from git instead.
+If your anti virus is too aggressive, and must have paket excluded, it will not
+be fully excluded unless you change the `BoostrapperOutputDir` to a folder that
+is excluded from the anti virus scanner, e.g. a sub folder inside the repository
+of the project utilizing magic mode.

--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -58,6 +58,9 @@ paket.bootstrapper.exe [prerelease|<version>] [--prefer-nuget] [--self] [-s] [-f
 * `--run`: Once downloaded run `paket.exe`. All arguments following this one are
   ignored and passed directly to `paket.exe`.
 
+* `--config-file=<config-file-path>`: Forces the bootstrapper to use another
+  config file instead of the default `paket.bootstrapper.exe.config` file.
+
 * `--help`: Show help detailing all possible options.
 
 ### In application settings
@@ -76,14 +79,16 @@ Example:
     <add key="ForceNuget" value="True"/>
     <add key="Prerelease" value="True"/>
     <add key="PaketVersion" value="1.5"/>
+    <add key="BoostrapperOutputDir" value="_workDir" />
   </appSettings>
 </configuration>
 ```
 
 * `PreferNuget`: Same as `--prefer-nuget` option.
 * `ForceNuget`: Same as `--force-nuget` option.
-* `PaketVersion`: Same as `<version>` option.
 * `Prerelease`: Same as `prerelease` option.
+* `PaketVersion`: Same as `<version>` option.
+* `BootstrapperOuputDir`: Same as `--output-dir=` option.
 
 ### With environment variables
 

--- a/docs/content/bootstrapper.md
+++ b/docs/content/bootstrapper.md
@@ -173,3 +173,10 @@ A few default settings are applied:
 * The bootstrapper is silenced and only errors are displayed. `-v` can be used
   once to restore normal output or twice to show more details.
 * If no version is specified a default `--max-file-age` of `12` hours is used.
+
+**IMPORTANT PERFOMANCE NOTE:**
+
+If you have aggresive Anti Virus monitoring, but have your development folder
+excluded, then be aware that the temp folder will be impacted in Magic Mode.
+To work around this, change the `BoostrapperOutputDir` to a folder that uses
+a path inside the repo, and exclude that folder from git instead.

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -557,7 +557,7 @@ namespace Paket.Bootstrapper.Tests
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
             Assert.That(result.DownloadArguments.IgnorePrerelease, Is.False);
             Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.Null);
-            Assert.That(result.DownloadArguments.Target, Does.StartWith(Path.Combine(MagicModeFileSystemSystem.GetTempPath(), "paket\\paket_")).And.EndsWith(".exe"));
+            Assert.That(result.DownloadArguments.Target, Does.StartWith(Path.Combine(MagicModeFileSystemSystem.GetTempPath(), "paket", "paket_")).And.EndsWith(".exe"));
         }
 
         [Test]
@@ -699,7 +699,7 @@ namespace Paket.Bootstrapper.Tests
           Assert.That(result, Is.Not.Null);
           Assert.That(result.UnprocessedCommandArgs, Is.Empty);
           Assert.That(result.Run, Is.True);
-          Assert.AreEqual("_workDir\\paket.exe", result.DownloadArguments.Target);
+          Assert.AreEqual(Path.Combine("_workDir", "paket.exe"), result.DownloadArguments.Target);
         }
 
         [Test]
@@ -716,7 +716,7 @@ namespace Paket.Bootstrapper.Tests
           Assert.That(result, Is.Not.Null);
           Assert.That(result.UnprocessedCommandArgs, Is.Empty);
           Assert.That(result.Run, Is.True);
-          Assert.AreEqual("_appSettingWorkDir\\paket.exe", result.DownloadArguments.Target);
+          Assert.AreEqual(Path.Combine("_appSettingWorkDir", "paket.exe"), result.DownloadArguments.Target);
         }
 
         [Test]
@@ -734,7 +734,7 @@ namespace Paket.Bootstrapper.Tests
           Assert.That(result.UnprocessedCommandArgs, Is.Empty);
           Assert.That(result.Run, Is.True);
           // CommandLine must take precedence
-          Assert.AreEqual("_workDir\\paket.exe", result.DownloadArguments.Target);
+          Assert.AreEqual(Path.Combine("_workDir", "paket.exe"), result.DownloadArguments.Target);
         }
 
 

--- a/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ArgumentParserTests.cs
@@ -21,11 +21,11 @@ namespace Paket.Bootstrapper.Tests
 
         class DummyFileSystemProxy : IFileSystemProxy
         {
-            private readonly string assembly;
+            private readonly string _assembly;
 
             public DummyFileSystemProxy(string assembly)
             {
-                this.assembly = assembly;
+                _assembly = assembly;
             }
 
             public bool FileExists(string filename)
@@ -98,7 +98,7 @@ namespace Paket.Bootstrapper.Tests
 
             public string GetExecutingAssemblyPath()
             {
-                return assembly;
+                return _assembly;
             }
 
             public string GetTempPath()
@@ -557,7 +557,7 @@ namespace Paket.Bootstrapper.Tests
             Assert.That(result.RunArgs, Is.Not.Empty.And.EqualTo(new[] {"-s", "--help", "foo"}));
             Assert.That(result.DownloadArguments.IgnorePrerelease, Is.False);
             Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.Null);
-            Assert.That(result.DownloadArguments.Target, Does.StartWith(MagicModeFileSystemSystem.GetTempPath()).And.EndsWith(".exe"));
+            Assert.That(result.DownloadArguments.Target, Does.StartWith(Path.Combine(MagicModeFileSystemSystem.GetTempPath(), "paket\\paket_")).And.EndsWith(".exe"));
         }
 
         [Test]
@@ -685,6 +685,56 @@ namespace Paket.Bootstrapper.Tests
             //assert
             Assert.That(result.DownloadArguments.MaxFileAgeInMinutes, Is.EqualTo(4242));
             Assert.That(result.UnprocessedCommandArgs, Is.Empty);
+        }
+
+        [Test]
+        public void Magic_WithOutputDirInCommandLine()
+        {
+          //arrange
+
+          //act
+          var result = ParseMagic(new[] {"--output-dir=_workDir"}, null, null);
+
+          //assert
+          Assert.That(result, Is.Not.Null);
+          Assert.That(result.UnprocessedCommandArgs, Is.Empty);
+          Assert.That(result.Run, Is.True);
+          Assert.AreEqual("_workDir\\paket.exe", result.DownloadArguments.Target);
+        }
+
+        [Test]
+        public void Magic_WithOutputDirInAppSettings()
+        {
+          //arrange
+          var appSettings = new NameValueCollection();
+          appSettings.Add(ArgumentParser.AppSettingKeys.BootstrapperOutputDir, "_appSettingWorkDir");
+
+          //act
+          var result = ParseMagic(new string[0], appSettings, null);
+
+          //assert
+          Assert.That(result, Is.Not.Null);
+          Assert.That(result.UnprocessedCommandArgs, Is.Empty);
+          Assert.That(result.Run, Is.True);
+          Assert.AreEqual("_appSettingWorkDir\\paket.exe", result.DownloadArguments.Target);
+        }
+
+        [Test]
+        public void Magic_WithOutputDirInCommandLineAndAppSettings()
+        {
+          //arrange
+          var appSettings = new NameValueCollection();
+          appSettings.Add(ArgumentParser.AppSettingKeys.BootstrapperOutputDir, "_appSettingWorkDir");
+
+          //act
+          var result = ParseMagic(new[] {"--output-dir=_workDir"}, appSettings, null);
+
+          //assert
+          Assert.That(result, Is.Not.Null);
+          Assert.That(result.UnprocessedCommandArgs, Is.Empty);
+          Assert.That(result.Run, Is.True);
+          // CommandLine must take precedence
+          Assert.AreEqual("_workDir\\paket.exe", result.DownloadArguments.Target);
         }
 
 


### PR DESCRIPTION
Attempt at fixing the AV related performance issue mentioned in #3661 .

This is done by allowing `OutputDir` to be set in AppSettings as well, so it can be included as a permanent setting for a repository.

Since magic mode recommends using paket.exe.config for AppSettings, I've renamed the setting to `BootstrapperOutputDir` in AppSettings, so it is clear that the output dir relates to the Bootstrapper only, and keeps some naming overlap from the same option provided to command line already.

I've also added testing and minor doc updates.

Fixes #3661 