### PR TITLE
Adding parsing logic for protocolVersion on source

### DIFF
--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -419,6 +419,7 @@ let rec private getPackageDetails alternativeProjectRoot root force (parameters:
                 | Some url ->
                     let nugetSource : NuGetSource =
                         { Url = url
+                          ProtocolVersion = NugetProtocolVersion.ProtocolVersion2
                           Authentication = nugetSource.Authentication }
                     return! tryV2 nugetSource force
                 | _ ->

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -419,7 +419,7 @@ let rec private getPackageDetails alternativeProjectRoot root force (parameters:
                 | Some url ->
                     let nugetSource : NuGetSource =
                         { Url = url
-                          ProtocolVersion = NugetProtocolVersion.ProtocolVersion2
+                          ProtocolVersion = ProtocolVersion2
                           Authentication = nugetSource.Authentication }
                     return! tryV2 nugetSource force
                 | _ ->

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -199,7 +199,7 @@ let getSearchAPI(auth,nugetUrl) =
             match calculateNuGet3Path nugetUrl with
             | None -> return None
             | Some v3Path ->
-                let source = { Url = v3Path; Authentication = auth }
+                let source = { Url = v3Path; ProtocolVersion = ProtocolVersion3; Authentication = auth }
                 let! v3res = getNuGetV3Resource source AutoComplete |> Async.Catch
                 return
                     match v3res with

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -56,10 +56,10 @@ type NugetV3ResourceType =
 
 // Cache for nuget indices of sources
 type ResourceIndex = Map<NugetV3ResourceType,string>
-let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<NuGetV3Source,Task<ResourceIndex>>()
+let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<NuGetSource,Task<ResourceIndex>>()
 let private rnd = Random()
 
-let getNuGetV3Resource (source : NuGetV3Source) (resourceType : NugetV3ResourceType) : Async<string> =
+let getNuGetV3Resource (source : NuGetSource) (resourceType : NugetV3ResourceType) : Async<string> =
     let key = source
     let getResourcesRaw () =
         async {
@@ -600,7 +600,7 @@ type PackageIndex =
       [<JsonProperty("count")>]
       Count : int }
 
-let private getPackageIndexRaw (source : NuGetV3Source) (packageName:PackageName) =
+let private getPackageIndexRaw (source : NuGetSource) (packageName:PackageName) =
     async {
         let! registrationUrl = getNuGetV3Resource source PackageIndex
         let url = registrationUrl.TrimEnd('/') + "/" + packageName.ToString().ToLowerInvariant() + "/index.json"
@@ -620,7 +620,7 @@ let private getPackageIndexMemoized =
 let getPackageIndex source packageName = getPackageIndexMemoized (source, packageName)
 
 
-let private getPackageIndexPageRaw (source:NuGetV3Source) (url:string) =
+let private getPackageIndexPageRaw (source: NuGetSource) (url:string) =
     async {
         let! rawData = safeGetFromUrl (source.Authentication, url, acceptJson)
         return
@@ -642,7 +642,7 @@ let private getPackageIndexPageMemoized =
 let getPackageIndexPage source (page:PackageIndexPage) = getPackageIndexPageMemoized (source, page.Id)
 
 
-let getRelevantPage (source:NuGetV3Source) (index:PackageIndex) (version:SemVerInfo) =
+let getRelevantPage (source:NuGetSource) (index:PackageIndex) (version:SemVerInfo) =
     async {
         try
             let normalizedVersion = SemVer.Parse (version.ToString().ToLowerInvariant())
@@ -703,7 +703,7 @@ let getRelevantPage (source:NuGetV3Source) (index:PackageIndex) (version:SemVerI
             return raise <| exn (sprintf "Failed to find relevant page in '%s'" index.Id, e)
     }
 
-let getPackageDetails (source:NuGetV3Source) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
+let getPackageDetails (source:NuGetSource) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
     async {
         let! pageIndex = getPackageIndex source packageName
         match pageIndex with
@@ -770,7 +770,7 @@ let getPackageDetails (source:NuGetV3Source) (packageName:PackageName) (version:
     }
 
 /// Uses the NuGet v3 registration endpoint to retrieve package details .
-let GetPackageDetails (force:bool) (source:NuGetV3Source) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
+let GetPackageDetails (force:bool) (source:NuGetSource) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
     getDetailsFromCacheOr
         force
         source.Url

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -103,7 +103,7 @@ let ExtractPackage(alternativeProjectRoot, root, groupName, sources, caches, for
         let! result = async {
             let source =
                 match package.Source with
-                | NuGetV2 _ | NuGetV3 _ ->
+                | NuGet _ ->
                     let normalizeFeedUrl s = (normalizeFeedUrl s).Replace("https://","http://")
 
                     let normalized = normalizeFeedUrl package.Source.Url
@@ -111,8 +111,7 @@ let ExtractPackage(alternativeProjectRoot, root, groupName, sources, caches, for
                         sources
                         |> List.tryPick (fun source ->
                             match source with
-                            | NuGetV2 s when normalizeFeedUrl s.Url = normalized -> Some source
-                            | NuGetV3 s when normalizeFeedUrl s.Url = normalized -> Some source
+                            | NuGet s when normalizeFeedUrl s.Url = normalized -> Some source
                             | _ -> None)
 
                     match source with

--- a/src/Paket.Core/PackageManagement/NugetConvert.fs
+++ b/src/Paket.Core/PackageManagement/NugetConvert.fs
@@ -334,7 +334,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
             |> List.map (fun (n, auth) -> n, auth |> Option.map (CredsMigrationMode.ToAuthentication mode n))
             |> List.filter (fun (key,v) -> key.Contains "NuGetFallbackFolder" |> not)
             |> List.map (fun (source, auth) -> 
-                            try PackageSource.Parse(source, Some NugetProtocolVersion.ProtocolVersion3, AuthProvider.ofFunction (fun _ -> auth)) |> ok
+                            try PackageSource.Parse(source, Some ProtocolVersion3, AuthProvider.ofFunction (fun _ -> auth)) |> ok
                             with _ -> source |> PackageSourceParseError |> fail
                             |> successTee PackageSource.WarnIfNoConnection)
                             

--- a/src/Paket.Core/PackageManagement/NugetConvert.fs
+++ b/src/Paket.Core/PackageManagement/NugetConvert.fs
@@ -334,7 +334,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
             |> List.map (fun (n, auth) -> n, auth |> Option.map (CredsMigrationMode.ToAuthentication mode n))
             |> List.filter (fun (key,v) -> key.Contains "NuGetFallbackFolder" |> not)
             |> List.map (fun (source, auth) -> 
-                            try PackageSource.Parse(source,AuthProvider.ofFunction (fun _ -> auth)) |> ok
+                            try PackageSource.Parse(source, Some NugetProtocolVersion.ProtocolVersion3, AuthProvider.ofFunction (fun _ -> auth)) |> ok
                             with _ -> source |> PackageSourceParseError |> fail
                             |> successTee PackageSource.WarnIfNoConnection)
                             

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -117,7 +117,7 @@ module LockFileSerializer =
                     hasReported := true
 
                   yield "  remote: " + String.quoted source
-                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some NugetProtocolVersion.ProtocolVersion2 then "2" else "3")
+                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some ProtocolVersion2 then "2" else "3")
 
                   for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
                       let versionStr = 
@@ -460,7 +460,7 @@ module LockFileParser =
                 if String.IsNullOrWhiteSpace line || line.Trim().StartsWith("specs:") then currentGroup::otherGroups else
                 match (currentGroup, line) with
                 | Remote(RemoteUrl(url)) -> { currentGroup with RemoteUrl = url}::otherGroups
-                | Remote(ProtocolVersion(protocolVersion)) -> { currentGroup with NugetProtocolVersion = (if protocolVersion = Some "2" then Some NugetProtocolVersion.ProtocolVersion2 else Some NugetProtocolVersion.ProtocolVersion3) }::otherGroups
+                | Remote(ProtocolVersion(protocolVersion)) -> { currentGroup with NugetProtocolVersion = (if protocolVersion = Some "2" then Some ProtocolVersion2 else Some ProtocolVersion3) }::otherGroups
                 | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
                 | InstallOption(Command(command)) -> 
                     let sourceFiles = 
@@ -509,7 +509,7 @@ module LockFileParser =
 
                     match (currentGroup.RemoteUrl, currentGroup.NugetProtocolVersion) with
                     | (Some remote, Some protocolVersion) -> handleNugetDetails remote (Some protocolVersion)
-                    | (Some remote, None) -> handleNugetDetails remote (Some NugetProtocolVersion.ProtocolVersion3)
+                    | (Some remote, None) -> handleNugetDetails remote (Some ProtocolVersion3)
                     | (None, _) -> failwith "no source has been specified."
                 | NugetDependency (name, v, frameworkSettings) ->
                     let version,_,isRuntimeDependency,settings = parsePackage v

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -114,7 +114,6 @@ module LockFileSerializer =
                   if not !hasReported then
                     yield "NUGET"
                     hasReported := true
-
                   yield "  remote: " + String.quoted source
                   match protocolVersion with
                   | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion2 then "2" else "3")
@@ -293,9 +292,13 @@ module LockFileParser =
         | _, "GIT" -> RepositoryType "GIT"
         | _, "NUGET" -> RepositoryType "NUGET"
         | _, "GITHUB" -> RepositoryType "GITHUB"
-        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed -> Remote(ProtocolVersion(Some (trimmed.Trim())))
-        | _, String.RemovePrefix "remote:" trimmed -> Remote(RemoteUrl(Some (trimmed.Trim())))
-        | Some "NUGET", String.RemovePrefix "remote:" trimmed -> Remote(RemoteUrl(Some (PackageSource.Parse("source " + trimmed.Trim()).ToString())))
+        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed ->
+                Remote(ProtocolVersion(Some (trimmed.Trim())))
+        | Some "NUGET", String.RemovePrefix "remote:" trimmed ->
+            let inner = PackageSource.Parse("source " + trimmed.Trim())
+            Remote(RemoteUrl(Some (inner.ToString())))
+        | _, String.RemovePrefix "remote:" trimmed ->
+            Remote(RemoteUrl(Some (trimmed.Trim())))
         | _, String.RemovePrefix "GROUP" trimmed -> Group(trimmed.Replace("GROUP","").Trim())
         | _, String.RemovePrefix "REFERENCES:" trimmed -> InstallOption(ReferencesMode(trimmed.Trim() = "STRICT"))
         | _, String.RemovePrefix "REDIRECTS:" trimmed ->

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -111,14 +111,15 @@ module LockFileSerializer =
             let hasReported = ref false
             [ yield! serializeOptionsAsLines options
 
-              for (source), packages in sources do
+              for (source, protocolVersion), packages in sources do
                   if not !hasReported then
                     yield "NUGET"
                     hasReported := true
 
                   yield "  remote: " + String.quoted source
+                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some NugetProtocolVersion.ProtocolVersion2 then "2" else "3")
 
-                  for _,_,package in packages |> Seq.sortBy (fun (_,_,p) -> p.Name) do
+                  for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
                       let versionStr = 
                           let s'' = package.Version.ToString()
                           let s' = 

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -256,6 +256,7 @@ module LockFileParser =
         GroupName : GroupName
         RepositoryType : string option
         RemoteUrl :string option
+        NugetProtocolVersion: NugetProtocolVersion options
         Packages : ResolvedPackage list
         SourceFiles : ResolvedSourceFile list
         LastWasPackage : bool

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -448,7 +448,7 @@ module LockFileParser =
 
             parts.[0],kind,isRuntimeDependency,InstallSettings.Parse(true, optionsString)
 
-        ([{ GroupName = Constants.MainDependencyGroup; RepositoryType = None; RemoteUrl = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false }], lockFileLines)
+        ([{ GroupName = Constants.MainDependencyGroup; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false }], lockFileLines)
         ||> Seq.fold(fun state line ->
             match state with
             | [] -> failwithf "error"
@@ -456,7 +456,7 @@ module LockFileParser =
                 if String.IsNullOrWhiteSpace line || line.Trim().StartsWith("specs:") then currentGroup::otherGroups else
                 match (currentGroup, line) with
                 | Remote url -> { currentGroup with RemoteUrl = Some url }::otherGroups
-                | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
+                | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
                 | InstallOption(Command(command)) -> 
                     let sourceFiles = 
                         match currentGroup.SourceFiles with

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -479,7 +479,7 @@ module LockFileParser =
                     { currentGroup with Options = extractOption currentGroup option }::otherGroups
                 | RepositoryType repoType -> { currentGroup with RepositoryType = Some repoType }::otherGroups
                 | NugetPackage details ->
-                    let handlerNugetDetails remote protocolVersion =
+                    let handleNugetDetails remote protocolVersion =
                         let package,kind,isRuntimeDependency,settings = parsePackage details
                         let parts' = package.Split ' '
                         let version = 
@@ -503,8 +503,8 @@ module LockFileParser =
                                       IsRuntimeDependency = isRuntimeDependency } :: currentGroup.Packages }::otherGroups
 
                     match (currentGroup.RemoteUrl, currentGroup.NugetProtocolVersion) with
-                    | (Some remote, Some protocolVersion) -> handlerNugetDetails remote (Some protocolVersion)
-                    | (Some remote, None) -> handlerNugetDetails remote (Some NugetProtocolVersion.ProtocolVersion3)
+                    | (Some remote, Some protocolVersion) -> handleNugetDetails remote (Some protocolVersion)
+                    | (Some remote, None) -> handleNugetDetails remote (Some NugetProtocolVersion.ProtocolVersion3)
                     | (None, _) -> failwith "no source has been specified."
                 | NugetDependency (name, v, frameworkSettings) ->
                     let version,_,isRuntimeDependency,settings = parsePackage v

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -283,15 +283,16 @@ module LockFileParser =
     | PackagePath of string
     | OperatingSystemRestriction of string
 
-    let private (|Remote|NugetPackage|NugetDependency|SourceFile|RepositoryType|Group|InstallOption|) (state, line:string) =
+    let private (|ProtocolVersion|Remote|NugetPackage|NugetDependency|SourceFile|RepositoryType|Group|InstallOption|) (state, line:string) =
         match (state.RepositoryType, line.Trim()) with
         | _, "HTTP" -> RepositoryType "HTTP"
         | _, "GIST" -> RepositoryType "GIST"
         | _, "GIT" -> RepositoryType "GIT"
         | _, "NUGET" -> RepositoryType "NUGET"
         | _, "GITHUB" -> RepositoryType "GITHUB"
-        | Some "NUGET", String.RemovePrefix "remote:" trimmed -> Remote(PackageSource.Parse("source " + trimmed.Trim()).ToString())
+        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed -> ProtocolVersion(trimmed.Trim())
         | _, String.RemovePrefix "remote:" trimmed -> Remote(trimmed.Trim())
+        | Some "NUGET", String.RemovePrefix "remote:" trimmed -> Remote(PackageSource.Parse("source " + trimmed.Trim()).ToString())
         | _, String.RemovePrefix "GROUP" trimmed -> Group(trimmed.Replace("GROUP","").Trim())
         | _, String.RemovePrefix "REFERENCES:" trimmed -> InstallOption(ReferencesMode(trimmed.Trim() = "STRICT"))
         | _, String.RemovePrefix "REDIRECTS:" trimmed -> 
@@ -456,6 +457,7 @@ module LockFileParser =
             | currentGroup::otherGroups ->
                 if String.IsNullOrWhiteSpace line || line.Trim().StartsWith("specs:") then currentGroup::otherGroups else
                 match (currentGroup, line) with
+                | ProtocolVersion protocolVersion -> { currentGroup with NugetProtocolVersion = Some protocolVersion }::otherGroups
                 | Remote url -> { currentGroup with RemoteUrl = Some url }::otherGroups
                 | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
                 | InstallOption(Command(command)) -> 

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -100,12 +100,12 @@ module LockFileSerializer =
             |> Seq.map (fun kv ->
                     let package = kv.Value
                     match package.Source with
-                    | NuGetV2 source -> source.Url,source.Authentication,package
-                    | NuGetV3 source -> source.Url,source.Authentication,package
+                    | NuGetV2 source -> source.Url,Some source.ProtocolVersion,source.Authentication,package
+                    | NuGetV3 source -> source.Url,Some source.ProtocolVersion,source.Authentication,package
                     // TODO: Add credentials provider...
-                    | LocalNuGet(path,_) -> path,AuthService.GetGlobalAuthenticationProvider path,package
+                    | LocalNuGet(path,_) -> path,None,AuthService.GetGlobalAuthenticationProvider path,package
                 )
-            |> Seq.groupBy (fun (a,b,_) -> a)
+            |> Seq.groupBy (fun (nugetSource, protocolVersion, authProvider,_) -> (nugetSource, protocolVersion))
 
         let all = 
             let hasReported = ref false

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -116,7 +116,9 @@ module LockFileSerializer =
                     hasReported := true
 
                   yield "  remote: " + String.quoted source
-                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some ProtocolVersion2 then "2" else "3")
+                  match protocolVersion with
+                  | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion2 then "2" else "3")
+                  | None -> ()
 
                   for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
                       let versionStr =

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -646,7 +646,7 @@ type Dependencies(dependenciesFileName: string) =
         |> Seq.distinct
         |> Seq.map (fun source ->
             match source with
-            | NuGetV2 s ->
+            | NuGet ({ ProtocolVersion = ProtocolVersion2 } as s) ->
                 let res = NuGetV3.getSearchAPI(s.Authentication,s.Url) |> Async.AwaitTask |> Async.RunSynchronously
                 match res with
                 | Some _ ->
@@ -655,7 +655,7 @@ type Dependencies(dependenciesFileName: string) =
                 | None ->
                     NuGetV2.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
                     |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
-            | NuGetV3 s ->
+            | NuGet ({ ProtocolVersion = ProtocolVersion3 } as s) ->
                 NuGetV3.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
                 |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
             | LocalNuGet(s,_) ->

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -108,7 +108,62 @@ let internal parseAuth(text:string, source) =
     else
         getAuth()
 
-let internal parseProtocolVersion(text:string, source) =
+let (|NugetV3Url|_|) (url: Uri) =
+  if url.ToString() = "https://api.nuget.org/v3/index.json" then Some () else None
+
+type 't ``[]`` with
+  member x.GetReverseIndex(i: int) = x.[x.Length - i]
+
+let (|Https|_|) (uri: Uri) = if uri.Scheme = "https" then Some () else None
+let (|Host|_|) (h: string) (uri: Uri) =
+    if uri.Host.EndsWith h
+    then Some ()
+    else None
+
+let (|LeadingPathSegments|_|) (segs: string[]) (uri: Uri) =
+    let segCount = segs.Length
+    let uriSegs = uri.Segments
+    if uriSegs.Length < segCount+1 then None // initial segment is a /, so we need to skip it
+    else
+        let items: string[] = uriSegs.[1..segCount]
+        let matched =
+            (items, segs)
+            ||> Array.zip
+            |> Array.forall(fun (l, r) -> l.TrimEnd('/') = r) // have to trim end because the Uri.Segments api keeps the /-separators on the end of the segment
+        if matched then Some () else None
+
+let (|TrailingPathSegments|_|) (segs: string []) (uri: Uri) =
+    let segCount = segs.Length
+    let uriSegs = uri.Segments
+    if uriSegs.Length < segCount then None
+    else
+        let items: string[] = uriSegs.[(uriSegs.Length-segCount)..]
+        let matched =
+            (items, segs)
+            ||> Array.zip
+            |> Array.forall(fun (l, r) -> l.TrimEnd('/') = r) // have to trim end because the Uri.Segments api keeps the /-separators on the end of the segment
+        if matched then Some () else None
+
+let (|MyGetV3Url|_|) (url: Uri) =
+
+  // https://<your_myget_domain>/F/<your-feed-name>/<feed_endpoint>
+  try
+      match url with
+      | Https & Host "myget.org" & TrailingPathSegments [|"api";"v3"; "index.json"|] -> Some ()
+      | _ -> None
+  with _ -> None
+
+let (|ArtifactoryV3Url|_|) (url: Uri) =
+    match url with
+    | LeadingPathSegments [|"artifactory"; "api";"nuget";"v3"|] -> Some ()
+    | _ -> None
+
+let (|KnownNugetV3Endpoint|_|) url =
+    match Uri url with
+    | NugetV3Url | MyGetV3Url | ArtifactoryV3Url -> Some ()
+    | _ -> None
+
+let internal parseProtocolVersion(text:string, nugetSource) =
     if text.Contains("protocolVersion:") then
         if not (protocolVersionRegex.IsMatch(text)) then
             failwithf "Could not parse protocolVersion in \"%s\"" text
@@ -121,7 +176,13 @@ let internal parseProtocolVersion(text:string, source) =
         | (true, 3) -> Some ProtocolVersion3
         | _ -> failwithf "Unsupported protocolVersion in \"%s\". Should be either 2 or 3" text
     else
-        None
+        // derive protocolVersion from some well-known urls
+        try
+            match nugetSource with
+            | KnownNugetV3Endpoint -> Some ProtocolVersion3
+            | _ -> None
+        with
+        | _ -> None
 
 /// Represents the package source type.
 type PackageSource =
@@ -150,7 +211,7 @@ type PackageSource =
 
         PackageSource.Parse(feed, parseProtocolVersion(line, feed), parseAuth(line, feed))
 
-    static member Parse(source,auth) =
+    static member Parse(source, protocolVersion, auth) =
         match tryParseWindowsStyleNetworkPath source with
         | Some path -> PackageSource.Parse(path)
         | _ ->

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -142,7 +142,7 @@ type PackageSource =
         | _ when urlSimilarToTfsOrVsts x.Url -> KnownNuGetSources.TfsOrVsts
         | _ -> KnownNuGetSources.UnknownNuGetServer
     static member Parse(line : string) =
-        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"][ ]*(protocolVersion[ ]*:\d)", RegexOptions.IgnoreCase)
+        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"](\s+.+)?", RegexOptions.IgnoreCase)
         let parts = line.Split ' '
         let source =
             if sourceRegex.IsMatch line then

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -199,7 +199,7 @@ type PackageSource =
         | _ when urlSimilarToTfsOrVsts x.Url -> KnownNuGetSources.TfsOrVsts
         | _ -> KnownNuGetSources.UnknownNuGetServer
     static member Parse(line : string) =
-        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"](\s+.+)?", RegexOptions.IgnoreCase)
+        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"]([ ]+.+)?", RegexOptions.IgnoreCase)
         let parts = line.Split ' '
         let source =
             if sourceRegex.IsMatch line then

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -119,8 +119,8 @@ let internal parseProtocolVersion(text:string, source) =
         let (parsed, specifiedProtocolVersion) = Int32.TryParse(textProtocolVersion)
 
         match (parsed,specifiedProtocolVersion) with
