### PR TITLE
Fixing In Page Links on Get Started Page

### DIFF
--- a/docs/content/get-started.md
+++ b/docs/content/get-started.md
@@ -2,9 +2,9 @@
 
 This guide shows how to get started with Paket in various ways, depending on your scenario:
 
-* [Get started with .NET Core (preferred)](get-started.md#net-core-preferred)
-* [Get started with the paket bootstrapper (legacy)](get-started.md#install-the-paket-bootstrapper-legacy)
-* [Convert from legacy NuGet](get-started.md#convert-from-legacy-nuget)
+* [Get started with .NET Core (preferred)](#net-core-preferred)
+* [Get started with the paket bootstrapper (legacy)](#install-the-paket-bootstrapper-legacy)
+* [Convert from legacy NuGet](#convert-from-legacy-nuget)
 
 ## .NET Core (preferred)
 

--- a/docs/content/get-started.md
+++ b/docs/content/get-started.md
@@ -4,7 +4,7 @@ This guide shows how to get started with Paket in various ways, depending on you
 
 * [Get started with .NET Core (preferred)](#net-core-preferred)
 * [Get started with the paket bootstrapper (legacy)](#install-the-paket-bootstrapper-legacy)
-* [Convert from legacy NuGet](#convert-from-legacy-nuget)
+* [Convert from legacy NuGet](#convert-from-nuget)
 
 ## .NET Core (preferred)
 


### PR DESCRIPTION
Updating markdown file to resolve #3761. 

Updated links still works while browsing as markdown file on github, and manually changing links on the https://fsprojects.github.io/Paket/get-started.html page to the values present here works as well. 