### PR TITLE
Corrects memozation of HttpHandlers.

### DIFF
--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -400,7 +400,13 @@ let createHttpHandlerRaw(url, auth: Auth option) : HttpMessageHandler =
     handler :> _
 
 
-let createHttpHandler = memoize createHttpHandlerRaw
+let createHttpHandler = 
+    memoizeBy 
+        // Truncates the url to only to host part, so there is only one handler per source/host.
+        // 8 chars as startindex is chosen because `https://` is 8 chars long and we need the host delimiting `/`.
+        // For instance `https://api.nuget.org/v3/index.json` and `https://api.nuget.org/v3-flatcontainer/fsharp.core/index.json?semVerLevel=2.0.0` both get truncated to `https://api.nuget.org/` and share one handler (and one connection pool).
+        (fun (url : string, auth) -> url.Substring(0, url.IndexOf('/', 8) + 1), auth) 
+        createHttpHandlerRaw 
 
 let createHttpClient (url,auth:Auth option) : HttpClient =
     let handler = createHttpHandler (url, auth)


### PR DESCRIPTION
This is in response to #3850 .
One `HttpHandler` instance has a connection pool, that is reused for different requests. 
Currently, part of the key for the Handler memoization is the request's URL. But the URL is different for basically any request. So in this PR I am truncating the URL for the memoization key to just the host part.

I could not test it, but I assume, that things like the NTLM auth do not break by this. [The docs](https://docs.microsoft.com/en-us/dotnet/api/system.net.networkcredential?view=netcore-3.1) give an example where they also only provide the host part of an URL to the `NetworkCredentials`.


In my tests for a paket.depedencies file which results in 75 unique packages, not downloaded, only resolved, all from NuGet.org, the current implementation opened 78 TCP connection. The implementation of this PR for the same setup only four. This is the expected amount, as per the supplied configs in https://github.com/fsprojects/Paket/blob/master/src/Paket.Core/Common/NetUtils.fs#L360