-        | (true, 2) -> Some NugetProtocolVersion.ProtocolVersion2
-        | (true, 3) -> Some NugetProtocolVersion.ProtocolVersion3
+        | (true, 2) -> Some ProtocolVersion2
+        | (true, 3) -> Some ProtocolVersion3
         | _ -> failwithf "Unsupported protocolVersion in \"%s\". Should be either 2 or 3" text
     else
         None
@@ -168,9 +168,9 @@ type PackageSource =
                     LocalNuGet(source,None)
                 else
                     match protocolVersion with
-                    | Some NugetProtocolVersion.ProtocolVersion2 -> NuGetV2 { Url = source; ProtocolVersion = NugetProtocolVersion.ProtocolVersion2; Authentication = auth }
-                    | Some NugetProtocolVersion.ProtocolVersion3 -> NuGetV3 { Url = source; ProtocolVersion = NugetProtocolVersion.ProtocolVersion3; Authentication = auth }
-                    | None -> NuGetV3 { Url = source; ProtocolVersion = NugetProtocolVersion.ProtocolVersion3; Authentication = auth }
+                    | Some ProtocolVersion2 -> NuGetV2 { Url = source; ProtocolVersion = ProtocolVersion2; Authentication = auth }
+                    | Some ProtocolVersion3 -> NuGetV3 { Url = source; ProtocolVersion = ProtocolVersion3; Authentication = auth }
+                    | None -> NuGetV3 { Url = source; ProtocolVersion = ProtocolVersion3; Authentication = auth }
             | _ ->  match System.Uri.TryCreate(source, System.UriKind.Relative) with
                     | true, uri -> LocalNuGet(source,None)
                     | _ -> failwithf "unable to parse package source: %s" source
@@ -192,8 +192,8 @@ type PackageSource =
         | NuGetV3 n -> n.Authentication
         | LocalNuGet(n,_) -> CredentialProviders.GetAuthenticationProvider n
 
-    static member NuGetV2Source url = NuGetV2 { Url = url; ProtocolVersion = NugetProtocolVersion.ProtocolVersion2; Authentication  = CredentialProviders.GetAuthenticationProvider url }
-    static member NuGetV3Source url = NuGetV3 { Url = url; ProtocolVersion = NugetProtocolVersion.ProtocolVersion3; Authentication  = CredentialProviders.GetAuthenticationProvider url }
+    static member NuGetV2Source url = NuGetV2 { Url = url; ProtocolVersion = ProtocolVersion2; Authentication  = CredentialProviders.GetAuthenticationProvider url }
+    static member NuGetV3Source url = NuGetV3 { Url = url; ProtocolVersion = ProtocolVersion3; Authentication  = CredentialProviders.GetAuthenticationProvider url }
 
     static member FromCache (cache:Cache) = LocalNuGet(cache.Location,Some cache)
 

--- a/tests/Paket.Tests.preview3/Paket.Tests.fsproj
+++ b/tests/Paket.Tests.preview3/Paket.Tests.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="$(PaketTestsSourcesDir)\Versioning\DependencySetSpecs.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\Versioning\FrameworkRestrictionTests.fs" />
     <Compile Include="$(PaketTestsSourcesDir)\Versioning\InterprojectReferencesConstraintSpecs.fs" />
