### PR TITLE
Apply version ranges to nuspecs during fix-up command

### DIFF
--- a/src/Paket.Core/Versioning/VersionRange.fs
+++ b/src/Paket.Core/Versioning/VersionRange.fs
@@ -18,12 +18,19 @@ type PreReleaseStatus =
 
 /// Represents version information.
 type VersionRange =
+    /// 'at least' version X, with inclusive lower bound
     | Minimum of SemVerInfo
+    /// 'at least' version X, with exclusive lower bound
     | GreaterThan of SemVerInfo
+    /// 'at most' version X, with inclusive upper bound
     | Maximum of SemVerInfo
+    /// 'at most' version X, with exclusive upper bound
     | LessThan of SemVerInfo
+    /// 'exactly' version X
     | Specific of SemVerInfo
+    /// 'hard' equality, where the minor/patch aren't expanded out to fill in missing zero elements
     | OverrideAll of SemVerInfo
+    /// explicit bounded range with inclusion/exclusion flags on either side
     | Range of fromB : VersionRangeBound * from : SemVerInfo * _to : SemVerInfo * _toB : VersionRangeBound
 
     static member AtLeast version = Minimum(SemVer.Parse version)
@@ -32,21 +39,21 @@ type VersionRange =
     static member BasicOperators = ["~>";"==";"<=";">=";"=";">";"<"]
     static member StrategyOperators = ['!';'@']
     static member Exactly version = Specific(SemVer.Parse version)
-    
+
     static member Between(lower,minimum,maximum,upper) =
-        Range(lower,minimum,maximum,upper)      
+        Range(lower,minimum,maximum,upper)
 
     static member Between(lower,version1,version2,upper) =
         let minimum = SemVer.Parse version1
         let maximum = SemVer.Parse version2
         VersionRange.Between(lower,minimum,maximum,upper)
-        
+
     static member Between(minimum:string,maximum:string) =
         VersionRange.Between(VersionRangeBound.Including,minimum,maximum,VersionRangeBound.Excluding)
-              
+
     static member Between(minimum:SemVerInfo,maximum:SemVerInfo) =
         VersionRange.Between(VersionRangeBound.Including,minimum,maximum,VersionRangeBound.Excluding)
-        
+
     member x.IsGlobalOverride = match x with | OverrideAll _ -> true | _ -> false
 
     member this.IsIncludedIn (other : VersionRange) =
@@ -58,20 +65,20 @@ type VersionRange =
         | GreaterThan v1, GreaterThan v2 when v1 < v2 -> true
         | GreaterThan v1, Specific v2 when v1 < v2 -> true
         | GreaterThan v1, Range(_, min2, max2, _) when v1 < min2 && v1 < max2 -> true
-        | Range(lower, min1, max1, upper), Specific v2 -> 
-            let left, right = 
+        | Range(lower, min1, max1, upper), Specific v2 ->
+            let left, right =
                 match lower, upper with
                 | VersionRangeBound.Excluding, VersionRangeBound.Excluding -> (<), (>)
                 | VersionRangeBound.Including, VersionRangeBound.Excluding -> (<=), (>)
                 | VersionRangeBound.Excluding, VersionRangeBound.Including -> (<), (>=)
                 | VersionRangeBound.Including, VersionRangeBound.Including -> (<=), (>=)
-            left min1 v2 && right max1 v2 
+            left min1 v2 && right max1 v2
         | Range(from1, min1, max1, upto1), Range(from2, min2, max2, upto2) ->
-            let lowerMatch = 
+            let lowerMatch =
                 match from1, from2 with
                 | VersionRangeBound.Excluding, VersionRangeBound.Including -> min1 < min2
                 | _ -> min1 <= min2
-            let upperMatch = 
+            let upperMatch =
                 match upto1, upto2 with
                 | VersionRangeBound.Including, VersionRangeBound.Excluding -> max2 < max1
                 | _ -> max2 <= max1
@@ -80,44 +87,44 @@ type VersionRange =
 
     member this.GetPreReleaseStatus =
         let prerelease =
-            match this with 
+            match this with
             | Minimum v1 -> v1.PreRelease
-            | GreaterThan v1 -> v1.PreRelease 
+            | GreaterThan v1 -> v1.PreRelease
             | Maximum v1 -> v1.PreRelease
             | LessThan v1 -> v1.PreRelease
             | Specific v1 -> v1.PreRelease
             | OverrideAll v1 -> v1.PreRelease
-            | Range(_,l1,r1,_) -> 
+            | Range(_,l1,r1,_) ->
                 match l1.PreRelease with
                 | Some(p) -> Some(p)
                 | None -> r1.PreRelease
-        match prerelease with 
-        | Some(prerelease) -> 
+        match prerelease with
+        | Some(prerelease) ->
             match prerelease.Name with
             | null | "" -> PreReleaseStatus.No
             | "prerelease" -> PreReleaseStatus.All
             | name -> PreReleaseStatus.Concrete [name]
         | None -> PreReleaseStatus.No
-    
+
     member this.IsConflicting (other : VersionRange) =
-        (other, this.GetPreReleaseStatus, other.GetPreReleaseStatus) |> this.IsConflicting 
+        (other, this.GetPreReleaseStatus, other.GetPreReleaseStatus) |> this.IsConflicting
 
     member this.IsConflicting (tuple : (VersionRange * PreReleaseStatus * PreReleaseStatus)) =
         let checkPre pre1 pre2 =
