### PR TITLE
Add IgnoreConflict option for paket push

### DIFF
--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -753,7 +753,7 @@ type Dependencies(dependenciesFileName: string) =
         PackageProcess.Pack(workingDir, dependenciesFile, outputPath, buildConfig, buildPlatform, version, specificVersions, releaseNotes, templateFile, excludedTemplates, lockDependencies, minimumFromLockFile, pinProjectReferences, interprojectReferencesConstraint, symbols, includeReferencedProjects, projectUrl)
 
     /// Pushes a nupkg file.
-    static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?paketVersion, ?maxTrials) =
+    static member Push(packageFileName, ?url, ?apiKey, (?endPoint: string), ?paketVersion, ?maxTrials, ?ignoreConflicts) =
         let urlWithEndpoint = RemoteUpload.GetUrlWithEndpoint url endPoint
         let envKey =
             match Environment.GetEnvironmentVariable("NUGET_KEY") |> Option.ofObj with
@@ -783,12 +783,14 @@ type Dependencies(dependenciesFileName: string) =
             failwithf "Could not push package %s due to missing credentials for the url %s. Please specify a NuGet API key via the command line, the environment variable \"nugetkey\", or by using 'paket config add-token'." packageFileName urlWithEndpoint
         | Some apiKey ->
             let maxTrials = defaultArg maxTrials 5
+            let ignoreConflicts = defaultArg ignoreConflicts false
             RemoteUpload.Push
                 maxTrials
                 urlWithEndpoint
                 apiKey
                 "4.1.0"  // see https://github.com/NuGet/NuGetGallery/issues/4315 - maybe us (defaultArg paketVersion "4.1.0")
                 packageFileName
+                ignoreConflicts
 
     /// Lists all paket.template files in the current solution.
     member this.ListTemplateFiles() : TemplateFile list =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -592,6 +592,8 @@ type PushArgs =
 
     | [<Unique>] Endpoint of path:string
     | [<Hidden;Unique;CustomCommandLine("endpoint")>] Endpoint_Legacy of path:string
+
+    | [<Unique;CustomCommandLine("--ignoreConflicts")>] Ignore_Conflicts
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -607,6 +609,8 @@ with
 
             | Endpoint(_) -> "API endpoint to push to (default: /api/v2/package)"
             | Endpoint_Legacy(_) -> "[obsolete]"
+
+            | Ignore_Conflicts -> "Ignore any HTTP409 (Conflict) errors and treat as success"
 
 type GenerateLoadScriptsArgs =
     | [<AltCommandLine("-g")>] Group of name:string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -739,11 +739,13 @@ let push paketVersion (results : ParseResults<_>) =
         (results.TryGetResult <@ PushArgs.Api_Key @>,
          results.TryGetResult <@ PushArgs.Api_Key_Legacy @>)
         |> legacyOption results (ReplaceArgument("--api-key", "apikey"))
+    let ignoreConflicts = results.Contains <@ PushArgs.Ignore_Conflicts @>
 
     Dependencies.Push(fileName,
                       ?url = url,
                       ?endPoint = endpoint,
-                      ?apiKey = apiKey)
+                      ?apiKey = apiKey,
+                      ignoreConflicts = ignoreConflicts)
 
 let generateLoadScripts (results : ParseResults<GenerateLoadScriptsArgs>) =
     let providedFrameworks =


### PR DESCRIPTION
In some situations you don't care that nuget returned a 409 conflict.

This gives the option to just ignore that.