+    <Compile Include="$(PaketTestsSourcesDir)\Versioning\PackageSourceSpecs.fs" />
     <TestAsset Include="Nuspec\EmptyLibs.nuspec" />
     <TestAsset Include="Nuspec\Fantomas.nuspec" />
     <TestAsset Include="Nuspec\FluentAssertions.nuspec" />

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -28,7 +28,7 @@ let ``should read config which only contains a source``() =
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
-    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head  |> shouldEqual (NuGetV2({ Url = "http://www.nuget.org/api/v2"; Authentication = AuthProvider.empty }))
+    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head  |> shouldEqual (NuGetV2({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual None
 let config1 = """
@@ -709,6 +709,7 @@ let ``should read config with encapsulated password source with no auth type spe
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual (Some (Credentials{ Username = "tatü tata"; Password = "you got hacked!"; Type = NetUtils.AuthType.Basic}))
@@ -726,6 +727,7 @@ let ``should read config with encapsulated password source and auth type specifi
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.ofUserPassword { Username = "tatü tata"; Password = "you got hacked!"; Type = NetUtils.AuthType.NTLM} } ]
 
 let configWithPasswordInSingleQuotes = """
@@ -756,6 +758,7 @@ let ``should read config with password in env variable``() =
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2;
             Authentication = AuthProvider.empty} ]
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual (Some (Credentials{ Username = "user XYZ"; Password = "pw Love"; Type = NetUtils.AuthType.Basic}))
@@ -775,6 +778,7 @@ let ``should read config with password in env variable and auth type specified``
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual (Some (Credentials{ Username = "user XYZ"; Password = "pw Love"; Type = NetUtils.AuthType.NTLM}))

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -11,7 +11,7 @@ open Paket.Requirements
 open Paket.ModuleResolver
 
 [<Test>]
-let ``should read empty config``() = 
+let ``should read empty config``() =
     let cfg = DependenciesFile.FromSource("")
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -23,12 +23,12 @@ source http://www.nuget.org/api/v2
 """
 
 [<Test>]
-let ``should read config which only contains a source``() = 
+let ``should read config which only contains a source``() =
     let cfg = DependenciesFile.FromSource(configWithSourceOnly)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
-    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head  |> shouldEqual (NuGetV2({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
+    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head |> shouldEqual (NuGet({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual None
 let config1 = """
@@ -41,7 +41,7 @@ nuget "SignalR" "= 3.3.2"
 """
 
 [<Test>]
-let ``should read simple config``() = 
+let ``should read simple config``() =
     let cfg = DependenciesFile.FromSource(config1)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -57,7 +57,7 @@ nuget Castle.Windsor-log4net >= 3.2 prerelease # test
 """
 
 [<Test>]
-let ``should read simple config with prerelease and comment``() = 
+let ``should read simple config with prerelease and comment``() =
     let cfg = DependenciesFile.FromSource(configWithComment)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -72,7 +72,7 @@ nuget Castle.Windsor-log4net
 """
 
 [<Test>]
-let ``should read simple config with version line for bootstrapper``() = 
+let ``should read simple config with version line for bootstrapper``() =
     DependenciesFile.FromSource(configWithVersionLine) |> ignore
 
 
@@ -86,7 +86,7 @@ nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read simple config with additional comment``() = 
+let ``should read simple config with additional comment``() =
     let cfg = DependenciesFile.FromSource(config2)
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"].Range |> shouldEqual (VersionRange.Between("2.2", "3.0"))
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FAKE"].Range |> shouldEqual (VersionRange.Between("3.0", "4.0"))
@@ -101,7 +101,7 @@ nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read simple config with comments``() = 
+let ``should read simple config with comments``() =
     let cfg = DependenciesFile.FromSource(config3)
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"].Range |> shouldEqual (VersionRange.Between("2.2", "3.0"))
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> List.head |> shouldEqual PackageSources.DefaultNuGetSource
@@ -111,13 +111,13 @@ let config4 = """
 source "https://www.nuget.org/api/v2" // first source
 source "http://nuget.org/api/v3"  // second
 
-nuget "FAKE" "~> 3.0" 
+nuget "FAKE" "~> 3.0"
 nuget "Rx-Main" "~> 2.2"
 nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read config with multiple sources``() = 
+let ``should read config with multiple sources``() =
     let cfg = DependenciesFile.FromSource(config4)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -145,7 +145,7 @@ let ``should read source file from config``() =
             Project = "FAKE"
             Origin = ModuleResolver.Origin.GitHubLink
             Name = "src/app/FAKE/FileWithCommit.fs"
-            Version = VersionRestriction.Concrete "bla123zxc" 
+            Version = VersionRestriction.Concrete "bla123zxc"
             Command = None
             OperatingSystemRestriction = None
             PackagePath = None
@@ -168,7 +168,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read strict config``() = 
+let ``should read strict config``() =
     let cfg = DependenciesFile.FromSource(strictConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual true
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual None
@@ -183,7 +183,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read config with redirects``() = 
+let ``should read config with redirects``() =
     let cfg = DependenciesFile.FromSource(redirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
@@ -198,7 +198,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read config with no redirects``() = 
+let ``should read config with no redirects``() =
     let cfg = DependenciesFile.FromSource(noRedirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.Off)
@@ -213,7 +213,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read content none config``() = 
+let ``should read content none config``() =
     let cfg = DependenciesFile.FromSource(noneContentConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual None
@@ -230,7 +230,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read config with specific framework``() = 
+let ``should read config with specific framework``() =
     let cfg = DependenciesFile.FromSource(specificFrameworkConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual None
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual None
@@ -249,7 +249,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read no targets import config``() = 
+let ``should read no targets import config``() =
     let cfg = DependenciesFile.FromSource(noTargetsImportConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.ImportTargets |> shouldEqual (Some false)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual (Some false)
@@ -281,7 +281,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read no copy_content_to_output_dir config``() = 
+let ``should read no copy_content_to_output_dir config``() =
     let cfg = DependenciesFile.FromSource(copyContent)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyContentToOutputDirectory |> shouldEqual (Some CopyToOutputDirectorySettings.Always)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual None
@@ -298,7 +298,7 @@ nuget SignalR = 3.3.2
 """
 
 [<Test>]
-let ``should read config without quotes``() = 
+let ``should read config without quotes``() =
     let cfg = DependenciesFile.FromSource(configWithoutQuotes)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).Count |> shouldEqual 4
@@ -317,7 +317,7 @@ nuget SignalR = 3.3.2
 """
 
 [<Test>]
-let ``should read config local quoted source``() = 
+let ``should read config local quoted source``() =
     let cfg = DependenciesFile.FromSource(configLocalQuotedSource)
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual "D:\code\\temp with space"
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
@@ -338,7 +338,7 @@ nuget SignalR    = 3.3.2
 """
 
 [<Test>]
-let ``should read config without quotes but lots of whitespace``() = 
+let ``should read config without quotes but lots of whitespace``() =
     let cfg = DependenciesFile.FromSource(configWithoutQuotes)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).Count |> shouldEqual 4
@@ -352,7 +352,7 @@ let ``should read config without quotes but lots of whitespace``() =
 [<Test>]
 let ``should read github source file from config without quotes``() =
     let config = """github fsharp/FAKE:master   src/app/FAKE/Cli.fs
-                    github    fsharp/FAKE:bla123zxc src/app/FAKE/FileWithCommit.fs 
+                    github    fsharp/FAKE:bla123zxc src/app/FAKE/FileWithCommit.fs
                     github    fsharp/FAKE src/app/FAKE/FileWithCommit.fs github
                  """
     let dependencies = DependenciesFile.FromSource(config)
@@ -375,7 +375,7 @@ let ``should read github source file from config without quotes``() =
             Command = None
             OperatingSystemRestriction = None
             PackagePath = None
-            AuthKey = None } 
+            AuthKey = None }
           { Owner = "fsharp"
             Project = "FAKE"
             Origin = ModuleResolver.Origin.GitHubLink
@@ -389,7 +389,7 @@ let ``should read github source file from config without quotes``() =
 [<Test>]
 let ``should read github source file from config with quotes``() =
     let config = """github fsharp/FAKE:master  "src/app/FAKE/Cli.fs"
-                    github fsharp/FAKE:bla123zxc "src/app/FAKE/FileWith Space.fs" 
+                    github fsharp/FAKE:bla123zxc "src/app/FAKE/FileWith Space.fs"
                     github fsharp/FAKE "src/app/FAKE/FileWith Space.fs" github
                  """
     let dependencies = DependenciesFile.FromSource(config)
@@ -562,7 +562,7 @@ let ``should read gist source file``() =
 
 nuget JetBrainsAnnotations.Fody
 
-gist misterx/5d9c6983004c1c9ec91f""" 
+gist misterx/5d9c6983004c1c9ec91f"""
     let dependencies = DependenciesFile.FromSource(config)
     dependencies.Groups.[Constants.MainDependencyGroup].RemoteFiles
     |> shouldEqual
@@ -688,7 +688,7 @@ nuget "FAKE"
 """
 
 [<Test>]
-let ``should read config without versions``() = 
+let ``should read config without versions``() =
     let cfg = DependenciesFile.FromSource(configWithoutVersions)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"] .Range|> shouldEqual (VersionRange.AtLeast "0")
@@ -702,12 +702,12 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with encapsulated password source with no auth type specified``() = 
+let ``should read config with encapsulated password source with no auth type specified``() =
     let cfg = DependenciesFile.FromSource(configWithPasswordNoAuthType)
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].Sources
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
@@ -720,12 +720,12 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with encapsulated password source and auth type specified``() = 
+let ``should read config with encapsulated password source and auth type specified``() =
     let cfg = DependenciesFile.FromSource(configWithPasswordWithAuthType)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.ofUserPassword { Username = "tatü tata"; Password = "you got hacked!"; Type = NetUtils.AuthType.NTLM} } ]
@@ -736,7 +736,7 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with single-quoted password source``() = 
+let ``should read config with single-quoted password source``() =
     try
         DependenciesFile.FromSource configWithPasswordInSingleQuotes |> ignore
         failwith "Expected error"
@@ -749,14 +749,14 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with password in env variable``() = 
+let ``should read config with password in env variable``() =
     Environment.SetEnvironmentVariable("FEED_USERNAME", "user XYZ", EnvironmentVariableTarget.Process)
     Environment.SetEnvironmentVariable("FEED_PASSWORD", "pw Love", EnvironmentVariableTarget.Process)
     let cfg = DependenciesFile.FromSource( configWithPasswordInEnvVariable)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2;
             Authentication = AuthProvider.empty} ]
@@ -769,14 +769,14 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with password in env variable and auth type specified``() = 
+let ``should read config with password in env variable and auth type specified``() =
     Environment.SetEnvironmentVariable("FEED_USERNAME", "user XYZ", EnvironmentVariableTarget.Process)
     Environment.SetEnvironmentVariable("FEED_PASSWORD", "pw Love", EnvironmentVariableTarget.Process)
     let cfg = DependenciesFile.FromSource( configWithPasswordInEnvVariableAndAuthType)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
@@ -786,12 +786,12 @@ let ``should read config with password in env variable and auth type specified``
 let configWithExplicitVersions = """
 source "http://www.nuget.org/api/v2"
 
-nuget FSharp.Compiler.Service == 0.0.62 
+nuget FSharp.Compiler.Service == 0.0.62
 nuget FsReveal == 0.0.5-beta
 """
 
 [<Test>]
-let ``should read config explicit versions``() = 
+let ``should read config explicit versions``() =
     let cfg = DependenciesFile.FromSource(configWithExplicitVersions)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.OverrideAll (SemVer.Parse "0.0.62"))
@@ -804,7 +804,7 @@ nuget Nancy.Owin 0.22.2
 """
 
 [<Test>]
-let ``should read config with local source``() = 
+let ``should read config with local source``() =
     let cfg = DependenciesFile.FromSource(configWithLocalSource)
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Nancy.Owin")
@@ -813,7 +813,7 @@ let ``should read config with local source``() =
 
 
 [<Test>]
-let ``should read config with package name containing nuget``() = 
+let ``should read config with package name containing nuget``() =
     let config = """
     nuget nuget.Core 0.1
     """
@@ -822,7 +822,7 @@ let ``should read config with package name containing nuget``() =
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "nuget.Core"].Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "0.1"))
 
 [<Test>]
-let ``should read config with single framework restriction``() = 
+let ``should read config with single framework restriction``() =
     let config = """
     nuget Foobar 1.2.3 framework: >= net40
     """
@@ -835,7 +835,7 @@ let ``should read config with single framework restriction``() =
 
 
 [<Test>]
-let ``should read config with framework restriction``() = 
+let ``should read config with framework restriction``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta framework: net35, >= net40
     """
@@ -849,7 +849,7 @@ let ``should read config with framework restriction``() =
     p.Settings.SpecificVersion |> shouldEqual None
 
 [<Test>]
