### PR TITLE
Update matching platform check 🚀

### DIFF
--- a/src/Paket.Core/Common/Utils.fs
+++ b/src/Paket.Core/Common/Utils.fs
@@ -327,8 +327,13 @@ let isMatchingOperatingSystem (operatingSystemFilter : string option) =
 let isMatchingPlatform (operatingSystemFilter : string option) =
     match operatingSystemFilter with
     | None -> true
+#if NETSTANDARD1_6 || NETSTANDARD2_0
+    | Some filter when filter = "mono" -> isMacOS || isUnix
+    | Some filter when filter = "windows" -> isWindows
+#else
     | Some filter when filter = "mono" -> isMonoRuntime
     | Some filter when filter = "windows" -> not isMonoRuntime
+#endif
     | _ -> isMatchingOperatingSystem operatingSystemFilter
 
 /// [omit]


### PR DESCRIPTION
`os:mono` and `os:windows` are behaving wrongly for .Net Core version of the Paket. This is caused by the fact the check depends on `isMonoRuntime` function which on .Net Core always return `false` which caused `os:mono` to never be matched, and `os:windows` be matched on all platforms.

The workaround for the problem is to use `os:win`, `os:linux` and `os:osx` - but it's breaking change for anyone already using those checks who just wanted to modernize build infrastructure (👋). 

Fix makes old syntax works correctly also on .Net Core by using the same checks as for `os:win`, `os:osx` and `os:linux`. 
`os:windows` will behave just like `os:win` and `os:mono` will be `os:osx || os:linux`