### PR TITLE
these lines checks seem to be triggering stack overflows

### DIFF
--- a/src/Paket.Core/Versioning/Requirements.fs
+++ b/src/Paket.Core/Versioning/Requirements.fs
@@ -1226,10 +1226,10 @@ type PackageRequirement =
 
     static member Compare(x,y,startWithPackage:PackageFilter option,boostX,boostY) =
         if obj.ReferenceEquals(x, y) then 0 else
-        let c = compare
-                  (not x.VersionRequirement.Range.IsGlobalOverride,x.Depth)
-                  (not y.VersionRequirement.Range.IsGlobalOverride,y.Depth)
-        if c <> 0 then c else
+//        let c = compare
+//                  (not x.VersionRequirement.Range.IsGlobalOverride,x.Depth)
+//                  (not y.VersionRequirement.Range.IsGlobalOverride,y.Depth)
+//        if c <> 0 then c else
         let c = match startWithPackage with
                     | Some filter when filter.Match x.Name -> -1
                     | Some filter when filter.Match y.Name -> 1


### PR DESCRIPTION
see #3690

Removing the `(x,y).Depth` parts of the `compare` calls, or swapping their order will cause paket to run without causing a StackOverflow on my repro. The behavior is the same whether or not the checks for `IsGlobalOverride` are separated.:

```fsharp
// this
let c = compare
    (not y.VersionRequirement.Range.IsGlobalOverride,y.Depth)
    (not x.VersionRequirement.Range.IsGlobalOverride,x.Depth)

// and this both "succeed"
let c = compare (x.VersionRequirement.Range.IsGlobalOverride, y.VersionRequirement.Range.IsGlobalOverride)
if c <> 0 then c else
let c = compare (y.Depth, x.Depth)

// this
let c = compare
     (not x.VersionRequirement.Range.IsGlobalOverride,x.Depth)
     (not y.VersionRequirement.Range.IsGlobalOverride,y.Depth)

// and this both "fail"
let c = compare (x.VersionRequirement.Range.IsGlobalOverride, y.VersionRequirement.Range.IsGlobalOverride)
if c<> 0 then c else
let c = compare (x.Depth, y.Depth)
```

Commenting the lines out as per https://github.com/fsprojects/Paket/commit/89d91444268535944dba2ea3fb95200388d586e8 also "succeeds". Seems like there might be something funky going on / a missed infinite recursion path around the logic for updating the requirements graph  of a `PackageRequirement`?