-let ``should read config with no targets import``() = 
+let ``should read config with no targets import``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta import_targets: false, copy_local: false, specific_version: false
     """
@@ -864,7 +864,7 @@ let ``should read config with no targets import``() =
     p.Settings.OmitContent |> shouldEqual None
 
 [<Test>]
-let ``should read config with content none``() = 
+let ``should read config with content none``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta content: none, copy_local: false, specific_version: true
     """
@@ -879,7 +879,7 @@ let ``should read config with content none``() =
     p.Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
 
 [<Test>]
-let ``should read config with  !~> 3.3``() = 
+let ``should read config with  !~> 3.3``() =
     let config = """source https://www.nuget.org/api/v2
 
 nuget AutoMapper ~> 3.2
@@ -903,11 +903,11 @@ nuget Caliburn.Micro !~> 2.0.2
 
 
 let configWithInvalidPrereleaseString = """
-    nuget Plossum.CommandLine !0.3.0.14   
+    nuget Plossum.CommandLine !0.3.0.14
 """
 
 [<Test>]
-let ``should report error on invalid prerelease string``() = 
+let ``should report error on invalid prerelease string``() =
     try
         DependenciesFile.FromSource(configWithInvalidPrereleaseString) |> ignore
         failwith "error"
@@ -919,7 +919,7 @@ let html = """
 """
 
 [<Test>]
-let ``should not read hhtml``() = 
+let ``should not read hhtml``() =
     try
         DependenciesFile.FromSource(html) |> ignore
         failwith "error"
@@ -939,7 +939,7 @@ nuget NUnit
 """
 
 [<Test>]
