### PR TITLE
Changes the close behaviour of `paket find-packages`.

### DIFF
--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -613,12 +613,13 @@ let findPackages silent (results : ParseResults<_>) =
 
     match search with
     | None ->
+        Console.CancelKeyPress.Add (fun c -> c.Cancel <- true)
         let rec repl () =
             if not silent then
-                tracefn " - Please enter search text (:q for exit):"
+                tracefn " - Please enter search text (press Ctrl+C to exit):"
 
             match Console.ReadLine() with
-            | ":q" -> ()
+            | null -> ()
             | searchText ->
                 searchAndPrint searchText
                 repl ()


### PR DESCRIPTION
`paket find-packages` without a search term gives a REPL experience to search for packages.
While I approve of the vim-style `:q` to quite I believe that pressing Ctrl+C is more CLI-like. 

This PR adds the graceful shutdown of Paket when pressing Ctrl+C (while removing the `;q` which could count as a breaking change…)