### PR TITLE
Correct flaky tests in bootstrapper

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/Paket.sln
+++ b/Paket.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27009.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{A6A6AF7D-D6E3-442D-9B1E-58CC91879BE1}"
 EndProject
@@ -68,13 +68,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{8E6D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{ED8079DD-2B06-4030-9F0F-DC548F98E1C4}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Paket.Tests", "tests\Paket.Tests\Paket.Tests.fsproj", "{E789C72A-5CFD-436B-8EF1-61AA2852A89F}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Paket.Tests", "tests\Paket.Tests\Paket.Tests.fsproj", "{E789C72A-5CFD-436B-8EF1-61AA2852A89F}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Paket", "src\Paket\Paket.fsproj", "{09B32F18-0C20-4489-8C83-5106D5C04C93}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Paket", "src\Paket\Paket.fsproj", "{09B32F18-0C20-4489-8C83-5106D5C04C93}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paket.Bootstrapper", "src\Paket.Bootstrapper\Paket.Bootstrapper.csproj", "{CE3F8B87-1ABD-462E-A35B-CDCEC695898B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paket.Bootstrapper", "src\Paket.Bootstrapper\Paket.Bootstrapper.csproj", "{CE3F8B87-1ABD-462E-A35B-CDCEC695898B}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Paket.Core", "src\Paket.Core\Paket.Core.fsproj", "{7BAB0AE2-089F-4761-B138-A717AA2F86C5}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Paket.Core", "src\Paket.Core\Paket.Core.fsproj", "{7BAB0AE2-089F-4761-B138-A717AA2F86C5}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "commands", "commands", "{4425A246-BD18-4622-86B5-0154F19165E4}"
 	ProjectSection(SolutionItems) = preProject
@@ -97,15 +97,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "commands", "commands", "{44
 		docs\content\commands\why.md = docs\content\commands\why.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Paket.Bootstrapper.Tests", "tests\Paket.Bootstrapper.Tests\Paket.Bootstrapper.Tests.csproj", "{7C622582-E281-4EAB-AADA-B5893BB89B45}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Paket.Bootstrapper.Tests", "tests\Paket.Bootstrapper.Tests\Paket.Bootstrapper.Tests.csproj", "{7C622582-E281-4EAB-AADA-B5893BB89B45}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Paket.IntegrationTests", "integrationtests\Paket.IntegrationTests\Paket.IntegrationTests.fsproj", "{7234B9B4-8CF5-4E68-AA29-050C087B9246}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Paket.IntegrationTests", "integrationtests\Paket.IntegrationTests\Paket.IntegrationTests.fsproj", "{7234B9B4-8CF5-4E68-AA29-050C087B9246}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{62D18A14-5240-4CB1-AA8A-762D3EB0E19A}"
 	ProjectSection(SolutionItems) = preProject
 		.paket\paket.exe.config = .paket\paket.exe.config
 		.paket\Paket.Restore.targets = .paket\Paket.Restore.targets
 		.paket\paket.targets = .paket\paket.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1C9A57E4-9D94-44D1-A106-FC588B7B72DE}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Global

--- a/src/Paket.Bootstrapper/BootstrapperHelper.cs
+++ b/src/Paket.Bootstrapper/BootstrapperHelper.cs
@@ -71,29 +71,29 @@ Options:
             return fileName;
         }
 
-        internal static void PrepareWebClient(WebClient client, string url)
+        internal static void PrepareWebClient(WebClient client, string url, IEnvProxy envProxy)
         {
             client.Headers.Add("user-agent", PaketBootstrapperUserAgent);
             client.UseDefaultCredentials = true;
-            client.Proxy = GetDefaultWebProxyFor(url);
+            client.Proxy = GetDefaultWebProxyFor(url, envProxy);
         }
 
-        internal static HttpWebRequest PrepareWebRequest(string url)
+        internal static HttpWebRequest PrepareWebRequest(string url, IEnvProxy envProxy)
         {
             var request = (HttpWebRequest)HttpWebRequest.Create(url);
             request.UserAgent = PaketBootstrapperUserAgent;
             request.UseDefaultCredentials = true;
-            request.Proxy = GetDefaultWebProxyFor(url);
+            request.Proxy = GetDefaultWebProxyFor(url, envProxy);
             request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
             return request;
         }
 