-let ``should read config with additional group``() = 
+let ``should read config with additional group``() =
     let cfg = DependenciesFile.FromSource(configWithAdditionalGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -961,7 +961,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with nested group``() = 
+let ``should read config with nested group``() =
     let cfg = DependenciesFile.FromSource(configWithNestedGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -986,7 +986,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with explizit main group``() = 
+let ``should read config with explizit main group``() =
     let cfg = DependenciesFile.FromSource(configWithExplicitMainGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -1011,7 +1011,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with reference condition``() = 
+let ``should read config with reference condition``() =
     let cfg = DependenciesFile.FromSource(configWithReferenceCondition)
 
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.ReferenceCondition |> shouldEqual (Some "MAIN-GROUP")
@@ -1029,7 +1029,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with NuGet v3 feed``() = 
+let ``should read config with NuGet v3 feed``() =
     let cfg = DependenciesFile.FromSource(configWithNugetV3Source)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual Constants.DefaultNuGetV3Stream
@@ -1041,7 +1041,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with NuGet http v3 feed``() = 
+let ``should read config with NuGet http v3 feed``() =
     let cfg = DependenciesFile.FromSource(configWithNugetV3HTTPSource)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual (Constants.DefaultNuGetV3Stream.Replace("https://","http://"))
@@ -1054,7 +1054,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with duplicate NuGet source``() = 
+let ``should read config with duplicate NuGet source``() =
     let cfg = DependenciesFile.FromSource(configWithDuplicateSource)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
@@ -1069,7 +1069,7 @@ nuget Oracle.ManagedDataAccess framework: >= net40 content: none
 """
 
 [<Test>]
-let ``should not read config with invalid settings``() = 
+let ``should not read config with invalid settings``() =
     shouldFail (fun () -> DependenciesFile.FromSource(configWithInvalidInstallSettings) |> ignore)
 
 let strategyConfig = sprintf """
@@ -1084,13 +1084,13 @@ group Test
 """
 
 [<Test>]
-let ``should read config with min and max strategy``() = 
+let ``should read config with min and max strategy``() =
     let cfg = DependenciesFile.FromSource(strategyConfig "min" "max")
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Max)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NuGetV2Source "http://www.nuget.org/api/v2"]
-    
+
 let noStrategyConfig = sprintf """
 strategy %s
 source "http://www.nuget.org/api/v2" // first source
@@ -1102,7 +1102,7 @@ group Test
 """
 
 [<Test>]
-let ``should read config with min and no strategy``() = 
+let ``should read config with min and no strategy``() =
     let cfg = DependenciesFile.FromSource(noStrategyConfig "min")
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual None
@@ -1119,7 +1119,7 @@ group Test
 """
 
 [<Test>]
-let ``should read config with no strategy``() = 
+let ``should read config with no strategy``() =
     let cfg = DependenciesFile.FromSource(noStrategyConfig')
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual None
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual None
@@ -1152,7 +1152,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with combined strategy``() = 
+let ``should read config with combined strategy``() =
     let cfg = DependenciesFile.FromSource(combinedStrategyConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
@@ -1169,7 +1169,7 @@ nuget FsReveal
 """
 
 [<Test>]
-let ``should read config with very similar feeds``() = 
+let ``should read config with very similar feeds``() =
     let cfg = DependenciesFile.FromSource(configWithVerySimilarFeeds)
 
     try
@@ -1177,12 +1177,12 @@ let ``should read config with very similar feeds``() =
     with e ->
         System.Console.Error.WriteLine("Credential Provider failed: " + e.Message)
         () // Might throw when we have a global authentication provider
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual "http://nexus1:8081/nexus/service/local/nuget/nuget-repo"
 
     try
         cfg.Groups.[Constants.MainDependencyGroup].Sources.Tail.Head.Auth.Retrieve false |> shouldNotEqual None
-    with e -> 
+    with e ->
         System.Console.Error.WriteLine("Credential Provider failed: " + e.Message)
         () // Might throw when we have a global authentication provider
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Tail.Head.Url |> shouldEqual "http://nexus2:8081/nexus/service/local/nuget/nuget-repo"
@@ -1195,7 +1195,7 @@ nuget System.Data.SQLite 1.0.98.1 content: none
 """
 
 [<Test>]
-let ``should read config with target framework``() = 
+let ``should read config with target framework``() =
     let cfg = DependenciesFile.FromSource(configTargetFramework)
 
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
@@ -1251,7 +1251,7 @@ let ``should throw on config with invalid target framework`` config =
     shouldFail<Exception> (fun () -> DependenciesFile.FromSource(config) |> ignore)
 
 [<Test>]
-let ``should read packages with redirects``() = 
+let ``should read packages with redirects``() =
     let config = """
 redirects on
 source http://www.nuget.org/api/v2
@@ -1293,7 +1293,7 @@ git http://github.com/fsprojects/Chessie.git master
 """
 
 [<Test>]
-let ``should read paket git config``() = 
+let ``should read paket git config``() =
     let cfg = DependenciesFile.FromSource(paketGitConfig)
     let gitSource = cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "git@github.com:fsprojects/Paket.git"
@@ -1341,7 +1341,7 @@ group Dev
 """
 
 [<Test>]
-let ``should read paket git config with build command``() = 
+let ``should read paket git config with build command``() =
     let cfg = DependenciesFile.FromSource(paketGitConfigWithBuildCommand)
     let gitSource = cfg.Groups.[GroupName "Dev"].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
@@ -1382,7 +1382,7 @@ let ``should read paket git config with build command``() =
     let nupkgtestSource = cfg.Groups.[GroupName "Dev"].Sources.Head
     nupkgtestSource.Url |> shouldEqual "paket-files/dev/github.com/forki/nupkgtest/source"
 
-    
+
     let buildSource = cfg.Groups.[GroupName "Dev"].RemoteFiles.Tail.Tail.Tail.Tail.Head
     buildSource.GetCloneUrl() |> shouldEqual "https://github.com/forki/nupkgtest.git"
     buildSource.Owner |> shouldEqual "github.com/forki"
@@ -1391,7 +1391,7 @@ let ``should read paket git config with build command``() =
     buildSource.PackagePath |> shouldEqual (Some "/source/")
     buildSource.Command |> shouldEqual (Some "build.cmd")
     buildSource.OperatingSystemRestriction |> shouldEqual None
- 
+
     cfg.Groups.[GroupName "Dev"].Sources
     |> List.map (fun x -> x.Url)
     |> shouldContain "paket-files/dev/github.com/forki/nupkgtest/source"
@@ -1411,9 +1411,9 @@ group Git
 """
 
 [<Test>]
-let ``should read paket git config with tags``() = 
+let ``should read paket git config with tags``() =
     let cfg = DependenciesFile.FromSource(paketGitTagsConfig)
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1440,7 +1440,7 @@ let ``should read paket git config with tags``() =
     gitSource.OperatingSystemRestriction |> shouldEqual None
     gitSource.PackagePath |> shouldEqual (Some "/temp/")
     gitSource.Project |> shouldEqual "Paket"
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Tail.Tail.Tail.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1449,7 +1449,7 @@ let ``should read paket git config with tags``() =
     gitSource.OperatingSystemRestriction |> shouldEqual None
     gitSource.PackagePath |> shouldEqual (Some "/temp/")
     gitSource.Project |> shouldEqual "Paket"
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Tail.Tail.Tail.Tail.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1472,7 +1472,7 @@ nuget Chessie
 """
 
 [<Test>]
-let ``should read config with caches``() = 
+let ``should read config with caches``() =
     let cfg = DependenciesFile.FromSource(simpleCacheConfig)
     let main = cfg.Groups.[Constants.MainDependencyGroup]
     main.Caches |> List.length |> shouldEqual 2
@@ -1489,7 +1489,7 @@ let ``should read config with caches``() =
 let ``async cache should work``() =
      // this test is already include in the to Visualfsharp repo
      let x = ref 0
-     let someSlowFunc mykey = async { 
+     let someSlowFunc mykey = async {
          Console.WriteLine "Simulated downloading..."
          do! Async.Sleep 400
          Console.WriteLine "Simulated downloading Done."
@@ -1500,7 +1500,7 @@ let ``async cache should work``() =
          do! memFunc "a" |> Async.Ignore
          do! memFunc "a" |> Async.Ignore
          do! memFunc "a" |> Async.Ignore
-         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a")) 
+         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a"))
              |> Async.Parallel |> Async.Ignore
          for i = 1 to 30 do
              Async.Start( memFunc "a" |> Async.Ignore )
@@ -1510,7 +1510,7 @@ let ``async cache should work``() =
          do! memFunc "a" |> Async.Ignore
          for i = 1 to 30 do
              Async.Start( memFunc "a" |> Async.Ignore )
-         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a")) 
+         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a"))
              |> Async.Parallel |> Async.Ignore
      } |> Async.RunSynchronously
      !x |> shouldEqual 1
@@ -1534,9 +1534,9 @@ nuget xunit
 """
 
 [<Test>]
-let ``should read autodetect from main group``() = 
+let ``should read autodetect from main group``() =
     let cfg = DependenciesFile.FromSource(autodetectconfig)
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions 
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
     |> shouldEqual FrameworkRestrictions.AutoDetectFramework
 
 let autodetectconfigSpecific = """
@@ -1560,9 +1560,9 @@ nuget xunit
 """
 
 [<Test>]
-let ``should read autodetect from specific main group``() = 
+let ``should read autodetect from specific main group``() =
     let cfg = DependenciesFile.FromSource(autodetectconfigSpecific)
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions 
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
     |> shouldEqual FrameworkRestrictions.AutoDetectFramework
 
 [<Test>]
@@ -1576,7 +1576,7 @@ let ``parsing generate load scripts`` () =
     ]
     let results = [
         for case, expectation in casesAndExpectation do
-            let config = 
+            let config =
                 DependenciesFile.FromSource <|
                 match case with
                 | Some value ->
@@ -1606,11 +1606,11 @@ nuget FAKE
 """
 
 [<Test>]
-let ``should read config with cli tool``() = 
+let ``should read config with cli tool``() =
     let cfg = DependenciesFile.FromSource(configWithCLitTool)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
     |> shouldEqual [PackageSources.DefaultNuGetSource]
 
     let tool = cfg.Groups.[Constants.MainDependencyGroup].Packages.Head

--- a/tests/Paket.Tests/InstallModel/RuntimeGraphTests.fs
+++ b/tests/Paket.Tests/InstallModel/RuntimeGraphTests.fs
@@ -149,6 +149,7 @@ let ``Check that runtime dependencies are saved as such in the lockfile`` () =
 
     let expectedLockFile = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     MyDependency (4.0)
     MyRuntimeDependency (4.0.1) - isRuntimeDependency: true"""
 
@@ -233,7 +234,7 @@ let ``Check that runtime dependencies are loaded from the lockfile`` () =
     |> List.sortBy (fun (t,_,_) ->t)
     |> shouldEqual expected
 
-    
+
 [<Test>]
 let ``Check that runtime inheritance works`` () =
     let runtimeGraph = RuntimeGraphParser.readRuntimeGraph rids
@@ -250,13 +251,13 @@ let ``Check that runtime inheritance works`` () =
     let model =
         InstallModel.EmptyModel (PackageName "testpackage", SemVer.Parse "1.0.0")
         |> InstallModel.addNuGetFiles content
-        
+
     let targetProfile = Paket.TargetProfile.SinglePlatform(Paket.FrameworkIdentifier.DotNetStandard (Paket.DotNetStandardVersion.V1_6))
     model.GetRuntimeAssemblies runtimeGraph (Rid.Of "win-x86") (targetProfile)
     |> Seq.map (fun fi -> fi.Library.PathWithinPackage)
     |> Seq.toList
     |> shouldEqual [ "runtimes/win/lib/netstandard1.1/testpackage.dll" ]
-    
+
 [<Test>]
 let ``Check that runtime inheritance works (2)`` () =
     let runtimeGraph = runtimeGraphMsNetCorePlatforms2_2_1
@@ -279,7 +280,7 @@ let ``Check that runtime inheritance works (2)`` () =
     let model =
         InstallModel.EmptyModel (PackageName "System.Runtime.InteropServices.RuntimeInformation", SemVer.Parse "4.3.0")
         |> InstallModel.addNuGetFiles content
-        
+
     let targetProfile = Paket.TargetProfile.SinglePlatform(Paket.FrameworkIdentifier.DotNetStandard (Paket.DotNetStandardVersion.V1_6))
     model.GetRuntimeAssemblies runtimeGraph (Rid.Of "win10-x86") (targetProfile)
     |> Seq.map (fun fi -> fi.Library.PathWithinPackage)
@@ -291,4 +292,3 @@ let ``Check correct inheritance list`` () =
     let runtimeGraph = RuntimeGraphParser.readRuntimeGraph rids
     RuntimeGraph.getInheritanceList (Rid.Of "win-x86") runtimeGraph
         |> shouldEqual [ Rid.Of "win-x86"; Rid.Of "win"; Rid.Of "any"; Rid.Of "base"]
-    

--- a/tests/Paket.Tests/InstallModel/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/InstallModel/UpdateProcessSpecs.fs
@@ -21,15 +21,15 @@ let lockFileData = """NUGET
     log4net (1.2.10)
 """
 
-let graph = 
-    [ "Castle.Core-log4net", "3.2.0", 
+let graph =
+    [ "Castle.Core-log4net", "3.2.0",
       [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "3.2.0",PreReleaseStatus.No)
         "log4net", VersionRequirement(VersionRange.Exactly "1.2.10",PreReleaseStatus.No) ]
-      "Castle.Core-log4net", "3.3.3", 
+      "Castle.Core-log4net", "3.3.3",
       [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "3.3.3",PreReleaseStatus.No)
         "log4net", VersionRequirement(VersionRange.Exactly "1.2.10",PreReleaseStatus.No) ]
-      "Castle.Core-log4net", "4.0.0", 
-      [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "4.0.0",PreReleaseStatus.No) 
+      "Castle.Core-log4net", "4.0.0",
+      [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "4.0.0",PreReleaseStatus.No)
         "log4net", VersionRequirement(VersionRange.Exactly "1.2.10",PreReleaseStatus.No) ]
       "Castle.Core", "3.2.0", []
       "Castle.Core", "3.3.3", []
@@ -49,20 +49,20 @@ let selectiveUpdateFromGraph graph force lockFile depsFile updateMode restrictio
     selectiveUpdate force noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) (GetRuntimeGraphFromGraph graph) lockFile depsFile updateMode restriction
 
 [<Test>]
-let ``SelectiveUpdate does not update any package when it is neither updating all nor selective updating``() = 
+let ``SelectiveUpdate does not update any package when it is neither updating all nor selective updating``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
-    
+
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
@@ -72,9 +72,9 @@ let ``SelectiveUpdate does not update any package when it is neither updating al
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates all packages not constraining version``() = 
+let ``SelectiveUpdate updates all packages not constraining version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -82,12 +82,12 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
     nuget FAKE""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.1");
@@ -97,9 +97,9 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates all packages constraining version``() = 
+let ``SelectiveUpdate updates all packages constraining version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -108,12 +108,12 @@ let ``SelectiveUpdate updates all packages constraining version``() =
     nuget FAKE = 4.0.0""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","3.3.3");
         ("FAKE","4.0.0");
@@ -123,9 +123,9 @@ let ``SelectiveUpdate updates all packages constraining version``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate removes a dependency when it is updated to a version that does not depend on a library``() = 
+let ``SelectiveUpdate removes a dependency when it is updated to a version that does not depend on a library``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -133,12 +133,12 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
     nuget FAKE""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","4.0.0");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.1");
@@ -148,24 +148,24 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates a single package``() = 
+let ``SelectiveUpdate updates a single package``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "FAKE" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.1");
@@ -175,24 +175,24 @@ let ``SelectiveUpdate updates a single package``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates a single constrained package``() = 
+let ``SelectiveUpdate updates a single constrained package``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.0");
@@ -202,9 +202,9 @@ let ``SelectiveUpdate updates a single constrained package``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-     
+
 [<Test>]
-let ``SelectiveUpdate updates a single package with constrained dependency in dependencies file``() = 
+let ``SelectiveUpdate updates a single package with constrained dependency in dependencies file``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -212,15 +212,15 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
     nuget Castle.Core ~> 3.2
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","3.3.3");
         ("FAKE","4.0.0");
@@ -230,9 +230,9 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate installs new packages``() = 
+let ``SelectiveUpdate installs new packages``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -241,12 +241,12 @@ let ``SelectiveUpdate installs new packages``() =
     nuget Newtonsoft.Json""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
@@ -257,24 +257,24 @@ let ``SelectiveUpdate installs new packages``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate removes a dependency when it updates a single package and it is updated to a version that does not depend on a library``() = 
+let ``SelectiveUpdate removes a dependency when it updates a single package and it is updated to a version that does not depend on a library``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","4.0.0");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.0");
@@ -284,9 +284,9 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate does not update when a dependency constrain is not met``() = 
+let ``SelectiveUpdate does not update when a dependency constrain is not met``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -294,26 +294,26 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
     nuget Castle.Core = 3.2.0
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
         |> Seq.sortBy fst
-        
+
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-   
+
 [<Test>]
-let ``SelectiveUpdate considers package name case difference``() = 
+let ``SelectiveUpdate considers package name case difference``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -321,27 +321,27 @@ let ``SelectiveUpdate considers package name case difference``() =
     nuget castle.core = 3.2.0
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
         |> Seq.sortBy fst
-        
+
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate conflicts when a dependency is contrained``() = 
+let ``SelectiveUpdate conflicts when a dependency is contrained``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -357,7 +357,7 @@ let ``SelectiveUpdate conflicts when a dependency is contrained``() =
     |> shouldFail
 
 [<Test>]
-let ``SelectiveUpdate generates paket.lock correctly``() = 
+let ``SelectiveUpdate generates paket.lock correctly``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -365,19 +365,20 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
     nuget Castle.Core
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
             String.Join
                 (Environment.NewLine,
-                    LockFileSerializer.serializePackages InstallOptions.Default lockFile.Groups.[Constants.MainDependencyGroup].Resolution, 
+                    LockFileSerializer.serializePackages InstallOptions.Default lockFile.Groups.[Constants.MainDependencyGroup].Resolution,
                     LockFileSerializer.serializeSourceFiles lockFile.Groups.[Constants.MainDependencyGroup].RemoteFiles)
 
 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Core (4.0)
     Castle.Core-log4net (3.2)
       Castle.Core (>= 3.2)
@@ -387,9 +388,9 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
 """
 
     result
-    |> shouldEqual (normalizeLineEndings expected)    
+    |> shouldEqual (normalizeLineEndings expected)
 
-let graph2 = 
+let graph2 =
     [ "Ninject", "2.2.1.4", []
       "Ninject", "2.2.1.5", []
       "Ninject", "2.3.1.4", []
@@ -413,7 +414,7 @@ let graph2 =
       "log4net", "1.2.11", []
       "log4net", "2.0.3", [] ]
     |> OfSimpleGraph
-      
+
 let lockFileData2 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -431,25 +432,25 @@ let lockFileData2 = """NUGET
 let lockFile2 = lockFileData2 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a transitive dependency with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a transitive dependency with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net""")
-    
+
     let packageFilter = PackageName "log4f" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph2 true lockFile2 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","2.2.0.4");
         ("Ninject.Extensions.Logging","2.2.0.4");
         ("Ninject", "2.2.1.4");
@@ -460,27 +461,27 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a transitive dependency in its own graph with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a transitive dependency in its own graph with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph2 true lockFile2 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
         ("Ninject", "3.2.0");
@@ -491,16 +492,16 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
 
-let graph3 = 
+
+let graph3 =
     graph2 @
     ([ "Ninject.Extensions.Interception", "2.2.1.2", [ "Ninject", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
        "Ninject.Extensions.Interception", "2.2.1.3", [ "Ninject", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
        "Ninject.Extensions.Interception", "3.2.0", [ "Ninject", VersionRequirement(VersionRange.Between("3.2.0.0","3.3.0.0"),PreReleaseStatus.No) ] ]
      |> OfSimpleGraph)
 
-      
+
 let lockFileData3 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -519,26 +520,26 @@ let lockFileData3 = """NUGET
 let lockFile3 = lockFileData3 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a transitive dependency of another package with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a transitive dependency of another package with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net
     nuget Ninject.Extensions.Interception""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph3 true lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3")
          ("Ninject.Extensions.Logging","3.2.3")
          ("Ninject.Extensions.Interception","3.2.0")
@@ -550,28 +551,28 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate does not conflict with a transitive dependency of another package when paket.dependencies requirement has changed``() = 
+let ``SelectiveUpdate does not conflict with a transitive dependency of another package when paket.dependencies requirement has changed``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Ninject ~> 3.0
     nuget Ninject.Extensions.Logging.Log4net
     nuget Ninject.Extensions.Interception""")
-    
+
     let packageFilter = PackageName "Ninject" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph3 true lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
         ("Ninject.Extensions.Interception","3.2.0");
@@ -582,28 +583,28 @@ let ``SelectiveUpdate does not conflict with a transitive dependency of another 
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency of another package to correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency of another package to correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net
     nuget Ninject.Extensions.Interception""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Interception" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph3 true lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
         ("Ninject.Extensions.Interception","3.2.0");
@@ -615,7 +616,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 let graph4 =
     graph2 @
      ([ "Ninject.Extensions.Logging.Log4net.Deep", "2.2.0.4", [ "Ninject.Extensions.Logging.Log4net", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
@@ -639,24 +640,24 @@ let lockFileData4 = """NUGET
 let lockFile4 = lockFileData4 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency in its own graph with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency in its own graph with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Ninject.Extensions.Logging.Log4net.Deep""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net.Deep" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph4 true lockFile4 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net.Deep","3.2.3");
         ("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
@@ -667,7 +668,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 let graph5 =
       [ "Ninject.Extensions.Interception", "0.0.2-alpha001", [ "Ninject", VersionRequirement(VersionRange.Between("0.0.1","0.0.3"),PreReleaseStatus.No) ]
         "Ninject.Extensions.Logging", "0.0.2-alpha001", [ "Ninject", VersionRequirement(VersionRange.Between("0.0.1","0.0.3"),PreReleaseStatus.No) ]
@@ -689,25 +690,25 @@ let lockFileData5 = """NUGET
 let lockFile5 = lockFileData5 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with transitive dependency with correct prerelease version``() = 
+let ``SelectiveUpdate updates package that conflicts with transitive dependency with correct prerelease version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Ninject.Extensions.Interception
     nuget Ninject.Extensions.Logging""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph5 true lockFile5 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Interception","0.0.2-alpha001");
         ("Ninject.Extensions.Logging","0.0.3");
         ("Ninject", "0.0.2-alpha001")]
@@ -725,23 +726,23 @@ let groupMap (lockFile : LockFile) =
         (string g,string resolved.Name, string resolved.Version))
 
 [<Test>]
-let ``SelectiveUpdate updates all packages from all groups if no group is specified``() = 
+let ``SelectiveUpdate updates all packages from all groups if no group is specified``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net ~> 4.0""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","log4net","1.2.10");
@@ -776,23 +777,23 @@ NUGET
 let groupedLockFile = groupedLockFileData |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates only packages from specific group if group is specified``() = 
+let ``SelectiveUpdate updates only packages from specific group if group is specified``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile |> Seq.toList
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","3.2.0");
         ("Group","Castle.Core","3.2.0");
         (mainGroup,"Castle.Core-log4net","4.0.0");
@@ -808,23 +809,23 @@ let ``SelectiveUpdate updates only packages from specific group if group is spec
     |> shouldEqual expected
 
 [<Test>]
-let ``SelectiveUpdate updates only packages from specified group``() = 
+let ``SelectiveUpdate updates only packages from specified group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group")) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","log4net","1.2.10");
@@ -837,7 +838,7 @@ let ``SelectiveUpdate updates only packages from specified group``() =
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 let lockFileData6 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -862,13 +863,13 @@ NUGET
 let lockFile6 = lockFileData6 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package from a specific group``() = 
+let ``SelectiveUpdate updates package from a specific group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -878,10 +879,10 @@ let ``SelectiveUpdate updates package from a specific group``() =
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","FAKE","4.0.0");
@@ -895,15 +896,15 @@ let ``SelectiveUpdate updates package from a specific group``() =
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate does not remove a dependency from group when it is a top-level dependency in that group``() = 
+let ``SelectiveUpdate does not remove a dependency from group when it is a top-level dependency in that group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.0
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -914,10 +915,10 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","FAKE","4.0.0");
@@ -931,15 +932,15 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates package from main group``() = 
+let ``SelectiveUpdate updates package from main group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -949,10 +950,10 @@ let ``SelectiveUpdate updates package from main group``() =
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","3.2.0");
         ("Group","Castle.Core","3.2.0");
         ("Group","FAKE","4.0.0");
@@ -966,7 +967,7 @@ let ``SelectiveUpdate updates package from main group``() =
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 let lockFileData7 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -975,7 +976,7 @@ let lockFileData7 = """NUGET
 """
 let lockFile7 = lockFileData7 |> getLockFile
 
-let graph7 = 
+let graph7 =
     [ "Package", "3.2.0", []
       "Package", "4.0.0", ["Newtonsoft.Json", VersionRequirement(VersionRange.AtLeast "7.0.0",PreReleaseStatus.No)]
       "APackage", "3.2.0", []
@@ -985,23 +986,23 @@ let graph7 =
     |> OfSimpleGraph
 
 [<Test>]
-let ``SelectiveUpdate updates package that has a new dependent package that also is a direct dependency``() = 
+let ``SelectiveUpdate updates package that has a new dependent package that also is a direct dependency``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Newtonsoft.Json
     nuget Package""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph7 true lockFile7 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Package" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Package","4.0.0");
         ("Newtonsoft.Json","7.0.1")]
         |> Seq.sortBy fst
@@ -1019,23 +1020,23 @@ let lockFileData8 = """NUGET
 let lockFile8 = lockFileData8 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates early package that has a new dependent package that also is a direct dependency``() = 
+let ``SelectiveUpdate updates early package that has a new dependent package that also is a direct dependency``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Newtonsoft.Json
     nuget APackage""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph7 true lockFile8 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "APackage" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("APackage","4.0.0");
         ("Newtonsoft.Json","7.0.1")]
         |> Seq.sortBy fst
@@ -1045,13 +1046,13 @@ let ``SelectiveUpdate updates early package that has a new dependent package tha
     |> shouldEqual expected
 
 [<Test>]
-let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specific group in minor version``() = 
+let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specific group in minor version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -1061,10 +1062,10 @@ let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specifi
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.KeepMinor
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","3.2.0");
         ("Group","Castle.Core","3.2.0");
         ("Group","FAKE","4.0.0");
@@ -1082,28 +1083,28 @@ let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specifi
 [<Test>]
 let ``adding new group to lockfile should not crash``() =
     let update deps lock = selectiveUpdateFromGraph graph true lock deps UpdateMode.Install SemVerUpdateMode.NoRestriction
-    
-    let initialDepsText = 
+
+    let initialDepsText =
         """source http://www.nuget.org/api/v2
         nuget Castle.Core-log4net ~> 3.2"""
     let emptyLock = LockFile.Parse("test", [||])
 
-    let addGroupDepsText = 
+    let addGroupDepsText =
         initialDepsText + """
         group build
             source http://www.nuget.org/api/v2
             nuget FAKE"""
     let deps = DependenciesFile.FromSource(initialDepsText)
-    
+
     let installlock,_ = update deps emptyLock
     installlock.Groups.Count |> shouldEqual 1
 
     let deps' = DependenciesFile.FromSource(addGroupDepsText)
     let updatelock,_ = update deps' installlock
-    
+
     updatelock.Groups.Count |> shouldEqual 2
 
     let group = updatelock.Groups.TryFind (GroupName "build")
     group |> shouldNotEqual None
     group.Value.Resolution.ContainsKey (PackageName "FAKE") |> shouldEqual true
-    
+

--- a/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
@@ -19,10 +19,11 @@ let graph =
 
 let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]
