### PR TITLE
Add support for UAP v10.0.10240

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -123,7 +123,7 @@ type NuGetPackageCache =
       Version: string
       CacheVersion: string }
 
-    static member CurrentCacheVersion = "5.224"
+    static member CurrentCacheVersion = "5.225"
 
     member this.WithDependencies (dependencies : (PackageName * VersionRequirement * FrameworkRestrictions) list) =
         { this with

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -150,6 +150,7 @@ type FrameworkVersion =
 // Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.
 type UAPVersion =
     | V10
+    | V10_0_10240
     | V10_0_14393
     | V10_0_15138
     | V10_0_16299
@@ -159,6 +160,7 @@ type UAPVersion =
     override this.ToString() =
         match this with
         | V10 -> "10.0"
+        | V10_0_10240 -> "10.0.10240"
         | V10_0_14393 -> "10.0.14393"
         | V10_0_15138 -> "10.0.15138"
         | V10_0_16299 -> "10.0.16299"
@@ -169,6 +171,7 @@ type UAPVersion =
     member this.ShortString() =
         match this with
         | UAPVersion.V10 -> "10.0"
+        | UAPVersion.V10_0_10240 -> "10.0.10240"
         | UAPVersion.V10_0_14393 -> "10.0.14393"
         | UAPVersion.V10_0_15138 -> "10.0.15138"
         | UAPVersion.V10_0_16299 -> "10.0.16299"
@@ -181,6 +184,7 @@ type UAPVersion =
         match this with
         // Assumed from C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore
         | UAPVersion.V10
+        | UAPVersion.V10_0_10240
         | UAPVersion.V10_0_14393
         | UAPVersion.V10_0_15138
         | UAPVersion.V10_0_16299
@@ -193,6 +197,7 @@ type UAPVersion =
     static member TryParse s =
         match s with
         | "" | "1" | "10" -> Some UAPVersion.V10
+        | "10.0.10240" -> Some UAPVersion.V10_1
         | "10.0.14393" -> Some UAPVersion.V10_1
         | "10.0.15138" -> Some UAPVersion.V10_1
         | "10.0.16299" -> Some UAPVersion.V10_1
@@ -659,6 +664,7 @@ type FrameworkIdentifier =
         | XamarinTV -> [ DotNetStandard DotNetStandardVersion.V1_6 ]
         | XamarinWatch -> [ DotNetStandard DotNetStandardVersion.V1_6 ]
         | UAP UAPVersion.V10 -> [ Windows WindowsVersion.V8_1; WindowsPhoneApp WindowsPhoneAppVersion.V8_1; DotNetStandard DotNetStandardVersion.V1_4  ]
+        | UAP UAPVersion.V10_0_10240 -> [ UAP UAPVersion.V10 ]
         | UAP UAPVersion.V10_0_14393 -> [ UAP UAPVersion.V10 ]
         | UAP UAPVersion.V10_0_15138 -> [ UAP UAPVersion.V10 ]
         | UAP UAPVersion.V10_0_16299 -> [ UAP UAPVersion.V10; DotNetStandard DotNetStandardVersion.V2_0 ]
@@ -1292,8 +1298,9 @@ module KnownTargetProfiles =
        MonoAndroidVersions
        |> List.map (MonoAndroid >> TargetProfile.SinglePlatform)
 
-    let UAPVersons = [
+    let UAPVersions = [
         UAPVersion.V10
+        UAPVersion.V10_0_10240
         UAPVersion.V10_0_14393
         UAPVersion.V10_0_15138
         UAPVersion.V10_0_16299
@@ -1303,7 +1310,7 @@ module KnownTargetProfiles =
     ]
 
     let UAPProfiles =
-       UAPVersons
+       UAPVersions
        |> List.map (UAP >> TargetProfile.SinglePlatform)
 
     let WindowsPhoneVersions = [

--- a/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
@@ -35,7 +35,7 @@ let ``Check that lists are updated``() =
     checkList KnownTargetProfiles.DotNetUnityVersions
     checkList KnownTargetProfiles.MonoAndroidVersions
     checkList KnownTargetProfiles.SilverlightVersions
-    checkList KnownTargetProfiles.UAPVersons
+    checkList KnownTargetProfiles.UAPVersions
     checkList KnownTargetProfiles.WindowsPhoneAppVersions
     checkList KnownTargetProfiles.WindowsPhoneVersions
     checkList KnownTargetProfiles.WindowsVersions


### PR DESCRIPTION
This is a fix for #3874.

I *think* it's right, but I've not used it to build anything which uses the UAP version in question (or any other UAP version for that matter). I have however used it to build a project which uses a Nuget package which declares a dependency for this UAP version, and it prevents it from reporting incorrect errors and warnings (i.e. it fixes the bug described by the issue mentioned above).