-        internal static IWebProxy GetDefaultWebProxyFor(String url)
+        internal static IWebProxy GetDefaultWebProxyFor(String url, IEnvProxy envProxy)
         {
             Uri uri = new Uri(url);
 
             IWebProxy result;
-            if (EnvProxy.TryGetProxyFor(uri, out result) && result.GetProxy(uri) != uri)
+            if (envProxy.TryGetProxyFor(uri, out result) && result.GetProxy(uri) != uri)
                 return result;
 
 #if NO_SYSTEMWEBPROXY

--- a/src/Paket.Bootstrapper/HelperProxies/DefaultProxyProvider.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/DefaultProxyProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Paket.Bootstrapper.HelperProxies
+{
+    public class DefaultProxyProvider : IProxyProvider
+    {
+        private IProxyProvider This => this;
+
+        IFileSystemProxy IProxyProvider.FileSystemProxy { get; } = new FileSystemProxy();
+
+        private readonly IWebRequestProxy webRequestProxy;
+        IWebRequestProxy IProxyProvider.WebRequestProxy => webRequestProxy;
+
+        private Lazy<EnvProxy> _instance = new Lazy<EnvProxy>();
+        IEnvProxy IProxyProvider.EnvProxy => _instance.Value;
+
+        public DefaultProxyProvider()
+        {
+            webRequestProxy = new WebRequestProxy(This.EnvProxy);
+        }
+    }
+}

--- a/src/Paket.Bootstrapper/HelperProxies/DefaultProxyProvider.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/DefaultProxyProvider.cs
@@ -1,22 +1,18 @@
-﻿using System;
-
-namespace Paket.Bootstrapper.HelperProxies
+﻿namespace Paket.Bootstrapper.HelperProxies
 {
     public class DefaultProxyProvider : IProxyProvider
     {
-        private IProxyProvider This => this;
+        public IFileSystemProxy FileSystemProxy { get; }
 
-        IFileSystemProxy IProxyProvider.FileSystemProxy { get; } = new FileSystemProxy();
+        public IWebRequestProxy WebRequestProxy { get; }
 
-        private readonly IWebRequestProxy webRequestProxy;
-        IWebRequestProxy IProxyProvider.WebRequestProxy => webRequestProxy;
-
-        private Lazy<EnvProxy> _instance = new Lazy<EnvProxy>();
-        IEnvProxy IProxyProvider.EnvProxy => _instance.Value;
+        public IEnvProxy EnvProxy { get; }
 
         public DefaultProxyProvider()
         {
-            webRequestProxy = new WebRequestProxy(This.EnvProxy);
+            FileSystemProxy = new FileSystemProxy();
+            EnvProxy = new EnvProxy();
+            WebRequestProxy = new WebRequestProxy(EnvProxy);
         }
     }
 }

--- a/src/Paket.Bootstrapper/HelperProxies/EnvProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/EnvProxy.cs
@@ -4,11 +4,10 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Linq;
 
-namespace Paket.Bootstrapper
+namespace Paket.Bootstrapper.HelperProxies
 {
-    internal class EnvProxy
+    internal class EnvProxy : IEnvProxy
     {
-        private static readonly EnvProxy instance = new EnvProxy();
         private readonly Dictionary<string, IWebProxy> proxies = new Dictionary<string, IWebProxy>(StringComparer.OrdinalIgnoreCase);
 
         private static string GetEnvVarValue(string name)
@@ -58,16 +57,16 @@ namespace Paket.Bootstrapper
             }
         }
 
-        protected EnvProxy()
+        public EnvProxy()
         {
             var bypassList = GetBypassList();
             AddProxy("http", bypassList);
             AddProxy("https", bypassList);
         }
 
-        public static bool TryGetProxyFor(Uri uri, out IWebProxy proxy)
+        public bool TryGetProxyFor(Uri uri, out IWebProxy proxy)
         {
-            return instance.proxies.TryGetValue(uri.Scheme, out proxy);
+            return proxies.TryGetValue(uri.Scheme, out proxy);
         }
     }
 }

--- a/src/Paket.Bootstrapper/HelperProxies/IEnvProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/IEnvProxy.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Net;
+
+namespace Paket.Bootstrapper.HelperProxies
+{
+  public interface IEnvProxy
+  {
+    bool TryGetProxyFor(Uri uri, out IWebProxy proxy);
+  }
+}

--- a/src/Paket.Bootstrapper/HelperProxies/IProxyProvider.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/IProxyProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace Paket.Bootstrapper.HelperProxies
+{
+  public interface IProxyProvider
+  {
+    IFileSystemProxy FileSystemProxy { get; }
+    IWebRequestProxy WebRequestProxy { get; }
+    IEnvProxy EnvProxy { get; }
+  }
+}