-let ``should generate no auth in lock file``() = 
+let ``should generate no auth in lock file``() =
     let cfg = DependenciesFile.FromSource(config1)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options

--- a/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
@@ -28,10 +28,11 @@ SPECIFIC-VERSION: TRUE
 RESTRICTION: >= net45
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]
-let ``should generate strict lock file``() = 
+let ``should generate strict lock file``() =
     let cfg = DependenciesFile.FromSource(config1)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph1, PackageDetailsFromGraph graph1).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -55,10 +56,11 @@ let expected2 = """IMPORT-TARGETS: FALSE
 CONTENT: NONE
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
-let ``should generate content none lock file``() = 
+let ``should generate content none lock file``() =
     let cfg = DependenciesFile.FromSource(configWithContent)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph2, PackageDetailsFromGraph graph2).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -71,7 +73,7 @@ source "http://www.nuget.org/api/v2"
 nuget "Microsoft.SqlServer.Types"
 """
 
-let graph3 = 
+let graph3 =
     OfSimpleGraph [
         "Microsoft.SqlServer.Types","1.0",[]
     ]
@@ -79,17 +81,18 @@ let graph3 =
 let expected3 = """REDIRECTS: ON
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
-let ``should generate redirects lock file``() = 
+let ``should generate redirects lock file``() =
     let cfg = DependenciesFile.FromSource(configWithRedirects)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
     |> shouldEqual (normalizeLineEndings expected3)
 
 [<Test>]
-let ``should generate strategy min lock file``() = 
+let ``should generate strategy min lock file``() =
     let config = """
     strategy min
     source "http://www.nuget.org/api/v2"
@@ -100,6 +103,7 @@ let ``should generate strategy min lock file``() =
     let expected = """STRATEGY: MIN
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -108,7 +112,7 @@ NUGET
     |> shouldEqual (normalizeLineEndings expected)
 
 [<Test>]
-let ``should generate strategy max lock file``() = 
+let ``should generate strategy max lock file``() =
     let config = """
     strategy max
     source "http://www.nuget.org/api/v2"
@@ -119,6 +123,7 @@ let ``should generate strategy max lock file``() =
     let expected = """STRATEGY: MAX
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -127,7 +132,7 @@ NUGET
     |> shouldEqual (normalizeLineEndings expected)
 
 [<Test>]
-let ``should generate lowest_matching true lock file``() = 
+let ``should generate lowest_matching true lock file``() =
     let config = """
     lowest_matching true
     source "http://www.nuget.org/api/v2"
@@ -138,6 +143,7 @@ let ``should generate lowest_matching true lock file``() =
     let expected = """LOWEST_MATCHING: TRUE
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -146,7 +152,7 @@ NUGET
     |> shouldEqual (normalizeLineEndings expected)
 
 [<Test>]
-let ``should generate lowest_matching false lock file``() = 
+let ``should generate lowest_matching false lock file``() =
     let config = """
     lowest_matching false
     source "http://www.nuget.org/api/v2"
@@ -157,6 +163,7 @@ let ``should generate lowest_matching false lock file``() =
     let expected = """LOWEST_MATCHING: FALSE
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -166,7 +173,7 @@ NUGET
 
 
 [<Test>]
-let ``should resolve config with global framework restrictions``() = 
+let ``should resolve config with global framework restrictions``() =
 
     let config = """framework: >= net40
 
@@ -186,19 +193,20 @@ nuget NLog.Contrib
     let expected = """RESTRICTION: >= net40
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     NLog (1.0.1) - restriction: == net40
     NLog.Contrib (1.0)
       NLog (>= 1.0.1)"""
 
     let cfg = DependenciesFile.FromSource(config)
     let group = cfg.Groups.[Constants.MainDependencyGroup]
-    group.Packages.Head.Settings.FrameworkRestrictions 
+    group.Packages.Head.Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4)))
 
     let resolved = ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     getVersion resolved.[PackageName "NLog"] |> shouldEqual "1.0.1"
-    resolved.[PackageName "NLog"].Settings.FrameworkRestrictions 
+    resolved.[PackageName "NLog"].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4)))
 

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -13,7 +13,7 @@ source "http://www.nuget.org/api/v2"
 nuget "Castle.Windsor-log4net" "~> 3.2"
 nuget "Rx-Main" "~> 2.0" """
 
-let graph = 
+let graph =
   OfSimpleGraph [
     "Castle.Windsor-log4net","3.2",[]
     "Castle.Windsor-log4net","3.3",["Castle.Windsor",VersionRequirement(VersionRange.AtLeast "2.0",PreReleaseStatus.No);"log4net",VersionRequirement(VersionRange.AtLeast "1.0",PreReleaseStatus.No)]
@@ -30,9 +30,10 @@ let graph =
   ]
 
 [<Test>]
-let ``should generate lock file for packages``() = 
+let ``should generate lock file for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)
@@ -56,9 +57,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 framework: net35
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with framework restrictions for packages``() = 
+let ``should generate lock file with framework restrictions for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - restriction: == net35
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -83,9 +85,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 import_targets: false, framework: net35
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with no targets import for packages``() = 
+let ``should generate lock file with no targets import for packages``() =
     let expected = """NUGET
   remote: "D:\code\temp with space"
+  protocolVersion: 2
     Castle.Windsor (2.1) - import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -109,9 +112,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 copy_local: false, import_targets: false, 
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with no copy local for packages``() = 
+let ``should generate lock file with no copy local for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - copy_local: false, import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - copy_local: false, import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -134,9 +138,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 specific_version: false, import_targets: f
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with no specific version for packages``() = 
+let ``should generate lock file with no specific version for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - specific_version: false, import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - specific_version: false, import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -159,9 +164,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 framework: net35
 nuget "Rx-Main" "~> 2.0" content: none, framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with disabled content for packages``() = 
+let ``should generate lock file with disabled content for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - restriction: == net35
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -221,11 +227,11 @@ github \"owner:project2:commit3\" \"folder/file3.fs\" githubAuth
 github \"owner:project3:master\""
 
     let cfg = DependenciesFile.FromSource(config)
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
-    |> List.map (fun f -> 
+    |> List.map (fun f ->
         match f.Version with
-        | VersionRestriction.Concrete commit -> 
+        | VersionRestriction.Concrete commit ->
             { Commit = commit
               Owner = f.Owner
               Origin = ModuleResolver.Origin.GitHubLink
@@ -254,10 +260,11 @@ let graph2 =
 
 let expected2 = """NUGET
   remote: https://www.myget.org/F/ravendb3
+  protocolVersion: 2
     RavenDB.Client (3.0.3498-Unstable)"""
 
 [<Test>]
-let ``should generate lock file for RavenDB.Client``() = 
+let ``should generate lock file for RavenDB.Client``() =
     let cfg = DependenciesFile.FromSource(config2)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph2, PackageDetailsFromGraph graph2).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -278,6 +285,7 @@ let graph3 =
 
 let expected3 = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     GreaterThan.Package (2.1)
       Maximum.Package (<= 3.0)
     LessThan.Package (1.9)
@@ -287,7 +295,7 @@ let expected3 = """NUGET
       LessThan.Package (< 2.0)"""
 
 [<Test>]
-let ``should generate other version ranges for packages``() = 
+let ``should generate other version ranges for packages``() =
     let cfg = DependenciesFile.FromSource(config3)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -311,13 +319,13 @@ let trivialResolve (f:ModuleResolver.UnresolvedSource) =
 let expectedWithHttp = """HTTP
   remote: http://www.fssnip.net
     test.fs (/raw/1M)"""
-    
+
 [<Test>]
-let ``should generate lock file for http source files``() = 
-    let config = """http "http://www.fssnip.net/raw/1M" "test.fs" """ 
+let ``should generate lock file for http source files``() =
+    let config = """http "http://www.fssnip.net/raw/1M" "test.fs" """
 
     let cfg = DependenciesFile.FromSource(config)
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
     |> List.map trivialResolve
     |> LockFileSerializer.serializeSourceFiles
@@ -334,23 +342,23 @@ GIST
     gistfile1.fs
   remote: Thorium/6088882
     FULLPROJECT"""
-    
+
 [<Test>]
-let ``should generate lock file for http and gist source files``() = 
+let ``should generate lock file for http and gist source files``() =
     let config = """source "http://www.nuget.org/api/v2
 
 http http://www.fssnip.net/raw/32 myFile2.fs
 http http://www.fssnip.net/raw/34 myFile5.fs httpAuth
 
 gist Thorium/1972308 gistfile1.fs
-gist Thorium/6088882 
+gist Thorium/6088882
 
 http http://www.fssnip.net/raw/1M myFile.fs
-http http://www.fssnip.net/raw/15 myFile3.fs """ 
+http http://www.fssnip.net/raw/15 myFile3.fs """
 
     let cfg = DependenciesFile.FromSource(config)
-    
-    let actual = 
+
+    let actual =
         cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
         |> List.map trivialResolve
         |> LockFileSerializer.serializeSourceFiles
@@ -381,12 +389,12 @@ http http://nlp.stanford.edu/software/stanford-segmenter-2014-10-26.zip"""
     let references =
         cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
         |> List.map trivialResolve
-    
+
     references.Length |> shouldEqual 6
 
     references.[5].Origin |> shouldEqual (Origin.HttpLink("http://nlp.stanford.edu"))
     references.[5].Commit |> shouldEqual ("/software/stanford-segmenter-2014-10-26.zip")  // That's strange
-    references.[5].Name |> shouldEqual "stanford-segmenter-2014-10-26.zip"  
+    references.[5].Name |> shouldEqual "stanford-segmenter-2014-10-26.zip"
 
     references
     |> LockFileSerializer.serializeSourceFiles
@@ -395,16 +403,17 @@ http http://nlp.stanford.edu/software/stanford-segmenter-2014-10-26.zip"""
 [<Test>]
 let ``should parse and regenerate http Stanford.NLP.NET project``() =
     let lockFile = LockFileParser.Parse(toLines expectedForStanfordNLPdotNET) |> List.head
-    
+
     lockFile.SourceFiles
     |> List.rev
     |> LockFileSerializer.serializeSourceFiles
     |> shouldEqual (normalizeLineEndings expectedForStanfordNLPdotNET)
 
 [<Test>]
-let ``should generate lock file with second group``() = 
+let ``should generate lock file with second group``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - copy_content_to_output_dir: preserve_newest
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -422,6 +431,7 @@ COPY-CONTENT-TO-OUTPUT-DIR: ALWAYS
 CONDITION: LEGACY
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     FAKE (4.0)
 """
     let lockFile = LockFile.Parse("Test",toLines expected)

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -88,7 +88,6 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 let ``should generate lock file with no targets import for packages``() =
     let expected = """NUGET
   remote: "D:\code\temp with space"
-  protocolVersion: 2
     Castle.Windsor (2.1) - import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)

--- a/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
@@ -31,6 +31,7 @@ let graph =
 
 let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)
