### PR TITLE
Allow the operating system to set the TLS version.

### DIFF
--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>paket.bootstrapper</AssemblyName>
     <ToolCommandName>paketbootstrapper</ToolCommandName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DefineConstants Condition=" '$(TargetFramework)' != 'net461'">NO_SSL3;NO_SYSTEMWEBPROXY;PAKET_BOOTSTRAP_NO_CACHE;PAKET_BOOTSTRAP_WORKAROUND_MSBUILD_URLS;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' != 'net461'">NO_SYSTEMWEBPROXY;PAKET_BOOTSTRAP_NO_CACHE;PAKET_BOOTSTRAP_WORKAROUND_MSBUILD_URLS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PaketUseLocalGithub)' == 'true' ">

--- a/src/Paket.Bootstrapper/Program.cs
+++ b/src/Paket.Bootstrapper/Program.cs
@@ -20,15 +20,7 @@ namespace Paket.Bootstrapper
 
         static void Main(string[] args)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
-                                         | SecurityProtocolType.Tls11
-                                         | SecurityProtocolType.Tls
-#if NO_SSL3
-                                         ;
-#else
-                                         | SecurityProtocolType.Ssl3;
-#endif
-
+            AppContext.SetSwitch("Switch.System.Net.DontEnableSystemDefaultTlsVersions", false);
             executionWatch.Start();
             Console.CancelKeyPress += CancelKeyPressed;
 

--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -24,11 +24,6 @@ let private uploadRequestTimeoutInMs = 20 * 60 * 1000
 
 let internal isRequestEnvVarSet = Environment.GetEnvironmentVariable("PAKET_DEBUG_REQUESTS") = "true"
 
-#if !NETSTANDARD1_6
-ServicePointManager.SecurityProtocol <- unbox 192 ||| unbox 768 ||| unbox 3072 ||| unbox 48
-                                        ///SecurityProtocolType.Tls ||| SecurityProtocolType.Tls11 ||| SecurityProtocolType.Tls12 ||| SecurityProtocolType.Ssl3
-#endif
-
 type AuthType = | Basic | NTLM
 type UserPassword = { Username: string; Password: string; Type : AuthType }
 type Auth =


### PR DESCRIPTION
This is the recommended way to handle TLS versions as explained [here](https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls).

Besides, SSL 3 is totally insecure and should be always disabled.