--- a/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
+++ b/src/Paket.Bootstrapper/HelperProxies/WebRequestProxy.cs
@@ -5,22 +5,25 @@ namespace Paket.Bootstrapper.HelperProxies
 {
     public class WebRequestProxy : IWebRequestProxy
     {
-        public WebRequestProxy()
+        private readonly IEnvProxy envProxy;
+
+        public WebRequestProxy(IEnvProxy envProxy)
         {
             Client = new WebClient();
+            this.envProxy = envProxy;
         }
 
         private WebClient Client { get; set; }
 
         public string DownloadString(string address)
         {
-            BootstrapperHelper.PrepareWebClient(Client, address);
+            BootstrapperHelper.PrepareWebClient(Client, address, envProxy);
             return Client.DownloadString(address);
         }
 
         public Stream GetResponseStream(string url)
         {
-            var request = BootstrapperHelper.PrepareWebRequest(url);
+            var request = BootstrapperHelper.PrepareWebRequest(url, envProxy);
 
             using (var httpResponse = (HttpWebResponse)request.GetResponse())
             {
@@ -30,7 +33,7 @@ namespace Paket.Bootstrapper.HelperProxies
 
         public void DownloadFile(string url, string targetLocation)
         {
-            BootstrapperHelper.PrepareWebClient(Client, url);
+            BootstrapperHelper.PrepareWebClient(Client, url, envProxy);
             Client.DownloadFile(url, targetLocation);
         }
     }

--- a/tests/Paket.Bootstrapper.Tests/HelperProxies/EnvWebProxyShould.cs
+++ b/tests/Paket.Bootstrapper.Tests/HelperProxies/EnvWebProxyShould.cs
@@ -1,25 +1,12 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Net;
-using System.Reflection;
 
-namespace Paket.Bootstrapper.Tests
+namespace Paket.Bootstrapper.Tests.HelperProxies
 {
     [TestFixture]
     class EnvWebProxyShould
     {
-        private sealed class FakeEnvProxy : EnvProxy
-        {
-            public FakeEnvProxy()
-            {
-                var instanceField = typeof(EnvProxy).GetField("instance", BindingFlags.Static | BindingFlags.NonPublic);
-                instanceField.SetValue(null, this);
-            }
-            new public bool TryGetProxyFor(Uri uri, out IWebProxy proxy)
-            {
-                return EnvProxy.TryGetProxyFor(uri, out proxy);
-            }
-        }
         private sealed class DisposableEnvVar : IDisposable
         {
             private readonly string name;
@@ -41,10 +28,10 @@ namespace Paket.Bootstrapper.Tests
             using (new DisposableEnvVar("http_proxy"))
             using (new DisposableEnvVar("https_proxy"))
             {
-                var envProxy = new FakeEnvProxy();
+                var envProxy = TestHelper.TestProxyProvider.EnvProxy;
                 IWebProxy proxy;
-                Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
-                Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("https://github.com"), out proxy));
+                Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("http://github.com"), out _));
+                Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("https://github.com"), out _));
             }
         }
 
