### PR TITLE
[Improvement of fix introduced in PR #3873] Search all the sub-directories under the default packages directory and do not use CompareString while searching under packages directory

### DIFF
--- a/src/Paket.Core/Dependencies/CacheExtensions.fs
+++ b/src/Paket.Core/Dependencies/CacheExtensions.fs
@@ -10,7 +10,7 @@ module CacheExtensions =
             let nuspec = Path.Combine(folder,sprintf "%O.nuspec" name)
             let fi = FileInfo(nuspec)
             // It happens in some cases that the package is not available in the cache, and in that case
-            // it would be sensible to recusrively search for the nuspec in the default package folder before returning
+            // it would be sensible to exhaustively search for the nuspec in the default package folder before returning
             // a Nuspec.All, see issue #3723
             // Maybe this method should be refactored/renamed now, as it not only tries to load from the cache
             // but also the packages folder.

--- a/src/Paket.Core/Dependencies/CacheExtensions.fs
+++ b/src/Paket.Core/Dependencies/CacheExtensions.fs
@@ -16,7 +16,7 @@ module CacheExtensions =
             // but also the packages folder.
             match fi.Exists with
             | true -> Nuspec.Load nuspec
-            | _ -> let candiateNupkgs = Directory.GetFiles(Constants.DefaultPackagesFolderName, sprintf "%O.nuspec" name.CompareString, SearchOption.AllDirectories)
+            | _ -> let candiateNupkgs = Directory.GetFiles(Constants.DefaultPackagesFolderName, sprintf "%O.nuspec" name, SearchOption.AllDirectories)
                    let expectedNumberOfMatches = 1
                    if (candiateNupkgs.Length = expectedNumberOfMatches) then Nuspec.Load candiateNupkgs.[0] else Nuspec.Load nuspec
 


### PR DESCRIPTION
## Problem:
While paket packing if a dependency is not available in the local user nuget cache, before returning the default Nuspec record, we used to seek the package in the default packages directory, but this method is not fool proof as the dependency might be located within a sub-directory of the default pakcages directory, for instance `packages\build`. Also, on Linux using `CompareString` causes problems because of case-sensitive file system.

## Solution:
Perform an exhaustive search under the default packages directory instead of looking at the top level on and use the plain package name instead of the `CompareString`