### PR TITLE
Add support for uap10.0.14393 and uap10.0.18362

### DIFF
--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -150,24 +150,30 @@ type FrameworkVersion =
 // Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
 type UAPVersion =
     | V10
+    | V10_0_14393
     | V10_0_15138
     | V10_0_16299
     | V10_0_16300
+    | V10_0_18362
     | V10_1
     override this.ToString() =
         match this with
         | V10 -> "10.0"
+        | V10_0_14393 -> "10.0.14393"
         | V10_0_15138 -> "10.0.15138"
         | V10_0_16299 -> "10.0.16299"
         | V10_0_16300 -> "10.0.16300"
+        | V10_0_18362 -> "10.0.18362"
         | V10_1 -> "10.1"
 
     member this.ShortString() =
         match this with
         | UAPVersion.V10 -> "10.0"
+        | UAPVersion.V10_0_14393 -> "10.0.14393"
         | UAPVersion.V10_0_15138 -> "10.0.15138"
         | UAPVersion.V10_0_16299 -> "10.0.16299"
         | UAPVersion.V10_0_16300 -> "10.0.16300"
+        | UAPVersion.V10_0_18362 -> "10.0.18362"
         | UAPVersion.V10_1 -> "10.1"
 
     member this.NetCoreVersion =
@@ -175,9 +181,11 @@ type UAPVersion =
         match this with
         // Assumed from C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore
         | UAPVersion.V10
+        | UAPVersion.V10_0_14393
         | UAPVersion.V10_0_15138
         | UAPVersion.V10_0_16299
-        | UAPVersion.V10_0_16300 -> "v5.0"
+        | UAPVersion.V10_0_16300
+        | UAPVersion.V10_0_18362 -> "v5.0"
         // No idea, for now use 5.0 to keep project files constant
         // If someone starts complaining fix this and update the baselines.
         | UAPVersion.V10_1 -> "v5.0"
@@ -185,9 +193,11 @@ type UAPVersion =
     static member TryParse s =
         match s with
         | "" | "1" | "10" -> Some UAPVersion.V10
+        | "10.0.14393" -> Some UAPVersion.V10_1
         | "10.0.15138" -> Some UAPVersion.V10_1
         | "10.0.16299" -> Some UAPVersion.V10_1
         | "10.0.16300" -> Some UAPVersion.V10_1
+        | "10.0.18362" -> Some UAPVersion.V10_1
         | "10.1" -> Some UAPVersion.V10_1
         | _ -> None
 
@@ -617,9 +627,11 @@ type FrameworkIdentifier =
         | XamarinTV -> [ DotNetStandard DotNetStandardVersion.V1_6 ]
         | XamarinWatch -> [ DotNetStandard DotNetStandardVersion.V1_6 ]
         | UAP UAPVersion.V10 -> [ Windows WindowsVersion.V8_1; WindowsPhoneApp WindowsPhoneAppVersion.V8_1; DotNetStandard DotNetStandardVersion.V1_4  ]
+        | UAP UAPVersion.V10_0_14393 -> [ UAP UAPVersion.V10 ]
         | UAP UAPVersion.V10_0_15138 -> [ UAP UAPVersion.V10 ]
         | UAP UAPVersion.V10_0_16299 -> [ UAP UAPVersion.V10; DotNetStandard DotNetStandardVersion.V2_0 ]
         | UAP UAPVersion.V10_0_16300 -> [ UAP UAPVersion.V10; DotNetStandard DotNetStandardVersion.V2_0 ]
+        | UAP UAPVersion.V10_0_18362 -> [ UAP UAPVersion.V10; DotNetStandard DotNetStandardVersion.V2_0 ]
         | UAP UAPVersion.V10_1 -> [ UAP UAPVersion.V10_0_15138 ]
         | DotNetFramework FrameworkVersion.V1 -> [ ]
         | DotNetFramework FrameworkVersion.V1_1 -> [ DotNetFramework FrameworkVersion.V1 ]
@@ -1246,9 +1258,11 @@ module KnownTargetProfiles =
 
     let UAPVersons = [
         UAPVersion.V10
+        UAPVersion.V10_0_14393
         UAPVersion.V10_0_15138
         UAPVersion.V10_0_16299
         UAPVersion.V10_0_16300
+        UAPVersion.V10_0_18362
         UAPVersion.V10_1
     ]
 


### PR DESCRIPTION
Added support for the TFMs `uap10.0.14393` and `uap10.0.18362` for packages targeting UWP versions 14393 and 18362.