@@ -53,9 +40,8 @@ namespace Paket.Bootstrapper.Tests
             using (new DisposableEnvVar("http_proxy", "http://proxy.local"))
             using (new DisposableEnvVar("no_proxy"))
             {
-                var envProxy = new FakeEnvProxy();
                 IWebProxy proxy;
-                Assert.IsTrue(envProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local")));
@@ -70,9 +56,8 @@ namespace Paket.Bootstrapper.Tests
             using (new DisposableEnvVar("http_proxy", "http://proxy.local:8080"))
             using (new DisposableEnvVar("no_proxy"))
             {
-                var envProxy = new FakeEnvProxy();
                 IWebProxy proxy;
-                Assert.IsTrue(envProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));
@@ -88,9 +73,8 @@ namespace Paket.Bootstrapper.Tests
             using (new DisposableEnvVar("http_proxy", string.Format("http://user:{0}@proxy.local:8080", Uri.EscapeDataString(password))))
             using (new DisposableEnvVar("no_proxy"))
             {
-                var envProxy = new FakeEnvProxy();
                 IWebProxy proxy;
-                Assert.IsTrue(envProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));
@@ -109,9 +93,8 @@ namespace Paket.Bootstrapper.Tests
             using (new DisposableEnvVar("https_proxy", string.Format("https://user:{0}@proxy.local:8080", Uri.EscapeDataString(password))))
             using (new DisposableEnvVar("no_proxy"))
             {
-                var envProxy = new FakeEnvProxy();
                 IWebProxy proxy;
-                Assert.IsTrue(envProxy.TryGetProxyFor(new Uri("https://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("https://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));
@@ -129,9 +112,8 @@ namespace Paket.Bootstrapper.Tests
             using (new DisposableEnvVar("http_proxy", string.Format("http://proxy.local:8080")))
             using (new DisposableEnvVar("no_proxy", ".local,127.0.0.1"))
             {
-                var envProxy = new FakeEnvProxy();
                 IWebProxy proxy;
-                Assert.IsTrue(envProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));

--- a/tests/Paket.Bootstrapper.Tests/HelperProxies/EnvWebProxyShould.cs
+++ b/tests/Paket.Bootstrapper.Tests/HelperProxies/EnvWebProxyShould.cs
@@ -28,7 +28,7 @@ namespace Paket.Bootstrapper.Tests.HelperProxies
             using (new DisposableEnvVar("http_proxy"))
             using (new DisposableEnvVar("https_proxy"))
             {
-                var envProxy = TestHelper.TestProxyProvider.EnvProxy;
+                var envProxy = TestHelper.NoSingletonProxyProvider.EnvProxy;
                 IWebProxy proxy;
                 Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("http://github.com"), out _));
                 Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("https://github.com"), out _));
@@ -41,7 +41,7 @@ namespace Paket.Bootstrapper.Tests.HelperProxies
             using (new DisposableEnvVar("no_proxy"))
             {
                 IWebProxy proxy;
-                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.NoSingletonProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local")));
@@ -57,7 +57,7 @@ namespace Paket.Bootstrapper.Tests.HelperProxies
             using (new DisposableEnvVar("no_proxy"))
             {
                 IWebProxy proxy;
-                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.NoSingletonProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));
@@ -74,7 +74,7 @@ namespace Paket.Bootstrapper.Tests.HelperProxies
             using (new DisposableEnvVar("no_proxy"))
             {
                 IWebProxy proxy;
-                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.NoSingletonProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));
@@ -94,7 +94,7 @@ namespace Paket.Bootstrapper.Tests.HelperProxies
             using (new DisposableEnvVar("no_proxy"))
             {
                 IWebProxy proxy;
-                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("https://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.NoSingletonProxyProvider.EnvProxy.TryGetProxyFor(new Uri("https://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));
@@ -113,7 +113,7 @@ namespace Paket.Bootstrapper.Tests.HelperProxies
             using (new DisposableEnvVar("no_proxy", ".local,127.0.0.1"))
             {
                 IWebProxy proxy;
-                Assert.IsTrue(TestHelper.TestProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
+                Assert.IsTrue(TestHelper.NoSingletonProxyProvider.EnvProxy.TryGetProxyFor(new Uri("http://github.com"), out proxy));
                 var webProxy = proxy as WebProxy;
                 Assert.IsNotNull(webProxy);
                 Assert.That(webProxy.Address, Is.EqualTo(new Uri("http://proxy.local:8080")));

--- a/tests/Paket.Bootstrapper.Tests/NoSingletonProxyProvider.cs
+++ b/tests/Paket.Bootstrapper.Tests/NoSingletonProxyProvider.cs
@@ -1,0 +1,13 @@
+﻿using Paket.Bootstrapper.HelperProxies;
+
+namespace Paket.Bootstrapper.Tests
+{
+    internal class NoSingletonProxyProvider : IProxyProvider
+    {
+        public IFileSystemProxy FileSystemProxy => new FileSystemProxy();
+
+        public IWebRequestProxy WebRequestProxy => new WebRequestProxy(EnvProxy);
+
+        public IEnvProxy EnvProxy => new EnvProxy();
+    }
+}

--- a/tests/Paket.Bootstrapper.Tests/ProgramTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ProgramTests.cs
@@ -15,7 +15,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -32,7 +32,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, false);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, false, TestHelper.ProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -48,7 +48,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true, TestHelper.ProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -63,7 +63,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments =  new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, true);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, true, TestHelper.ProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -78,7 +78,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, true, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<GitHubDownloadStrategy>());
@@ -93,7 +93,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, true, 10);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<TemporarilyIgnoreUpdatesDownloadStrategy>());
@@ -111,7 +111,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, 10);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true, TestHelper.ProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<TemporarilyIgnoreUpdatesDownloadStrategy>());