@@ -43,7 +44,7 @@ let expected = """NUGET
       Rx-Core (>= 2.1)"""
 
 [<Test>]
-let ``should generate lock file``() = 
+let ``should generate lock file``() =
     let cfg = DependenciesFile.FromSource(config1)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -12,6 +12,7 @@ open Paket.PackageSources
 let lockFile = """COPY-LOCAL: FALSE
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
@@ -31,7 +32,7 @@ GITHUB
 """
 
 [<Test>]
-let ``should parse lock file``() = 
+let ``should parse lock file``() =
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 6
@@ -48,7 +49,7 @@ let ``should parse lock file``() =
     packages.[1].Name |> shouldEqual (PackageName "Castle.Windsor-log4net")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.3")
     packages.[1].Dependencies |> shouldEqual (Set.ofList [PackageName "Castle.Windsor", VersionRequirement(Minimum(SemVer.Parse "2.0"), PreReleaseStatus.No), makeOrList []; PackageName "log4net", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), makeOrList []])
-    
+
     packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
@@ -76,7 +77,7 @@ let ``should parse lock file``() =
             PackagePath = None
             Commit = "Globbing"
             AuthKey = None } ]
-    
+
     sourceFiles.[0].Commit |> shouldEqual "7699e40e335f3cc54ab382a8969253fecc1e08a9"
     sourceFiles.[0].Name |> shouldEqual "src/app/FAKE/Cli.fs"
     sourceFiles.[0].ToString() |> shouldEqual "fsharp/FAKE:7699e40e335f3cc54ab382a8969253fecc1e08a9 src/app/FAKE/Cli.fs"
@@ -85,6 +86,7 @@ let strictLockFile = """REFERENCES: STRICT
 IMPORT-TARGETS: FALSE
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
@@ -99,7 +101,7 @@ NUGET
 """
 
 [<Test>]
-let ``should parse strict lock file``() = 
+let ``should parse strict lock file``() =
     let lockFile = LockFileParser.Parse(toLines strictLockFile) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 6
@@ -136,7 +138,7 @@ NUGET
 """
 
 [<Test>]
-let ``should parse redirects lock file``() = 
+let ``should parse redirects lock file``() =
     let lockFile = LockFileParser.Parse(toLines redirectsLockFile)
 
     let main = lockFile.Tail.Tail.Head
@@ -164,12 +166,13 @@ let lockFileWithFrameworkRestrictions = """FRAMEWORK: >= NET45
 IMPORT-TARGETS: TRUE
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Castle.Windsor (2.1)
 """
 
 [<Test>]
-let ``should parse lock file with framework restrictions``() = 
+let ``should parse lock file with framework restrictions``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithFrameworkRestrictions) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 1
@@ -180,6 +183,7 @@ let ``should parse lock file with framework restrictions``() =
 
 let dogfood = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     DotNetZip (1.9.3)
     FAKE (3.5.5)
@@ -215,7 +219,7 @@ GITHUB
       Octokit (>= 0)"""
 
 [<Test>]
-let ``should parse own lock file``() = 
+let ``should parse own lock file``() =
     let lockFile = LockFileParser.Parse(toLines dogfood) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 16
@@ -230,6 +234,7 @@ let ``should parse own lock file``() =
 
 let dogfood2 = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     DotNetZip (1.9.3)
     FAKE (3.5.5)
@@ -265,7 +270,7 @@ GITHUB
       Octokit"""
 
 [<Test>]
-let ``should parse own lock file2``() = 
+let ``should parse own lock file2``() =
     let lockFile = LockFileParser.Parse(toLines dogfood2) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 16
@@ -281,6 +286,7 @@ let ``should parse own lock file2``() =
 
 let frameworkRestricted = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Fleece (0.4.0)
       FSharpPlus (>= 0.0.4)
@@ -299,7 +305,7 @@ let frameworkRestricted = """NUGET
 """
 
 [<Test>]
-let ``should parse framework restricted lock file``() = 
+let ``should parse framework restricted lock file``() =
     let lockFile = LockFileParser.Parse(toLines frameworkRestricted) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 7
@@ -312,7 +318,7 @@ let ``should parse framework restricted lock file``() =
     packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
-    packages.[3].Settings.FrameworkRestrictions 
+    packages.[3].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5)))
     packages.[3].Settings.ImportTargets |> shouldEqual None
@@ -340,6 +346,7 @@ let ``should parse framework restricted lock file``() =
 
 let frameworkRestricted' = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Fleece (0.4.0) - license_download: true
       FSharpPlus (>= 0.0.4)
@@ -358,7 +365,7 @@ let frameworkRestricted' = """NUGET
 """
 
 [<Test>]
-let ``should parse framework restricted lock file in new syntax``() = 
+let ``should parse framework restricted lock file in new syntax``() =
     let lockFile = LockFileParser.Parse(toLines frameworkRestricted') |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 7
@@ -375,7 +382,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
     packages.[3].Settings.CopyContentToOutputDirectory |> shouldEqual (Some CopyToOutputDirectorySettings.Never)
     packages.[3].Settings.FrameworkRestrictions
-    |> getExplicitRestriction 
+    |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5)))
     packages.[3].Settings.CopyLocal |> shouldEqual None
     packages.[3].Settings.SpecificVersion |> shouldEqual None
@@ -404,7 +411,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[5].Settings.SpecificVersion |> shouldEqual (Some true)
     packages.[5].Settings.OmitContent |> shouldEqual None
     packages.[5].Settings.IncludeVersionInPath |> shouldEqual None
-    packages.[5].Settings.FrameworkRestrictions 
+    packages.[5].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
@@ -418,7 +425,7 @@ HTTP
 """
 
 [<Test>]
-let ``should parse simple http reference``() = 
+let ``should parse simple http reference``() =
     let lockFile = LockFileParser.Parse(toLines simpleHTTP) |> List.head
     let references = lockFile.SourceFiles
 
@@ -467,7 +474,7 @@ let ``should parse portable lockfile``() =
 
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 2
-    
+
     packages.[1].Name |> shouldEqual (PackageName "Zlib.Portable")
     packages.[1].Version |> shouldEqual (SemVer.Parse "1.10.0")
     (packages.[1].Settings.FrameworkRestrictions |> getExplicitRestriction).ToString() |> shouldEqual ">= portable-net40+sl5+win8+wp8"
@@ -514,7 +521,7 @@ let ``should parse reactiveui lockfile``() =
     references.Length |> shouldEqual 0
 
     let packages = List.rev lockFile.Packages
-    
+
     packages.[8].Name |> shouldEqual (PackageName "Rx-WindowStoreApps")
     packages.[8].Version |> shouldEqual (SemVer.Parse "2.2.5")
     (packages.[8].Settings.FrameworkRestrictions |> getExplicitRestriction).ToString() |> shouldEqual "== win8"
@@ -525,11 +532,13 @@ let ``should parse reactiveui lockfile``() =
 
 let multipleFeedLockFileLegacy = """NUGET
   remote: http://internalfeed/NugetWebFeed/nuget
+  protocolVersion: 2
     Internal_1 (1.2.10)
       Newtonsoft.Json (>= 6.0 < 6.1)
     log4net (1.2.10)
     Newtonsoft.Json (6.0.6)
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.AspNet.WebApi (5.2.3)
       Microsoft.AspNet.WebApi.WebHost (>= 5.2.3 < 5.3)
     Microsoft.AspNet.WebApi.Client (5.2.3)
@@ -543,11 +552,13 @@ let multipleFeedLockFileLegacy = """NUGET
 
 let multipleFeedLockFile = """NUGET
   remote: http://internalfeed/NugetWebFeed/nuget
+  protocolVersion: 2
     Internal_1 (1.2.10)
       Newtonsoft.Json (>= 6.0 < 6.1)
     log4net (1.2.10)
     Newtonsoft.Json (6.0.6)
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.AspNet.WebApi (5.2.3)
       Microsoft.AspNet.WebApi.WebHost (>= 5.2.3 < 5.3)
     Microsoft.AspNet.WebApi.Client (5.2.3)
@@ -569,7 +580,7 @@ let ``should parse lockfile with multiple feeds``() =
 
         let packages = List.rev lockFile.Packages
         packages.Length |> shouldEqual 7
-    
+
         packages.[3].Name |> shouldEqual (PackageName "Microsoft.AspNet.WebApi")
         packages.[3].Version |> shouldEqual (SemVer.Parse "5.2.3")
         packages.[3].Source.ToString() |> shouldEqual "https://www.nuget.org/api/v2"
@@ -580,7 +591,7 @@ let ``should parse and serialise multiple feed lockfile``() =
         let lockFile = LockFile.Parse("",toLines lockFileText)
         let lockFile' = lockFile.ToString()
 
-        normalizeLineEndings lockFile' 
+        normalizeLineEndings lockFile'
         |> shouldEqual (normalizeLineEndings multipleFeedLockFile)
 
 
@@ -602,11 +613,11 @@ NUGET
 """
 
 [<Test>]
-let ``should parse lock file with groups``() = 
+let ``should parse lock file with groups``() =
     let lockFile1 = LockFileParser.Parse(toLines groupsLockFile) |> List.skip 1 |> List.head
     lockFile1.GroupName |> shouldEqual Constants.MainDependencyGroup
     let packages1 = List.rev lockFile1.Packages
-    
+
     packages1.Length |> shouldEqual 1
     lockFile1.Options.Strict |> shouldEqual false
     lockFile1.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
@@ -621,7 +632,7 @@ let ``should parse lock file with groups``() =
     let lockFile2 = LockFileParser.Parse(toLines groupsLockFile) |> List.head
     lockFile2.GroupName.ToString() |> shouldEqual "Build"
     let packages2 = List.rev lockFile2.Packages
-    
+
     packages2.Length |> shouldEqual 1
     lockFile2.Options.Strict |> shouldEqual false
     lockFile2.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
@@ -640,11 +651,11 @@ let ``should parse and serialise groups lockfile``() =
     let lockFile = LockFile.Parse("",toLines groupsLockFile)
     let lockFile' = lockFile.ToString()
 
-    normalizeLineEndings lockFile' 
+    normalizeLineEndings lockFile'
     |> shouldEqual (normalizeLineEndings groupsLockFile)
 
 [<Test>]
-let ``should parse strategy min lock file``() = 
+let ``should parse strategy min lock file``() =
     let lockFile = """STRATEGY: MIN
 NUGET
   remote: "D:\code\temp with space"
@@ -652,12 +663,12 @@ NUGET
 """
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
-    
+
     packages.Length |> shouldEqual 1
     lockFile.Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
-    
+
 [<Test>]
-let ``should parse strategy max lock file``() = 
+let ``should parse strategy max lock file``() =
     let lockFile = """STRATEGY: MAX
 NUGET
   remote: "D:\code\temp with space"
@@ -666,12 +677,12 @@ NUGET
 """
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
-    
+
     packages.Length |> shouldEqual 1
     lockFile.Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Max)
 
 [<Test>]
-let ``should parse no strategy lock file``() = 
+let ``should parse no strategy lock file``() =
     let lockFile = """NUGET
   remote: "D:\code\temp with space"
   specs:
@@ -679,10 +690,10 @@ let ``should parse no strategy lock file``() =
 """
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
-    
+
     packages.Length |> shouldEqual 1
     lockFile.Options.ResolverStrategyForTransitives |> shouldEqual None
-    
+
 let packageRedirectsLockFile = """REDIRECTS: ON
 NUGET
   remote: "D:\code\temp with space"
@@ -704,11 +715,11 @@ NUGET
 """
 
 [<Test>]
