### PR TITLE
Add support for licenseExpression in paket.template

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -33,7 +33,7 @@ A `paket.template` file using `type project` may look like this:
 
 ```text
 type project
-licenseUrl http://opensource.org/licenses/MIT
+licenseExpression MIT
 ```
 
 This template file will be used to create a `.nupkg`
@@ -113,7 +113,8 @@ field of the same name in the `.nupkg`.
 * `language`
 * `projectUrl`
 * `iconUrl`
-* `licenseUrl`
+* `licenseExpression`: More info on what you can specify: <https://docs.microsoft.com/de-de/nuget/reference/nuspec#license>  
+* `licenseUrl` (deprecated by NuGet)
 * `repositoryType`
 * `repositoryUrl`
 * `copyright`

--- a/src/Paket.Core/Packaging/NupkgWriter.fs
+++ b/src/Paket.Core/Packaging/NupkgWriter.fs
@@ -161,6 +161,13 @@ module internal NupkgWriter =
         (!!?) "title" optional.Title
         !! "authors" (core.Authors |> String.concat ", ")
         if optional.Owners <> [] then !! "owners" (String.Join(", ",optional.Owners))
+        match optional.LicenseExpression with
+        | Some licenseExpression ->
+            let el = XElement(ns + "license")
+            el.SetAttributeValue(XName.Get "type", "expression")
+            el.SetValue(licenseExpression)
+            metadataNode.Add el
+        | _ -> ()
         (!!?) "licenseUrl" optional.LicenseUrl
         match optional.RepositoryType, optional.RepositoryUrl with
         | Some t, Some url ->

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -2090,6 +2090,7 @@ type ProjectFile with
             Language = prop "Langauge"
             ProjectUrl = prop "ProjectUrl"
             IconUrl = prop "IconUrl"
+            LicenseExpression = prop "LicenseExpression"
             LicenseUrl = prop "LicenseUrl"
             Copyright = prop "Copyright"
             RepositoryType = prop "RepositoryType"

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -145,6 +145,7 @@ type OptionalPackagingInfo =
       Language : string option
       ProjectUrl : string option
       IconUrl : string option
+      LicenseExpression : string option
       LicenseUrl : string option
       RepositoryUrl : string option
       RepositoryType : string option
@@ -172,6 +173,7 @@ type OptionalPackagingInfo =
           Summary = None
           Language = None
           ProjectUrl = None
+          LicenseExpression = None
           LicenseUrl = None
           RepositoryUrl = None
           RepositoryType = None
@@ -537,6 +539,7 @@ module internal TemplateFile =
           IconUrl = get "iconUrl"
           RepositoryType = get "repositoryType"
           RepositoryUrl = get "repositoryUrl"
+          LicenseExpression = get "licenseExpression"
           LicenseUrl = get "licenseUrl"
           Copyright = get "copyright"
           RequireLicenseAcceptance = requireLicenseAcceptance

--- a/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
+++ b/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
@@ -363,7 +363,7 @@ let ``should not serialize all properties``() =
     <title>A title</title>
     <authors>Michael, Steffen</authors>
     <owners>Steffen, Alex</owners>
-    <licenseUrl>http://www.somewhere.com/license.html</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>http://www.somewhere.com</projectUrl>
     <iconUrl>http://www.somewhere.com/Icon</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -397,7 +397,7 @@ second line</releaseNotes>
               Summary = Some "summary"
               Language = Some "en-US"
               ProjectUrl = Some "http://www.somewhere.com"
-              LicenseUrl = Some "http://www.somewhere.com/license.html"
+              LicenseExpression = Some "MIT"
               IconUrl = Some "http://www.somewhere.com/Icon"
               Copyright = Some "Paket owners 2015"
               RequireLicenseAcceptance = true

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -154,8 +154,8 @@ projectUrl
     http://github.com/fsprojects/Chessie
 iconUrl
     https://raw.githubusercontent.com/fsprojects/Chessie/master/docs/files/img/logo.png
-licenseUrl
-    http://github.com/fsprojects/Chessie/blob/master/LICENSE.txt
+licenseExpression
+    Unlicense
 requireLicenseAcceptance
     false
 copyright
@@ -199,7 +199,7 @@ let ``Optional fields are read`` (fileContent : string) =
     sut.Copyright |> shouldEqual (Some "Copyright 2015")
     sut.Summary |> shouldEqual (Some "Railway-oriented programming for .NET")
     sut.IconUrl |> shouldEqual (Some "https://raw.githubusercontent.com/fsprojects/Chessie/master/docs/files/img/logo.png")
-    sut.LicenseUrl |> shouldEqual (Some "http://github.com/fsprojects/Chessie/blob/master/LICENSE.txt")
+    sut.LicenseExpression |> shouldEqual (Some "Unlicense")
     sut.ProjectUrl |> shouldEqual (Some "http://github.com/fsprojects/Chessie")
     sut.Tags |> shouldEqual ["rop";"fsharp";"F#"]
     sut.Owners |> shouldEqual ["Steffen Forkmann";"Max Malook";"Tomasz Heimowski"]


### PR DESCRIPTION
I wanted to add the license of my project with paket pack in a similar way I am used to with dotnet pack and stumbled across #3710 

A while ago Nuget deprecated licenseUrl and this is not yet reflected in paket.template. (https://docs.microsoft.com/de-de/nuget/reference/nuspec#license)
Therefore I tried adding support for the license expression.

I tried to adjust tests a bit and edited documentation. I hope I did everything right.

Thanks for your work! Paket is a really helpful tool :)