-            match pre1 with 
+            match pre1 with
             | PreReleaseStatus.No -> true
             | PreReleaseStatus.All -> pre2 = PreReleaseStatus.No
             | PreReleaseStatus.Concrete list1 ->
-                match pre2 with 
+                match pre2 with
                 | PreReleaseStatus.No -> true
-                | PreReleaseStatus.All -> false 
+                | PreReleaseStatus.All -> false
                 | PreReleaseStatus.Concrete list2 -> list1.Head <> list2.Head
-        
-        let other, pre1, pre2 = tuple   
-             
+
+        let other, pre1, pre2 = tuple
+
         let (>) v1 v2 = v1 > v2 && checkPre pre1 pre2
         let (<) v1 v2 = v1 < v2 && checkPre pre1 pre2
-        
+
         let isConflict this other =
             match this, other with
             | Minimum v1, Specific v2 when v1 > v2 -> true
@@ -258,7 +265,7 @@ type VersionRequirement =
 
         let parseRange (text:string) =
 
-            let parseBound s = 
+            let parseBound s =
                 match s with
                 | '[' | ']' -> VersionRangeBound.Including
                 | '(' | ')' -> VersionRangeBound.Excluding
@@ -266,8 +273,8 @@ type VersionRequirement =
 
             let parsed =
                 if not (text.Contains ",") then
-                    if text.StartsWith "[" then 
-                        text.Trim([|'['; ']'|]) 
+                    if text.StartsWith "[" then
+                        text.Trim([|'['; ']'|])
                         |> analyzeVersion Specific
                     else analyzeVersion Minimum text
                 else
@@ -299,21 +306,21 @@ type VersionRequirement =
                     | 0 -> Minimum(SemVer.Zero)
                     | _ -> failwithf "unable to parse %s" text
             match parsed with
-            | Range(fromB, from, _to, _toB) -> 
+            | Range(fromB, from, _to, _toB) ->
                 if (fromB = VersionRangeBound.Including) && (_toB = VersionRangeBound.Including) && (from = _to) then
                     Specific from
                 else
                     VersionRange.Between(fromB,from,_to,_toB)
             | x -> x
-            
+
         let range = parseRange text
-        
-        let prerelease = 
+
+        let prerelease =
             match prereleases |> Seq.where (fun s -> not(String.IsNullOrEmpty s)) |> Seq.distinct |> List.ofSeq with
             | [] -> PreReleaseStatus.No
-            | list when list |> List.contains "prerelease" -> PreReleaseStatus.All 
+            | list when list |> List.contains "prerelease" -> PreReleaseStatus.All
             | list -> PreReleaseStatus.Concrete list
-            
+
         VersionRequirement(range,prerelease)
 
 
@@ -334,7 +341,7 @@ type VersionRequirement =
                 | _ -> "-prerelease"
 
             let normalize (v:SemVerInfo) =
-                let s = 
+                let s =
                     let u = v.ToString()
                     let n = v.Normalize()
                     if u.Length > n.Length then u else n // Do not short version since Klondike doesn't understand
@@ -350,7 +357,7 @@ type VersionRequirement =
                 | GreaterThan(version) -> sprintf "(%s,)" (normalize version)
                 | Maximum(version) -> sprintf "(,%s]" (normalize version)
                 | LessThan(version) -> sprintf "(,%s)" (normalize version)
-                | Specific(version) -> 
+                | Specific(version) ->
                     let v = normalize version
                     if v.EndsWith "-prerelease" then
                         let getMinDelimiter (v:VersionRangeBound) =


### PR DESCRIPTION
Per #2883, version ranges specified in paket.dependencies weren't patched into auto-generated nuspecs as part of the `fix-nuspecs` call.  This PR attempts to add them in, in addition to a slight cleanup of the existing logic to make it easier to follow in my view.

The approach is to first determine what the nuspec file ranges should be for all known dependencies. This is done by taking the ranges specified in the dependencies file, which are optimistic, and modifying them with the 'resolved' information from the lock file. What this means depends on the type of range specified:

* for greater than, minimums, specific versions and overrides, this means changing the semver used for that bound to be the locked version. This seems safe for every case.
* for maximums, this means changing the range to a Between, because we want to ensure that consumers use _at least_ the version that this package was built against, while not going higher than this package's own build requirements
* similarly for less than, we want to ensure that the minimum bound is changed to the version that _this package_ was built against
* finally for Ranges, we change the lower bound to an inclusive lower bound on the locked version for similar reasons.

Once we have these ranges derived, we iterate through the dependencies in the nuspec as before, only taking action if we encounter a dependency that _we know_ is a direct dependency.


Caveats:
* this only tracks the main group of dependencies
  * we have the references file for this project, we could use that information to look for the range of the group that was actually referenced.
* this does not take into account targetframework restrictions.

I don't have tests for this yet, but from manual testing on F# Formatting (after adding an upper bound myself to the dependencies file and manually calling `fix-nuspecs` on the generated nuspecs), this seems to work:

```
nuget FSharp.Compiler.Service >= 35.0 < 36.0 lowest_matching:true
```
results in a nuspec with the range
```
<dependency id="FSharp.Compiler.Service" version="[35.0.0,36.0.0)" exclude="Build,Analyzers" />
```