### PR TITLE
Add props from root build folders

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -125,6 +125,11 @@ module TargetsFolder =
           RootContents = f folder.RootContents
           FrameworkFolders = folder.FrameworkFolders
                              |> List.map (FrameworkFolder.map f) }
+    let mapFrameworkFolders f (folder: TargetsFolder<'a>) : TargetsFolder<'a> =
+        { Name = folder.Name
+          RootContents = folder.RootContents
+          FrameworkFolders = folder.FrameworkFolders |> List.map f }
+        
 type AnalyzerLanguage =
     | Any | CSharp | FSharp | VisualBasic
 
@@ -805,7 +810,7 @@ module InstallModel =
         references |> Seq.fold addFrameworkAssemblyReference (installModel:InstallModel)
 
 
-    let filterExcludes (excludes:string list) (installModel:InstallModel) =
+    let filterExcludes (excludes:string list) (installModel:InstallModel) =    
         let excluded (e: string) (pathOrName:string) =
             pathOrName.Contains e
 
@@ -857,6 +862,14 @@ module InstallModel =
                     installModel.RuntimeAssemblyFolders
                     |> List.map applyRestriction
                     |> List.filter (fun folder -> not folder.Targets.IsEmpty)
+
+                TargetsFileFolders =
+                    installModel.TargetsFileFolders
+                    |> List.map (TargetsFolder.mapFrameworkFolders applyRestriction)
+                    |> List.map (fun targetFolder ->
+                        { targetFolder
+                          with FrameworkFolders = targetFolder.FrameworkFolders
+                                                  |> List.filter (fun folder -> not folder.Targets.IsEmpty) })
             }
             
     let getRootFiles (targetsFiles:UnparsedPackageFile list) =

--- a/tests/Paket.Tests/InstallModel/ProcessingSpecs.fs
+++ b/tests/Paket.Tests/InstallModel/ProcessingSpecs.fs
@@ -777,6 +777,17 @@ let ``should handle props files``() =
 
     model.GetTargetsFiles(TargetProfile.SinglePlatform (DotNetFramework FrameworkVersion.V2))
         |> Seq.map (fun f -> f.Path) |> shouldContain @"..\xunit.runner.visualstudio\build\net20\xunit.runner.visualstudio.props"
+        
+[<Test>]
+let ``should handle global props files``() = 
+    let model =
+        InstallModel.EmptyModel(PackageName "xunit.runner.visualstudio",SemVer.Parse "0.1").AddTargetsFiles(
+            [ @"..\xunit.runner.visualstudio\build\xunit.runner.visualstudio.props"
+              @"..\xunit.runner.visualstudio\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.runner.visualstudio.props" ] |> fromLegacyList @"..\xunit.runner.visualstudio\")
+            .FilterBlackList()
+
+    model.GetTargetsFiles(TargetProfile.SinglePlatform (DotNetFramework FrameworkVersion.V2))
+        |> Seq.map (fun f -> f.Path) |> shouldContain @"..\xunit.runner.visualstudio\build\xunit.runner.visualstudio.props"
 
 [<Test>]
 let ``should handle Targets files``() = 


### PR DESCRIPTION
#3816 

Props and target files were not added to project files if they were found in the root of build, buildTransitive or buildMultiTargeting folders.