### PR TITLE
treat nuget repo as v3 if url ends with index.json

### DIFF
--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -145,7 +145,7 @@ type PackageSource =
 #endif
                     LocalNuGet(source,None)
                 else
-                    if source.Contains("/v3/") || (source.Contains "github.com" && source.EndsWith("index.json")) then
+                    if source.Contains("/v3/") || source.EndsWith("index.json") then
                         NuGetV3 { Url = source; Authentication = auth }
                     else
                         NuGetV2 { Url = source; Authentication = auth }


### PR DESCRIPTION
can't we treat a nuget repo as v3 if the url ends with "index.json" in general? we use a nexus nuget v3 proxy and it is not possible to have "/v3/ " in the repo url unless you name the nuget repo "v3" which is a not very good solution.