### PR TITLE
Add rollforward to globaljson

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-      "version": "3.1.302"
+      "version": "3.1.302",
+      "rollForward":"minor"
     }
 }


### PR DESCRIPTION
Pinning to a specific version can lead to unexpected issues, like Visual Studio removing the SDK it installed and replacing it with a new one, causing all projects to fail to load.

This will ensure that you can continue to update your tools and (usually) not get affected.