--- a/tests/Paket.Bootstrapper.Tests/ProgramTests.cs
+++ b/tests/Paket.Bootstrapper.Tests/ProgramTests.cs
@@ -15,7 +15,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProxyProvider);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProductionProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -32,7 +32,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, false, TestHelper.ProxyProvider);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, false, TestHelper.ProductionProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -48,7 +48,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true, TestHelper.ProxyProvider);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true, TestHelper.ProductionProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -63,7 +63,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments =  new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, true, TestHelper.ProxyProvider);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, true, TestHelper.ProductionProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<CacheDownloadStrategy>());
@@ -78,7 +78,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, true, null);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProxyProvider);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProductionProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<GitHubDownloadStrategy>());
@@ -93,7 +93,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, true, 10);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProxyProvider);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, false, false, TestHelper.ProductionProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<TemporarilyIgnoreUpdatesDownloadStrategy>());
@@ -111,7 +111,7 @@ namespace Paket.Bootstrapper.Tests
 
             //act
             var downloadArguments = new DownloadArguments(String.Empty, true, "any", "any", false, String.Empty, false, 10);
-            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true, TestHelper.ProxyProvider);
+            var strategy = Program.GetEffectiveDownloadStrategy(downloadArguments, true, true, TestHelper.ProductionProxyProvider);
 
             //assert
             Assert.That(strategy, Is.TypeOf<TemporarilyIgnoreUpdatesDownloadStrategy>());

--- a/tests/Paket.Bootstrapper.Tests/TestHelper.cs
+++ b/tests/Paket.Bootstrapper.Tests/TestHelper.cs
@@ -2,19 +2,9 @@
 
 namespace Paket.Bootstrapper.Tests
 {
-    internal static class TestHelper
+    internal static partial class TestHelper
     {
-        public static IProxyProvider ProxyProvider { get; } = new DefaultProxyProvider();
-        public static IProxyProvider TestProxyProvider { get; } = new NoSingletonProxyProvider();
-
-        private class NoSingletonProxyProvider : IProxyProvider
-        {
-            private IProxyProvider This => this;
-            IFileSystemProxy IProxyProvider.FileSystemProxy => new FileSystemProxy();
-
-            IWebRequestProxy IProxyProvider.WebRequestProxy => new WebRequestProxy(This.EnvProxy);
-
-            IEnvProxy IProxyProvider.EnvProxy => new EnvProxy();
-        }
+        public static IProxyProvider ProductionProxyProvider { get; } = new DefaultProxyProvider();
+        public static IProxyProvider NoSingletonProxyProvider { get; } = new NoSingletonProxyProvider();
     }
 }

--- a/tests/Paket.Bootstrapper.Tests/TestHelper.cs
+++ b/tests/Paket.Bootstrapper.Tests/TestHelper.cs
@@ -1,0 +1,20 @@
+﻿using Paket.Bootstrapper.HelperProxies;
+
+namespace Paket.Bootstrapper.Tests
+{
+    internal static class TestHelper
+    {
+        public static IProxyProvider ProxyProvider { get; } = new DefaultProxyProvider();
+        public static IProxyProvider TestProxyProvider { get; } = new NoSingletonProxyProvider();
+
+        private class NoSingletonProxyProvider : IProxyProvider
+        {
+            private IProxyProvider This => this;
+            IFileSystemProxy IProxyProvider.FileSystemProxy => new FileSystemProxy();
+
+            IWebRequestProxy IProxyProvider.WebRequestProxy => new WebRequestProxy(This.EnvProxy);
+
+            IEnvProxy IProxyProvider.EnvProxy => new EnvProxy();
+        }
+    }
+}


### PR DESCRIPTION
I was trying to set up my local dev environment and ran into issues with flaky tests for the boostrapper, as well as having my dev environment overriding the code style in the repo.

Last thing first, was the simple thing: I added an `.editorconfig` file with the correct whitespace settings for cs files. I didn't dive deeper into how it should be for the rest of the repo, but now there is a place to add that config and have Visual Studio respect is (as well as a ton of other IDE's supporting it).

As for fixing the flaky test, it seems it broke with .NET Core 3.0 because readonly fields can no longer be overridden with reflection, so I had to refactor a bit, so it no longer relied on a static field.

It might not be the prettiest way of doing it (it is getting very close to needing an actual IoC Container instead), but for the current scope this seems to do the trick. I added an "IProxyProvider" that contains methods to aquire the different proxies, so it can be changed in the integration tests, removing the Singleton behavior entirely.

How do I check if the unit tests works here on Github though? I can't find any buildlogs with the Boostrapper tests in them? Locally it works just fine now though, but I'm having difficulties understanding how the build.fsx works. My current guess is though, that the unit tests for the boostrapper are only run locally, and not on appveyor.

NB: The DateTimeProxy should probably also be included in the new IProxyProvider, but it served no gain at the moment, and the current implementation works.