-let ``should parse redirects lock file and packages``() = 
+let ``should parse redirects lock file and packages``() =
     let lockFile = LockFileParser.Parse(toLines packageRedirectsLockFile)
     let main = lockFile.Tail.Tail.Head
     let packages = List.rev main.Packages
-    
+
     packages.Length |> shouldEqual 4
     main.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
 
@@ -716,10 +727,10 @@ let ``should parse redirects lock file and packages``() =
     packages.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some BindingRedirectsSettings.On)
     packages.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some BindingRedirectsSettings.Off)
     packages.Tail.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some BindingRedirectsSettings.Force)
-    
+
     let build = lockFile.Tail.Head
     let packages = List.rev build.Packages
-    
+
     packages.Length |> shouldEqual 1
     build.Options.Redirects |> shouldEqual None
 
@@ -727,7 +738,7 @@ let ``should parse redirects lock file and packages``() =
 
     let test = lockFile.Head
     let packages = List.rev test.Packages
-    
+
     packages.Length |> shouldEqual 1
     test.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.Off)
 
@@ -738,7 +749,7 @@ let ``should parse and serialize redirects lockfile``() =
     let lockFile = LockFile.Parse("",toLines packageRedirectsLockFile)
     let lockFile' = lockFile.ToString()
 
-    normalizeLineEndings lockFile' 
+    normalizeLineEndings lockFile'
     |> shouldEqual (normalizeLineEndings packageRedirectsLockFile)
 
 let autodetectLockFile = """REDIRECTS: ON
@@ -769,11 +780,11 @@ NUGET
 """
 
 [<Test>]
-let ``should parse lock file from auto-detect settings``() = 
+let ``should parse lock file from auto-detect settings``() =
     let lockFile = LockFileParser.Parse(toLines autodetectLockFile)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     packages.Length |> shouldEqual 8
 
     packages.Head.Name |> shouldEqual (PackageName "Autofac")
@@ -790,18 +801,19 @@ let lockFileWithManyFrameworksLegacy = """NUGET
 
 let lockFileWithManyFrameworks = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     CommonServiceLocator (1.3) - restriction: || (== sl5) (>= net40) (>= portable-net45+win8+wp8+wpa81)
     MvvmLightLibs (5.2)
       CommonServiceLocator (>= 1.0) - restriction: || (== net35) (== sl4)
       CommonServiceLocator (>= 1.3) - restriction: || (== sl5) (>= net40) (>= portable-net45+win8+wp8+wpa81)"""
 
 [<Test>]
-let ``should parse lock file many frameworks``() = 
+let ``should parse lock file many frameworks``() =
     for lockFile in [lockFileWithManyFrameworksLegacy;lockFileWithManyFrameworks] do
         let lockFile = LockFileParser.Parse(toLines lockFile)
         let main = lockFile.Head
         let packages = List.rev main.Packages
-    
+
         packages.Length |> shouldEqual 2
 
         packages.Head.Name |> shouldEqual (PackageName "CommonServiceLocator")
@@ -812,6 +824,7 @@ let ``should parse lock file many frameworks``() =
 
 let lockFileWithDependencies = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Argu (2.1)
     Chessie (0.4)
       FSharp.Core
@@ -819,17 +832,18 @@ let lockFileWithDependencies = """NUGET
     Newtonsoft.Json (8.0.3) - redirects: force"""
 
 [<Test>]
-let ``should parse lock file with depdencies``() = 
+let ``should parse lock file with dependencies``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithDependencies)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithDependencies)
 
 let lockFileWithGreaterZeroDependency = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Argu (2.1)
     Chessie (0.4)
@@ -838,11 +852,11 @@ let lockFileWithGreaterZeroDependency = """NUGET
     Newtonsoft.Json (8.0.3) - redirects: force"""
 
 [<Test>]
-let ``should parse lock file with greater zero dependency``() = 
+let ``should parse lock file with greater zero dependency``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithGreaterZeroDependency)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithDependencies)
@@ -855,7 +869,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse full git lock file``() = 
+let ``should parse full git lock file``() =
     let lockFile = LockFileParser.Parse(toLines fullGitLockFile)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "git@github.com:fsprojects/Paket.git")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "528024723f314aa1011499a122258167b53699f7"
@@ -869,7 +883,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse local git lock file``() = 
+let ``should parse local git lock file``() =
     let lockFile = LockFileParser.Parse(toLines localGitLockFile)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "file:///c:/code/Paket.VisualStudio")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "528024723f314aa1011499a122258167b53699f7"
@@ -890,7 +904,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse local git lock file with build``() = 
+let ``should parse local git lock file with build``() =
     let lockFile = LockFileParser.Parse(toLines localGitLockFileWithBuild)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "https://github.com/forki/nupkgtest.git")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
@@ -910,7 +924,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse local git lock file with build and no specs``() = 
+let ``should parse local git lock file with build and no specs``() =
     let lockFile = LockFileParser.Parse(toLines localGitLockFileWithBuildAndNoSpecs)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "https://github.com/forki/nupkgtest.git")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
@@ -953,6 +967,7 @@ let ``should parse lock file with spaces in file names``() =
 
 let lockFileWithNewRestrictions = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     MathNet.Numerics (3.2.3)
       TaskParallelLibrary (>= 1.0.2856) - restriction: && (>= net35) (< net40)
     MathNet.Numerics.FSharp (3.2.3)
@@ -964,13 +979,14 @@ let ``should parse new restrictions && (>= net35) (< net40)``() =
     let lockFile = LockFileParser.Parse (toLines lockFileWithNewRestrictions)
     let main = lockFile.Head
     let packages = lockFile.Tail
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithNewRestrictions)
 
 let lockFileWithNewComplexRestrictions = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     AWSSDK.Core (3.1.5.3)
       Microsoft.Net.Http (>= 2.2.29) - restriction: && (< net45) (>= portable-net45+win8+wp8+wpa81)
       PCLStorage (>= 1.0.2) - restriction: && (< net45) (>= portable-net45+win8+wp8+wpa81)
@@ -991,13 +1007,14 @@ let ``should parse new restrictions || (&& (< net45) (>= portable-net45+win8+wp8
     let lockFile = LockFileParser.Parse (toLines lockFileWithNewComplexRestrictions)
     let main = lockFile.Head
     let packages = lockFile.Tail
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithNewComplexRestrictions)
 
 let lockFileWithMissingVersion = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.Bcl (1.1.10) - restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21) - import_targets: false, restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
@@ -1012,13 +1029,14 @@ let ``should parse lockfile with missing version``() =
     let lockFile = LockFileParser.Parse (toLines lockFileWithMissingVersion)
     let main = lockFile.Head
     let packages = lockFile.Tail
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithMissingVersion)
 
 let lockFileWithCLiTool = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Argu (2.1)
     Chessie (0.4)
       FSharp.Core
@@ -1027,11 +1045,11 @@ let lockFileWithCLiTool = """NUGET
     Newtonsoft.Json (8.0.3) - redirects: force"""
 
 [<Test>]
-let ``should parse lock file with cli tool``() = 
+let ``should parse lock file with cli tool``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithCLiTool)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     packages
     |> List.find (fun p -> p.Name = PackageName "dotnet-fable")
     |> fun p -> p.Kind |> shouldEqual Paket.PackageResolver.ResolvedPackageKind.DotnetCliTool

--- a/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
@@ -89,3 +89,38 @@ let ``should parse protocol v2 even on wellknown nuget v3 source when protocolVe
     | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
         failwithf "%s should be parsed as a v2 protocol when protocolVersion explicitly specify v2" feed
     | e -> failwithf "%s %A" feed e
+
+
+[<TestCase("a")>]
+[<TestCase("")>]
+[<TestCase("          ")>]
+[<TestCase(".")>]
+[<TestCase("-1")>]
+let ``should not parse line if version for 'protocolVersion' is invalid or missing`` (invalidProtocolVersion: string) =
+    let line = sprintf "source https://api.nuget.org/v3/index.json protocolVersion: %s" invalidProtocolVersion
+
+    try
+        let _ = PackageSource.Parse(line)
+        failwith "expected error"
+    with
+    | e -> 
+        e.Message
+        |> shouldEqual (sprintf "Could not parse protocolVersion in \"%s\"" line)
+    |> ignore
+
+
+[<TestCase("0")>]
+[<TestCase("1")>]
+[<TestCase("4")>]
+let ``should not parse line if version for 'protocolVersion' is not a supported version`` (invalidProtocolVersion: string) =
+    let line = sprintf "source https://api.nuget.org/v3/index.json protocolVersion: %s" invalidProtocolVersion
+    
+    try
+        let _ = PackageSource.Parse(line)
+        failwith "expected error"
+    with
+    | e -> 
+        e.Message
+        |> shouldEqual (sprintf "Unsupported protocolVersion in \"%s\". Should be either 2 or 3" line)
+    |> ignore
+    

--- a/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
@@ -46,3 +46,46 @@ let ``should parse known nuget3 source``(feed : string) =
     | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
         failwithf "%s should be parsed as a v3 protocol" feed
     | _ -> failwith feed
+
+[<TestCase("https://nuget.org/api/v2", 3)>]
+[<TestCase("https://nuget.org/api/v2/", 3)>]
+[<TestCase("https://www.myget.org/F/roslyn-tools/", 3)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nugetsource/", 3)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nuget-local/", 3)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nuget_proxy/", 3)>]
+let ``should parse protocol v3 even on wellknown nuget v2 source when protocolVersion is explicit`` (feed: string, protocolVersion: int) =
+    let line = sprintf "source %s protocolVersion: %d" feed protocolVersion
+
+    match PackageSource.Parse(line) with
+    | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+        let quoted = sprintf "source  \"%s\" protocolVersion: %d" feed protocolVersion
+        match PackageSource.Parse(quoted) with
+        | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+            source |> shouldEqual qsource
+        | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+            failwithf "%s should be parsed as a v3 protocol when quoted and when protocolVersion explicitly specify v" feed
+        | _ -> failwith quoted
+    | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+        failwithf "%s should be parsed as a v3 protocol when protocolVersion explicitly specify v3" feed
+    | e -> failwithf "%s %A" feed e
+
+[<TestCase("https://api.nuget.org/v3/index.json", 2)>]
+[<TestCase("https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json", 2)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nugetsource/index.json", 2)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nuget-local/index.json", 2)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nuget_proxy/index.json", 2)>]
+let ``should parse protocol v2 even on wellknown nuget v3 source when protocolVersion is explicit`` (feed: string, protocolVersion: int) =
+    let line = sprintf "source %s protocolVersion: %d" feed protocolVersion
+
+    match PackageSource.Parse(line) with
+    | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+        let quoted = sprintf "source  \"%s\" protocolVersion: %d" feed protocolVersion
+        match PackageSource.Parse(quoted) with
+        | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+            source |> shouldEqual qsource
+        | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+            failwithf "%s should be parsed as a v2 protocol when quoted and when protocolVersion explicitly specify v2" feed
+        | _ -> failwith quoted
+    | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+        failwithf "%s should be parsed as a v2 protocol when protocolVersion explicitly specify v2" feed
+    | e -> failwithf "%s %A" feed e


### PR DESCRIPTION
## Disclamer
Near to zero `FSharp` knowledge / experience
Near to zero `Paket` code background
Though, used paket for few years now on several C# solution (aside with `Fake` build and custom `Fake targets`)

## Descritpion
(it's suppose to address: #3842)
This PR intend to stop guessing the `protocolVersion` of a nuget source based on various `string.Contains`
* If nothing is specified `paket` will assume `Nuget protocolVersion 3`, no fallback to `protocolVersion 2`
* If a `protocolVersion` is specified, it will stick to it
* it should then persist that `protocolVersion` for that source in the `lockfile` to be able to also work during `paket restore`

## Target
The initial plan was to release it for `v6.x` but after discussing with @baronfel it's possible to also target `v5.x`
The PR has been rebased to `bugfix` branch
In order to make it to `v6` few code of code will probably need to be change or deleted :
* https://github.com/tebeco/Paket/pull/2#discussion_r421271567
* https://github.com/tebeco/Paket/pull/2#discussion_r421273251
* https://github.com/tebeco/Paket/pull/2#discussion_r421330301
* https://github.com/tebeco/Paket/pull/2#discussion_r421361695

## Current state of the PR (will be edited to avoid scrolling if needed)
 - [x] parsing `paket.dependencies`
 - [x] Persists feed version in `paket.lock`
 - [x] parsing `paket.lock`
 - [x] still use "smart guess" on URL if no `protocolVersion` specified (=> does not default to `v3`)
 - [x] `NugetConvert`
    - [!] `NugetConvert` parsing proper handling : in fact `nuget.config` could already have a `protocolVersion="3"`)  <=== not this PR I think
- [x] Tests
  - [x] `paket.dependencies`
      - [x] Should read `protocolVersion`
      - [x] Should fail if no `version` specified after the token `protocolVersion:`
      - [x] Should fail if unsupported `version` specified after the token `protocolVersion:`
  - [x] `paket.lock`
    - [x] Should read back `paket.lock`
    - [x] Should add test specific to `protocolVersion: 3`

