### PR TITLE
`WIP` Paket global and local tools

### DIFF
--- a/src/Paket.Bootstrapper/WindowsProcessArguments.cs
+++ b/src/Paket.Bootstrapper/WindowsProcessArguments.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Paket.Bootstrapper
 {
-    static class WindowsProcessArguments
+    public static class WindowsProcessArguments
     {
         static void AddBackslashes(StringBuilder builder, int backslashes, bool beforeQuote)
         {

--- a/src/Paket.CmdLineHelpers/Paket.CmdLineHelpers.csproj
+++ b/src/Paket.CmdLineHelpers/Paket.CmdLineHelpers.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Paket.Bootstrapper\WindowsProcessArguments.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>Paket</PackageId>
     <AssemblyName>paket</AssemblyName>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Paket.Core\Paket.Core.fsproj" />
+    <ProjectReference Include="..\Paket.CmdLineHelpers\Paket.CmdLineHelpers.csproj" Condition=" '$(TargetFramework)' == 'netcoreapp2.1' " />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <Version>5.239.0-beta-0001</Version>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>Paket</PackageId>
     <AssemblyName>paket</AssemblyName>
@@ -18,6 +19,7 @@
     <!-- .net tools support netcoreapp only -->
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+	  <DefineConstants>PAKET_GLOBAL_LOCAL;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -28,15 +30,38 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(PackAsTool)' == 'true' ">
     <!-- include the merged paket.exe inside the package, in tools dir -->
-    <Content Include="..\..\bin\merged\paket.exe">
+    <!-- <Content Include="..\..\bin\merged\paket.exe">
       <Pack>true</Pack>
       <PackagePath>tools</PackagePath>
       <Visible>true</Visible>
-    </Content>
+    </Content> -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Paket.Core\Paket.Core.fsproj" />
     <ProjectReference Include="..\Paket.CmdLineHelpers\Paket.CmdLineHelpers.csproj" Condition=" '$(TargetFramework)' == 'netcoreapp2.1' " />
   </ItemGroup>
+  
+  <Target Name="Install">
+     <Exec Command='dotnet pack /p:PackAsTool=true' />
+
+     <!-- reinstall as global -->
+     <Exec Command='dotnet tool uninstall -g Paket'
+           IgnoreExitCode="true"
+           />
+     <Exec Command='dotnet tool install -g Paket --version $(Version) --add-source "$(MSBuildThisFileDirectory)\bin\Debug"' />
+
+     <!-- reinstall as local -->
+     <Exec Command='dotnet tool uninstall --local Paket'
+           WorkingDirectory="C:\temp_p\a"
+           IgnoreExitCode="true"
+           />
+     <RemoveDir Directories="C:\Users\e0s01ao\.nuget\packages\paket\$(Version)"
+           />
+     <Exec Command='dotnet tool install --local Paket --version $(Version) --add-source "$(MSBuildThisFileDirectory)\bin\Debug"'
+           WorkingDirectory="C:\temp_p\a"
+           />
+
+  </Target>
+
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -11,6 +11,9 @@
     <PackageIconUrl>https://raw.githubusercontent.com/fsprojects/Paket/master/docs/files/img/logo.png</PackageIconUrl>
     <PackageTags>nuget;bundler;F#</PackageTags>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+	  <DefineConstants>PAKET_GLOBAL_LOCAL;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
     <!-- .net tools support netcoreapp only -->
     <TargetFrameworks></TargetFrameworks>

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -37,10 +37,11 @@ let processWithValidationEx printUsage silent validateF commandF result =
         traceError ("  " + String.Join(" ",Environment.GetCommandLineArgs()))
         printUsage result
 
-        Environment.ExitCode <- 1
+        1
     else
         try
             commandF result
+            0
         finally
             sw.Stop()
             if not silent then
@@ -954,13 +955,15 @@ let main() =
                 | None -> null
 
             handleCommand silent (results.GetSubCommand())
+        else
+            0
     with
     | exn when not (exn :? System.NullReferenceException) ->
-        Environment.ExitCode <- 1
         traceErrorfn "Paket failed with"
         if Environment.GetEnvironmentVariable "PAKET_DETAILED_ERRORS" = "true" then
             printErrorExt true true true exn
         else printError exn
+        1
 
 
 [<EntryPoint>]

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -869,6 +869,15 @@ let handleCommand silent command =
 
 #if PAKET_GLOBAL_LOCAL
 
+(*
+#load @"..\Paket.Core\Common\Domain.fs"
+#load @"..\Paket.Core\Common\Logging.fs"
+#load @"..\Paket.Core\Common\Constants.fs"
+open System
+open System.IO
+open Paket
+*)
+
 let rec findRootInHierarchyFrom (dir: DirectoryInfo) =
     printfn "searching in %s" dir.FullName
     if not (dir.Exists) then
@@ -888,8 +897,6 @@ let rec findRootInHierarchyFrom (dir: DirectoryInfo) =
 let findRootInHierarchy () =
     (Directory.GetCurrentDirectory() |> DirectoryInfo)
     |> findRootInHierarchyFrom
-
-open System.Text
 
 let runIt exeName exeArgs =
     printfn "%s %A" exeName exeArgs

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -895,6 +895,26 @@ let dotnetToolManifestPath (dir: DirectoryInfo) =
     Path.Combine(dir.FullName, ".config", "dotnet-tools.json")
     |> FileInfo
 
+open System.Reflection
+
+let isToolLocal () =
+    let x = typeof<AddArgs>.Assembly.Location
+    printfn "%s" x
+
+    // local
+    // C:\Users\e0s01ao\.nuget\packages\paket\5.239.0-beta-0001\tools\netcoreapp2.1\any\paket.dll
+
+    // global
+    // C:\Users\e0s01ao\.dotnet\tools\.store\paket\5.239.0-beta-0001\paket\5.239.0-beta-0001\tools\netcoreapp2.1\any\paket.dll
+
+    let isToolGlobal = x.Contains(".store")
+
+    printfn "tg %O" isToolGlobal
+
+    let isToolLocal = not isToolGlobal
+
+    isToolLocal
+
 #endif
 
 let main() =
@@ -976,19 +996,22 @@ let main() =
 
 [<EntryPoint>]
 let theMain argv =
+    printfn "real main"
 
 #if PAKET_GLOBAL_LOCAL
+    let isToolLocal = isToolLocal ()
 
-    let isToolGlobal = true
-    let isToolLocal = not isToolGlobal
+    printfn "local: %O" isToolLocal
 
     if isToolLocal then
+        printfn "localtool: run main"
         main ()
     else
         let paketRoot = findRootInHierarchy ()
         match paketRoot with
         | None ->
             // act as global tool
+            printfn "globaltool: run mainglobal"
             mainGlobal ()
         | Some dir ->
             let manifestToolPath = dotnetToolManifestPath dir
@@ -1001,5 +1024,7 @@ let theMain argv =
                 runIt (Path.Combine(Constants.PaketFolderName, Constants.PaketFileName)) argv
 
 #else
+    printfn "main not g"
+
     main ()
 #endif


### PR DESCRIPTION
modify `Paket` too so can be installed global (`-g`) and local (`--local`) with different behaviour.

as global tool, installed like `dotnet tool install -g Paket`, behaviour depends:
- if the working directory is a repo with paket (`.paket/paket.exe` OR `dotnet paket`), it execute the repo paket exe, passing the same arguments (sort of magic mode). so `paket --help` is like `.paket/paket.exe --help`
- if the working directory is not a repo with paket, just a subset of commands exists. like `paket init`.

as local tool, installed like `dotnet tool install --local Paket` (the `--local` i think is optional), is:
- pinned in the tool manifest
- can be run as `dotnet paket`
- `paket --help` -> `dotnet paket --help`, so will forward.

### Current status

works now as ☝️ in windows, printing the command who will run

### TODO

- [ ] fix the `TODO` comments
- [ ] use `PRocessStartInfo.ArgumentList` ? or continue to use Paket.Bootstrapper quoting code.
- [ ] message errors (if tool manifest exists but doesnt contains paket)
- [ ] add another init, to use tool manifest
- [ ] fix the sdk integration (should be fast, should run `dotnet paket` ALWAYS)

ref #3623 
