### PR TITLE
Skip restore warning

### DIFF
--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -238,10 +238,12 @@ let extractRestoreTargets root =
         else
             let (fileWritten, path) = extractElement root "Paket.Restore.targets"
             copiedElements := true
-            if fileWritten then tracefn "Extracted Paket.Restore.targets to: %s (Can be disabled with PAKET_SKIP_RESTORE_TARGETS=true)" path
+            if fileWritten then
+                if verbose then tracefn "Extracted Paket.Restore.targets to: %s (Can be disabled with PAKET_SKIP_RESTORE_TARGETS=true)" path
+                else tracefn "Extracted Paket.Restore.targets to: %s" path
             path
     else 
-        tracefn "Skipping extraction of Paket.Restore.targets - if it was enabled, it would have been extracted to: %s (Can be re-enabled with PAKET_SKIP_RESTORE_TARGETS=false or deleting the environment variable to revert to default behavior)" path
+        if verbose then tracefn "Skipping extraction of Paket.Restore.targets - if it was enabled, it would have been extracted to: %s (Can be re-enabled with PAKET_SKIP_RESTORE_TARGETS=false or deleting the environment variable to revert to default behavior)" path
         path
 
 let CreateInstallModel(alternativeProjectRoot, root, groupName, sources, caches, force, package) =

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -240,7 +240,9 @@ let extractRestoreTargets root =
             copiedElements := true
             if fileWritten then tracefn "Extracted Paket.Restore.targets to: %s (Can be disabled with PAKET_SKIP_RESTORE_TARGETS=true)" path
             path
-    else path
+    else 
+        tracefn "Skipping extraction of Paket.Restore.targets - if it was enabled, it would have been extracted to: %s (Can be re-enabled with PAKET_SKIP_RESTORE_TARGETS=false or deleting the environment variable to revert to default behavior)" path
+        path
 
 let CreateInstallModel(alternativeProjectRoot, root, groupName, sources, caches, force, package) =
     async {


### PR DESCRIPTION
There a various scenarios where restoring Paket.Restore.targets are skipped by default, which is per design in the methods.

There is also an override however that is a bit more subtle, where skipping is done due to Environment var PAKET_SKIP_RESTORE_TARGETS being set to "true". This does not alter the output in any way.

This PR attempts to increase the verbosity of that action, by printing out when this happens.

Resolves #3869