### PR TITLE
Introduce protocolVersion on source and default is not v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     # just flaky tests
     - PAKET_TESTSUITE_FLAKYTESTS=true
 
-dotnet: 3.0.100
+dotnet: 3.1.302
 
 mono:
   - 5.18.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 init:
   - git config --global core.autocrlf input
 

--- a/build.cmd
+++ b/build.cmd
@@ -9,6 +9,8 @@ setlocal
 
 set MSBuild=%~dp0packages\build\RoslynTools.MSBuild\tools\msbuild
 
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -InstallDir './.dotnet' -Version '3.1.302'"
+
 packages\build\FAKE\tools\FAKE.exe build.fsx %*
 
 endlocal

--- a/build.fsx
+++ b/build.fsx
@@ -267,10 +267,10 @@ Target "RunTests" (fun _ ->
             })
 
     runTest "net" "Paket.Tests" "net461"
-    runTest "netcore" "Paket.Tests" "netcoreapp3.0"
+    runTest "netcore" "Paket.Tests" "netcoreapp3.1"
 
     runTest "net" "Paket.Bootstrapper.Tests" "net461"
-    runTest "netcore" "Paket.Bootstrapper.Tests" "netcoreapp3.0"
+    runTest "netcore" "Paket.Bootstrapper.Tests" "netcoreapp3.1"
 )
 
 Target "QuickTest" (fun _ ->
@@ -349,7 +349,7 @@ Target "RunIntegrationTestsNetCore" (fun _ ->
     DotNetCli.Test (fun c ->
         { c with
             Project = "integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj"
-            Framework = "netcoreapp3.0"
+            Framework = "netcoreapp3.1"
             AdditionalArgs =
               [ "--filter"; (if testSuiteFilterFlakyTests then "TestCategory=Flaky" else "TestCategory!=Flaky")
                 sprintf "--logger:trx;LogFileName=%s" ("tests_result/netcore/Paket.IntegrationTests/TestResult.trx" |> Path.GetFullPath) ]

--- a/build.fsx
+++ b/build.fsx
@@ -145,8 +145,8 @@ Target "AssemblyInfo" (fun _ ->
 
 Target "InstallDotNetCore" (fun _ ->
     dotnetExePath <- DotNetCli.InstallDotNetSDK dotnetcliVersion
-    Environment.SetEnvironmentVariable("DOTNET_EXE_PATH", dotnetExePath)
-)
+    Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+    Environment.SetEnvironmentVariable("DOTNET_ROOT", (directory dotnetExePath)))
 
 // --------------------------------------------------------------------------------------
 // Clean build results

--- a/build.fsx
+++ b/build.fsx
@@ -254,6 +254,10 @@ Target "Publish" (fun _ ->
 Target "RunTests" (fun _ ->
 
     let runTest fw proj tfm =
+        traceImportant (sprintf " ******************* %s %s %s PATH : %s" (fw) (proj) (tfm) (Environment.GetEnvironmentVariable("PATH")))
+        traceImportant (sprintf " ******************* %s %s %s DOTNET_ROOT : %s" (fw) (proj) (tfm) (Environment.GetEnvironmentVariable("DOTNET_ROOT")))
+        traceImportant (sprintf " ******************* %s %s %s DOTNET_MULTILEVEL_LOOKUP : %s" (fw) (proj) (tfm) (Environment.GetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP")))
+
         CreateDir (sprintf "tests_result/%s/%s" fw proj)
 
         let logFilePath = (sprintf "tests_result/%s/%s/TestResult.trx" fw proj) |> Path.GetFullPath

--- a/build.fsx
+++ b/build.fsx
@@ -145,8 +145,12 @@ Target "AssemblyInfo" (fun _ ->
 
 Target "InstallDotNetCore" (fun _ ->
     dotnetExePath <- DotNetCli.InstallDotNetSDK dotnetcliVersion
+    let sdkPath = DotNetCli.DotnetSDKPath 
+    let path = Environment.GetEnvironmentVariable("PATH")
+    Environment.SetEnvironmentVariable("DOTNET_ROOT", sdkPath)
     Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
-    Environment.SetEnvironmentVariable("DOTNET_ROOT", (directory dotnetExePath)))
+    Environment.SetEnvironmentVariable("PATH", (sprintf "%s;%s" sdkPath path))
+)
 
 // --------------------------------------------------------------------------------------
 // Clean build results

--- a/build.fsx
+++ b/build.fsx
@@ -144,12 +144,15 @@ Target "AssemblyInfo" (fun _ ->
 )
 
 Target "InstallDotNetCore" (fun _ ->
-    dotnetExePath <- DotNetCli.InstallDotNetSDK dotnetcliVersion
-    let sdkPath = DotNetCli.DotnetSDKPath 
+    // dotnetExePath <- DotNetCli.InstallDotNetSDK dotnetcliVersion
     let path = Environment.GetEnvironmentVariable("PATH")
-    Environment.SetEnvironmentVariable("DOTNET_ROOT", sdkPath)
+    Environment.SetEnvironmentVariable("DOTNET_ROOT", "./.dotnet")
     Environment.SetEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
-    Environment.SetEnvironmentVariable("PATH", (sprintf "%s;%s" sdkPath path))
+    Environment.SetEnvironmentVariable("PATH", (sprintf "%s;%s" (directory "./.dotnet") path))
+    traceImportant (Environment.GetEnvironmentVariable("PATH"))
+    traceImportant (Environment.GetEnvironmentVariable("PATH"))
+    traceImportant (Environment.GetEnvironmentVariable("PATH"))
+    traceImportant (Environment.GetEnvironmentVariable("PATH"))
 )
 
 // --------------------------------------------------------------------------------------

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ then
   	exit $exit_code
   fi
   MSBuild=`pwd -W`/packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
+  
+  &powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -InstallDir './.dotnet' -Version '3.1.302'"
 else
   mono .paket/paket.exe restore
   exit_code=$?
@@ -28,6 +30,9 @@ else
   fi
   # Note: the bundled MSBuild crashes hard on linux, so we still rely on the system-installed version
   #export MSBuild=packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe
+
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 3.1.302 --install-dir ./.dotnet
+
   mono packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
 fi
 

--- a/docs/content/paket.dependencies
+++ b/docs/content/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Formatting
 nuget FsUnit

--- a/docs/content/paket.lock
+++ b/docs/content/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: https://nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     FSharp.Compiler.Service (0.0.67)
     FSharp.Data (2.1.0)

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
-    "sdk": {
-      "version": "3.1.302"
-    }
+  "sdk": {
+    "version": "3.1.302",
+    "rollForward": "latestFeature"
+  }
 }

--- a/integrationtests/Directory.Build.props
+++ b/integrationtests/Directory.Build.props
@@ -5,7 +5,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/integrationtests/Paket.IntegrationTests/PaketCoreSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PaketCoreSpecs.fs
@@ -16,7 +16,7 @@ let alternativeProjectRoot = None
 [<Test>]
 let ``#1251 full installer demo``() = 
     use __ = prepare "i001251-installer-demo"
-    let deps = """source https://nuget.org/api/v2
+    let deps = """source https://api.nuget.org/v3/index.json
     nuget FAKE
     nuget FSharp.Formatting"""
 
@@ -35,7 +35,7 @@ let ``#1251 full installer demo``() =
 [<Test>]
 let ``#1251 install FSharp.Collections.ParallelSeq``() = 
     use __ = prepare "i001251-installer-demo"
-    let deps = """source https://nuget.org/api/v2
+    let deps = """source https://api.nuget.org/v3/index.json
     nuget FSharp.Collections.ParallelSeq"""
 
     let dependenciesFile = DependenciesFile.FromSource(scenarioTempPath "i001251-installer-demo",deps)
@@ -56,7 +56,7 @@ let ``#1259 install via script``() =
 
     Paket.Dependencies
        .Install("""
-    source https://nuget.org/api/v2
+    source https://api.nuget.org/v3/index.json
     nuget FSharp.Data
     nuget Suave
 """, path = scenarioTempPath "i001259-install-script")

--- a/integrationtests/Paket.IntegrationTests/SymbolicLinkSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/SymbolicLinkSpecs.fs
@@ -42,7 +42,7 @@ let ``#3127 symlink enabled -> disabled on all dependencies on existing paket.lo
     |> SymlinkUtils.isDirectoryLink 
     |> shouldEqual true
 
-    let paketDependenciesWithoutConfig = """source https://www.nuget.org/api/v2
+    let paketDependenciesWithoutConfig = """source https://api.nuget.org/v3/index.json
 nuget NUnit < 3.0.0"""
     
     paketDependenciesWithoutConfig
@@ -65,7 +65,7 @@ let ``#3127 symlink disabled -> enabled on all dependencies on existing paket.lo
     let workingDir = scenarioTempPath scenario
     let packagesDir = workingDir </> "packages"
     
-    let paketDependenciesWithoutConfig = """source https://www.nuget.org/api/v2
+    let paketDependenciesWithoutConfig = """source https://api.nuget.org/v3/index.json
 nuget NUnit < 3.0.0"""
     
     paketDependenciesWithoutConfig 
@@ -79,7 +79,7 @@ nuget NUnit < 3.0.0"""
     |> SymlinkUtils.isDirectoryLink 
     |> shouldEqual false
 
-    let paketDependenciesWithConfig = """source https://www.nuget.org/api/v2
+    let paketDependenciesWithConfig = """source https://api.nuget.org/v3/index.json
 storage: symlink
 nuget NUnit < 3.0.0"""
     

--- a/integrationtests/Paket.IntegrationTests/TestHelper.fs
+++ b/integrationtests/Paket.IntegrationTests/TestHelper.fs
@@ -15,20 +15,28 @@ let disableScenarioCleanup = false // change to true to debug a single test temp
 let isLiveUnitTesting = AppDomain.CurrentDomain.GetAssemblies() |> Seq.exists (fun a -> a.GetName().Name = "Microsoft.CodeAnalysis.LiveUnitTesting.Runtime")
 
 let dotnetToolPath =
-    match Environment.GetEnvironmentVariable "DOTNET_EXE_PATH" with
+    match Environment.GetEnvironmentVariable "DOTNET_ROOT" with
     | null | "" -> "dotnet"
-    | s -> s
+    | s -> sprintf "%s/dotnet" (s.TrimEnd('/').TrimEnd('\\'))
 
 let paketToolPath =
 #if PAKET_NETCORE
+#if DEBUG
+    dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../src/Paket/bin/Debug/netcoreapp2.1/paket.dll")
+#else
     dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../bin/netcoreapp2.1/paket.dll")
+#endif
 #else
     "", FullName(__SOURCE_DIRECTORY__ + "../../../bin/net461/paket.exe")
 #endif
 
 let paketBootstrapperToolPath =
 #if PAKET_NETCORE
+#if DEBUG
+    dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../src/Paket.Bootstrapper/netcoreapp2.1/paket.bootstrapper.dll")
+#else
     dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../bin_bootstrapper/netcoreapp2.1/paket.bootstrapper.dll")
+#endif
 #else
     "", FullName(__SOURCE_DIRECTORY__ + "../../../bin_bootstrapper/net461/paket.bootstrapper.exe")
 #endif

--- a/integrationtests/scenarios/i000055-resolve-with-pessimistic-strategy/before/paket.dependencies
+++ b/integrationtests/scenarios/i000055-resolve-with-pessimistic-strategy/before/paket.dependencies
@@ -1,5 +1,5 @@
 strategy min
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Castle.Windsor" ">= 0"
 nuget "Nancy.Bootstrappers.Windsor" "~> 0.23"

--- a/integrationtests/scenarios/i000071-ignore-trailing-zero-during-resolve/before/paket.dependencies
+++ b/integrationtests/scenarios/i000071-ignore-trailing-zero-during-resolve/before/paket.dependencies
@@ -1,2 +1,2 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 nuget "Newtonsoft.Json" "6.0.5.0"

--- a/integrationtests/scenarios/i000108-case-insensitive-nuget-packages/before/paket.dependencies
+++ b/integrationtests/scenarios/i000108-case-insensitive-nuget-packages/before/paket.dependencies
@@ -1,4 +1,4 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "bootstrap" "3.2.0"
 nuget "jQuery" "1.9.0"

--- a/integrationtests/scenarios/i000140-resolve-framework-restrictions/before/paket.dependencies
+++ b/integrationtests/scenarios/i000140-resolve-framework-restrictions/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 # Core Dependencies
 nuget FParsec ~> 1.0.1

--- a/integrationtests/scenarios/i000144-resolve-nunit/before/paket.dependencies
+++ b/integrationtests/scenarios/i000144-resolve-nunit/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget NUnit ~> 2.6
 nuget FsUnit ~> 1.3

--- a/integrationtests/scenarios/i000156-resolve-prerelease-logary/before/paket.dependencies
+++ b/integrationtests/scenarios/i000156-resolve-prerelease-logary/before/paket.dependencies
@@ -1,2 +1,2 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget FSharp.Actor-logary 2.0.0-alpha5

--- a/integrationtests/scenarios/i000173-resolve-primary-dependency-optimistic/before/paket.dependencies
+++ b/integrationtests/scenarios/i000173-resolve-primary-dependency-optimistic/before/paket.dependencies
@@ -1,2 +1,2 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget FSharp.Formatting !~> 2.4

--- a/integrationtests/scenarios/i000183-outdated-with-special-parameters/before/paket.dependencies
+++ b/integrationtests/scenarios/i000183-outdated-with-special-parameters/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Formatting ~> 2.4
 nuget Newtonsoft.Json ~> 6.0.7

--- a/integrationtests/scenarios/i000183-outdated-with-special-parameters/before/paket.lock
+++ b/integrationtests/scenarios/i000183-outdated-with-special-parameters/before/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: http://nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     FSharp.Compiler.Service (1.4.2.1)
     FSharp.Formatting (2.4)

--- a/integrationtests/scenarios/i000220-use-exactly-this-constraint/before/paket.dependencies
+++ b/integrationtests/scenarios/i000220-use-exactly-this-constraint/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 framework: >= net40
 

--- a/integrationtests/scenarios/i000299-restore-package-that-ends-in-lib/before/paket.dependencies
+++ b/integrationtests/scenarios/i000299-restore-package-that-ends-in-lib/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FunScript.TypeScript.Binding.lib

--- a/integrationtests/scenarios/i000310-add-should-not-create-invalid-resolution/before/paket.dependencies
+++ b/integrationtests/scenarios/i000310-add-should-not-create-invalid-resolution/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Castle.Core >= 3.2 < 3.3

--- a/integrationtests/scenarios/i000310-add-should-not-create-invalid-resolution/before/paket.lock
+++ b/integrationtests/scenarios/i000310-add-should-not-create-invalid-resolution/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: http://nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.2.2)

--- a/integrationtests/scenarios/i000320-add-clitool/before/paket.dependencies
+++ b/integrationtests/scenarios/i000320-add-clitool/before/paket.dependencies
@@ -1,1 +1,1 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i000321-add-nuget/before/paket.dependencies
+++ b/integrationtests/scenarios/i000321-add-nuget/before/paket.dependencies
@@ -1,1 +1,1 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i000359-packagename-contains-nuget/before/paket.dependencies
+++ b/integrationtests/scenarios/i000359-packagename-contains-nuget/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget nuget.CommandLine

--- a/integrationtests/scenarios/i001117-aws/before/paket.dependencies
+++ b/integrationtests/scenarios/i001117-aws/before/paket.dependencies
@@ -1,2 +1,2 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget AWSSDK.Core 3.1.5.3

--- a/integrationtests/scenarios/i001125-update-and-keep-minor/before/paket.dependencies
+++ b/integrationtests/scenarios/i001125-update-and-keep-minor/before/paket.dependencies
@@ -1,2 +1,2 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget FSharp.Formatting

--- a/integrationtests/scenarios/i001125-update-and-keep-minor/before/paket.lock
+++ b/integrationtests/scenarios/i001125-update-and-keep-minor/before/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     FSharp.Compiler.Service (2.0.0.6)
     FSharp.Formatting (2.14.2)
       FSharp.Compiler.Service (2.0.0.6)

--- a/integrationtests/scenarios/i001135-stable-install-on-framework-restrictions/before/paket.dependencies
+++ b/integrationtests/scenarios/i001135-stable-install-on-framework-restrictions/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget StackExchange.Redis ~> 1.0

--- a/integrationtests/scenarios/i001135-stable-install-on-framework-restrictions/before/paket.lock
+++ b/integrationtests/scenarios/i001135-stable-install-on-framework-restrictions/before/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: https://nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Microsoft.Bcl (1.1.10) - framework: net40
       Microsoft.Bcl.Build (>= 1.0.14)

--- a/integrationtests/scenarios/i001166-resolve-nancy-fast/before/paket.dependencies
+++ b/integrationtests/scenarios/i001166-resolve-nancy-fast/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Formatting
 nuget Microsoft.AspNet.SignalR.Core

--- a/integrationtests/scenarios/i001174-resolve-fast-conflict/before/paket.dependencies
+++ b/integrationtests/scenarios/i001174-resolve-fast-conflict/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Microsoft.AspNet.SignalR.JS
 nuget Nancy.Serialization.JsonNet

--- a/integrationtests/scenarios/i001177-resolve-with-pessimistic-strategy/before/paket.dependencies
+++ b/integrationtests/scenarios/i001177-resolve-with-pessimistic-strategy/before/paket.dependencies
@@ -1,5 +1,5 @@
 strategy min
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Castle.Core
 nuget Castle.Windsor = 3.2.1

--- a/integrationtests/scenarios/i001178-update-with-regex/before/paket.dependencies
+++ b/integrationtests/scenarios/i001178-update-with-regex/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Castle.Windsor                      
 nuget NUnit                          

--- a/integrationtests/scenarios/i001178-update-with-regex/before/paket.lock
+++ b/integrationtests/scenarios/i001178-update-with-regex/before/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: https://nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.3.3)
     Castle.Windsor (2.5.1)

--- a/integrationtests/scenarios/i001182-framework-restrictions/before/paket.dependencies
+++ b/integrationtests/scenarios/i001182-framework-restrictions/before/paket.dependencies
@@ -2,7 +2,7 @@ framework: net452
 content: none
 redirects: off
 
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 source https://nuget.bittitan.com/nuget/Components
 
 

--- a/integrationtests/scenarios/i001187-binding-redirect/before/paket.dependencies
+++ b/integrationtests/scenarios/i001187-binding-redirect/before/paket.dependencies
@@ -1,4 +1,4 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget Albedo 1.0.2
 nuget AutoFixture 3.36.9

--- a/integrationtests/scenarios/i001189-allow-#-in-path/before/paket.dependencies
+++ b/integrationtests/scenarios/i001189-allow-#-in-path/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 
 nuget FAKE

--- a/integrationtests/scenarios/i001189-allow-#-in-path/before/paket.lock
+++ b/integrationtests/scenarios/i001189-allow-#-in-path/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     FAKE (4.7.3)

--- a/integrationtests/scenarios/i001190-transitive-dependencies-with-restr/before/paket.dependencies
+++ b/integrationtests/scenarios/i001190-transitive-dependencies-with-restr/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 nuget xunit

--- a/integrationtests/scenarios/i001190-transitive-deps/before/paket.dependencies
+++ b/integrationtests/scenarios/i001190-transitive-deps/before/paket.dependencies
@@ -1,3 +1,3 @@
 framework: net45
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 nuget xunit

--- a/integrationtests/scenarios/i001195-broken-appconfig/before/paket.dependencies
+++ b/integrationtests/scenarios/i001195-broken-appconfig/before/paket.dependencies
@@ -1,4 +1,4 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget Albedo 1.0.2
 nuget AutoFixture.Idioms 3.35.1

--- a/integrationtests/scenarios/i001197-too-strict-frameworks/before/paket.dependencies
+++ b/integrationtests/scenarios/i001197-too-strict-frameworks/before/paket.dependencies
@@ -1,4 +1,4 @@
 framework: net40, net45, sl5
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget log4net.ElasticSearch

--- a/integrationtests/scenarios/i001213-framework-propagation/before/paket.dependencies
+++ b/integrationtests/scenarios/i001213-framework-propagation/before/paket.dependencies
@@ -1,6 +1,6 @@
 framework: >= net40
 
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Newtonsoft.Json redirects: on
 nuget Nancy.Serialization.JsonNet ~> 1.2 framework: >= net451

--- a/integrationtests/scenarios/i001215-framework-propagation-no-restriction/before/paket.dependencies
+++ b/integrationtests/scenarios/i001215-framework-propagation-no-restriction/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 
 nuget Microsoft.Bcl.Async 
 nuget OwinMiddlewares.Log4net

--- a/integrationtests/scenarios/i001218-binding-redirect/before/paket.dependencies
+++ b/integrationtests/scenarios/i001218-binding-redirect/before/paket.dependencies
@@ -1,4 +1,4 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget Albedo 1.0.2
 nuget AutoFixture 3.36.9

--- a/integrationtests/scenarios/i001232-sql-lite/before/paket.dependencies
+++ b/integrationtests/scenarios/i001232-sql-lite/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 framework: >=net40
 

--- a/integrationtests/scenarios/i001234-missing-assemblyname/before/paket.dependencies
+++ b/integrationtests/scenarios/i001234-missing-assemblyname/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001242-v3/before/paket.dependencies
+++ b/integrationtests/scenarios/i001242-v3/before/paket.dependencies
@@ -1,7 +1,7 @@
 redirects: on
 
 source https://api.nuget.org/v3/index.json
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Control.Reactive
 nuget FSharp.Data framework: >= net40

--- a/integrationtests/scenarios/i001254-unlisted/before/paket.dependencies
+++ b/integrationtests/scenarios/i001254-unlisted/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget ServiceStack.Host.AspNet

--- a/integrationtests/scenarios/i001256-wrong-lock/before/paket.dependencies
+++ b/integrationtests/scenarios/i001256-wrong-lock/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FAKE

--- a/integrationtests/scenarios/i001256-wrong-lock/before/paket.lock
+++ b/integrationtests/scenarios/i001256-wrong-lock/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     FAKE

--- a/integrationtests/scenarios/i001260-csharp-wpf-project/before/paket.dependencies
+++ b/integrationtests/scenarios/i001260-csharp-wpf-project/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MahApps.Metro.Resources 0.5.0

--- a/integrationtests/scenarios/i001270-force-redirects/before/paket.dependencies
+++ b/integrationtests/scenarios/i001270-force-redirects/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 nuget Alphafs redirects: on
 nuget FSharp.Core redirects: force
 nuget Newtonsoft.Json 7.0.1 redirects: off

--- a/integrationtests/scenarios/i001270-net461/before/paket.dependencies
+++ b/integrationtests/scenarios/i001270-net461/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 nuget Alphafs

--- a/integrationtests/scenarios/i001375-pack-specific/before/paket.dependencies
+++ b/integrationtests/scenarios/i001375-pack-specific/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MySql.Data 6.9.8

--- a/integrationtests/scenarios/i001375-pack-specific/before/paket.lock
+++ b/integrationtests/scenarios/i001375-pack-specific/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     MySql.Data (6.9.8)

--- a/integrationtests/scenarios/i001376-pack-template-plus/before/paket.dependencies
+++ b/integrationtests/scenarios/i001376-pack-template-plus/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MySql.Data 6.9.8

--- a/integrationtests/scenarios/i001376-pack-template-plus/before/paket.lock
+++ b/integrationtests/scenarios/i001376-pack-template-plus/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     MySql.Data (6.9.8)

--- a/integrationtests/scenarios/i001376-pack-template/before/paket.dependencies
+++ b/integrationtests/scenarios/i001376-pack-template/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MySql.Data 6.9.8

--- a/integrationtests/scenarios/i001376-pack-template/before/paket.lock
+++ b/integrationtests/scenarios/i001376-pack-template/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     MySql.Data (6.9.8)

--- a/integrationtests/scenarios/i001427-content-none/before/paket.dependencies
+++ b/integrationtests/scenarios/i001427-content-none/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 nuget Costura.Fody ~> 1.3.3.0 content:none

--- a/integrationtests/scenarios/i001427-content-once-remove/before/paket.dependencies
+++ b/integrationtests/scenarios/i001427-content-once-remove/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 nuget Costura.Fody ~> 1.3.3.0 content: once

--- a/integrationtests/scenarios/i001427-content-once-stable/before/paket.dependencies
+++ b/integrationtests/scenarios/i001427-content-once-stable/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 nuget Costura.Fody ~> 1.3.3.0 content: once

--- a/integrationtests/scenarios/i001427-content-once/before/paket.dependencies
+++ b/integrationtests/scenarios/i001427-content-once/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 nuget Costura.Fody ~> 1.3.3.0 content: once

--- a/integrationtests/scenarios/i001427-content-true/before/paket.dependencies
+++ b/integrationtests/scenarios/i001427-content-true/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 nuget Costura.Fody ~> 1.3.3.0

--- a/integrationtests/scenarios/i001427-ref-content-once/before/paket.dependencies
+++ b/integrationtests/scenarios/i001427-ref-content-once/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 nuget Costura.Fody ~> 1.3.3.0

--- a/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/paket.dependencies
+++ b/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MySql.Data >= 1.2.3

--- a/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/paket.lock
+++ b/integrationtests/scenarios/i001429-pack-deps-minimum-from-lock/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     MySql.Data (6.9.8)

--- a/integrationtests/scenarios/i001429-pack-deps-specific/before/paket.dependencies
+++ b/integrationtests/scenarios/i001429-pack-deps-specific/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MySql.Data 2.3.4

--- a/integrationtests/scenarios/i001429-pack-deps-specific/before/paket.lock
+++ b/integrationtests/scenarios/i001429-pack-deps-specific/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     MySql.Data (2.3.4)

--- a/integrationtests/scenarios/i001429-pack-deps/before/paket.dependencies
+++ b/integrationtests/scenarios/i001429-pack-deps/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MySql.Data 6.9.8

--- a/integrationtests/scenarios/i001429-pack-deps/before/paket.lock
+++ b/integrationtests/scenarios/i001429-pack-deps/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     MySql.Data (6.9.8)

--- a/integrationtests/scenarios/i001440-auto-detect/before/paket.dependencies
+++ b/integrationtests/scenarios/i001440-auto-detect/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework auto-detect
 
 nuget Newtonsoft.Json

--- a/integrationtests/scenarios/i001442-dont-warn/before/paket.dependencies
+++ b/integrationtests/scenarios/i001442-dont-warn/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 
 nuget SonarLint

--- a/integrationtests/scenarios/i001442-warn-Rx/before/paket.dependencies
+++ b/integrationtests/scenarios/i001442-warn-Rx/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 
 nuget Rx-WinRT

--- a/integrationtests/scenarios/i001458-group-conflict/before/paket.dependencies
+++ b/integrationtests/scenarios/i001458-group-conflict/before/paket.dependencies
@@ -1,10 +1,10 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget Nancy.Bootstrappers.Windsor
 
 group test
-  source https://nuget.org/api/v2
+  source https://api.nuget.org/v3/index.json
   nuget Nancy.Testing
 
 group hosting
-  source https://nuget.org/api/v2
+  source https://api.nuget.org/v3/index.json
   nuget Nancy.Owin

--- a/integrationtests/scenarios/i001458-group-conflict/before/paket.lock
+++ b/integrationtests/scenarios/i001458-group-conflict/before/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.3.3)
     Castle.Windsor (3.3.0)
@@ -11,7 +11,7 @@ NUGET
 
 GROUP hosting
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Nancy (1.4.3)
     Nancy.Owin (1.4.1)
@@ -21,7 +21,7 @@ NUGET
 
 GROUP test
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     CsQuery (1.3.4)
     Nancy (1.4.1)

--- a/integrationtests/scenarios/i001466-expressive/before/paket.dependencies
+++ b/integrationtests/scenarios/i001466-expressive/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 content: none
 import_targets: false
 framework: net45

--- a/integrationtests/scenarios/i001466-expressive/before/paket.lock
+++ b/integrationtests/scenarios/i001466-expressive/before/paket.lock
@@ -3,7 +3,7 @@ IMPORT-TARGETS: FALSE
 CONTENT: NONE
 FRAMEWORK: NET45
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     ExpressiveAnnotations (2.4.0)
       jQuery (>= 1.8.2)

--- a/integrationtests/scenarios/i001469-darkseid/before/paket.dependencies
+++ b/integrationtests/scenarios/i001469-darkseid/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Darkseid 

--- a/integrationtests/scenarios/i001472-globbing/before/paket.dependencies
+++ b/integrationtests/scenarios/i001472-globbing/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001472-pack-in-relative/before/paket.dependencies
+++ b/integrationtests/scenarios/i001472-pack-in-relative/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001472-pack-in-root/before/paket.dependencies
+++ b/integrationtests/scenarios/i001472-pack-in-root/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001473-blocking/before/paket.dependencies
+++ b/integrationtests/scenarios/i001473-blocking/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001474-restore-no-locks/before/paket.dependencies
+++ b/integrationtests/scenarios/i001474-restore-no-locks/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 
 nuget Newtonsoft.Json

--- a/integrationtests/scenarios/i001506-pack-ending/before/paket.dependencies
+++ b/integrationtests/scenarios/i001506-pack-ending/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001510-download/before/paket.dependencies
+++ b/integrationtests/scenarios/i001510-download/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget CsQuery
 nuget FSharp.Data

--- a/integrationtests/scenarios/i001520-pinned-error/before/paket.dependencies
+++ b/integrationtests/scenarios/i001520-pinned-error/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget Microsoft.ApplicationInsights.WindowsServer = 1.2.3

--- a/integrationtests/scenarios/i001522-copy-content/before/paket.dependencies
+++ b/integrationtests/scenarios/i001522-copy-content/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 nuget Costura.Fody ~> 1.3.3.0 content: once, copy_content_to_output_dir: always

--- a/integrationtests/scenarios/i001538-symbols-src-folder-structure/before/paket.dependencies
+++ b/integrationtests/scenarios/i001538-symbols-src-folder-structure/before/paket.dependencies
@@ -1,2 +1,2 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 

--- a/integrationtests/scenarios/i001574-redirect-gac/before/paket.dependencies
+++ b/integrationtests/scenarios/i001574-redirect-gac/before/paket.dependencies
@@ -1,4 +1,4 @@
 redirects: off
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Core redirects: force

--- a/integrationtests/scenarios/i001574-redirect-gac/before/paket.lock
+++ b/integrationtests/scenarios/i001574-redirect-gac/before/paket.lock
@@ -1,5 +1,5 @@
 REDIRECTS: OFF
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     FSharp.Core (3.1.2.1) - redirects: force

--- a/integrationtests/scenarios/i001579-unlisted/before/paket.dependencies
+++ b/integrationtests/scenarios/i001579-unlisted/before/paket.dependencies
@@ -1,5 +1,5 @@
 source bin
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Mvvmlight ~> 4
 

--- a/integrationtests/scenarios/i001585-websharper-props/before/paket.dependencies
+++ b/integrationtests/scenarios/i001585-websharper-props/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net45
 
 nuget WebSharper 3.6.11.234

--- a/integrationtests/scenarios/i001586-pack-referenced/before/paket.dependencies
+++ b/integrationtests/scenarios/i001586-pack-referenced/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget MySql.Data 6.9.8

--- a/integrationtests/scenarios/i001586-pack-referenced/before/paket.lock
+++ b/integrationtests/scenarios/i001586-pack-referenced/before/paket.lock
@@ -1,4 +1,4 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     MySql.Data (6.9.8)

--- a/integrationtests/scenarios/i001594-pack/before/paket.dependencies
+++ b/integrationtests/scenarios/i001594-pack/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001596-pack-reflectedDefinition/before/paket.dependencies
+++ b/integrationtests/scenarios/i001596-pack-reflectedDefinition/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i001621-different-framework/before/paket.dependencies
+++ b/integrationtests/scenarios/i001621-different-framework/before/paket.dependencies
@@ -1,4 +1,4 @@
 redirects: on
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget NUnit = 3.0.1

--- a/integrationtests/scenarios/i001633-local-source-override/before/paket.dependencies
+++ b/integrationtests/scenarios/i001633-local-source-override/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget NUnit < 3.0.0

--- a/integrationtests/scenarios/i001633-local-source-override/before/paket.lock
+++ b/integrationtests/scenarios/i001633-local-source-override/before/paket.lock
@@ -1,3 +1,3 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NUnit (2.6.3)

--- a/integrationtests/scenarios/i001663-build-targets/before/paket.dependencies
+++ b/integrationtests/scenarios/i001663-build-targets/before/paket.dependencies
@@ -1,7 +1,7 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 group Build
-	source https://nuget.org/api/v2
+	source https://api.nuget.org/v3/index.json
 
 	nuget BuildBundlerMinifier 1.8.154
 	nuget BuildWebCompiler 1.10.310

--- a/integrationtests/scenarios/i001701-keep-major/before/paket.dependencies
+++ b/integrationtests/scenarios/i001701-keep-major/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget bootstrap content:none

--- a/integrationtests/scenarios/i001701-keep-major/before/paket.lock
+++ b/integrationtests/scenarios/i001701-keep-major/before/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     bootstrap (3.3.6) - content: none
       jQuery (>= 1.9.1 < 3.0)

--- a/integrationtests/scenarios/i001720-explicit-net45/before/paket.dependencies
+++ b/integrationtests/scenarios/i001720-explicit-net45/before/paket.dependencies
@@ -1,4 +1,4 @@
 framework: net45
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Newtonsoft.JSON 8.0.3

--- a/integrationtests/scenarios/i001720-explicit-net45/before/paket.lock
+++ b/integrationtests/scenarios/i001720-explicit-net45/before/paket.lock
@@ -1,4 +1,4 @@
 FRAMEWORK: NET45
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Newtonsoft.Json (8.0.3)

--- a/integrationtests/scenarios/i001737-simplify-with-auto-framework/before/paket.dependencies
+++ b/integrationtests/scenarios/i001737-simplify-with-auto-framework/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 framework: auto-detect
 

--- a/integrationtests/scenarios/i001746-hard-legacy/before/paket.dependencies
+++ b/integrationtests/scenarios/i001746-hard-legacy/before/paket.dependencies
@@ -1,5 +1,5 @@
 redirects: off
 framework: net40, net45, sl5
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget microsoft.bcl.async v1.0.168

--- a/integrationtests/scenarios/i001779-net20-only-in-net461/before/paket.dependencies
+++ b/integrationtests/scenarios/i001779-net20-only-in-net461/before/paket.dependencies
@@ -1,3 +1,3 @@
 framework: net461
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 nuget EPPlus ~> 4.0.5

--- a/integrationtests/scenarios/i001779-net20-only-in-net461/before/paket.lock
+++ b/integrationtests/scenarios/i001779-net20-only-in-net461/before/paket.lock
@@ -1,4 +1,4 @@
 FRAMEWORK: NET461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     EPPlus (4.0.5)

--- a/integrationtests/scenarios/i001783-different-versions/before/paket.dependencies
+++ b/integrationtests/scenarios/i001783-different-versions/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 redirects: on
 framework: net45
 
@@ -6,7 +6,7 @@ nuget Newtonsoft.Json.FSharp 3.2.2
 nuget Newtonsoft.Json ~> 7.0
 
 group B
-	source https://www.nuget.org/api/v2
+	source https://api.nuget.org/v3/index.json
 	redirects: on
 	framework: net45
 

--- a/integrationtests/scenarios/i001816-pack-localized-happy-path/before/paket.dependencies
+++ b/integrationtests/scenarios/i001816-pack-localized-happy-path/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 

--- a/integrationtests/scenarios/i001816-pack-localized-missing-dll/before/paket.dependencies
+++ b/integrationtests/scenarios/i001816-pack-localized-missing-dll/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 

--- a/integrationtests/scenarios/i001848-pack-all-templates-with-incl-flag/before/paket.dependencies
+++ b/integrationtests/scenarios/i001848-pack-all-templates-with-incl-flag/before/paket.dependencies
@@ -1,3 +1,3 @@
 framework: net461
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget nunit 3.8.1

--- a/integrationtests/scenarios/i001848-pack-all-templates-with-incl-flag/before/paket.lock
+++ b/integrationtests/scenarios/i001848-pack-all-templates-with-incl-flag/before/paket.lock
@@ -1,4 +1,4 @@
 RESTRICTION: == net461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NUnit (3.8.1)

--- a/integrationtests/scenarios/i001848-pack-all-templates-wo-incl-flag/before/paket.dependencies
+++ b/integrationtests/scenarios/i001848-pack-all-templates-wo-incl-flag/before/paket.dependencies
@@ -1,3 +1,3 @@
 framework: net461
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget nunit 3.8.1

--- a/integrationtests/scenarios/i001848-pack-all-templates-wo-incl-flag/before/paket.lock
+++ b/integrationtests/scenarios/i001848-pack-all-templates-wo-incl-flag/before/paket.lock
@@ -1,4 +1,4 @@
 RESTRICTION: == net461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NUnit (3.8.1)

--- a/integrationtests/scenarios/i001848-pack-single-template-with-incl-flag/before/paket.dependencies
+++ b/integrationtests/scenarios/i001848-pack-single-template-with-incl-flag/before/paket.dependencies
@@ -1,3 +1,3 @@
 framework: net461
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget nunit 3.8.1

--- a/integrationtests/scenarios/i001848-pack-single-template-with-incl-flag/before/paket.lock
+++ b/integrationtests/scenarios/i001848-pack-single-template-with-incl-flag/before/paket.lock
@@ -1,4 +1,4 @@
 RESTRICTION: == net461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NUnit (3.8.1)

--- a/integrationtests/scenarios/i001848-pack-single-template-wo-incl-flag/before/paket.dependencies
+++ b/integrationtests/scenarios/i001848-pack-single-template-wo-incl-flag/before/paket.dependencies
@@ -1,3 +1,3 @@
 framework: net461
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget nunit 3.8.1

--- a/integrationtests/scenarios/i001848-pack-single-template-wo-incl-flag/before/paket.lock
+++ b/integrationtests/scenarios/i001848-pack-single-template-wo-incl-flag/before/paket.lock
@@ -1,4 +1,4 @@
 RESTRICTION: == net461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NUnit (3.8.1)

--- a/integrationtests/scenarios/i001848-pack-with-non-packed-deps/before/paket.dependencies
+++ b/integrationtests/scenarios/i001848-pack-with-non-packed-deps/before/paket.dependencies
@@ -1,3 +1,3 @@
 framework: net461
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget nunit 3.8.1

--- a/integrationtests/scenarios/i001848-pack-with-non-packed-deps/before/paket.lock
+++ b/integrationtests/scenarios/i001848-pack-with-non-packed-deps/before/paket.lock
@@ -1,4 +1,4 @@
 RESTRICTION: == net461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NUnit (3.8.1)

--- a/integrationtests/scenarios/i001860-attribute/before/paket.dependencies
+++ b/integrationtests/scenarios/i001860-attribute/before/paket.dependencies
@@ -1,5 +1,5 @@
 strategy: max
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 redirects: on
 framework: >= net40
 

--- a/integrationtests/scenarios/i001860-attribute/before/paket.lock
+++ b/integrationtests/scenarios/i001860-attribute/before/paket.lock
@@ -2,7 +2,7 @@ REDIRECTS: ON
 STRATEGY: MAX
 FRAMEWORK: >= NET40
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Argu (3.2) - condition: azure
     FSharp.Core (4.0.0.1) - condition: azure
     FsPickler (2.1) - condition: azure

--- a/integrationtests/scenarios/i001871-suave/before/paket.dependencies
+++ b/integrationtests/scenarios/i001871-suave/before/paket.dependencies
@@ -1,7 +1,7 @@
-source http://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework >= net45
 
 group Main
-source http://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Suave >= 1.0.0

--- a/integrationtests/scenarios/i001883-chessie/before/paket.dependencies
+++ b/integrationtests/scenarios/i001883-chessie/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework >= net45
 nuget Chessie 0.6

--- a/integrationtests/scenarios/i001883-machine/before/paket.dependencies
+++ b/integrationtests/scenarios/i001883-machine/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework >= net45
 nuget Machine.Specifications 0.11

--- a/integrationtests/scenarios/i002408-indenting-appconfig/before/paket.dependencies
+++ b/integrationtests/scenarios/i002408-indenting-appconfig/before/paket.dependencies
@@ -1,3 +1,3 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget Castle.Core 3.3.3

--- a/integrationtests/scenarios/i002496/before/paket.dependencies
+++ b/integrationtests/scenarios/i002496/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Elasticsearch.Net

--- a/integrationtests/scenarios/i002496/before/paket.lock
+++ b/integrationtests/scenarios/i002496/before/paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Elasticsearch.Net (5.4)
       Microsoft.CSharp (>= 4.3) - restriction: && (< net45) (>= netstandard1.3)
       NETStandard.Library (>= 1.6) - restriction: && (< net45) (>= netstandard1.3)

--- a/integrationtests/scenarios/i002520-interproject-references-constraint/before/paket.dependencies
+++ b/integrationtests/scenarios/i002520-interproject-references-constraint/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i002572-pinned-error/before/paket.dependencies
+++ b/integrationtests/scenarios/i002572-pinned-error/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/
+source https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/ protocolVersion: 2
 source https://api.nuget.org/v3/index.json
 
 clitool dotnet-xunit 2.3.0-beta3-build3705

--- a/integrationtests/scenarios/i002572-pinned-error/before/paket.dependencies
+++ b/integrationtests/scenarios/i002572-pinned-error/before/paket.dependencies
@@ -1,5 +1,5 @@
 source https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 
 clitool dotnet-xunit 2.3.0-beta3-build3705
 nuget xunit 2.3.0-beta3-build3705

--- a/integrationtests/scenarios/i002640/before/paket.dependencies
+++ b/integrationtests/scenarios/i002640/before/paket.dependencies
@@ -1,4 +1,4 @@
 source my-package-source
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget paket-issue-i002640-never-exists-on-nuget-gallery 1.0.0

--- a/integrationtests/scenarios/i002694/before/console/console.csproj
+++ b/integrationtests/scenarios/i002694/before/console/console.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/integrationtests/scenarios/i002694/before/paket.dependencies
+++ b/integrationtests/scenarios/i002694/before/paket.dependencies
@@ -1,4 +1,4 @@
 source https://api.nuget.org/v3/index.json
-restriction: || (==netstandard20) (== netcoreapp20)
+restriction: || (==netstandard20) (== netcoreapp21)
 storage: none
 nuget FSharp.Core

--- a/integrationtests/scenarios/i002694/before/paket.lock
+++ b/integrationtests/scenarios/i002694/before/paket.lock
@@ -1,5 +1,5 @@
 STORAGE: NONE
-RESTRICTION: || (== netstandard2.0) (== netcoreapp2.0)
+RESTRICTION: || (== netstandard2.0) (== netcoreapp2.1)
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (4.2.3)

--- a/integrationtests/scenarios/i002765-evaluate-only-single-template/before/paket.dependencies
+++ b/integrationtests/scenarios/i002765-evaluate-only-single-template/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i002776-pack-transitive-project-refs/before/paket.dependencies
+++ b/integrationtests/scenarios/i002776-pack-transitive-project-refs/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: netstandard2.0
 
 nuget nlog 4.5.11

--- a/integrationtests/scenarios/i002776-pack-transitive-project-refs/before/paket.lock
+++ b/integrationtests/scenarios/i002776-pack-transitive-project-refs/before/paket.lock
@@ -1,4 +1,4 @@
 RESTRICTION: == netstandard2.0
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NLog (4.5.11)

--- a/integrationtests/scenarios/i002776-pack-transitive-with-template/before/paket.dependencies
+++ b/integrationtests/scenarios/i002776-pack-transitive-with-template/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: netstandard2.0
 
 nuget nlog 4.5.11

--- a/integrationtests/scenarios/i002776-pack-transitive-with-template/before/paket.lock
+++ b/integrationtests/scenarios/i002776-pack-transitive-with-template/before/paket.lock
@@ -1,4 +1,4 @@
 RESTRICTION: == netstandard2.0
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     NLog (4.5.11)

--- a/integrationtests/scenarios/i002788-pack-with-include-pdbs-true/before/paket.dependencies
+++ b/integrationtests/scenarios/i002788-pack-with-include-pdbs-true/before/paket.dependencies
@@ -1,2 +1,2 @@
-source https://www.nuget.org/api/v2/
+source https://api.nuget.org/v3/index.json
 

--- a/integrationtests/scenarios/i003012/before/dotnet/Directory.Build.props
+++ b/integrationtests/scenarios/i003012/before/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Framework>netcoreapp2.0</Framework>
+    <Framework>netcoreapp2.1</Framework>
   </PropertyGroup>
 
 </Project>

--- a/integrationtests/scenarios/i003014-add-github/before/paket.dependencies
+++ b/integrationtests/scenarios/i003014-add-github/before/paket.dependencies
@@ -1,1 +1,1 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i003062-external-lock/before/external.paket.lock
+++ b/integrationtests/scenarios/i003062-external-lock/before/external.paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: http://api.nuget.org/v3/index.json
+  remote: https://api.nuget.org/v3/index.json
     Machine.Specifications (0.12)
       NETStandard.Library (>= 1.6) - restriction: && (< net35) (>= netstandard1.3)
       System.Diagnostics.TextWriterTraceListener (>= 4.0) - restriction: && (< net35) (>= netstandard1.3)

--- a/integrationtests/scenarios/i003062-external-lock/before/external.paket.lock
+++ b/integrationtests/scenarios/i003062-external-lock/before/external.paket.lock
@@ -1,5 +1,5 @@
 NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: http://api.nuget.org/v3/index.json
     Machine.Specifications (0.12)
       NETStandard.Library (>= 1.6) - restriction: && (< net35) (>= netstandard1.3)
       System.Diagnostics.TextWriterTraceListener (>= 4.0) - restriction: && (< net35) (>= netstandard1.3)

--- a/integrationtests/scenarios/i003062-external-lock/before/paket.dependencies
+++ b/integrationtests/scenarios/i003062-external-lock/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 external_lock ./external.paket.lock
 

--- a/integrationtests/scenarios/i003127-storage-symlink/before/paket.dependencies
+++ b/integrationtests/scenarios/i003127-storage-symlink/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 storage: symlink
 nuget NUnit < 3.0.0

--- a/integrationtests/scenarios/i003164-pack-analyzer/before/paket.dependencies
+++ b/integrationtests/scenarios/i003164-pack-analyzer/before/paket.dependencies
@@ -1,8 +1,8 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 group Roslyn
   storage: none
-  source http://nuget.org/api/v2
+  source https://api.nuget.org/v3/index.json
   nuget Microsoft.CodeAnalysis.CSharp.Workspaces 2.3.1
   nuget System.Collections.Immutable 1.3.1
   nuget System.Reflection.Metadata 1.4.2
@@ -10,7 +10,7 @@ group Roslyn
 
 group Analyzers
   storage: none
-  source http://www.nuget.org/api/v2/
+  source https://api.nuget.org/v3/index.json/
   nuget AsyncUsageAnalyzers
   nuget Gu.Analyzers
   nuget IDisposableAnalyzers

--- a/integrationtests/scenarios/i003164-pack-analyzer/before/paket.lock
+++ b/integrationtests/scenarios/i003164-pack-analyzer/before/paket.lock
@@ -3,7 +3,7 @@
 GROUP Analyzers
 STORAGE: NONE
 NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     AsyncUsageAnalyzers (1.0.0-alpha003)
     Gu.Analyzers (1.2.11-dev)
     IDisposableAnalyzers (2.0.1)
@@ -12,7 +12,7 @@ NUGET
 GROUP Roslyn
 STORAGE: NONE
 NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     ManagedEsent (1.9.4) - restriction: >= net46
     Microsoft.CodeAnalysis.Analyzers (2.6) - restriction: >= netstandard1.3
     Microsoft.CodeAnalysis.Common (2.3.1)

--- a/integrationtests/scenarios/i003275-pack-localized-netstandard/before/paket.dependencies
+++ b/integrationtests/scenarios/i003275-pack-localized-netstandard/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i003317-pack-multitarget-with-p2p/before/paket.dependencies
+++ b/integrationtests/scenarios/i003317-pack-multitarget-with-p2p/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: >= net45
 
 nuget FSharp.Core >= 3.1.2.5 lowest_matching: true
@@ -6,7 +6,7 @@ nuget Suave
 nuget Argu
 
 group NetStandard
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: netstandard2.0
 
 nuget Suave

--- a/integrationtests/scenarios/i003317-pack-multitarget-with-p2p/before/paket.lock
+++ b/integrationtests/scenarios/i003317-pack-multitarget-with-p2p/before/paket.lock
@@ -1,6 +1,6 @@
 RESTRICTION: >= net45
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Argu (4.2.1)
       FSharp.Core (>= 3.1.2)
     FSharp.Core (3.1.2.5)
@@ -10,7 +10,7 @@ NUGET
 GROUP NetStandard
 RESTRICTION: == netstandard2.0
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Argu (5.1)
       FSharp.Core (>= 4.3.2)
       System.Configuration.ConfigurationManager (>= 4.4)

--- a/integrationtests/scenarios/i003410-readonly-obj/before/dotnet/Directory.Build.props
+++ b/integrationtests/scenarios/i003410-readonly-obj/before/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Framework>netcoreapp2.0</Framework>
+    <Framework>netcoreapp2.1</Framework>
   </PropertyGroup>
 
 </Project>

--- a/integrationtests/scenarios/i003558-pack-multitarget-with-p2p-by-tfm/before/paket.dependencies
+++ b/integrationtests/scenarios/i003558-pack-multitarget-with-p2p-by-tfm/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net45, netstandard2.0
 
 nuget FSharp.Core >= 3.1.2.5 lowest_matching: true

--- a/integrationtests/scenarios/i003558-pack-multitarget-with-p2p-by-tfm/before/paket.lock
+++ b/integrationtests/scenarios/i003558-pack-multitarget-with-p2p-by-tfm/before/paket.lock
@@ -1,6 +1,6 @@
 RESTRICTION: || (== net45) (== netstandard2.0)
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Argu (5.2) - restriction: == netstandard2.0
       FSharp.Core (>= 4.3.2) - restriction: == netstandard2.0
       System.Configuration.ConfigurationManager (>= 4.4) - restriction: == netstandard2.0

--- a/integrationtests/scenarios/i003707-repositoryUrl/before/paket.dependencies
+++ b/integrationtests/scenarios/i003707-repositoryUrl/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/i004010-pack-template-only/before/paket.dependencies
+++ b/integrationtests/scenarios/i004010-pack-template-only/before/paket.dependencies
@@ -1,1 +1,1 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json

--- a/integrationtests/scenarios/loading-scripts/add-namespace/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/add-namespace/before/paket.dependencies
@@ -1,4 +1,4 @@
 generate_load_scripts: true
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net45
 nuget NLog 4.5.10

--- a/integrationtests/scenarios/loading-scripts/dependencies-file-flag/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/dependencies-file-flag/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net35
 generate_load_scripts: on
 nuget NHibernate ~> 3

--- a/integrationtests/scenarios/loading-scripts/framework-specified/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/framework-specified/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net35
 
 nuget NHibernate ~> 3

--- a/integrationtests/scenarios/loading-scripts/fsharpcore/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/fsharpcore/before/paket.dependencies
@@ -1,4 +1,4 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework:net45
 
 nuget Suave = 1.1.3

--- a/integrationtests/scenarios/loading-scripts/fslab/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/fslab/before/paket.dependencies
@@ -1,4 +1,4 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 framework:net45
 
 nuget FsLab 1.0.2

--- a/integrationtests/scenarios/loading-scripts/issue-1676/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/issue-1676/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework:>= net40
 
 nuget EntityFramework = 6.1.0

--- a/integrationtests/scenarios/loading-scripts/issue-2156/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/issue-2156/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 nuget Newtonsoft.Json
 framework: netstandard1.6

--- a/integrationtests/scenarios/loading-scripts/issue-2939/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/issue-2939/before/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net45
 generate_load_scripts: true
 nuget Newtonsoft.Json

--- a/integrationtests/scenarios/loading-scripts/issue-3381/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/issue-3381/before/paket.dependencies
@@ -1,4 +1,4 @@
 generate_load_scripts: true
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net45
 nuget NLog 4.5.10

--- a/integrationtests/scenarios/loading-scripts/mscorlib/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/mscorlib/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net45
 nuget Microsoft.Azure.Management.ResourceManager = 1.1.1-preview

--- a/integrationtests/scenarios/loading-scripts/no-references/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/no-references/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FAKE = 4.29.2

--- a/integrationtests/scenarios/loading-scripts/simple-dependencies/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/simple-dependencies/before/paket.dependencies
@@ -1,4 +1,4 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 framework:net40
 
 nuget NUnit ~> 2

--- a/integrationtests/scenarios/loading-scripts/single-file-type/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/single-file-type/before/paket.dependencies
@@ -1,4 +1,4 @@
-source "http://nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 nuget NUnit ~> 2
 nuget Argu ~> 1
 nuget log4net ~> 1

--- a/integrationtests/scenarios/loading-scripts/wrong-args/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts/wrong-args/before/paket.dependencies
@@ -1,3 +1,3 @@
-source http://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 framework: net45
 nuget NUnit

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,4 +1,4 @@
-source https://nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 content: none
 
 nuget Newtonsoft.Json >= 10.0.3 redirects: force
@@ -27,7 +27,7 @@ github forki/FsUnit FsUnit.fs
 
 group NetCoreTools
   storage: none
-  source https://nuget.org/api/v2
+  source https://api.nuget.org/v3/index.json
 
   nuget SourceLink.Create.CommandLine 2.1.1
   nuget SourceLink.Embed.PaketFiles 2.1.1
@@ -35,7 +35,7 @@ group NetCoreTools
 group Build
   content: none
   framework >= net461
-  source https://nuget.org/api/v2
+  source https://api.nuget.org/v3/index.json
   source https://ci.appveyor.com/nuget/fsharp-formatting
 
   nuget FAKE < 5

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,6 @@
 CONTENT: NONE
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Argu (5.1)
       FSharp.Core (>= 4.0.0.1) - restriction: >= net45
       FSharp.Core (>= 4.3.2) - restriction: && (< net45) (>= netstandard2.0)
@@ -1158,7 +1158,7 @@ GROUP Build
 CONTENT: NONE
 RESTRICTION: >= net461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     0x53A.ReferenceAssemblies.Paket (0.2)
     FAKE (4.64.17)
     FSharp.Compiler.Service (17.0.1)
@@ -1192,7 +1192,7 @@ GITHUB
 GROUP NetCoreTools
 STORAGE: NONE
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Microsoft.Build.Framework (15.3.409) - restriction: >= netstandard1.4
       System.Collections (>= 4.0.11) - restriction: >= netstandard1.3
       System.Diagnostics.Debug (>= 4.0.11) - restriction: >= netstandard1.3

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.1" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
+++ b/src/Paket.Bootstrapper/DownloadStrategies/NugetDownloadStrategy.cs
@@ -17,7 +17,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             private readonly string nugetSource;
 
             const string NugetSourceAppSettingsKey = "NugetSource";
-            const string DefaultNugetSource = "https://www.nuget.org/api/v2";
+            const string DefaultNugetV2Source = "https://www.nuget.org/api/v2";
             const string GetPackageVersionTemplate = "{0}/package-versions/{1}";
             const string GetLatestFromNugetUrlTemplate = "{0}/package/{1}";
             const string GetSpecificFromNugetUrlTemplate = "{0}/package/{1}/{2}";
@@ -25,7 +25,7 @@ namespace Paket.Bootstrapper.DownloadStrategies
             public NugetApiHelper(string packageName, string nugetSource)
             {
                 this.packageName = packageName;
-                this.nugetSource = nugetSource ?? ConfigurationManager.AppSettings[NugetSourceAppSettingsKey] ?? DefaultNugetSource;
+                this.nugetSource = nugetSource ?? ConfigurationManager.AppSettings[NugetSourceAppSettingsKey] ?? DefaultNugetV2Source;
             }
 
             internal string GetAllPackageVersions(bool includePrerelease)

--- a/src/Paket.Core/Common/Constants.fs
+++ b/src/Paket.Core/Common/Constants.fs
@@ -6,8 +6,9 @@ open Paket.Domain
 
 
 let [<Literal>] GitHubUrl                 = "https://github.com"
-let [<Literal>] DefaultNuGetStream        = "https://www.nuget.org/api/v2"
+let [<Literal>] DefaultNuGetV2Stream      = "https://www.nuget.org/api/v2"
 let [<Literal>] DefaultNuGetV3Stream      = "https://api.nuget.org/v3/index.json"
+let [<Literal>] DefaultNuGetStream        = DefaultNuGetV3Stream
 let [<Literal>] GitHubReleasesUrl         = "https://api.github.com/repos/fsprojects/Paket/releases"
 let [<Literal>] GithubReleaseDownloadUrl  = "https://github.com/fsprojects/Paket/releases/download"
 /// 'paket.lock'

--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -59,10 +59,10 @@ let normalizeFeedUrl (source:string) =
     match source.TrimEnd([|'/'|]) with
     | "https://api.nuget.org/v3/index.json" -> Constants.DefaultNuGetV3Stream
     | "http://api.nuget.org/v3/index.json" -> Constants.DefaultNuGetV3Stream.Replace("https","http")
-    | "https://nuget.org/api/v2" -> Constants.DefaultNuGetStream
-    | "http://nuget.org/api/v2" -> Constants.DefaultNuGetStream.Replace("https","http")
-    | "https://www.nuget.org/api/v2" -> Constants.DefaultNuGetStream
-    | "http://www.nuget.org/api/v2" -> Constants.DefaultNuGetStream.Replace("https","http")
+    | "https://nuget.org/api/v2" -> Constants.DefaultNuGetV2Stream
+    | "http://nuget.org/api/v2" -> Constants.DefaultNuGetV2Stream.Replace("https","http")
+    | "https://www.nuget.org/api/v2" -> Constants.DefaultNuGetV2Stream
+    | "http://www.nuget.org/api/v2" -> Constants.DefaultNuGetV2Stream.Replace("https","http")
     | source -> source
 
 #if CUSTOM_WEBPROXY

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -419,6 +419,7 @@ let rec private getPackageDetails alternativeProjectRoot root force (parameters:
                 | Some url ->
                     let nugetSource : NuGetSource =
                         { Url = url
+                          ProtocolVersion = NugetProtocolVersion.ProtocolVersion2
                           Authentication = nugetSource.Authentication }
                     return! tryV2 nugetSource force
                 | _ ->

--- a/src/Paket.Core/Dependencies/NuGet.fs
+++ b/src/Paket.Core/Dependencies/NuGet.fs
@@ -419,7 +419,7 @@ let rec private getPackageDetails alternativeProjectRoot root force (parameters:
                 | Some url ->
                     let nugetSource : NuGetSource =
                         { Url = url
-                          ProtocolVersion = NugetProtocolVersion.ProtocolVersion2
+                          ProtocolVersion = ProtocolVersion2
                           Authentication = nugetSource.Authentication }
                     return! tryV2 nugetSource force
                 | _ ->

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -199,7 +199,7 @@ let getSearchAPI(auth,nugetUrl) =
             match calculateNuGet3Path nugetUrl with
             | None -> return None
             | Some v3Path ->
-                let source = { Url = v3Path; Authentication = auth }
+                let source = { Url = v3Path; ProtocolVersion = ProtocolVersion3; Authentication = auth }
                 let! v3res = getNuGetV3Resource source AutoComplete |> Async.Catch
                 return
                     match v3res with

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -56,10 +56,10 @@ type NugetV3ResourceType =
 
 // Cache for nuget indices of sources
 type ResourceIndex = Map<NugetV3ResourceType,string>
-let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<NuGetV3Source,Task<ResourceIndex>>()
+let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<NuGetSource,Task<ResourceIndex>>()
 let private rnd = Random()
 
-let getNuGetV3Resource (source : NuGetV3Source) (resourceType : NugetV3ResourceType) : Async<string> =
+let getNuGetV3Resource (source : NuGetSource) (resourceType : NugetV3ResourceType) : Async<string> =
     let key = source
     let getResourcesRaw () =
         async {
@@ -600,7 +600,7 @@ type PackageIndex =
       [<JsonProperty("count")>]
       Count : int }
 
-let private getPackageIndexRaw (source : NuGetV3Source) (packageName:PackageName) =
+let private getPackageIndexRaw (source : NuGetSource) (packageName:PackageName) =
     async {
         let! registrationUrl = getNuGetV3Resource source PackageIndex
         let url = registrationUrl.TrimEnd('/') + "/" + packageName.ToString().ToLowerInvariant() + "/index.json"
@@ -620,7 +620,7 @@ let private getPackageIndexMemoized =
 let getPackageIndex source packageName = getPackageIndexMemoized (source, packageName)
 
 
-let private getPackageIndexPageRaw (source:NuGetV3Source) (url:string) =
+let private getPackageIndexPageRaw (source: NuGetSource) (url:string) =
     async {
         let! rawData = safeGetFromUrl (source.Authentication, url, acceptJson)
         return
@@ -642,7 +642,7 @@ let private getPackageIndexPageMemoized =
 let getPackageIndexPage source (page:PackageIndexPage) = getPackageIndexPageMemoized (source, page.Id)
 
 
-let getRelevantPage (source:NuGetV3Source) (index:PackageIndex) (version:SemVerInfo) =
+let getRelevantPage (source:NuGetSource) (index:PackageIndex) (version:SemVerInfo) =
     async {
         try
             let normalizedVersion = SemVer.Parse (version.ToString().ToLowerInvariant())
@@ -703,7 +703,7 @@ let getRelevantPage (source:NuGetV3Source) (index:PackageIndex) (version:SemVerI
             return raise <| exn (sprintf "Failed to find relevant page in '%s'" index.Id, e)
     }
 
-let getPackageDetails (source:NuGetV3Source) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
+let getPackageDetails (source:NuGetSource) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
     async {
         let! pageIndex = getPackageIndex source packageName
         match pageIndex with
@@ -770,7 +770,7 @@ let getPackageDetails (source:NuGetV3Source) (packageName:PackageName) (version:
     }
 
 /// Uses the NuGet v3 registration endpoint to retrieve package details .
-let GetPackageDetails (force:bool) (source:NuGetV3Source) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
+let GetPackageDetails (force:bool) (source:NuGetSource) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
     getDetailsFromCacheOr
         force
         source.Url

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -103,7 +103,7 @@ let ExtractPackage(alternativeProjectRoot, root, groupName, sources, caches, for
         let! result = async {
             let source =
                 match package.Source with
-                | NuGetV2 _ | NuGetV3 _ ->
+                | NuGet _ ->
                     let normalizeFeedUrl s = (normalizeFeedUrl s).Replace("https://","http://")
 
                     let normalized = normalizeFeedUrl package.Source.Url
@@ -111,8 +111,7 @@ let ExtractPackage(alternativeProjectRoot, root, groupName, sources, caches, for
                         sources
                         |> List.tryPick (fun source ->
                             match source with
-                            | NuGetV2 s when normalizeFeedUrl s.Url = normalized -> Some source
-                            | NuGetV3 s when normalizeFeedUrl s.Url = normalized -> Some source
+                            | NuGet s when normalizeFeedUrl s.Url = normalized -> Some source
                             | _ -> None)
 
                     match source with

--- a/src/Paket.Core/PackageManagement/NugetConvert.fs
+++ b/src/Paket.Core/PackageManagement/NugetConvert.fs
@@ -334,7 +334,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
             |> List.map (fun (n, auth) -> n, auth |> Option.map (CredsMigrationMode.ToAuthentication mode n))
             |> List.filter (fun (key,v) -> key.Contains "NuGetFallbackFolder" |> not)
             |> List.map (fun (source, auth) -> 
-                            try PackageSource.Parse(source, Some NugetProtocolVersion.ProtocolVersion3, AuthProvider.ofFunction (fun _ -> auth)) |> ok
+                            try PackageSource.Parse(source, Some ProtocolVersion3, AuthProvider.ofFunction (fun _ -> auth)) |> ok
                             with _ -> source |> PackageSourceParseError |> fail
                             |> successTee PackageSource.WarnIfNoConnection)
                             

--- a/src/Paket.Core/PackageManagement/NugetConvert.fs
+++ b/src/Paket.Core/PackageManagement/NugetConvert.fs
@@ -334,7 +334,7 @@ let createDependenciesFileR (rootDirectory : DirectoryInfo) nugetEnv mode =
             |> List.map (fun (n, auth) -> n, auth |> Option.map (CredsMigrationMode.ToAuthentication mode n))
             |> List.filter (fun (key,v) -> key.Contains "NuGetFallbackFolder" |> not)
             |> List.map (fun (source, auth) -> 
-                            try PackageSource.Parse(source,AuthProvider.ofFunction (fun _ -> auth)) |> ok
+                            try PackageSource.Parse(source, Some NugetProtocolVersion.ProtocolVersion3, AuthProvider.ofFunction (fun _ -> auth)) |> ok
                             with _ -> source |> PackageSourceParseError |> fail
                             |> successTee PackageSource.WarnIfNoConnection)
                             

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -117,7 +117,7 @@ module LockFileSerializer =
                     hasReported := true
 
                   yield "  remote: " + String.quoted source
-                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some NugetProtocolVersion.ProtocolVersion2 then "2" else "3")
+                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some ProtocolVersion2 then "2" else "3")
 
                   for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
                       let versionStr = 
@@ -460,7 +460,7 @@ module LockFileParser =
                 if String.IsNullOrWhiteSpace line || line.Trim().StartsWith("specs:") then currentGroup::otherGroups else
                 match (currentGroup, line) with
                 | Remote(RemoteUrl(url)) -> { currentGroup with RemoteUrl = url}::otherGroups
-                | Remote(ProtocolVersion(protocolVersion)) -> { currentGroup with NugetProtocolVersion = (if protocolVersion = Some "2" then Some NugetProtocolVersion.ProtocolVersion2 else Some NugetProtocolVersion.ProtocolVersion3) }::otherGroups
+                | Remote(ProtocolVersion(protocolVersion)) -> { currentGroup with NugetProtocolVersion = (if protocolVersion = Some "2" then Some ProtocolVersion2 else Some ProtocolVersion3) }::otherGroups
                 | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
                 | InstallOption(Command(command)) -> 
                     let sourceFiles = 
@@ -509,7 +509,7 @@ module LockFileParser =
 
                     match (currentGroup.RemoteUrl, currentGroup.NugetProtocolVersion) with
                     | (Some remote, Some protocolVersion) -> handleNugetDetails remote (Some protocolVersion)
-                    | (Some remote, None) -> handleNugetDetails remote (Some NugetProtocolVersion.ProtocolVersion3)
+                    | (Some remote, None) -> handleNugetDetails remote (Some ProtocolVersion3)
                     | (None, _) -> failwith "no source has been specified."
                 | NugetDependency (name, v, frameworkSettings) ->
                     let version,_,isRuntimeDependency,settings = parsePackage v

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -114,7 +114,6 @@ module LockFileSerializer =
                   if not !hasReported then
                     yield "NUGET"
                     hasReported := true
-
                   yield "  remote: " + String.quoted source
                   match protocolVersion with
                   | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion2 then "2" else "3")
@@ -293,9 +292,13 @@ module LockFileParser =
         | _, "GIT" -> RepositoryType "GIT"
         | _, "NUGET" -> RepositoryType "NUGET"
         | _, "GITHUB" -> RepositoryType "GITHUB"
-        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed -> Remote(ProtocolVersion(Some (trimmed.Trim())))
-        | _, String.RemovePrefix "remote:" trimmed -> Remote(RemoteUrl(Some (trimmed.Trim())))
-        | Some "NUGET", String.RemovePrefix "remote:" trimmed -> Remote(RemoteUrl(Some (PackageSource.Parse("source " + trimmed.Trim()).ToString())))
+        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed ->
+                Remote(ProtocolVersion(Some (trimmed.Trim())))
+        | Some "NUGET", String.RemovePrefix "remote:" trimmed ->
+            let inner = PackageSource.Parse("source " + trimmed.Trim())
+            Remote(RemoteUrl(Some (inner.ToString())))
+        | _, String.RemovePrefix "remote:" trimmed ->
+            Remote(RemoteUrl(Some (trimmed.Trim())))
         | _, String.RemovePrefix "GROUP" trimmed -> Group(trimmed.Replace("GROUP","").Trim())
         | _, String.RemovePrefix "REFERENCES:" trimmed -> InstallOption(ReferencesMode(trimmed.Trim() = "STRICT"))
         | _, String.RemovePrefix "REDIRECTS:" trimmed ->

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -111,14 +111,15 @@ module LockFileSerializer =
             let hasReported = ref false
             [ yield! serializeOptionsAsLines options
 
-              for (source), packages in sources do
+              for (source, protocolVersion), packages in sources do
                   if not !hasReported then
                     yield "NUGET"
                     hasReported := true
 
                   yield "  remote: " + String.quoted source
+                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some NugetProtocolVersion.ProtocolVersion2 then "2" else "3")
 
-                  for _,_,package in packages |> Seq.sortBy (fun (_,_,p) -> p.Name) do
+                  for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
                       let versionStr = 
                           let s'' = package.Version.ToString()
                           let s' = 

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -256,6 +256,7 @@ module LockFileParser =
         GroupName : GroupName
         RepositoryType : string option
         RemoteUrl :string option
+        NugetProtocolVersion: NugetProtocolVersion options
         Packages : ResolvedPackage list
         SourceFiles : ResolvedSourceFile list
         LastWasPackage : bool

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -448,7 +448,7 @@ module LockFileParser =
 
             parts.[0],kind,isRuntimeDependency,InstallSettings.Parse(true, optionsString)
 
-        ([{ GroupName = Constants.MainDependencyGroup; RepositoryType = None; RemoteUrl = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false }], lockFileLines)
+        ([{ GroupName = Constants.MainDependencyGroup; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false }], lockFileLines)
         ||> Seq.fold(fun state line ->
             match state with
             | [] -> failwithf "error"
@@ -456,7 +456,7 @@ module LockFileParser =
                 if String.IsNullOrWhiteSpace line || line.Trim().StartsWith("specs:") then currentGroup::otherGroups else
                 match (currentGroup, line) with
                 | Remote url -> { currentGroup with RemoteUrl = Some url }::otherGroups
-                | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
+                | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
                 | InstallOption(Command(command)) -> 
                     let sourceFiles = 
                         match currentGroup.SourceFiles with

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -520,7 +520,7 @@ module LockFileParser =
 
                     match (currentGroup.RemoteUrl, currentGroup.NugetProtocolVersion) with
                     | (Some remote, Some protocolVersion) -> handleNugetDetails remote (Some protocolVersion)
-                    | (Some remote, None) -> handleNugetDetails remote (Some ProtocolVersion2) // TODO: set this default to 3 with 6.0.0
+                    | (Some remote, None) -> handleNugetDetails remote (Some ProtocolVersion3)
                     | (None, _) -> failwith "no source has been specified."
                 | NugetDependency (name, v, frameworkSettings) ->
                     let version,_,isRuntimeDependency,settings = parsePackage v

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -479,7 +479,7 @@ module LockFileParser =
                     { currentGroup with Options = extractOption currentGroup option }::otherGroups
                 | RepositoryType repoType -> { currentGroup with RepositoryType = Some repoType }::otherGroups
                 | NugetPackage details ->
-                    let handlerNugetDetails remote protocolVersion =
+                    let handleNugetDetails remote protocolVersion =
                         let package,kind,isRuntimeDependency,settings = parsePackage details
                         let parts' = package.Split ' '
                         let version = 
@@ -503,8 +503,8 @@ module LockFileParser =
                                       IsRuntimeDependency = isRuntimeDependency } :: currentGroup.Packages }::otherGroups
 
                     match (currentGroup.RemoteUrl, currentGroup.NugetProtocolVersion) with
-                    | (Some remote, Some protocolVersion) -> handlerNugetDetails remote (Some protocolVersion)
-                    | (Some remote, None) -> handlerNugetDetails remote (Some NugetProtocolVersion.ProtocolVersion3)
+                    | (Some remote, Some protocolVersion) -> handleNugetDetails remote (Some protocolVersion)
+                    | (Some remote, None) -> handleNugetDetails remote (Some NugetProtocolVersion.ProtocolVersion3)
                     | (None, _) -> failwith "no source has been specified."
                 | NugetDependency (name, v, frameworkSettings) ->
                     let version,_,isRuntimeDependency,settings = parsePackage v

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -116,7 +116,7 @@ module LockFileSerializer =
                     hasReported := true
                   yield "  remote: " + String.quoted source
                   match protocolVersion with
-                  | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion2 then "2" else "3")
+                  | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion3 then "3" else "2")
                   | None -> ()
 
                   for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
@@ -467,10 +467,10 @@ module LockFileParser =
                 | Remote(ProtocolVersion(protocolVersion)) ->
                     let protocol =
                         match protocolVersion with
-                        | Some "2" -> ProtocolVersion2
                         | Some "3" -> ProtocolVersion3
-                        | None -> ProtocolVersion2 // TODO: for Paket 6.x change this default to 3
-                        | Some v -> failwithf "unknown nuget protocol version '%s', allowed protocols are 2 and 3" v //TODO: ok to fail like this?
+                        | Some "2" -> ProtocolVersion2
+                        | None -> ProtocolVersion3
+                        | Some unknowVersion -> failwithf "unknown nuget protocol version '%s', allowed protocols are 2 and 3" unknowVersion //TODO: ok to fail like this?
                     { currentGroup with NugetProtocolVersion = Some protocol }::otherGroups
                 | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
                 | InstallOption(Command(command)) ->

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -283,15 +283,16 @@ module LockFileParser =
     | PackagePath of string
     | OperatingSystemRestriction of string
 
-    let private (|Remote|NugetPackage|NugetDependency|SourceFile|RepositoryType|Group|InstallOption|) (state, line:string) =
+    let private (|ProtocolVersion|Remote|NugetPackage|NugetDependency|SourceFile|RepositoryType|Group|InstallOption|) (state, line:string) =
         match (state.RepositoryType, line.Trim()) with
         | _, "HTTP" -> RepositoryType "HTTP"
         | _, "GIST" -> RepositoryType "GIST"
         | _, "GIT" -> RepositoryType "GIT"
         | _, "NUGET" -> RepositoryType "NUGET"
         | _, "GITHUB" -> RepositoryType "GITHUB"
-        | Some "NUGET", String.RemovePrefix "remote:" trimmed -> Remote(PackageSource.Parse("source " + trimmed.Trim()).ToString())
+        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed -> ProtocolVersion(trimmed.Trim())
         | _, String.RemovePrefix "remote:" trimmed -> Remote(trimmed.Trim())
+        | Some "NUGET", String.RemovePrefix "remote:" trimmed -> Remote(PackageSource.Parse("source " + trimmed.Trim()).ToString())
         | _, String.RemovePrefix "GROUP" trimmed -> Group(trimmed.Replace("GROUP","").Trim())
         | _, String.RemovePrefix "REFERENCES:" trimmed -> InstallOption(ReferencesMode(trimmed.Trim() = "STRICT"))
         | _, String.RemovePrefix "REDIRECTS:" trimmed -> 
@@ -456,6 +457,7 @@ module LockFileParser =
             | currentGroup::otherGroups ->
                 if String.IsNullOrWhiteSpace line || line.Trim().StartsWith("specs:") then currentGroup::otherGroups else
                 match (currentGroup, line) with
+                | ProtocolVersion protocolVersion -> { currentGroup with NugetProtocolVersion = Some protocolVersion }::otherGroups
                 | Remote url -> { currentGroup with RemoteUrl = Some url }::otherGroups
                 | Group groupName -> { GroupName = GroupName groupName; RepositoryType = None; RemoteUrl = None; NugetProtocolVersion = None; Packages = []; SourceFiles = []; Options = InstallOptions.Default; LastWasPackage = false } :: currentGroup :: otherGroups
                 | InstallOption(Command(command)) -> 

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -100,12 +100,12 @@ module LockFileSerializer =
             |> Seq.map (fun kv ->
                     let package = kv.Value
                     match package.Source with
-                    | NuGetV2 source -> source.Url,source.Authentication,package
-                    | NuGetV3 source -> source.Url,source.Authentication,package
+                    | NuGetV2 source -> source.Url,Some source.ProtocolVersion,source.Authentication,package
+                    | NuGetV3 source -> source.Url,Some source.ProtocolVersion,source.Authentication,package
                     // TODO: Add credentials provider...
-                    | LocalNuGet(path,_) -> path,AuthService.GetGlobalAuthenticationProvider path,package
+                    | LocalNuGet(path,_) -> path,None,AuthService.GetGlobalAuthenticationProvider path,package
                 )
-            |> Seq.groupBy (fun (a,b,_) -> a)
+            |> Seq.groupBy (fun (nugetSource, protocolVersion, authProvider,_) -> (nugetSource, protocolVersion))
 
         let all = 
             let hasReported = ref false

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -116,7 +116,9 @@ module LockFileSerializer =
                     hasReported := true
 
                   yield "  remote: " + String.quoted source
-                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some ProtocolVersion2 then "2" else "3")
+                  match protocolVersion with
+                  | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion2 then "2" else "3")
+                  | None -> ()
 
                   for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
                       let versionStr =

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -641,7 +641,7 @@ type Dependencies(dependenciesFileName: string) =
         let maxResults = defaultArg maxResults 1000
         let sources = sources |> Seq.toList |> List.distinct
         match sources with
-        | [] -> [PackageSources.DefaultNuGetV2Source]
+        | [] -> [PackageSources.DefaultNuGetSource]
         | _ -> sources
         |> Seq.distinct
         |> Seq.map (fun source ->

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -646,6 +646,9 @@ type Dependencies(dependenciesFileName: string) =
         |> Seq.distinct
         |> Seq.map (fun source ->
             match source with
+            | NuGet ({ ProtocolVersion = ProtocolVersion3 } as s) ->
+                NuGetV3.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
+                |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
             | NuGet ({ ProtocolVersion = ProtocolVersion2 } as s) ->
                 let res = NuGetV3.getSearchAPI(s.Authentication,s.Url) |> Async.AwaitTask |> Async.RunSynchronously
                 match res with
@@ -655,9 +658,6 @@ type Dependencies(dependenciesFileName: string) =
                 | None ->
                     NuGetV2.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
                     |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
-            | NuGet ({ ProtocolVersion = ProtocolVersion3 } as s) ->
-                NuGetV3.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
-                |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
             | LocalNuGet(s,_) ->
                 async {
                     return

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -646,7 +646,7 @@ type Dependencies(dependenciesFileName: string) =
         |> Seq.distinct
         |> Seq.map (fun source ->
             match source with
-            | NuGetV2 s ->
+            | NuGet ({ ProtocolVersion = ProtocolVersion2 } as s) ->
                 let res = NuGetV3.getSearchAPI(s.Authentication,s.Url) |> Async.AwaitTask |> Async.RunSynchronously
                 match res with
                 | Some _ ->
@@ -655,7 +655,7 @@ type Dependencies(dependenciesFileName: string) =
                 | None ->
                     NuGetV2.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
                     |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
-            | NuGetV3 s ->
+            | NuGet ({ ProtocolVersion = ProtocolVersion3 } as s) ->
                 NuGetV3.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
                 |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
             | LocalNuGet(s,_) ->

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -641,7 +641,7 @@ type Dependencies(dependenciesFileName: string) =
         let maxResults = defaultArg maxResults 1000
         let sources = sources |> Seq.toList |> List.distinct
         match sources with
-        | [] -> [PackageSources.DefaultNuGetSource]
+        | [] -> [PackageSources.DefaultNuGetV2Source]
         | _ -> sources
         |> Seq.distinct
         |> Seq.map (fun source ->

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -108,7 +108,62 @@ let internal parseAuth(text:string, source) =
     else
         getAuth()
 
-let internal parseProtocolVersion(text:string, source) =
+let (|NugetV3Url|_|) (url: Uri) =
+  if url.ToString() = "https://api.nuget.org/v3/index.json" then Some () else None
+
+type 't ``[]`` with
+  member x.GetReverseIndex(i: int) = x.[x.Length - i]
+
+let (|Https|_|) (uri: Uri) = if uri.Scheme = "https" then Some () else None
+let (|Host|_|) (h: string) (uri: Uri) =
+    if uri.Host.EndsWith h
+    then Some ()
+    else None
+
+let (|LeadingPathSegments|_|) (segs: string[]) (uri: Uri) =
+    let segCount = segs.Length
+    let uriSegs = uri.Segments
+    if uriSegs.Length < segCount+1 then None // initial segment is a /, so we need to skip it
+    else
+        let items: string[] = uriSegs.[1..segCount]
+        let matched =
+            (items, segs)
+            ||> Array.zip
+            |> Array.forall(fun (l, r) -> l.TrimEnd('/') = r) // have to trim end because the Uri.Segments api keeps the /-separators on the end of the segment
+        if matched then Some () else None
+
+let (|TrailingPathSegments|_|) (segs: string []) (uri: Uri) =
+    let segCount = segs.Length
+    let uriSegs = uri.Segments
+    if uriSegs.Length < segCount then None
+    else
+        let items: string[] = uriSegs.[(uriSegs.Length-segCount)..]
+        let matched =
+            (items, segs)
+            ||> Array.zip
+            |> Array.forall(fun (l, r) -> l.TrimEnd('/') = r) // have to trim end because the Uri.Segments api keeps the /-separators on the end of the segment
+        if matched then Some () else None
+
+let (|MyGetV3Url|_|) (url: Uri) =
+
+  // https://<your_myget_domain>/F/<your-feed-name>/<feed_endpoint>
+  try
+      match url with
+      | Https & Host "myget.org" & TrailingPathSegments [|"api";"v3"; "index.json"|] -> Some ()
+      | _ -> None
+  with _ -> None
+
+let (|ArtifactoryV3Url|_|) (url: Uri) =
+    match url with
+    | LeadingPathSegments [|"artifactory"; "api";"nuget";"v3"|] -> Some ()
+    | _ -> None
+
+let (|KnownNugetV3Endpoint|_|) url =
+    match Uri url with
+    | NugetV3Url | MyGetV3Url | ArtifactoryV3Url -> Some ()
+    | _ -> None
+
+let internal parseProtocolVersion(text:string, nugetSource) =
     if text.Contains("protocolVersion:") then
         if not (protocolVersionRegex.IsMatch(text)) then
             failwithf "Could not parse protocolVersion in \"%s\"" text
@@ -121,7 +176,13 @@ let internal parseProtocolVersion(text:string, source) =
         | (true, 3) -> Some ProtocolVersion3
         | _ -> failwithf "Unsupported protocolVersion in \"%s\". Should be either 2 or 3" text
     else
-        None
+        // derive protocolVersion from some well-known urls
+        try
+            match nugetSource with
+            | KnownNugetV3Endpoint -> Some ProtocolVersion3
+            | _ -> None
+        with
+        | _ -> None
 
 /// Represents the package source type.
 type PackageSource =
@@ -150,7 +211,7 @@ type PackageSource =
 
         PackageSource.Parse(feed, parseProtocolVersion(line, feed), parseAuth(line, feed))
 
-    static member Parse(source,auth) =
+    static member Parse(source, protocolVersion, auth) =
         match tryParseWindowsStyleNetworkPath source with
         | Some path -> PackageSource.Parse(path)
         | _ ->

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -142,7 +142,7 @@ type PackageSource =
         | _ when urlSimilarToTfsOrVsts x.Url -> KnownNuGetSources.TfsOrVsts
         | _ -> KnownNuGetSources.UnknownNuGetServer
     static member Parse(line : string) =
-        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"][ ]*(protocolVersion[ ]*:\d)", RegexOptions.IgnoreCase)
+        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"](\s+.+)?", RegexOptions.IgnoreCase)
         let parts = line.Split ' '
         let source =
             if sourceRegex.IsMatch line then

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -199,7 +199,7 @@ type PackageSource =
         | _ when urlSimilarToTfsOrVsts x.Url -> KnownNuGetSources.TfsOrVsts
         | _ -> KnownNuGetSources.UnknownNuGetServer
     static member Parse(line : string) =
-        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"](\s+.+)?", RegexOptions.IgnoreCase)
+        let sourceRegex = Regex("source[ ]*[\"]([^\"]*)[\"]([ ]+.+)?", RegexOptions.IgnoreCase)
         let parts = line.Split ' '
         let source =
             if sourceRegex.IsMatch line then

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -119,8 +119,8 @@ let internal parseProtocolVersion(text:string, source) =
         let (parsed, specifiedProtocolVersion) = Int32.TryParse(textProtocolVersion)
 
         match (parsed,specifiedProtocolVersion) with
-        | (true, 2) -> Some NugetProtocolVersion.ProtocolVersion2
-        | (true, 3) -> Some NugetProtocolVersion.ProtocolVersion3
+        | (true, 2) -> Some ProtocolVersion2
+        | (true, 3) -> Some ProtocolVersion3
         | _ -> failwithf "Unsupported protocolVersion in \"%s\". Should be either 2 or 3" text
     else
         None
@@ -168,9 +168,9 @@ type PackageSource =
                     LocalNuGet(source,None)
                 else
                     match protocolVersion with
-                    | Some NugetProtocolVersion.ProtocolVersion2 -> NuGetV2 { Url = source; ProtocolVersion = NugetProtocolVersion.ProtocolVersion2; Authentication = auth }
-                    | Some NugetProtocolVersion.ProtocolVersion3 -> NuGetV3 { Url = source; ProtocolVersion = NugetProtocolVersion.ProtocolVersion3; Authentication = auth }
-                    | None -> NuGetV3 { Url = source; ProtocolVersion = NugetProtocolVersion.ProtocolVersion3; Authentication = auth }
+                    | Some ProtocolVersion2 -> NuGetV2 { Url = source; ProtocolVersion = ProtocolVersion2; Authentication = auth }
+                    | Some ProtocolVersion3 -> NuGetV3 { Url = source; ProtocolVersion = ProtocolVersion3; Authentication = auth }
+                    | None -> NuGetV3 { Url = source; ProtocolVersion = ProtocolVersion3; Authentication = auth }
             | _ ->  match System.Uri.TryCreate(source, System.UriKind.Relative) with
                     | true, uri -> LocalNuGet(source,None)
                     | _ -> failwithf "unable to parse package source: %s" source
@@ -192,8 +192,8 @@ type PackageSource =
         | NuGetV3 n -> n.Authentication
         | LocalNuGet(n,_) -> CredentialProviders.GetAuthenticationProvider n
 
-    static member NuGetV2Source url = NuGetV2 { Url = url; ProtocolVersion = NugetProtocolVersion.ProtocolVersion2; Authentication  = CredentialProviders.GetAuthenticationProvider url }
-    static member NuGetV3Source url = NuGetV3 { Url = url; ProtocolVersion = NugetProtocolVersion.ProtocolVersion3; Authentication  = CredentialProviders.GetAuthenticationProvider url }
+    static member NuGetV2Source url = NuGetV2 { Url = url; ProtocolVersion = ProtocolVersion2; Authentication  = CredentialProviders.GetAuthenticationProvider url }
+    static member NuGetV3Source url = NuGetV3 { Url = url; ProtocolVersion = ProtocolVersion3; Authentication  = CredentialProviders.GetAuthenticationProvider url }
 
     static member FromCache (cache:Cache) = LocalNuGet(cache.Location,Some cache)
 

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -212,8 +212,9 @@ type PackageSource =
             if not (Directory.Exists (RemoveOutsideQuotes path)) then
                 traceWarnfn "Local NuGet feed doesn't exist: %s." path
 
-let DefaultNuGetSource = PackageSource.NuGetV2Source Constants.DefaultNuGetStream
+let DefaultNuGetV2Source = PackageSource.NuGetV2Source Constants.DefaultNuGetV2Stream
 let DefaultNuGetV3Source = PackageSource.NuGetV3Source Constants.DefaultNuGetV3Stream
+let DefaultNuGetSource = DefaultNuGetV3Source
 
 type NugetPackage = {
     Id : string

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -1,0 +1,28 @@
+:: Does `startvs.cmd` needs a Copyright HEADER ? as this was inspired from `dotnet/aspnetcore` ? 
+
+@ECHO OFF
+SETLOCAL
+
+:: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
+
+:: This tells .NET Core to use .dotnet\dotnet.exe
+SET DOTNET_ROOT=%AppData%\..\Local\dotnetcore\
+
+:: This tells .NET Core not to go looking for .NET Core in other places
+SET DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+SET PATH=%DOTNET_ROOT%;%PATH%
+
+SET sln=%~1
+
+IF "%sln%"=="" (
+    SET sln=paket.sln
+)
+
+IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
+    echo .NET Core has not yet been installed. Running restore.cmd to install it.
+    call restore.cmd
+)
+
+start "" "%sln%"

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -6,7 +6,7 @@ SETLOCAL
 :: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
 
 :: This tells .NET Core to use .dotnet\dotnet.exe
-SET DOTNET_ROOT=%AppData%\..\Local\dotnetcore\
+SET DOTNET_ROOT=%LOCALAPPDATA%\dotnetcore\
 
 :: This tells .NET Core not to go looking for .NET Core in other places
 SET DOTNET_MULTILEVEL_LOOKUP=0

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
+++ b/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Paket.Tests/DependenciesFile/AddGitFilesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddGitFilesSpecs.fs
@@ -10,13 +10,13 @@ open Paket.Requirements
 
 [<Test>]
 let ``should add new git repositories to the end``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 git https://github.com/fsharp/FAKE.git"""
 
     let cfg = DependenciesFile.FromSource(config).AddGit(Constants.MainDependencyGroup, "https://github.com/fsprojects/FsUnit.git")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 git https://github.com/fsharp/FAKE.git
 git https://github.com/fsprojects/FsUnit.git"""
@@ -57,14 +57,14 @@ let ``should not error when adding existing git repository``() =
 
 [<Test>]
 let ``should add new git repositories to the main group``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 group Test
 git https://github.com/fsprojects/FAKE.git"""
 
     let cfg = DependenciesFile.FromSource(config).AddGit(Constants.MainDependencyGroup, "https://github.com/fsprojects/FsUnit.git")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 git https://github.com/fsprojects/FsUnit.git
 
 group Test
@@ -75,7 +75,7 @@ git https://github.com/fsprojects/FAKE.git"""
 
 [<Test>]
 let ``should add new repositories to the specified group``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 group Test
 git https://github.com/fsprojects/FAKE.git
@@ -85,7 +85,7 @@ git https://github.com/fsprojects/SQLProvider.git"""
 
     let cfg = DependenciesFile.FromSource(config).AddGit(GroupName "Test", "https://github.com/fsprojects/FsUnit.git")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 group Test
 git https://github.com/fsprojects/FAKE.git
@@ -99,14 +99,14 @@ git https://github.com/fsprojects/SQLProvider.git"""
 
 [<Test>]
 let ``should add new group if not already exists``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 group Test
 git https://github.com/fsprojects/SQLProvider.git"""
 
     let cfg = DependenciesFile.FromSource(config).AddGit(GroupName "Test2", "https://github.com/fsprojects/FsUnit.git")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 group Test
 git https://github.com/fsprojects/SQLProvider.git

--- a/tests/Paket.Tests/DependenciesFile/AddGitFilesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddGitFilesSpecs.fs
@@ -112,7 +112,7 @@ group Test
 git https://github.com/fsprojects/SQLProvider.git
 
 group Test2
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 git https://github.com/fsprojects/FsUnit.git"""
 

--- a/tests/Paket.Tests/DependenciesFile/AddGithubFilesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddGithubFilesSpecs.fs
@@ -112,7 +112,7 @@ group Test
 github fsprojects/SQLProvider
 
 group Test2
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 github fsprojects/FsUnit"""
 

--- a/tests/Paket.Tests/DependenciesFile/AddGithubFilesSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddGithubFilesSpecs.fs
@@ -10,13 +10,13 @@ open Paket.Requirements
 
 [<Test>]
 let ``should add new repositories to the end``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 github fsprojects/FAKE"""
 
     let cfg = DependenciesFile.FromSource(config).AddGithub(Constants.MainDependencyGroup, "fsprojects/FsUnit")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 github fsprojects/FAKE
 github fsprojects/FsUnit"""
@@ -57,14 +57,14 @@ let ``should not error when adding existing github-repository``() =
 
 [<Test>]
 let ``should add new repositories to the main group``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 group Test
 github fsprojects/FAKE"""
 
     let cfg = DependenciesFile.FromSource(config).AddGithub(Constants.MainDependencyGroup, "fsprojects/FsUnit")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 github fsprojects/FsUnit
 
 group Test
@@ -75,7 +75,7 @@ github fsprojects/FAKE"""
 
 [<Test>]
 let ``should add new repositories to the specified group``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 group Test
 github fsprojects/FAKE
@@ -85,7 +85,7 @@ github fsprojects/SQLProvider"""
 
     let cfg = DependenciesFile.FromSource(config).AddGithub(GroupName "Test", "fsprojects/FsUnit")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 group Test
 github fsprojects/FAKE
@@ -99,14 +99,14 @@ github fsprojects/SQLProvider"""
 
 [<Test>]
 let ``should add new group if not already exists``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 group Test
 github fsprojects/SQLProvider"""
 
     let cfg = DependenciesFile.FromSource(config).AddGithub(GroupName "Test2", "fsprojects/FsUnit")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 group Test
 github fsprojects/SQLProvider

--- a/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
@@ -118,7 +118,7 @@ let ``should add new packages even to empty package section``() =
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "FAKE","~> 1.2")
     
-    let expected = """source https://www.nuget.org/api/v2
+    let expected = """source https://api.nuget.org/v3/index.json
 
 nuget FAKE ~> 1.2
 
@@ -133,7 +133,7 @@ let ``should add new packages with nuget package resolution strategy``() =
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "FAKE","!~> 1.2")
     
-    let expected = """source https://www.nuget.org/api/v2
+    let expected = """source https://api.nuget.org/v3/index.json
 
 nuget FAKE !~> 1.2
 """
@@ -698,7 +698,7 @@ group Build
   github fsharp/FAKE modules/Octokit/Octokit.fsx
 
 group Test
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Compiler.Service 1.4.0.1"""
 
@@ -749,7 +749,7 @@ group Build
   github fsharp/FAKE modules/Octokit/Octokit.fsx
 
 group Test
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Microsoft.AspNet.WebApi"""
 
@@ -784,7 +784,7 @@ github fsharp/FAKE src/app/FakeLib/Globbing/Globbing.fs
 github fsprojects/Chessie src/Chessie/ErrorHandling.fs
 
 group Build
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Microsoft.AspNet.WebApi
 
@@ -802,7 +802,7 @@ let ``should add Microsoft.AspNet.WebApi package to very first group``() =
                 .Add(GroupName "Build", PackageName "Microsoft.AspNet.WebApi","")
     
     let expected = """group Build
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 nuget Microsoft.AspNet.WebApi"""
 
@@ -853,7 +853,7 @@ let ``should add new packages with paket package resolution strategy``() =
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "FAKE","@~> 1.2")
     
-    let expected = """source https://www.nuget.org/api/v2
+    let expected = """source https://api.nuget.org/v3/index.json
 
 nuget FAKE @~> 1.2
 """

--- a/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/AddPackageSpecs.fs
@@ -9,7 +9,7 @@ open Paket.Requirements
 
 [<Test>]
 let ``should add new packages to the end``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
@@ -18,7 +18,7 @@ nuget SignalR = 3.3.2"""
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "xunit","")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
@@ -31,7 +31,7 @@ nuget xunit"""
 
 [<Test>]
 let ``should add new packages to alphabetical position``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget FAKE = 1.1
@@ -40,7 +40,7 @@ nuget SignalR = 3.3.2"""
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "Rz","")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget FAKE = 1.1
@@ -53,7 +53,7 @@ nuget SignalR = 3.3.2"""
 
 [<Test>]
 let ``should add new packages before github files``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
@@ -64,7 +64,7 @@ github forki/FsUnit FsUnit.fs"""
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "xunit","")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
@@ -80,7 +80,7 @@ github forki/FsUnit FsUnit.fs"""
 
 [<Test>]
 let ``should add new packages with ~> version if we give it``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 
@@ -88,7 +88,7 @@ github forki/FsUnit FsUnit.fs"""
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "FAKE","~> 1.2")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget FAKE ~> 1.2
@@ -100,12 +100,12 @@ github forki/FsUnit FsUnit.fs"""
 
 [<Test>]
 let ``should add new packages with specific version if we give it``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 nuget Castle.Windsor-log4net ~> 3.2"""
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "FAKE","1.2")
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 nuget Castle.Windsor-log4net ~> 3.2
 nuget FAKE 1.2"""
 
@@ -144,7 +144,7 @@ nuget FAKE !~> 1.2
 
 [<Test>]
 let ``should not fail if package already exists``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
@@ -155,7 +155,7 @@ nuget SignalR = 3.3.2"""
     
 [<Test>]
 let ``should not fail if package already exists - case insensitive``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
@@ -811,13 +811,13 @@ nuget Microsoft.AspNet.WebApi"""
 
 [<Test>]
 let ``should pin in correct group``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.0
     nuget FAKE
     
     group Group
-        source http://www.nuget.org/api/v2
+        source https://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net
         nuget FAKE
@@ -831,14 +831,14 @@ let ``should pin in correct group``() =
                         InstallSettings.Default)
 
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.0
     nuget FAKE
 nuget Castle.Core 3.2.0
     
     group Group
-        source http://www.nuget.org/api/v2
+        source https://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net
         nuget FAKE
@@ -880,7 +880,7 @@ nuget FAKE @~> 1.2
 
 [<Test>]
 let ``should add clitool packages``() = 
-    let config = """source http://www.nuget.org/api/v2
+    let config = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 nuget Rx-Main ~> 2.0
@@ -889,7 +889,7 @@ nuget SignalR = 3.3.2"""
 
     let cfg = DependenciesFile.FromSource(config).Add(Constants.MainDependencyGroup, PackageName "dotnet-fable","1.3.7", InstallSettings.Default, PackageRequirementKind.DotnetCliTool)
     
-    let expected = """source http://www.nuget.org/api/v2
+    let expected = """source https://www.nuget.org/api/v2
 
 nuget Castle.Windsor-log4net ~> 3.2
 clitool dotnet-fable 1.3.7

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -28,7 +28,7 @@ let ``should read config which only contains a source``() =
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
-    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head  |> shouldEqual (NuGetV2({ Url = "http://www.nuget.org/api/v2"; Authentication = AuthProvider.empty }))
+    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head  |> shouldEqual (NuGetV2({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual None
 let config1 = """
@@ -709,6 +709,7 @@ let ``should read config with encapsulated password source with no auth type spe
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual (Some (Credentials{ Username = "tatü tata"; Password = "you got hacked!"; Type = NetUtils.AuthType.Basic}))
@@ -726,6 +727,7 @@ let ``should read config with encapsulated password source and auth type specifi
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.ofUserPassword { Username = "tatü tata"; Password = "you got hacked!"; Type = NetUtils.AuthType.NTLM} } ]
 
 let configWithPasswordInSingleQuotes = """
@@ -756,6 +758,7 @@ let ``should read config with password in env variable``() =
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2;
             Authentication = AuthProvider.empty} ]
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual (Some (Credentials{ Username = "user XYZ"; Password = "pw Love"; Type = NetUtils.AuthType.Basic}))
@@ -775,6 +778,7 @@ let ``should read config with password in env variable and auth type specified``
     |> shouldEqual [ 
         PackageSource.NuGetV2 { 
             Url = "http://www.nuget.org/api/v2"
+            ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual (Some (Credentials{ Username = "user XYZ"; Password = "pw Love"; Type = NetUtils.AuthType.NTLM}))

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -108,7 +108,7 @@ nuget "MinPackage" "1.1.3"
 let ``should read simple config with comments``() =
     let cfg = DependenciesFile.FromSource(config3)
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"].Range |> shouldEqual (VersionRange.Between("2.2", "3.0"))
-    cfg.Groups.[Constants.MainDependencyGroup].Sources |> List.head |> shouldEqual PackageSources.DefaultNuGetSource
+    cfg.Groups.[Constants.MainDependencyGroup].Sources |> List.head |> shouldEqual PackageSources.DefaultNuGetV2Source
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FAKE"].Range |> shouldEqual (VersionRange.Between("3.0", "4.0"))
 
 let config4 = """
@@ -125,7 +125,7 @@ let ``should read config with multiple sources``() =
     let cfg = DependenciesFile.FromSource(config4)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
-    cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSources.DefaultNuGetSource; PackageSource.NuGetV2Source "http://nuget.org/api/v3"]
+    cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSources.DefaultNuGetV2Source; PackageSource.NuGetV3Source "http://nuget.org/api/v3"]
 
 [<Test>]
 let ``should read source file from config``() =
@@ -1603,7 +1603,7 @@ let ``parsing generate load scripts`` () =
 
 
 let configWithCLitTool = """
-source https://www.nuget.org/api/v2
+source https://api.nuget.org/v3/index.json
 
 clitool dotnet-fable
 nuget FAKE
@@ -1615,7 +1615,7 @@ let ``should read config with cli tool``() =
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources
-    |> shouldEqual [PackageSources.DefaultNuGetSource]
+    |> shouldEqual [PackageSources.DefaultNuGetV3Source]
 
     let tool = cfg.Groups.[Constants.MainDependencyGroup].Packages.Head
     let nuget = cfg.Groups.[Constants.MainDependencyGroup].Packages.Tail.Head

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -1062,7 +1062,7 @@ let ``should read config with duplicate NuGet source``() =
     let cfg = DependenciesFile.FromSource(configWithDuplicateSource)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
-    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head |> shouldEqual PackageSources.DefaultNuGetSource
+    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head |> shouldEqual PackageSources.DefaultNuGetV2Source
 
 let configWithInvalidInstallSettings = """
 source https://www.nuget.org/api/v2
@@ -1485,7 +1485,7 @@ let ``should read config with caches``() =
     (main.Caches |> List.item 1).Location |> shouldEqual "//hive/dependencies"
     (main.Caches |> List.item 1).CacheType |> shouldEqual (Some CacheType.AllVersions)
 
-    (main.Sources |> List.item 0) |> shouldEqual PackageSources.DefaultNuGetSource
+    (main.Sources |> List.item 0) |> shouldEqual PackageSources.DefaultNuGetV2Source
     (main.Sources |> List.item 1).Url |> shouldEqual "./dependencies"
     (main.Sources |> List.item 2).Url |> shouldEqual "//hive/dependencies"
 

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -28,6 +28,10 @@ let ``should read config which only contains a source``() =
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
+    let source = cfg.Groups.[Constants.MainDependencyGroup].Sources.Head
+    match source with 
+    | NuGet n -> n.ProtocolVersion |> shouldEqual ProtocolVersion3
+    | _ -> failwith "foo"
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head |> shouldEqual (NuGet({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual None

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -11,7 +11,7 @@ open Paket.Requirements
 open Paket.ModuleResolver
 
 [<Test>]
-let ``should read empty config``() = 
+let ``should read empty config``() =
     let cfg = DependenciesFile.FromSource("")
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -23,12 +23,12 @@ source http://www.nuget.org/api/v2
 """
 
 [<Test>]
-let ``should read config which only contains a source``() = 
+let ``should read config which only contains a source``() =
     let cfg = DependenciesFile.FromSource(configWithSourceOnly)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
-    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head  |> shouldEqual (NuGetV2({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
+    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head |> shouldEqual (NuGet({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual None
 let config1 = """
@@ -41,7 +41,7 @@ nuget "SignalR" "= 3.3.2"
 """
 
 [<Test>]
-let ``should read simple config``() = 
+let ``should read simple config``() =
     let cfg = DependenciesFile.FromSource(config1)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -57,7 +57,7 @@ nuget Castle.Windsor-log4net >= 3.2 prerelease # test
 """
 
 [<Test>]
-let ``should read simple config with prerelease and comment``() = 
+let ``should read simple config with prerelease and comment``() =
     let cfg = DependenciesFile.FromSource(configWithComment)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -72,7 +72,7 @@ nuget Castle.Windsor-log4net
 """
 
 [<Test>]
-let ``should read simple config with version line for bootstrapper``() = 
+let ``should read simple config with version line for bootstrapper``() =
     DependenciesFile.FromSource(configWithVersionLine) |> ignore
 
 
@@ -86,7 +86,7 @@ nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read simple config with additional comment``() = 
+let ``should read simple config with additional comment``() =
     let cfg = DependenciesFile.FromSource(config2)
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"].Range |> shouldEqual (VersionRange.Between("2.2", "3.0"))
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FAKE"].Range |> shouldEqual (VersionRange.Between("3.0", "4.0"))
@@ -101,7 +101,7 @@ nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read simple config with comments``() = 
+let ``should read simple config with comments``() =
     let cfg = DependenciesFile.FromSource(config3)
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"].Range |> shouldEqual (VersionRange.Between("2.2", "3.0"))
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> List.head |> shouldEqual PackageSources.DefaultNuGetSource
@@ -111,13 +111,13 @@ let config4 = """
 source "https://www.nuget.org/api/v2" // first source
 source "http://nuget.org/api/v3"  // second
 
-nuget "FAKE" "~> 3.0" 
+nuget "FAKE" "~> 3.0"
 nuget "Rx-Main" "~> 2.2"
 nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read config with multiple sources``() = 
+let ``should read config with multiple sources``() =
     let cfg = DependenciesFile.FromSource(config4)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -145,7 +145,7 @@ let ``should read source file from config``() =
             Project = "FAKE"
             Origin = ModuleResolver.Origin.GitHubLink
             Name = "src/app/FAKE/FileWithCommit.fs"
-            Version = VersionRestriction.Concrete "bla123zxc" 
+            Version = VersionRestriction.Concrete "bla123zxc"
             Command = None
             OperatingSystemRestriction = None
             PackagePath = None
@@ -168,7 +168,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read strict config``() = 
+let ``should read strict config``() =
     let cfg = DependenciesFile.FromSource(strictConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual true
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual None
@@ -183,7 +183,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read config with redirects``() = 
+let ``should read config with redirects``() =
     let cfg = DependenciesFile.FromSource(redirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
@@ -198,7 +198,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read config with no redirects``() = 
+let ``should read config with no redirects``() =
     let cfg = DependenciesFile.FromSource(noRedirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.Off)
@@ -213,7 +213,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read content none config``() = 
+let ``should read content none config``() =
     let cfg = DependenciesFile.FromSource(noneContentConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual None
@@ -230,7 +230,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read config with specific framework``() = 
+let ``should read config with specific framework``() =
     let cfg = DependenciesFile.FromSource(specificFrameworkConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual None
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual None
@@ -249,7 +249,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read no targets import config``() = 
+let ``should read no targets import config``() =
     let cfg = DependenciesFile.FromSource(noTargetsImportConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.ImportTargets |> shouldEqual (Some false)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual (Some false)
@@ -281,7 +281,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read no copy_content_to_output_dir config``() = 
+let ``should read no copy_content_to_output_dir config``() =
     let cfg = DependenciesFile.FromSource(copyContent)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyContentToOutputDirectory |> shouldEqual (Some CopyToOutputDirectorySettings.Always)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual None
@@ -298,7 +298,7 @@ nuget SignalR = 3.3.2
 """
 
 [<Test>]
-let ``should read config without quotes``() = 
+let ``should read config without quotes``() =
     let cfg = DependenciesFile.FromSource(configWithoutQuotes)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).Count |> shouldEqual 4
@@ -317,7 +317,7 @@ nuget SignalR = 3.3.2
 """
 
 [<Test>]
-let ``should read config local quoted source``() = 
+let ``should read config local quoted source``() =
     let cfg = DependenciesFile.FromSource(configLocalQuotedSource)
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual "D:\code\\temp with space"
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
@@ -338,7 +338,7 @@ nuget SignalR    = 3.3.2
 """
 
 [<Test>]
-let ``should read config without quotes but lots of whitespace``() = 
+let ``should read config without quotes but lots of whitespace``() =
     let cfg = DependenciesFile.FromSource(configWithoutQuotes)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).Count |> shouldEqual 4
@@ -352,7 +352,7 @@ let ``should read config without quotes but lots of whitespace``() =
 [<Test>]
 let ``should read github source file from config without quotes``() =
     let config = """github fsharp/FAKE:master   src/app/FAKE/Cli.fs
-                    github    fsharp/FAKE:bla123zxc src/app/FAKE/FileWithCommit.fs 
+                    github    fsharp/FAKE:bla123zxc src/app/FAKE/FileWithCommit.fs
                     github    fsharp/FAKE src/app/FAKE/FileWithCommit.fs github
                  """
     let dependencies = DependenciesFile.FromSource(config)
@@ -375,7 +375,7 @@ let ``should read github source file from config without quotes``() =
             Command = None
             OperatingSystemRestriction = None
             PackagePath = None
-            AuthKey = None } 
+            AuthKey = None }
           { Owner = "fsharp"
             Project = "FAKE"
             Origin = ModuleResolver.Origin.GitHubLink
@@ -389,7 +389,7 @@ let ``should read github source file from config without quotes``() =
 [<Test>]
 let ``should read github source file from config with quotes``() =
     let config = """github fsharp/FAKE:master  "src/app/FAKE/Cli.fs"
-                    github fsharp/FAKE:bla123zxc "src/app/FAKE/FileWith Space.fs" 
+                    github fsharp/FAKE:bla123zxc "src/app/FAKE/FileWith Space.fs"
                     github fsharp/FAKE "src/app/FAKE/FileWith Space.fs" github
                  """
     let dependencies = DependenciesFile.FromSource(config)
@@ -562,7 +562,7 @@ let ``should read gist source file``() =
 
 nuget JetBrainsAnnotations.Fody
 
-gist misterx/5d9c6983004c1c9ec91f""" 
+gist misterx/5d9c6983004c1c9ec91f"""
     let dependencies = DependenciesFile.FromSource(config)
     dependencies.Groups.[Constants.MainDependencyGroup].RemoteFiles
     |> shouldEqual
@@ -688,7 +688,7 @@ nuget "FAKE"
 """
 
 [<Test>]
-let ``should read config without versions``() = 
+let ``should read config without versions``() =
     let cfg = DependenciesFile.FromSource(configWithoutVersions)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"] .Range|> shouldEqual (VersionRange.AtLeast "0")
@@ -702,12 +702,12 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with encapsulated password source with no auth type specified``() = 
+let ``should read config with encapsulated password source with no auth type specified``() =
     let cfg = DependenciesFile.FromSource(configWithPasswordNoAuthType)
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].Sources
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
@@ -720,12 +720,12 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with encapsulated password source and auth type specified``() = 
+let ``should read config with encapsulated password source and auth type specified``() =
     let cfg = DependenciesFile.FromSource(configWithPasswordWithAuthType)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.ofUserPassword { Username = "tatü tata"; Password = "you got hacked!"; Type = NetUtils.AuthType.NTLM} } ]
@@ -736,7 +736,7 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with single-quoted password source``() = 
+let ``should read config with single-quoted password source``() =
     try
         DependenciesFile.FromSource configWithPasswordInSingleQuotes |> ignore
         failwith "Expected error"
@@ -749,14 +749,14 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with password in env variable``() = 
+let ``should read config with password in env variable``() =
     Environment.SetEnvironmentVariable("FEED_USERNAME", "user XYZ", EnvironmentVariableTarget.Process)
     Environment.SetEnvironmentVariable("FEED_PASSWORD", "pw Love", EnvironmentVariableTarget.Process)
     let cfg = DependenciesFile.FromSource( configWithPasswordInEnvVariable)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2;
             Authentication = AuthProvider.empty} ]
@@ -769,14 +769,14 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with password in env variable and auth type specified``() = 
+let ``should read config with password in env variable and auth type specified``() =
     Environment.SetEnvironmentVariable("FEED_USERNAME", "user XYZ", EnvironmentVariableTarget.Process)
     Environment.SetEnvironmentVariable("FEED_PASSWORD", "pw Love", EnvironmentVariableTarget.Process)
     let cfg = DependenciesFile.FromSource( configWithPasswordInEnvVariableAndAuthType)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
@@ -786,12 +786,12 @@ let ``should read config with password in env variable and auth type specified``
 let configWithExplicitVersions = """
 source "http://www.nuget.org/api/v2"
 
-nuget FSharp.Compiler.Service == 0.0.62 
+nuget FSharp.Compiler.Service == 0.0.62
 nuget FsReveal == 0.0.5-beta
 """
 
 [<Test>]
-let ``should read config explicit versions``() = 
+let ``should read config explicit versions``() =
     let cfg = DependenciesFile.FromSource(configWithExplicitVersions)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.OverrideAll (SemVer.Parse "0.0.62"))
@@ -804,7 +804,7 @@ nuget Nancy.Owin 0.22.2
 """
 
 [<Test>]
-let ``should read config with local source``() = 
+let ``should read config with local source``() =
     let cfg = DependenciesFile.FromSource(configWithLocalSource)
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Nancy.Owin")
@@ -813,7 +813,7 @@ let ``should read config with local source``() =
 
 
 [<Test>]
-let ``should read config with package name containing nuget``() = 
+let ``should read config with package name containing nuget``() =
     let config = """
     nuget nuget.Core 0.1
     """
@@ -822,7 +822,7 @@ let ``should read config with package name containing nuget``() =
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "nuget.Core"].Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "0.1"))
 
 [<Test>]
-let ``should read config with single framework restriction``() = 
+let ``should read config with single framework restriction``() =
     let config = """
     nuget Foobar 1.2.3 framework: >= net40
     """
@@ -835,7 +835,7 @@ let ``should read config with single framework restriction``() =
 
 
 [<Test>]
-let ``should read config with framework restriction``() = 
+let ``should read config with framework restriction``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta framework: net35, >= net40
     """
@@ -849,7 +849,7 @@ let ``should read config with framework restriction``() =
     p.Settings.SpecificVersion |> shouldEqual None
 
 [<Test>]
-let ``should read config with no targets import``() = 
+let ``should read config with no targets import``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta import_targets: false, copy_local: false, specific_version: false
     """
@@ -864,7 +864,7 @@ let ``should read config with no targets import``() =
     p.Settings.OmitContent |> shouldEqual None
 
 [<Test>]
-let ``should read config with content none``() = 
+let ``should read config with content none``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta content: none, copy_local: false, specific_version: true
     """
@@ -879,7 +879,7 @@ let ``should read config with content none``() =
     p.Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
 
 [<Test>]
-let ``should read config with  !~> 3.3``() = 
+let ``should read config with  !~> 3.3``() =
     let config = """source https://www.nuget.org/api/v2
 
 nuget AutoMapper ~> 3.2
@@ -903,11 +903,11 @@ nuget Caliburn.Micro !~> 2.0.2
 
 
 let configWithInvalidPrereleaseString = """
-    nuget Plossum.CommandLine !0.3.0.14   
+    nuget Plossum.CommandLine !0.3.0.14
 """
 
 [<Test>]
-let ``should report error on invalid prerelease string``() = 
+let ``should report error on invalid prerelease string``() =
     try
         DependenciesFile.FromSource(configWithInvalidPrereleaseString) |> ignore
         failwith "error"
@@ -919,7 +919,7 @@ let html = """
 """
 
 [<Test>]
-let ``should not read hhtml``() = 
+let ``should not read hhtml``() =
     try
         DependenciesFile.FromSource(html) |> ignore
         failwith "error"
@@ -939,7 +939,7 @@ nuget NUnit
 """
 
 [<Test>]
-let ``should read config with additional group``() = 
+let ``should read config with additional group``() =
     let cfg = DependenciesFile.FromSource(configWithAdditionalGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -961,7 +961,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with nested group``() = 
+let ``should read config with nested group``() =
     let cfg = DependenciesFile.FromSource(configWithNestedGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -986,7 +986,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with explizit main group``() = 
+let ``should read config with explizit main group``() =
     let cfg = DependenciesFile.FromSource(configWithExplicitMainGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -1011,7 +1011,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with reference condition``() = 
+let ``should read config with reference condition``() =
     let cfg = DependenciesFile.FromSource(configWithReferenceCondition)
 
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.ReferenceCondition |> shouldEqual (Some "MAIN-GROUP")
@@ -1029,7 +1029,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with NuGet v3 feed``() = 
+let ``should read config with NuGet v3 feed``() =
     let cfg = DependenciesFile.FromSource(configWithNugetV3Source)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual Constants.DefaultNuGetV3Stream
@@ -1041,7 +1041,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with NuGet http v3 feed``() = 
+let ``should read config with NuGet http v3 feed``() =
     let cfg = DependenciesFile.FromSource(configWithNugetV3HTTPSource)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual (Constants.DefaultNuGetV3Stream.Replace("https://","http://"))
@@ -1054,7 +1054,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with duplicate NuGet source``() = 
+let ``should read config with duplicate NuGet source``() =
     let cfg = DependenciesFile.FromSource(configWithDuplicateSource)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
@@ -1069,7 +1069,7 @@ nuget Oracle.ManagedDataAccess framework: >= net40 content: none
 """
 
 [<Test>]
-let ``should not read config with invalid settings``() = 
+let ``should not read config with invalid settings``() =
     shouldFail (fun () -> DependenciesFile.FromSource(configWithInvalidInstallSettings) |> ignore)
 
 let strategyConfig = sprintf """
@@ -1084,13 +1084,13 @@ group Test
 """
 
 [<Test>]
-let ``should read config with min and max strategy``() = 
+let ``should read config with min and max strategy``() =
     let cfg = DependenciesFile.FromSource(strategyConfig "min" "max")
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Max)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NuGetV2Source "http://www.nuget.org/api/v2"]
-    
+
 let noStrategyConfig = sprintf """
 strategy %s
 source "http://www.nuget.org/api/v2" // first source
@@ -1102,7 +1102,7 @@ group Test
 """
 
 [<Test>]
-let ``should read config with min and no strategy``() = 
+let ``should read config with min and no strategy``() =
     let cfg = DependenciesFile.FromSource(noStrategyConfig "min")
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual None
@@ -1119,7 +1119,7 @@ group Test
 """
 
 [<Test>]
-let ``should read config with no strategy``() = 
+let ``should read config with no strategy``() =
     let cfg = DependenciesFile.FromSource(noStrategyConfig')
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual None
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual None
@@ -1152,7 +1152,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with combined strategy``() = 
+let ``should read config with combined strategy``() =
     let cfg = DependenciesFile.FromSource(combinedStrategyConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
@@ -1169,7 +1169,7 @@ nuget FsReveal
 """
 
 [<Test>]
-let ``should read config with very similar feeds``() = 
+let ``should read config with very similar feeds``() =
     let cfg = DependenciesFile.FromSource(configWithVerySimilarFeeds)
 
     try
@@ -1177,12 +1177,12 @@ let ``should read config with very similar feeds``() =
     with e ->
         System.Console.Error.WriteLine("Credential Provider failed: " + e.Message)
         () // Might throw when we have a global authentication provider
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual "http://nexus1:8081/nexus/service/local/nuget/nuget-repo"
 
     try
         cfg.Groups.[Constants.MainDependencyGroup].Sources.Tail.Head.Auth.Retrieve false |> shouldNotEqual None
-    with e -> 
+    with e ->
         System.Console.Error.WriteLine("Credential Provider failed: " + e.Message)
         () // Might throw when we have a global authentication provider
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Tail.Head.Url |> shouldEqual "http://nexus2:8081/nexus/service/local/nuget/nuget-repo"
@@ -1195,7 +1195,7 @@ nuget System.Data.SQLite 1.0.98.1 content: none
 """
 
 [<Test>]
-let ``should read config with target framework``() = 
+let ``should read config with target framework``() =
     let cfg = DependenciesFile.FromSource(configTargetFramework)
 
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
@@ -1251,7 +1251,7 @@ let ``should throw on config with invalid target framework`` config =
     shouldFail<Exception> (fun () -> DependenciesFile.FromSource(config) |> ignore)
 
 [<Test>]
-let ``should read packages with redirects``() = 
+let ``should read packages with redirects``() =
     let config = """
 redirects on
 source http://www.nuget.org/api/v2
@@ -1293,7 +1293,7 @@ git http://github.com/fsprojects/Chessie.git master
 """
 
 [<Test>]
-let ``should read paket git config``() = 
+let ``should read paket git config``() =
     let cfg = DependenciesFile.FromSource(paketGitConfig)
     let gitSource = cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "git@github.com:fsprojects/Paket.git"
@@ -1341,7 +1341,7 @@ group Dev
 """
 
 [<Test>]
-let ``should read paket git config with build command``() = 
+let ``should read paket git config with build command``() =
     let cfg = DependenciesFile.FromSource(paketGitConfigWithBuildCommand)
     let gitSource = cfg.Groups.[GroupName "Dev"].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
@@ -1382,7 +1382,7 @@ let ``should read paket git config with build command``() =
     let nupkgtestSource = cfg.Groups.[GroupName "Dev"].Sources.Head
     nupkgtestSource.Url |> shouldEqual "paket-files/dev/github.com/forki/nupkgtest/source"
 
-    
+
     let buildSource = cfg.Groups.[GroupName "Dev"].RemoteFiles.Tail.Tail.Tail.Tail.Head
     buildSource.GetCloneUrl() |> shouldEqual "https://github.com/forki/nupkgtest.git"
     buildSource.Owner |> shouldEqual "github.com/forki"
@@ -1391,7 +1391,7 @@ let ``should read paket git config with build command``() =
     buildSource.PackagePath |> shouldEqual (Some "/source/")
     buildSource.Command |> shouldEqual (Some "build.cmd")
     buildSource.OperatingSystemRestriction |> shouldEqual None
- 
+
     cfg.Groups.[GroupName "Dev"].Sources
     |> List.map (fun x -> x.Url)
     |> shouldContain "paket-files/dev/github.com/forki/nupkgtest/source"
@@ -1411,9 +1411,9 @@ group Git
 """
 
 [<Test>]
-let ``should read paket git config with tags``() = 
+let ``should read paket git config with tags``() =
     let cfg = DependenciesFile.FromSource(paketGitTagsConfig)
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1440,7 +1440,7 @@ let ``should read paket git config with tags``() =
     gitSource.OperatingSystemRestriction |> shouldEqual None
     gitSource.PackagePath |> shouldEqual (Some "/temp/")
     gitSource.Project |> shouldEqual "Paket"
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Tail.Tail.Tail.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1449,7 +1449,7 @@ let ``should read paket git config with tags``() =
     gitSource.OperatingSystemRestriction |> shouldEqual None
     gitSource.PackagePath |> shouldEqual (Some "/temp/")
     gitSource.Project |> shouldEqual "Paket"
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Tail.Tail.Tail.Tail.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1472,7 +1472,7 @@ nuget Chessie
 """
 
 [<Test>]
-let ``should read config with caches``() = 
+let ``should read config with caches``() =
     let cfg = DependenciesFile.FromSource(simpleCacheConfig)
     let main = cfg.Groups.[Constants.MainDependencyGroup]
     main.Caches |> List.length |> shouldEqual 2
@@ -1489,7 +1489,7 @@ let ``should read config with caches``() =
 let ``async cache should work``() =
      // this test is already include in the to Visualfsharp repo
      let x = ref 0
-     let someSlowFunc mykey = async { 
+     let someSlowFunc mykey = async {
          Console.WriteLine "Simulated downloading..."
          do! Async.Sleep 400
          Console.WriteLine "Simulated downloading Done."
@@ -1500,7 +1500,7 @@ let ``async cache should work``() =
          do! memFunc "a" |> Async.Ignore
          do! memFunc "a" |> Async.Ignore
          do! memFunc "a" |> Async.Ignore
-         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a")) 
+         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a"))
              |> Async.Parallel |> Async.Ignore
          for i = 1 to 30 do
              Async.Start( memFunc "a" |> Async.Ignore )
@@ -1510,7 +1510,7 @@ let ``async cache should work``() =
          do! memFunc "a" |> Async.Ignore
          for i = 1 to 30 do
              Async.Start( memFunc "a" |> Async.Ignore )
-         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a")) 
+         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a"))
              |> Async.Parallel |> Async.Ignore
      } |> Async.RunSynchronously
      !x |> shouldEqual 1
@@ -1534,9 +1534,9 @@ nuget xunit
 """
 
 [<Test>]
-let ``should read autodetect from main group``() = 
+let ``should read autodetect from main group``() =
     let cfg = DependenciesFile.FromSource(autodetectconfig)
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions 
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
     |> shouldEqual FrameworkRestrictions.AutoDetectFramework
 
 let autodetectconfigSpecific = """
@@ -1560,9 +1560,9 @@ nuget xunit
 """
 
 [<Test>]
-let ``should read autodetect from specific main group``() = 
+let ``should read autodetect from specific main group``() =
     let cfg = DependenciesFile.FromSource(autodetectconfigSpecific)
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions 
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
     |> shouldEqual FrameworkRestrictions.AutoDetectFramework
 
 [<Test>]
@@ -1576,7 +1576,7 @@ let ``parsing generate load scripts`` () =
     ]
     let results = [
         for case, expectation in casesAndExpectation do
-            let config = 
+            let config =
                 DependenciesFile.FromSource <|
                 match case with
                 | Some value ->
@@ -1606,11 +1606,11 @@ nuget FAKE
 """
 
 [<Test>]
-let ``should read config with cli tool``() = 
+let ``should read config with cli tool``() =
     let cfg = DependenciesFile.FromSource(configWithCLitTool)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
     |> shouldEqual [PackageSources.DefaultNuGetSource]
 
     let tool = cfg.Groups.[Constants.MainDependencyGroup].Packages.Head

--- a/tests/Paket.Tests/InstallModel/RuntimeGraphTests.fs
+++ b/tests/Paket.Tests/InstallModel/RuntimeGraphTests.fs
@@ -153,7 +153,7 @@ let ``Check that runtime dependencies are saved as such in the lockfile`` () =
     MyDependency (4.0)
     MyRuntimeDependency (4.0.1) - isRuntimeDependency: true"""
 
-    let depsFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let depsFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2 protocolVersion: 2
 nuget MyDependency""")
     let lockFile, resolution =
         UpdateProcess.selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) (GetRuntimeGraphFromGraph graph) lockFile depsFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
@@ -197,7 +197,7 @@ let ``Check that runtime dependencies we don't use are ignored`` () =
           "MyRuntimeDependency", "4.0.1", [], RuntimeGraph.Empty ]
         |> OfGraphWithRuntimeDeps
 
-    let depsFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let depsFile = DependenciesFile.FromSource("""source http://api.nuget.org/v3/index.json
 nuget MyDependency""")
     let lockFile, resolution =
         UpdateProcess.selectiveUpdate true noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) (GetRuntimeGraphFromGraph graph) lockFile depsFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
@@ -217,7 +217,8 @@ nuget MyDependency""")
 [<Test>]
 let ``Check that runtime dependencies are loaded from the lockfile`` () =
     let lockFile = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: http://api.nuget.org/v3/index.json
+    protocolVersion: 3
     MyDependency (4.0)
     MyRuntimeDependency (4.0.1) - isRuntimeDependency: true"""
 

--- a/tests/Paket.Tests/InstallModel/RuntimeGraphTests.fs
+++ b/tests/Paket.Tests/InstallModel/RuntimeGraphTests.fs
@@ -149,6 +149,7 @@ let ``Check that runtime dependencies are saved as such in the lockfile`` () =
 
     let expectedLockFile = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     MyDependency (4.0)
     MyRuntimeDependency (4.0.1) - isRuntimeDependency: true"""
 
@@ -233,7 +234,7 @@ let ``Check that runtime dependencies are loaded from the lockfile`` () =
     |> List.sortBy (fun (t,_,_) ->t)
     |> shouldEqual expected
 
-    
+
 [<Test>]
 let ``Check that runtime inheritance works`` () =
     let runtimeGraph = RuntimeGraphParser.readRuntimeGraph rids
@@ -250,13 +251,13 @@ let ``Check that runtime inheritance works`` () =
     let model =
         InstallModel.EmptyModel (PackageName "testpackage", SemVer.Parse "1.0.0")
         |> InstallModel.addNuGetFiles content
-        
+
     let targetProfile = Paket.TargetProfile.SinglePlatform(Paket.FrameworkIdentifier.DotNetStandard (Paket.DotNetStandardVersion.V1_6))
     model.GetRuntimeAssemblies runtimeGraph (Rid.Of "win-x86") (targetProfile)
     |> Seq.map (fun fi -> fi.Library.PathWithinPackage)
     |> Seq.toList
     |> shouldEqual [ "runtimes/win/lib/netstandard1.1/testpackage.dll" ]
-    
+
 [<Test>]
 let ``Check that runtime inheritance works (2)`` () =
     let runtimeGraph = runtimeGraphMsNetCorePlatforms2_2_1
@@ -279,7 +280,7 @@ let ``Check that runtime inheritance works (2)`` () =
     let model =
         InstallModel.EmptyModel (PackageName "System.Runtime.InteropServices.RuntimeInformation", SemVer.Parse "4.3.0")
         |> InstallModel.addNuGetFiles content
-        
+
     let targetProfile = Paket.TargetProfile.SinglePlatform(Paket.FrameworkIdentifier.DotNetStandard (Paket.DotNetStandardVersion.V1_6))
     model.GetRuntimeAssemblies runtimeGraph (Rid.Of "win10-x86") (targetProfile)
     |> Seq.map (fun fi -> fi.Library.PathWithinPackage)
@@ -291,4 +292,3 @@ let ``Check correct inheritance list`` () =
     let runtimeGraph = RuntimeGraphParser.readRuntimeGraph rids
     RuntimeGraph.getInheritanceList (Rid.Of "win-x86") runtimeGraph
         |> shouldEqual [ Rid.Of "win-x86"; Rid.Of "win"; Rid.Of "any"; Rid.Of "base"]
-    

--- a/tests/Paket.Tests/InstallModel/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/InstallModel/UpdateProcessSpecs.fs
@@ -21,15 +21,15 @@ let lockFileData = """NUGET
     log4net (1.2.10)
 """
 
-let graph = 
-    [ "Castle.Core-log4net", "3.2.0", 
+let graph =
+    [ "Castle.Core-log4net", "3.2.0",
       [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "3.2.0",PreReleaseStatus.No)
         "log4net", VersionRequirement(VersionRange.Exactly "1.2.10",PreReleaseStatus.No) ]
-      "Castle.Core-log4net", "3.3.3", 
+      "Castle.Core-log4net", "3.3.3",
       [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "3.3.3",PreReleaseStatus.No)
         "log4net", VersionRequirement(VersionRange.Exactly "1.2.10",PreReleaseStatus.No) ]
-      "Castle.Core-log4net", "4.0.0", 
-      [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "4.0.0",PreReleaseStatus.No) 
+      "Castle.Core-log4net", "4.0.0",
+      [ "Castle.Core", VersionRequirement(VersionRange.AtLeast "4.0.0",PreReleaseStatus.No)
         "log4net", VersionRequirement(VersionRange.Exactly "1.2.10",PreReleaseStatus.No) ]
       "Castle.Core", "3.2.0", []
       "Castle.Core", "3.3.3", []
@@ -49,20 +49,20 @@ let selectiveUpdateFromGraph graph force lockFile depsFile updateMode restrictio
     selectiveUpdate force noSha1 (VersionsFromGraph graph) (PackageDetailsFromGraph graph) (GetRuntimeGraphFromGraph graph) lockFile depsFile updateMode restriction
 
 [<Test>]
-let ``SelectiveUpdate does not update any package when it is neither updating all nor selective updating``() = 
+let ``SelectiveUpdate does not update any package when it is neither updating all nor selective updating``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
-    
+
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
@@ -72,9 +72,9 @@ let ``SelectiveUpdate does not update any package when it is neither updating al
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates all packages not constraining version``() = 
+let ``SelectiveUpdate updates all packages not constraining version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -82,12 +82,12 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
     nuget FAKE""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.1");
@@ -97,9 +97,9 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates all packages constraining version``() = 
+let ``SelectiveUpdate updates all packages constraining version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -108,12 +108,12 @@ let ``SelectiveUpdate updates all packages constraining version``() =
     nuget FAKE = 4.0.0""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","3.3.3");
         ("FAKE","4.0.0");
@@ -123,9 +123,9 @@ let ``SelectiveUpdate updates all packages constraining version``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate removes a dependency when it is updated to a version that does not depend on a library``() = 
+let ``SelectiveUpdate removes a dependency when it is updated to a version that does not depend on a library``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -133,12 +133,12 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
     nuget FAKE""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","4.0.0");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.1");
@@ -148,24 +148,24 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates a single package``() = 
+let ``SelectiveUpdate updates a single package``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "FAKE" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.1");
@@ -175,24 +175,24 @@ let ``SelectiveUpdate updates a single package``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates a single constrained package``() = 
+let ``SelectiveUpdate updates a single constrained package``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.0");
@@ -202,9 +202,9 @@ let ``SelectiveUpdate updates a single constrained package``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-     
+
 [<Test>]
-let ``SelectiveUpdate updates a single package with constrained dependency in dependencies file``() = 
+let ``SelectiveUpdate updates a single package with constrained dependency in dependencies file``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -212,15 +212,15 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
     nuget Castle.Core ~> 3.2
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.3.3");
         ("Castle.Core","3.3.3");
         ("FAKE","4.0.0");
@@ -230,9 +230,9 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate installs new packages``() = 
+let ``SelectiveUpdate installs new packages``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -241,12 +241,12 @@ let ``SelectiveUpdate installs new packages``() =
     nuget Newtonsoft.Json""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.Install SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
@@ -257,24 +257,24 @@ let ``SelectiveUpdate installs new packages``() =
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate removes a dependency when it updates a single package and it is updated to a version that does not depend on a library``() = 
+let ``SelectiveUpdate removes a dependency when it updates a single package and it is updated to a version that does not depend on a library``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","4.0.0");
         ("Castle.Core","4.0.0");
         ("FAKE","4.0.0");
@@ -284,9 +284,9 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate does not update when a dependency constrain is not met``() = 
+let ``SelectiveUpdate does not update when a dependency constrain is not met``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -294,26 +294,26 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
     nuget Castle.Core = 3.2.0
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
         |> Seq.sortBy fst
-        
+
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-   
+
 [<Test>]
-let ``SelectiveUpdate considers package name case difference``() = 
+let ``SelectiveUpdate considers package name case difference``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -321,27 +321,27 @@ let ``SelectiveUpdate considers package name case difference``() =
     nuget castle.core = 3.2.0
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Seq.map (fun (KeyValue (_,resolved)) -> (string resolved.Name, string resolved.Version))
 
-    let expected = 
+    let expected =
         [("Castle.Core-log4net","3.2.0");
         ("Castle.Core","3.2.0");
         ("FAKE","4.0.0");
         ("log4net","1.2.10")]
         |> Seq.sortBy fst
-        
+
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate conflicts when a dependency is contrained``() = 
+let ``SelectiveUpdate conflicts when a dependency is contrained``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -357,7 +357,7 @@ let ``SelectiveUpdate conflicts when a dependency is contrained``() =
     |> shouldFail
 
 [<Test>]
-let ``SelectiveUpdate generates paket.lock correctly``() = 
+let ``SelectiveUpdate generates paket.lock correctly``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
@@ -365,19 +365,20 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
     nuget Castle.Core
     nuget FAKE""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
             String.Join
                 (Environment.NewLine,
-                    LockFileSerializer.serializePackages InstallOptions.Default lockFile.Groups.[Constants.MainDependencyGroup].Resolution, 
+                    LockFileSerializer.serializePackages InstallOptions.Default lockFile.Groups.[Constants.MainDependencyGroup].Resolution,
                     LockFileSerializer.serializeSourceFiles lockFile.Groups.[Constants.MainDependencyGroup].RemoteFiles)
 
 
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Core (4.0)
     Castle.Core-log4net (3.2)
       Castle.Core (>= 3.2)
@@ -387,9 +388,9 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
 """
 
     result
-    |> shouldEqual (normalizeLineEndings expected)    
+    |> shouldEqual (normalizeLineEndings expected)
 
-let graph2 = 
+let graph2 =
     [ "Ninject", "2.2.1.4", []
       "Ninject", "2.2.1.5", []
       "Ninject", "2.3.1.4", []
@@ -413,7 +414,7 @@ let graph2 =
       "log4net", "1.2.11", []
       "log4net", "2.0.3", [] ]
     |> OfSimpleGraph
-      
+
 let lockFileData2 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -431,25 +432,25 @@ let lockFileData2 = """NUGET
 let lockFile2 = lockFileData2 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a transitive dependency with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a transitive dependency with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net""")
-    
+
     let packageFilter = PackageName "log4f" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph2 true lockFile2 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","2.2.0.4");
         ("Ninject.Extensions.Logging","2.2.0.4");
         ("Ninject", "2.2.1.4");
@@ -460,27 +461,27 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a transitive dependency in its own graph with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a transitive dependency in its own graph with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph2 true lockFile2 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
         ("Ninject", "3.2.0");
@@ -491,16 +492,16 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
 
-let graph3 = 
+
+let graph3 =
     graph2 @
     ([ "Ninject.Extensions.Interception", "2.2.1.2", [ "Ninject", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
        "Ninject.Extensions.Interception", "2.2.1.3", [ "Ninject", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
        "Ninject.Extensions.Interception", "3.2.0", [ "Ninject", VersionRequirement(VersionRange.Between("3.2.0.0","3.3.0.0"),PreReleaseStatus.No) ] ]
      |> OfSimpleGraph)
 
-      
+
 let lockFileData3 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -519,26 +520,26 @@ let lockFileData3 = """NUGET
 let lockFile3 = lockFileData3 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a transitive dependency of another package with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a transitive dependency of another package with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net
     nuget Ninject.Extensions.Interception""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph3 true lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3")
          ("Ninject.Extensions.Logging","3.2.3")
          ("Ninject.Extensions.Interception","3.2.0")
@@ -550,28 +551,28 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate does not conflict with a transitive dependency of another package when paket.dependencies requirement has changed``() = 
+let ``SelectiveUpdate does not conflict with a transitive dependency of another package when paket.dependencies requirement has changed``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Ninject ~> 3.0
     nuget Ninject.Extensions.Logging.Log4net
     nuget Ninject.Extensions.Interception""")
-    
+
     let packageFilter = PackageName "Ninject" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph3 true lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
         ("Ninject.Extensions.Interception","3.2.0");
@@ -582,28 +583,28 @@ let ``SelectiveUpdate does not conflict with a transitive dependency of another 
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency of another package to correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency of another package to correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net
     nuget Ninject.Extensions.Interception""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Interception" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph3 true lockFile3 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
         ("Ninject.Extensions.Interception","3.2.0");
@@ -615,7 +616,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 let graph4 =
     graph2 @
      ([ "Ninject.Extensions.Logging.Log4net.Deep", "2.2.0.4", [ "Ninject.Extensions.Logging.Log4net", VersionRequirement(VersionRange.Between("2.2.0.0","2.3.0.0"),PreReleaseStatus.No) ]
@@ -639,24 +640,24 @@ let lockFileData4 = """NUGET
 let lockFile4 = lockFileData4 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency in its own graph with correct version``() = 
+let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency in its own graph with correct version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Ninject.Extensions.Logging.Log4net.Deep""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging.Log4net.Deep" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph4 true lockFile4 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Logging.Log4net.Deep","3.2.3");
         ("Ninject.Extensions.Logging.Log4net","3.2.3");
         ("Ninject.Extensions.Logging","3.2.3");
@@ -667,7 +668,7 @@ let ``SelectiveUpdate updates package that conflicts with a deep transitive depe
     result
     |> Seq.sortBy fst
     |> shouldEqual expected
-    
+
 let graph5 =
       [ "Ninject.Extensions.Interception", "0.0.2-alpha001", [ "Ninject", VersionRequirement(VersionRange.Between("0.0.1","0.0.3"),PreReleaseStatus.No) ]
         "Ninject.Extensions.Logging", "0.0.2-alpha001", [ "Ninject", VersionRequirement(VersionRange.Between("0.0.1","0.0.3"),PreReleaseStatus.No) ]
@@ -689,25 +690,25 @@ let lockFileData5 = """NUGET
 let lockFile5 = lockFileData5 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package that conflicts with transitive dependency with correct prerelease version``() = 
+let ``SelectiveUpdate updates package that conflicts with transitive dependency with correct prerelease version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Ninject.Extensions.Interception
     nuget Ninject.Extensions.Logging""")
-    
+
     let packageFilter = PackageName "Ninject.Extensions.Logging" |> PackageFilter.ofName
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph5 true lockFile5 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, packageFilter)) SemVerUpdateMode.NoRestriction
-    
-    let result = 
+
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Ninject.Extensions.Interception","0.0.2-alpha001");
         ("Ninject.Extensions.Logging","0.0.3");
         ("Ninject", "0.0.2-alpha001")]
@@ -725,23 +726,23 @@ let groupMap (lockFile : LockFile) =
         (string g,string resolved.Name, string resolved.Version))
 
 [<Test>]
-let ``SelectiveUpdate updates all packages from all groups if no group is specified``() = 
+let ``SelectiveUpdate updates all packages from all groups if no group is specified``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net ~> 4.0""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true lockFile dependenciesFile PackageResolver.UpdateMode.UpdateAll SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","log4net","1.2.10");
@@ -776,23 +777,23 @@ NUGET
 let groupedLockFile = groupedLockFileData |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates only packages from specific group if group is specified``() = 
+let ``SelectiveUpdate updates only packages from specific group if group is specified``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup Constants.MainDependencyGroup) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile |> Seq.toList
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","3.2.0");
         ("Group","Castle.Core","3.2.0");
         (mainGroup,"Castle.Core-log4net","4.0.0");
@@ -808,23 +809,23 @@ let ``SelectiveUpdate updates only packages from specific group if group is spec
     |> shouldEqual expected
 
 [<Test>]
-let ``SelectiveUpdate updates only packages from specified group``() = 
+let ``SelectiveUpdate updates only packages from specified group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
         nuget Castle.Core-log4net""")
 
     let lockFile,_ = selectiveUpdateFromGraph graph true groupedLockFile dependenciesFile (PackageResolver.UpdateMode.UpdateGroup(GroupName "Group")) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","log4net","1.2.10");
@@ -837,7 +838,7 @@ let ``SelectiveUpdate updates only packages from specified group``() =
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 let lockFileData6 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -862,13 +863,13 @@ NUGET
 let lockFile6 = lockFileData6 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates package from a specific group``() = 
+let ``SelectiveUpdate updates package from a specific group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -878,10 +879,10 @@ let ``SelectiveUpdate updates package from a specific group``() =
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","FAKE","4.0.0");
@@ -895,15 +896,15 @@ let ``SelectiveUpdate updates package from a specific group``() =
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate does not remove a dependency from group when it is a top-level dependency in that group``() = 
+let ``SelectiveUpdate does not remove a dependency from group when it is a top-level dependency in that group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.0
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -914,10 +915,10 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","4.0.0");
         ("Group","Castle.Core","4.0.0");
         ("Group","FAKE","4.0.0");
@@ -931,15 +932,15 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 [<Test>]
-let ``SelectiveUpdate updates package from main group``() = 
+let ``SelectiveUpdate updates package from main group``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -949,10 +950,10 @@ let ``SelectiveUpdate updates package from main group``() =
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","3.2.0");
         ("Group","Castle.Core","3.2.0");
         ("Group","FAKE","4.0.0");
@@ -966,7 +967,7 @@ let ``SelectiveUpdate updates package from main group``() =
     result
     |> Seq.sortBy gfst
     |> shouldEqual expected
-    
+
 let lockFileData7 = """NUGET
   remote: http://www.nuget.org/api/v2
   specs:
@@ -975,7 +976,7 @@ let lockFileData7 = """NUGET
 """
 let lockFile7 = lockFileData7 |> getLockFile
 
-let graph7 = 
+let graph7 =
     [ "Package", "3.2.0", []
       "Package", "4.0.0", ["Newtonsoft.Json", VersionRequirement(VersionRange.AtLeast "7.0.0",PreReleaseStatus.No)]
       "APackage", "3.2.0", []
@@ -985,23 +986,23 @@ let graph7 =
     |> OfSimpleGraph
 
 [<Test>]
-let ``SelectiveUpdate updates package that has a new dependent package that also is a direct dependency``() = 
+let ``SelectiveUpdate updates package that has a new dependent package that also is a direct dependency``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Newtonsoft.Json
     nuget Package""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph7 true lockFile7 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "Package" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("Package","4.0.0");
         ("Newtonsoft.Json","7.0.1")]
         |> Seq.sortBy fst
@@ -1019,23 +1020,23 @@ let lockFileData8 = """NUGET
 let lockFile8 = lockFileData8 |> getLockFile
 
 [<Test>]
-let ``SelectiveUpdate updates early package that has a new dependent package that also is a direct dependency``() = 
+let ``SelectiveUpdate updates early package that has a new dependent package that also is a direct dependency``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Newtonsoft.Json
     nuget APackage""")
 
-    let lockFile,_ = 
+    let lockFile,_ =
         selectiveUpdateFromGraph graph7 true lockFile8 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(Constants.MainDependencyGroup, PackageName "APackage" |> PackageFilter.ofName)) SemVerUpdateMode.NoRestriction
 
-    let result = 
+    let result =
         lockFile.GetGroupedResolution()
         |> Map.toSeq
         |> Seq.map (fun (_,r) -> (string r.Name, string r.Version))
 
-    let expected = 
+    let expected =
         [("APackage","4.0.0");
         ("Newtonsoft.Json","7.0.1")]
         |> Seq.sortBy fst
@@ -1045,13 +1046,13 @@ let ``SelectiveUpdate updates early package that has a new dependent package tha
     |> shouldEqual expected
 
 [<Test>]
-let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specific group in minor version``() = 
+let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specific group in minor version``() =
 
     let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
-    
+
     group Group
         source http://www.nuget.org/api/v2
 
@@ -1061,10 +1062,10 @@ let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specifi
     let lockFile,_ =
         selectiveUpdateFromGraph graph true lockFile6 dependenciesFile
             (PackageResolver.UpdateMode.UpdateFiltered(GroupName "Group", PackageName "Castle.Core-log4net" |> PackageFilter.ofName)) SemVerUpdateMode.KeepMinor
-    
+
     let result = groupMap lockFile
 
-    let expected = 
+    let expected =
         [("Group","Castle.Core-log4net","3.2.0");
         ("Group","Castle.Core","3.2.0");
         ("Group","FAKE","4.0.0");
@@ -1082,28 +1083,28 @@ let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specifi
 [<Test>]
 let ``adding new group to lockfile should not crash``() =
     let update deps lock = selectiveUpdateFromGraph graph true lock deps UpdateMode.Install SemVerUpdateMode.NoRestriction
-    
-    let initialDepsText = 
+
+    let initialDepsText =
         """source http://www.nuget.org/api/v2
         nuget Castle.Core-log4net ~> 3.2"""
     let emptyLock = LockFile.Parse("test", [||])
 
-    let addGroupDepsText = 
+    let addGroupDepsText =
         initialDepsText + """
         group build
             source http://www.nuget.org/api/v2
             nuget FAKE"""
     let deps = DependenciesFile.FromSource(initialDepsText)
-    
+
     let installlock,_ = update deps emptyLock
     installlock.Groups.Count |> shouldEqual 1
 
     let deps' = DependenciesFile.FromSource(addGroupDepsText)
     let updatelock,_ = update deps' installlock
-    
+
     updatelock.Groups.Count |> shouldEqual 2
 
     let group = updatelock.Groups.TryFind (GroupName "build")
     group |> shouldNotEqual None
     group.Value.Resolution.ContainsKey (PackageName "FAKE") |> shouldEqual true
-    
+

--- a/tests/Paket.Tests/InstallModel/UpdateProcessSpecs.fs
+++ b/tests/Paket.Tests/InstallModel/UpdateProcessSpecs.fs
@@ -11,7 +11,7 @@ open FsUnit
 open System
 
 let lockFileData = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.2.0)
     Castle.Core-log4net (3.2.0)
@@ -51,7 +51,7 @@ let selectiveUpdateFromGraph graph force lockFile depsFile updateMode restrictio
 [<Test>]
 let ``SelectiveUpdate does not update any package when it is neither updating all nor selective updating``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
@@ -76,7 +76,7 @@ let ``SelectiveUpdate does not update any package when it is neither updating al
 [<Test>]
 let ``SelectiveUpdate updates all packages not constraining version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
@@ -101,7 +101,7 @@ let ``SelectiveUpdate updates all packages not constraining version``() =
 [<Test>]
 let ``SelectiveUpdate updates all packages constraining version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net < 4.0
     nuget Castle.Core ~> 3.2
@@ -127,7 +127,7 @@ let ``SelectiveUpdate updates all packages constraining version``() =
 [<Test>]
 let ``SelectiveUpdate removes a dependency when it is updated to a version that does not depend on a library``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget FAKE""")
@@ -152,7 +152,7 @@ let ``SelectiveUpdate removes a dependency when it is updated to a version that 
 [<Test>]
 let ``SelectiveUpdate updates a single package``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget FAKE""")
@@ -179,7 +179,7 @@ let ``SelectiveUpdate updates a single package``() =
 [<Test>]
 let ``SelectiveUpdate updates a single constrained package``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE""")
@@ -206,7 +206,7 @@ let ``SelectiveUpdate updates a single constrained package``() =
 [<Test>]
 let ``SelectiveUpdate updates a single package with constrained dependency in dependencies file``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget Castle.Core ~> 3.2
@@ -234,7 +234,7 @@ let ``SelectiveUpdate updates a single package with constrained dependency in de
 [<Test>]
 let ``SelectiveUpdate installs new packages``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget FAKE
@@ -261,7 +261,7 @@ let ``SelectiveUpdate installs new packages``() =
 [<Test>]
 let ``SelectiveUpdate removes a dependency when it updates a single package and it is updated to a version that does not depend on a library``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget FAKE""")
@@ -288,7 +288,7 @@ let ``SelectiveUpdate removes a dependency when it updates a single package and 
 [<Test>]
 let ``SelectiveUpdate does not update when a dependency constrain is not met``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget Castle.Core = 3.2.0
@@ -315,7 +315,7 @@ let ``SelectiveUpdate does not update when a dependency constrain is not met``()
 [<Test>]
 let ``SelectiveUpdate considers package name case difference``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget castle.core = 3.2.0
@@ -343,7 +343,7 @@ let ``SelectiveUpdate considers package name case difference``() =
 [<Test>]
 let ``SelectiveUpdate conflicts when a dependency is contrained``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget Castle.Core = 3.2.0
@@ -359,7 +359,7 @@ let ``SelectiveUpdate conflicts when a dependency is contrained``() =
 [<Test>]
 let ``SelectiveUpdate generates paket.lock correctly``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget Castle.Core
@@ -377,8 +377,8 @@ let ``SelectiveUpdate generates paket.lock correctly``() =
 
 
     let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Core (4.0)
     Castle.Core-log4net (3.2)
       Castle.Core (>= 3.2)
@@ -416,7 +416,8 @@ let graph2 =
     |> OfSimpleGraph
 
 let lockFileData2 = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
   specs:
     log4f (0.4.0)
       log4net (>= 1.2.10 < 2.0.0)
@@ -434,7 +435,7 @@ let lockFile2 = lockFileData2 |> getLockFile
 [<Test>]
 let ``SelectiveUpdate updates package that conflicts with a transitive dependency with correct version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net""")
@@ -465,7 +466,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
 [<Test>]
 let ``SelectiveUpdate updates package that conflicts with a transitive dependency in its own graph with correct version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net""")
@@ -503,7 +504,8 @@ let graph3 =
 
 
 let lockFileData3 = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
   specs:
     log4f (0.4.0)
       log4net (>= 1.2.10 < 2.0.0)
@@ -522,7 +524,7 @@ let lockFile3 = lockFileData3 |> getLockFile
 [<Test>]
 let ``SelectiveUpdate updates package that conflicts with a transitive dependency of another package with correct version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net
@@ -555,7 +557,7 @@ let ``SelectiveUpdate updates package that conflicts with a transitive dependenc
 [<Test>]
 let ``SelectiveUpdate does not conflict with a transitive dependency of another package when paket.dependencies requirement has changed``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Ninject ~> 3.0
     nuget Ninject.Extensions.Logging.Log4net
@@ -587,7 +589,7 @@ let ``SelectiveUpdate does not conflict with a transitive dependency of another 
 [<Test>]
 let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency of another package to correct version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget log4f
     nuget Ninject.Extensions.Logging.Log4net
@@ -625,7 +627,7 @@ let graph4 =
       |> OfSimpleGraph)
 
 let lockFileData4 = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     log4net (1.0.4)
     Ninject (2.2.1.4)
@@ -642,7 +644,7 @@ let lockFile4 = lockFileData4 |> getLockFile
 [<Test>]
 let ``SelectiveUpdate updates package that conflicts with a deep transitive dependency in its own graph with correct version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Ninject.Extensions.Logging.Log4net.Deep""")
 
@@ -679,7 +681,7 @@ let graph5 =
       |> OfSimpleGraph
 
 let lockFileData5 = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Ninject (0.0.2-alpha001)
     Ninject.Extensions.Interception (0.0.2-alpha001)
@@ -692,7 +694,7 @@ let lockFile5 = lockFileData5 |> getLockFile
 [<Test>]
 let ``SelectiveUpdate updates package that conflicts with transitive dependency with correct prerelease version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Ninject.Extensions.Interception
     nuget Ninject.Extensions.Logging""")
@@ -728,13 +730,13 @@ let groupMap (lockFile : LockFile) =
 [<Test>]
 let ``SelectiveUpdate updates all packages from all groups if no group is specified``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
 
     group Group
-        source http://www.nuget.org/api/v2
+        source https://api.nuget.org/v3/index.json
 
         nuget Castle.Core-log4net ~> 4.0""")
 
@@ -757,7 +759,7 @@ let ``SelectiveUpdate updates all packages from all groups if no group is specif
     |> shouldEqual expected
 
 let groupedLockFileData = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.2.0)
     Castle.Core-log4net (3.2.0)
@@ -768,7 +770,7 @@ let groupedLockFileData = """NUGET
 
 GROUP Group
 NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.2.0)
     Castle.Core-log4net (3.2.0)
@@ -779,13 +781,13 @@ let groupedLockFile = groupedLockFileData |> getLockFile
 [<Test>]
 let ``SelectiveUpdate updates only packages from specific group if group is specified``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget FAKE
 
     group Group
-        source http://www.nuget.org/api/v2
+        source https://api.nuget.org/v3/index.json
 
         nuget Castle.Core-log4net""")
 
@@ -811,13 +813,13 @@ let ``SelectiveUpdate updates only packages from specific group if group is spec
 [<Test>]
 let ``SelectiveUpdate updates only packages from specified group``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net
     nuget FAKE
 
     group Group
-        source http://www.nuget.org/api/v2
+        source https://api.nuget.org/v3/index.json
 
         nuget Castle.Core-log4net""")
 
@@ -840,7 +842,7 @@ let ``SelectiveUpdate updates only packages from specified group``() =
     |> shouldEqual expected
 
 let lockFileData6 = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.2.0)
     Castle.Core-log4net (3.2.0)
@@ -851,7 +853,7 @@ let lockFileData6 = """NUGET
 
 GROUP Group
 NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Castle.Core (3.2.0)
     Castle.Core-log4net (3.2.0)
@@ -865,13 +867,13 @@ let lockFile6 = lockFileData6 |> getLockFile
 [<Test>]
 let ``SelectiveUpdate updates package from a specific group``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
 
     group Group
-        source http://www.nuget.org/api/v2
+        source https://api.nuget.org/v3/index.json
 
         nuget Castle.Core-log4net
         nuget FAKE""")
@@ -900,13 +902,13 @@ let ``SelectiveUpdate updates package from a specific group``() =
 [<Test>]
 let ``SelectiveUpdate does not remove a dependency from group when it is a top-level dependency in that group``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.0
     nuget FAKE
 
     group Group
-        source http://www.nuget.org/api/v2
+        source https://api.nuget.org/v3/index.json
 
         nuget Castle.Core-log4net
         nuget FAKE
@@ -936,13 +938,13 @@ let ``SelectiveUpdate does not remove a dependency from group when it is a top-l
 [<Test>]
 let ``SelectiveUpdate updates package from main group``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
 
     group Group
-        source http://www.nuget.org/api/v2
+        source https://api.nuget.org/v3/index.json
 
         nuget Castle.Core-log4net
         nuget FAKE""")
@@ -969,7 +971,7 @@ let ``SelectiveUpdate updates package from main group``() =
     |> shouldEqual expected
 
 let lockFileData7 = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Newtonsoft.Json (6.0.8)
     Package (3.2.0)
@@ -988,7 +990,7 @@ let graph7 =
 [<Test>]
 let ``SelectiveUpdate updates package that has a new dependent package that also is a direct dependency``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Newtonsoft.Json
     nuget Package""")
@@ -1012,7 +1014,7 @@ let ``SelectiveUpdate updates package that has a new dependent package that also
     |> shouldEqual expected
 
 let lockFileData8 = """NUGET
-  remote: http://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
   specs:
     APackage (3.2.0)
     Newtonsoft.Json (6.0.8)
@@ -1022,7 +1024,7 @@ let lockFile8 = lockFileData8 |> getLockFile
 [<Test>]
 let ``SelectiveUpdate updates early package that has a new dependent package that also is a direct dependency``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Newtonsoft.Json
     nuget APackage""")
@@ -1048,13 +1050,13 @@ let ``SelectiveUpdate updates early package that has a new dependent package tha
 [<Test>]
 let ``SelectiveUpdate with SemVerUpdateMode.Minor updates package from a specific group in minor version``() =
 
-    let dependenciesFile = DependenciesFile.FromSource("""source http://www.nuget.org/api/v2
+    let dependenciesFile = DependenciesFile.FromSource("""source https://api.nuget.org/v3/index.json
 
     nuget Castle.Core-log4net ~> 3.2
     nuget FAKE
 
     group Group
-        source http://www.nuget.org/api/v2
+        source https://api.nuget.org/v3/index.json
 
         nuget Castle.Core-log4net
         nuget FAKE""")
@@ -1085,14 +1087,14 @@ let ``adding new group to lockfile should not crash``() =
     let update deps lock = selectiveUpdateFromGraph graph true lock deps UpdateMode.Install SemVerUpdateMode.NoRestriction
 
     let initialDepsText =
-        """source http://www.nuget.org/api/v2
+        """source https://api.nuget.org/v3/index.json
         nuget Castle.Core-log4net ~> 3.2"""
     let emptyLock = LockFile.Parse("test", [||])
 
     let addGroupDepsText =
         initialDepsText + """
         group build
-            source http://www.nuget.org/api/v2
+            source https://api.nuget.org/v3/index.json
             nuget FAKE"""
     let deps = DependenciesFile.FromSource(initialDepsText)
 

--- a/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
@@ -7,7 +7,7 @@ open TestHelpers
 open Paket.Domain
 
 let config1 = """
-source "http://www.nuget.org/api/v2"  username: "user" password: "pass"
+source "https://api.nuget.org/v3/index.json"  username: "user" password: "pass"
 
 nuget "Castle.Windsor-log4net" "~> 3.2"
 """
@@ -18,8 +18,8 @@ let graph =
     ]
 
 let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]

--- a/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateAuthModeSpecs.fs
@@ -19,10 +19,11 @@ let graph =
 
 let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]
-let ``should generate no auth in lock file``() = 
+let ``should generate no auth in lock file``() =
     let cfg = DependenciesFile.FromSource(config1)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options

--- a/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
@@ -28,10 +28,11 @@ SPECIFIC-VERSION: TRUE
 RESTRICTION: >= net45
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]
-let ``should generate strict lock file``() = 
+let ``should generate strict lock file``() =
     let cfg = DependenciesFile.FromSource(config1)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph1, PackageDetailsFromGraph graph1).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -55,10 +56,11 @@ let expected2 = """IMPORT-TARGETS: FALSE
 CONTENT: NONE
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
-let ``should generate content none lock file``() = 
+let ``should generate content none lock file``() =
     let cfg = DependenciesFile.FromSource(configWithContent)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph2, PackageDetailsFromGraph graph2).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -71,7 +73,7 @@ source "http://www.nuget.org/api/v2"
 nuget "Microsoft.SqlServer.Types"
 """
 
-let graph3 = 
+let graph3 =
     OfSimpleGraph [
         "Microsoft.SqlServer.Types","1.0",[]
     ]
@@ -79,17 +81,18 @@ let graph3 =
 let expected3 = """REDIRECTS: ON
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
-let ``should generate redirects lock file``() = 
+let ``should generate redirects lock file``() =
     let cfg = DependenciesFile.FromSource(configWithRedirects)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
     |> shouldEqual (normalizeLineEndings expected3)
 
 [<Test>]
-let ``should generate strategy min lock file``() = 
+let ``should generate strategy min lock file``() =
     let config = """
     strategy min
     source "http://www.nuget.org/api/v2"
@@ -100,6 +103,7 @@ let ``should generate strategy min lock file``() =
     let expected = """STRATEGY: MIN
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -108,7 +112,7 @@ NUGET
     |> shouldEqual (normalizeLineEndings expected)
 
 [<Test>]
-let ``should generate strategy max lock file``() = 
+let ``should generate strategy max lock file``() =
     let config = """
     strategy max
     source "http://www.nuget.org/api/v2"
@@ -119,6 +123,7 @@ let ``should generate strategy max lock file``() =
     let expected = """STRATEGY: MAX
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -127,7 +132,7 @@ NUGET
     |> shouldEqual (normalizeLineEndings expected)
 
 [<Test>]
-let ``should generate lowest_matching true lock file``() = 
+let ``should generate lowest_matching true lock file``() =
     let config = """
     lowest_matching true
     source "http://www.nuget.org/api/v2"
@@ -138,6 +143,7 @@ let ``should generate lowest_matching true lock file``() =
     let expected = """LOWEST_MATCHING: TRUE
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -146,7 +152,7 @@ NUGET
     |> shouldEqual (normalizeLineEndings expected)
 
 [<Test>]
-let ``should generate lowest_matching false lock file``() = 
+let ``should generate lowest_matching false lock file``() =
     let config = """
     lowest_matching false
     source "http://www.nuget.org/api/v2"
@@ -157,6 +163,7 @@ let ``should generate lowest_matching false lock file``() =
     let expected = """LOWEST_MATCHING: FALSE
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -166,7 +173,7 @@ NUGET
 
 
 [<Test>]
-let ``should resolve config with global framework restrictions``() = 
+let ``should resolve config with global framework restrictions``() =
 
     let config = """framework: >= net40
 
@@ -186,19 +193,20 @@ nuget NLog.Contrib
     let expected = """RESTRICTION: >= net40
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     NLog (1.0.1) - restriction: == net40
     NLog.Contrib (1.0)
       NLog (>= 1.0.1)"""
 
     let cfg = DependenciesFile.FromSource(config)
     let group = cfg.Groups.[Constants.MainDependencyGroup]
-    group.Packages.Head.Settings.FrameworkRestrictions 
+    group.Packages.Head.Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4)))
 
     let resolved = ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     getVersion resolved.[PackageName "NLog"] |> shouldEqual "1.0.1"
-    resolved.[PackageName "NLog"].Settings.FrameworkRestrictions 
+    resolved.[PackageName "NLog"].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4)))
 

--- a/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GenerateWithOptionsSpecs.fs
@@ -12,7 +12,7 @@ references strict
 framework: >= net45
 copy_local false
 specific_version true
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Castle.Windsor-log4net" "~> 3.2"
 """
@@ -27,8 +27,8 @@ COPY-LOCAL: FALSE
 SPECIFIC-VERSION: TRUE
 RESTRICTION: >= net45
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor-log4net (3.2)"""
 
 [<Test>]
@@ -42,7 +42,7 @@ let ``should generate strict lock file``() =
 let configWithContent = """
 content none
 import_targets false
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Microsoft.SqlServer.Types"
 """
@@ -55,8 +55,8 @@ let graph2 =
 let expected2 = """IMPORT-TARGETS: FALSE
 CONTENT: NONE
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
@@ -68,7 +68,7 @@ let ``should generate content none lock file``() =
 
 let configWithRedirects = """
 redirects on
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Microsoft.SqlServer.Types"
 """
@@ -80,8 +80,8 @@ let graph3 =
 
 let expected3 = """REDIRECTS: ON
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Microsoft.SqlServer.Types (1.0)"""
 
 [<Test>]
@@ -95,15 +95,15 @@ let ``should generate redirects lock file``() =
 let ``should generate strategy min lock file``() =
     let config = """
     strategy min
-    source "http://www.nuget.org/api/v2"
+    source "https://api.nuget.org/v3/index.json"
 
     nuget "Microsoft.SqlServer.Types"
     """
 
     let expected = """STRATEGY: MIN
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -115,15 +115,15 @@ NUGET
 let ``should generate strategy max lock file``() =
     let config = """
     strategy max
-    source "http://www.nuget.org/api/v2"
+    source "https://api.nuget.org/v3/index.json"
 
     nuget "Microsoft.SqlServer.Types"
     """
 
     let expected = """STRATEGY: MAX
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -135,15 +135,15 @@ NUGET
 let ``should generate lowest_matching true lock file``() =
     let config = """
     lowest_matching true
-    source "http://www.nuget.org/api/v2"
+    source "https://api.nuget.org/v3/index.json"
 
     nuget "Microsoft.SqlServer.Types"
     """
 
     let expected = """LOWEST_MATCHING: TRUE
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -155,15 +155,15 @@ NUGET
 let ``should generate lowest_matching false lock file``() =
     let config = """
     lowest_matching false
-    source "http://www.nuget.org/api/v2"
+    source "https://api.nuget.org/v3/index.json"
 
     nuget "Microsoft.SqlServer.Types"
     """
 
     let expected = """LOWEST_MATCHING: FALSE
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Microsoft.SqlServer.Types (1.0)"""
 
     let cfg = DependenciesFile.FromSource(config)
@@ -193,7 +193,7 @@ nuget NLog.Contrib
     let expected = """RESTRICTION: >= net40
 NUGET
   remote: https://www.nuget.org/api/v2
-  protocolVersion: 2
+  protocolVersion: 3
     NLog (1.0.1) - restriction: == net40
     NLog.Contrib (1.0)
       NLog (>= 1.0.1)"""

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -13,7 +13,7 @@ source "http://www.nuget.org/api/v2"
 nuget "Castle.Windsor-log4net" "~> 3.2"
 nuget "Rx-Main" "~> 2.0" """
 
-let graph = 
+let graph =
   OfSimpleGraph [
     "Castle.Windsor-log4net","3.2",[]
     "Castle.Windsor-log4net","3.3",["Castle.Windsor",VersionRequirement(VersionRange.AtLeast "2.0",PreReleaseStatus.No);"log4net",VersionRequirement(VersionRange.AtLeast "1.0",PreReleaseStatus.No)]
@@ -30,9 +30,10 @@ let graph =
   ]
 
 [<Test>]
-let ``should generate lock file for packages``() = 
+let ``should generate lock file for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)
@@ -56,9 +57,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 framework: net35
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with framework restrictions for packages``() = 
+let ``should generate lock file with framework restrictions for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - restriction: == net35
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -83,9 +85,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 import_targets: false, framework: net35
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with no targets import for packages``() = 
+let ``should generate lock file with no targets import for packages``() =
     let expected = """NUGET
   remote: "D:\code\temp with space"
+  protocolVersion: 2
     Castle.Windsor (2.1) - import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -109,9 +112,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 copy_local: false, import_targets: false, 
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with no copy local for packages``() = 
+let ``should generate lock file with no copy local for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - copy_local: false, import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - copy_local: false, import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -134,9 +138,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 specific_version: false, import_targets: f
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with no specific version for packages``() = 
+let ``should generate lock file with no specific version for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - specific_version: false, import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - specific_version: false, import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -159,9 +164,10 @@ nuget "Castle.Windsor-log4net" ~> 3.2 framework: net35
 nuget "Rx-Main" "~> 2.0" content: none, framework: >= net40 """
 
 [<Test>]
-let ``should generate lock file with disabled content for packages``() = 
+let ``should generate lock file with disabled content for packages``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - restriction: == net35
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -221,11 +227,11 @@ github \"owner:project2:commit3\" \"folder/file3.fs\" githubAuth
 github \"owner:project3:master\""
 
     let cfg = DependenciesFile.FromSource(config)
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
-    |> List.map (fun f -> 
+    |> List.map (fun f ->
         match f.Version with
-        | VersionRestriction.Concrete commit -> 
+        | VersionRestriction.Concrete commit ->
             { Commit = commit
               Owner = f.Owner
               Origin = ModuleResolver.Origin.GitHubLink
@@ -254,10 +260,11 @@ let graph2 =
 
 let expected2 = """NUGET
   remote: https://www.myget.org/F/ravendb3
+  protocolVersion: 2
     RavenDB.Client (3.0.3498-Unstable)"""
 
 [<Test>]
-let ``should generate lock file for RavenDB.Client``() = 
+let ``should generate lock file for RavenDB.Client``() =
     let cfg = DependenciesFile.FromSource(config2)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph2, PackageDetailsFromGraph graph2).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -278,6 +285,7 @@ let graph3 =
 
 let expected3 = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     GreaterThan.Package (2.1)
       Maximum.Package (<= 3.0)
     LessThan.Package (1.9)
@@ -287,7 +295,7 @@ let expected3 = """NUGET
       LessThan.Package (< 2.0)"""
 
 [<Test>]
-let ``should generate other version ranges for packages``() = 
+let ``should generate other version ranges for packages``() =
     let cfg = DependenciesFile.FromSource(config3)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph3, PackageDetailsFromGraph graph3).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options
@@ -311,13 +319,13 @@ let trivialResolve (f:ModuleResolver.UnresolvedSource) =
 let expectedWithHttp = """HTTP
   remote: http://www.fssnip.net
     test.fs (/raw/1M)"""
-    
+
 [<Test>]
-let ``should generate lock file for http source files``() = 
-    let config = """http "http://www.fssnip.net/raw/1M" "test.fs" """ 
+let ``should generate lock file for http source files``() =
+    let config = """http "http://www.fssnip.net/raw/1M" "test.fs" """
 
     let cfg = DependenciesFile.FromSource(config)
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
     |> List.map trivialResolve
     |> LockFileSerializer.serializeSourceFiles
@@ -334,23 +342,23 @@ GIST
     gistfile1.fs
   remote: Thorium/6088882
     FULLPROJECT"""
-    
+
 [<Test>]
-let ``should generate lock file for http and gist source files``() = 
+let ``should generate lock file for http and gist source files``() =
     let config = """source "http://www.nuget.org/api/v2
 
 http http://www.fssnip.net/raw/32 myFile2.fs
 http http://www.fssnip.net/raw/34 myFile5.fs httpAuth
 
 gist Thorium/1972308 gistfile1.fs
-gist Thorium/6088882 
+gist Thorium/6088882
 
 http http://www.fssnip.net/raw/1M myFile.fs
-http http://www.fssnip.net/raw/15 myFile3.fs """ 
+http http://www.fssnip.net/raw/15 myFile3.fs """
 
     let cfg = DependenciesFile.FromSource(config)
-    
-    let actual = 
+
+    let actual =
         cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
         |> List.map trivialResolve
         |> LockFileSerializer.serializeSourceFiles
@@ -381,12 +389,12 @@ http http://nlp.stanford.edu/software/stanford-segmenter-2014-10-26.zip"""
     let references =
         cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles
         |> List.map trivialResolve
-    
+
     references.Length |> shouldEqual 6
 
     references.[5].Origin |> shouldEqual (Origin.HttpLink("http://nlp.stanford.edu"))
     references.[5].Commit |> shouldEqual ("/software/stanford-segmenter-2014-10-26.zip")  // That's strange
-    references.[5].Name |> shouldEqual "stanford-segmenter-2014-10-26.zip"  
+    references.[5].Name |> shouldEqual "stanford-segmenter-2014-10-26.zip"
 
     references
     |> LockFileSerializer.serializeSourceFiles
@@ -395,16 +403,17 @@ http http://nlp.stanford.edu/software/stanford-segmenter-2014-10-26.zip"""
 [<Test>]
 let ``should parse and regenerate http Stanford.NLP.NET project``() =
     let lockFile = LockFileParser.Parse(toLines expectedForStanfordNLPdotNET) |> List.head
-    
+
     lockFile.SourceFiles
     |> List.rev
     |> LockFileSerializer.serializeSourceFiles
     |> shouldEqual (normalizeLineEndings expectedForStanfordNLPdotNET)
 
 [<Test>]
-let ``should generate lock file with second group``() = 
+let ``should generate lock file with second group``() =
     let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1) - copy_content_to_output_dir: preserve_newest
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -422,6 +431,7 @@ COPY-CONTENT-TO-OUTPUT-DIR: ALWAYS
 CONDITION: LEGACY
 NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     FAKE (4.0)
 """
     let lockFile = LockFile.Parse("Test",toLines expected)

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -88,7 +88,6 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 let ``should generate lock file with no targets import for packages``() =
     let expected = """NUGET
   remote: "D:\code\temp with space"
-  protocolVersion: 2
     Castle.Windsor (2.1) - import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -270,7 +270,7 @@ let ``should generate lock file for RavenDB.Client``() =
     |> shouldEqual (normalizeLineEndings expected2)
 
 let config3 = """
-source "https://api.nuget.org/v3/index.json protocolVersion: 3"
+source "https://api.nuget.org/v3/index.json" protocolVersion: 3
 
 nuget "OtherVersionRanges.Package" "~> 1.0" """
 

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -8,7 +8,7 @@ open Paket.ModuleResolver
 open Paket.Domain
 
 let config1 = """
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Castle.Windsor-log4net" "~> 3.2"
 nuget "Rx-Main" "~> 2.0" """
@@ -32,8 +32,8 @@ let graph =
 [<Test>]
 let ``should generate lock file for packages``() =
     let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)
@@ -51,7 +51,7 @@ let ``should generate lock file for packages``() =
     |> shouldEqual (normalizeLineEndings expected)
 
 let configWithRestrictions = """
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Castle.Windsor-log4net" ~> 3.2 framework: net35
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
@@ -59,8 +59,8 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 [<Test>]
 let ``should generate lock file with framework restrictions for packages``() =
     let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor (2.1) - restriction: == net35
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -105,7 +105,7 @@ let ``should generate lock file with no targets import for packages``() =
     |> shouldEqual (normalizeLineEndings expected)
 
 let configWithCopyLocal = """
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Castle.Windsor-log4net" ~> 3.2 copy_local: false, import_targets: false, framework: net35
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
@@ -113,8 +113,8 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 [<Test>]
 let ``should generate lock file with no copy local for packages``() =
     let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor (2.1) - copy_local: false, import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - copy_local: false, import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -131,7 +131,7 @@ let ``should generate lock file with no copy local for packages``() =
     |> shouldEqual (normalizeLineEndings expected)
 
 let configWithSpecificVersion = """
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Castle.Windsor-log4net" ~> 3.2 specific_version: false, import_targets: false, framework: net35
 nuget "Rx-Main" "~> 2.0" framework: >= net40 """
@@ -139,8 +139,8 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 [<Test>]
 let ``should generate lock file with no specific version for packages``() =
     let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor (2.1) - specific_version: false, import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - specific_version: false, import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -157,7 +157,7 @@ let ``should generate lock file with no specific version for packages``() =
     |> shouldEqual (normalizeLineEndings expected)
 
 let configWithDisabledContent = """
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json"
 
 nuget "Castle.Windsor-log4net" ~> 3.2 framework: net35
 nuget "Rx-Main" "~> 2.0" content: none, framework: >= net40 """
@@ -165,8 +165,8 @@ nuget "Rx-Main" "~> 2.0" content: none, framework: >= net40 """
 [<Test>]
 let ``should generate lock file with disabled content for packages``() =
     let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor (2.1) - restriction: == net35
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -247,7 +247,7 @@ github \"owner:project3:master\""
 
 
 let config2 = """
-source https://www.myget.org/F/ravendb3/
+source https://www.myget.org/F/ravendb3/ protocolVersion: 2
 
 nuget RavenDB.Client == 3.0.3498-Unstable
  """
@@ -270,7 +270,7 @@ let ``should generate lock file for RavenDB.Client``() =
     |> shouldEqual (normalizeLineEndings expected2)
 
 let config3 = """
-source "http://www.nuget.org/api/v2"
+source "https://api.nuget.org/v3/index.json protocolVersion: 3"
 
 nuget "OtherVersionRanges.Package" "~> 1.0" """
 
@@ -283,8 +283,8 @@ let graph3 =
   ]
 
 let expected3 = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     GreaterThan.Package (2.1)
       Maximum.Package (<= 3.0)
     LessThan.Package (1.9)
@@ -344,7 +344,7 @@ GIST
 
 [<Test>]
 let ``should generate lock file for http and gist source files``() =
-    let config = """source "http://www.nuget.org/api/v2
+    let config = """source "https://api.nuget.org/v3/index.json
 
 http http://www.fssnip.net/raw/32 myFile2.fs
 http http://www.fssnip.net/raw/34 myFile5.fs httpAuth
@@ -411,8 +411,8 @@ let ``should parse and regenerate http Stanford.NLP.NET project``() =
 [<Test>]
 let ``should generate lock file with second group``() =
     let expected = """NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     Castle.Windsor (2.1) - copy_content_to_output_dir: preserve_newest
     Castle.Windsor-log4net (3.3) - restriction: == net35
       Castle.Windsor (>= 2.0)
@@ -429,8 +429,8 @@ COPY-LOCAL: TRUE
 COPY-CONTENT-TO-OUTPUT-DIR: ALWAYS
 CONDITION: LEGACY
 NUGET
-  remote: http://www.nuget.org/api/v2
-  protocolVersion: 2
+  remote: https://api.nuget.org/v3/index.json
+  protocolVersion: 3
     FAKE (4.0)
 """
     let lockFile = LockFile.Parse("Test",toLines expected)

--- a/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
@@ -7,7 +7,7 @@ open TestHelpers
 open Paket.Domain
 
 let config1 = """
-source "http://www.nuget.org/api/v2"
+source "http://www.nuget.org/api/v2 protocolVersion: 2"
 source "http://nuget.org/api/v3"
 
 nuget "Castle.Windsor-log4net" "~> 3.2"

--- a/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
@@ -31,6 +31,7 @@ let graph =
 
 let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)
@@ -43,7 +44,7 @@ let expected = """NUGET
       Rx-Core (>= 2.1)"""
 
 [<Test>]
-let ``should generate lock file``() = 
+let ``should generate lock file``() =
     let cfg = DependenciesFile.FromSource(config1)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options

--- a/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
@@ -7,7 +7,7 @@ open TestHelpers
 open Paket.Domain
 
 let config1 = """
-source "http://www.nuget.org/api/v2 protocolVersion: 2"
+source "http://www.nuget.org/api/v2" protocolVersion: 2
 source "http://nuget.org/api/v3"
 
 nuget "Castle.Windsor-log4net" "~> 3.2"

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -12,6 +12,7 @@ open Paket.PackageSources
 let lockFile = """COPY-LOCAL: FALSE
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
@@ -31,7 +32,7 @@ GITHUB
 """
 
 [<Test>]
-let ``should parse lock file``() = 
+let ``should parse lock file``() =
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 6
@@ -48,7 +49,7 @@ let ``should parse lock file``() =
     packages.[1].Name |> shouldEqual (PackageName "Castle.Windsor-log4net")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.3")
     packages.[1].Dependencies |> shouldEqual (Set.ofList [PackageName "Castle.Windsor", VersionRequirement(Minimum(SemVer.Parse "2.0"), PreReleaseStatus.No), makeOrList []; PackageName "log4net", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), makeOrList []])
-    
+
     packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
@@ -76,7 +77,7 @@ let ``should parse lock file``() =
             PackagePath = None
             Commit = "Globbing"
             AuthKey = None } ]
-    
+
     sourceFiles.[0].Commit |> shouldEqual "7699e40e335f3cc54ab382a8969253fecc1e08a9"
     sourceFiles.[0].Name |> shouldEqual "src/app/FAKE/Cli.fs"
     sourceFiles.[0].ToString() |> shouldEqual "fsharp/FAKE:7699e40e335f3cc54ab382a8969253fecc1e08a9 src/app/FAKE/Cli.fs"
@@ -85,6 +86,7 @@ let strictLockFile = """REFERENCES: STRICT
 IMPORT-TARGETS: FALSE
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
@@ -99,7 +101,7 @@ NUGET
 """
 
 [<Test>]
-let ``should parse strict lock file``() = 
+let ``should parse strict lock file``() =
     let lockFile = LockFileParser.Parse(toLines strictLockFile) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 6
@@ -136,7 +138,7 @@ NUGET
 """
 
 [<Test>]
-let ``should parse redirects lock file``() = 
+let ``should parse redirects lock file``() =
     let lockFile = LockFileParser.Parse(toLines redirectsLockFile)
 
     let main = lockFile.Tail.Tail.Head
@@ -164,12 +166,13 @@ let lockFileWithFrameworkRestrictions = """FRAMEWORK: >= NET45
 IMPORT-TARGETS: TRUE
 NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Castle.Windsor (2.1)
 """
 
 [<Test>]
-let ``should parse lock file with framework restrictions``() = 
+let ``should parse lock file with framework restrictions``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithFrameworkRestrictions) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 1
@@ -180,6 +183,7 @@ let ``should parse lock file with framework restrictions``() =
 
 let dogfood = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     DotNetZip (1.9.3)
     FAKE (3.5.5)
@@ -215,7 +219,7 @@ GITHUB
       Octokit (>= 0)"""
 
 [<Test>]
-let ``should parse own lock file``() = 
+let ``should parse own lock file``() =
     let lockFile = LockFileParser.Parse(toLines dogfood) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 16
@@ -230,6 +234,7 @@ let ``should parse own lock file``() =
 
 let dogfood2 = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     DotNetZip (1.9.3)
     FAKE (3.5.5)
@@ -265,7 +270,7 @@ GITHUB
       Octokit"""
 
 [<Test>]
-let ``should parse own lock file2``() = 
+let ``should parse own lock file2``() =
     let lockFile = LockFileParser.Parse(toLines dogfood2) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 16
@@ -281,6 +286,7 @@ let ``should parse own lock file2``() =
 
 let frameworkRestricted = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Fleece (0.4.0)
       FSharpPlus (>= 0.0.4)
@@ -299,7 +305,7 @@ let frameworkRestricted = """NUGET
 """
 
 [<Test>]
-let ``should parse framework restricted lock file``() = 
+let ``should parse framework restricted lock file``() =
     let lockFile = LockFileParser.Parse(toLines frameworkRestricted) |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 7
@@ -312,7 +318,7 @@ let ``should parse framework restricted lock file``() =
     packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
-    packages.[3].Settings.FrameworkRestrictions 
+    packages.[3].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5)))
     packages.[3].Settings.ImportTargets |> shouldEqual None
@@ -340,6 +346,7 @@ let ``should parse framework restricted lock file``() =
 
 let frameworkRestricted' = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Fleece (0.4.0) - license_download: true
       FSharpPlus (>= 0.0.4)
@@ -358,7 +365,7 @@ let frameworkRestricted' = """NUGET
 """
 
 [<Test>]
-let ``should parse framework restricted lock file in new syntax``() = 
+let ``should parse framework restricted lock file in new syntax``() =
     let lockFile = LockFileParser.Parse(toLines frameworkRestricted') |> List.head
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 7
@@ -375,7 +382,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
     packages.[3].Settings.CopyContentToOutputDirectory |> shouldEqual (Some CopyToOutputDirectorySettings.Never)
     packages.[3].Settings.FrameworkRestrictions
-    |> getExplicitRestriction 
+    |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.Between(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2),FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5)))
     packages.[3].Settings.CopyLocal |> shouldEqual None
     packages.[3].Settings.SpecificVersion |> shouldEqual None
@@ -404,7 +411,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[5].Settings.SpecificVersion |> shouldEqual (Some true)
     packages.[5].Settings.OmitContent |> shouldEqual None
     packages.[5].Settings.IncludeVersionInPath |> shouldEqual None
-    packages.[5].Settings.FrameworkRestrictions 
+    packages.[5].Settings.FrameworkRestrictions
     |> getExplicitRestriction
     |> shouldEqual ([FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V2))
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
@@ -418,7 +425,7 @@ HTTP
 """
 
 [<Test>]
-let ``should parse simple http reference``() = 
+let ``should parse simple http reference``() =
     let lockFile = LockFileParser.Parse(toLines simpleHTTP) |> List.head
     let references = lockFile.SourceFiles
 
@@ -467,7 +474,7 @@ let ``should parse portable lockfile``() =
 
     let packages = List.rev lockFile.Packages
     packages.Length |> shouldEqual 2
-    
+
     packages.[1].Name |> shouldEqual (PackageName "Zlib.Portable")
     packages.[1].Version |> shouldEqual (SemVer.Parse "1.10.0")
     (packages.[1].Settings.FrameworkRestrictions |> getExplicitRestriction).ToString() |> shouldEqual ">= portable-net40+sl5+win8+wp8"
@@ -514,7 +521,7 @@ let ``should parse reactiveui lockfile``() =
     references.Length |> shouldEqual 0
 
     let packages = List.rev lockFile.Packages
-    
+
     packages.[8].Name |> shouldEqual (PackageName "Rx-WindowStoreApps")
     packages.[8].Version |> shouldEqual (SemVer.Parse "2.2.5")
     (packages.[8].Settings.FrameworkRestrictions |> getExplicitRestriction).ToString() |> shouldEqual "== win8"
@@ -525,11 +532,13 @@ let ``should parse reactiveui lockfile``() =
 
 let multipleFeedLockFileLegacy = """NUGET
   remote: http://internalfeed/NugetWebFeed/nuget
+  protocolVersion: 2
     Internal_1 (1.2.10)
       Newtonsoft.Json (>= 6.0 < 6.1)
     log4net (1.2.10)
     Newtonsoft.Json (6.0.6)
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.AspNet.WebApi (5.2.3)
       Microsoft.AspNet.WebApi.WebHost (>= 5.2.3 < 5.3)
     Microsoft.AspNet.WebApi.Client (5.2.3)
@@ -543,11 +552,13 @@ let multipleFeedLockFileLegacy = """NUGET
 
 let multipleFeedLockFile = """NUGET
   remote: http://internalfeed/NugetWebFeed/nuget
+  protocolVersion: 2
     Internal_1 (1.2.10)
       Newtonsoft.Json (>= 6.0 < 6.1)
     log4net (1.2.10)
     Newtonsoft.Json (6.0.6)
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.AspNet.WebApi (5.2.3)
       Microsoft.AspNet.WebApi.WebHost (>= 5.2.3 < 5.3)
     Microsoft.AspNet.WebApi.Client (5.2.3)
@@ -569,7 +580,7 @@ let ``should parse lockfile with multiple feeds``() =
 
         let packages = List.rev lockFile.Packages
         packages.Length |> shouldEqual 7
-    
+
         packages.[3].Name |> shouldEqual (PackageName "Microsoft.AspNet.WebApi")
         packages.[3].Version |> shouldEqual (SemVer.Parse "5.2.3")
         packages.[3].Source.ToString() |> shouldEqual "https://www.nuget.org/api/v2"
@@ -580,7 +591,7 @@ let ``should parse and serialise multiple feed lockfile``() =
         let lockFile = LockFile.Parse("",toLines lockFileText)
         let lockFile' = lockFile.ToString()
 
-        normalizeLineEndings lockFile' 
+        normalizeLineEndings lockFile'
         |> shouldEqual (normalizeLineEndings multipleFeedLockFile)
 
 
@@ -602,11 +613,11 @@ NUGET
 """
 
 [<Test>]
-let ``should parse lock file with groups``() = 
+let ``should parse lock file with groups``() =
     let lockFile1 = LockFileParser.Parse(toLines groupsLockFile) |> List.skip 1 |> List.head
     lockFile1.GroupName |> shouldEqual Constants.MainDependencyGroup
     let packages1 = List.rev lockFile1.Packages
-    
+
     packages1.Length |> shouldEqual 1
     lockFile1.Options.Strict |> shouldEqual false
     lockFile1.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
@@ -621,7 +632,7 @@ let ``should parse lock file with groups``() =
     let lockFile2 = LockFileParser.Parse(toLines groupsLockFile) |> List.head
     lockFile2.GroupName.ToString() |> shouldEqual "Build"
     let packages2 = List.rev lockFile2.Packages
-    
+
     packages2.Length |> shouldEqual 1
     lockFile2.Options.Strict |> shouldEqual false
     lockFile2.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
@@ -640,11 +651,11 @@ let ``should parse and serialise groups lockfile``() =
     let lockFile = LockFile.Parse("",toLines groupsLockFile)
     let lockFile' = lockFile.ToString()
 
-    normalizeLineEndings lockFile' 
+    normalizeLineEndings lockFile'
     |> shouldEqual (normalizeLineEndings groupsLockFile)
 
 [<Test>]
-let ``should parse strategy min lock file``() = 
+let ``should parse strategy min lock file``() =
     let lockFile = """STRATEGY: MIN
 NUGET
   remote: "D:\code\temp with space"
@@ -652,12 +663,12 @@ NUGET
 """
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
-    
+
     packages.Length |> shouldEqual 1
     lockFile.Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
-    
+
 [<Test>]
-let ``should parse strategy max lock file``() = 
+let ``should parse strategy max lock file``() =
     let lockFile = """STRATEGY: MAX
 NUGET
   remote: "D:\code\temp with space"
@@ -666,12 +677,12 @@ NUGET
 """
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
-    
+
     packages.Length |> shouldEqual 1
     lockFile.Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Max)
 
 [<Test>]
-let ``should parse no strategy lock file``() = 
+let ``should parse no strategy lock file``() =
     let lockFile = """NUGET
   remote: "D:\code\temp with space"
   specs:
@@ -679,10 +690,10 @@ let ``should parse no strategy lock file``() =
 """
     let lockFile = LockFileParser.Parse(toLines lockFile) |> List.head
     let packages = List.rev lockFile.Packages
-    
+
     packages.Length |> shouldEqual 1
     lockFile.Options.ResolverStrategyForTransitives |> shouldEqual None
-    
+
 let packageRedirectsLockFile = """REDIRECTS: ON
 NUGET
   remote: "D:\code\temp with space"
@@ -704,11 +715,11 @@ NUGET
 """
 
 [<Test>]
-let ``should parse redirects lock file and packages``() = 
+let ``should parse redirects lock file and packages``() =
     let lockFile = LockFileParser.Parse(toLines packageRedirectsLockFile)
     let main = lockFile.Tail.Tail.Head
     let packages = List.rev main.Packages
-    
+
     packages.Length |> shouldEqual 4
     main.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
 
@@ -716,10 +727,10 @@ let ``should parse redirects lock file and packages``() =
     packages.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some BindingRedirectsSettings.On)
     packages.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some BindingRedirectsSettings.Off)
     packages.Tail.Tail.Tail.Head.Settings.CreateBindingRedirects |> shouldEqual (Some BindingRedirectsSettings.Force)
-    
+
     let build = lockFile.Tail.Head
     let packages = List.rev build.Packages
-    
+
     packages.Length |> shouldEqual 1
     build.Options.Redirects |> shouldEqual None
 
@@ -727,7 +738,7 @@ let ``should parse redirects lock file and packages``() =
 
     let test = lockFile.Head
     let packages = List.rev test.Packages
-    
+
     packages.Length |> shouldEqual 1
     test.Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.Off)
 
@@ -738,7 +749,7 @@ let ``should parse and serialize redirects lockfile``() =
     let lockFile = LockFile.Parse("",toLines packageRedirectsLockFile)
     let lockFile' = lockFile.ToString()
 
-    normalizeLineEndings lockFile' 
+    normalizeLineEndings lockFile'
     |> shouldEqual (normalizeLineEndings packageRedirectsLockFile)
 
 let autodetectLockFile = """REDIRECTS: ON
@@ -769,11 +780,11 @@ NUGET
 """
 
 [<Test>]
-let ``should parse lock file from auto-detect settings``() = 
+let ``should parse lock file from auto-detect settings``() =
     let lockFile = LockFileParser.Parse(toLines autodetectLockFile)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     packages.Length |> shouldEqual 8
 
     packages.Head.Name |> shouldEqual (PackageName "Autofac")
@@ -790,18 +801,19 @@ let lockFileWithManyFrameworksLegacy = """NUGET
 
 let lockFileWithManyFrameworks = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     CommonServiceLocator (1.3) - restriction: || (== sl5) (>= net40) (>= portable-net45+win8+wp8+wpa81)
     MvvmLightLibs (5.2)
       CommonServiceLocator (>= 1.0) - restriction: || (== net35) (== sl4)
       CommonServiceLocator (>= 1.3) - restriction: || (== sl5) (>= net40) (>= portable-net45+win8+wp8+wpa81)"""
 
 [<Test>]
-let ``should parse lock file many frameworks``() = 
+let ``should parse lock file many frameworks``() =
     for lockFile in [lockFileWithManyFrameworksLegacy;lockFileWithManyFrameworks] do
         let lockFile = LockFileParser.Parse(toLines lockFile)
         let main = lockFile.Head
         let packages = List.rev main.Packages
-    
+
         packages.Length |> shouldEqual 2
 
         packages.Head.Name |> shouldEqual (PackageName "CommonServiceLocator")
@@ -812,6 +824,7 @@ let ``should parse lock file many frameworks``() =
 
 let lockFileWithDependencies = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Argu (2.1)
     Chessie (0.4)
       FSharp.Core
@@ -819,17 +832,18 @@ let lockFileWithDependencies = """NUGET
     Newtonsoft.Json (8.0.3) - redirects: force"""
 
 [<Test>]
-let ``should parse lock file with depdencies``() = 
+let ``should parse lock file with dependencies``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithDependencies)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithDependencies)
 
 let lockFileWithGreaterZeroDependency = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
   specs:
     Argu (2.1)
     Chessie (0.4)
@@ -838,11 +852,11 @@ let lockFileWithGreaterZeroDependency = """NUGET
     Newtonsoft.Json (8.0.3) - redirects: force"""
 
 [<Test>]
-let ``should parse lock file with greater zero dependency``() = 
+let ``should parse lock file with greater zero dependency``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithGreaterZeroDependency)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithDependencies)
@@ -855,7 +869,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse full git lock file``() = 
+let ``should parse full git lock file``() =
     let lockFile = LockFileParser.Parse(toLines fullGitLockFile)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "git@github.com:fsprojects/Paket.git")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "528024723f314aa1011499a122258167b53699f7"
@@ -869,7 +883,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse local git lock file``() = 
+let ``should parse local git lock file``() =
     let lockFile = LockFileParser.Parse(toLines localGitLockFile)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "file:///c:/code/Paket.VisualStudio")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "528024723f314aa1011499a122258167b53699f7"
@@ -890,7 +904,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse local git lock file with build``() = 
+let ``should parse local git lock file with build``() =
     let lockFile = LockFileParser.Parse(toLines localGitLockFileWithBuild)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "https://github.com/forki/nupkgtest.git")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
@@ -910,7 +924,7 @@ GIT
 """
 
 [<Test>]
-let ``should parse local git lock file with build and no specs``() = 
+let ``should parse local git lock file with build and no specs``() =
     let lockFile = LockFileParser.Parse(toLines localGitLockFileWithBuildAndNoSpecs)
     lockFile.Head.RemoteUrl |> shouldEqual (Some "https://github.com/forki/nupkgtest.git")
     lockFile.Head.SourceFiles.Head.Commit |> shouldEqual "2942d23fcb13a2574b635194203aed7610b21903"
@@ -953,6 +967,7 @@ let ``should parse lock file with spaces in file names``() =
 
 let lockFileWithNewRestrictions = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     MathNet.Numerics (3.2.3)
       TaskParallelLibrary (>= 1.0.2856) - restriction: && (>= net35) (< net40)
     MathNet.Numerics.FSharp (3.2.3)
@@ -964,13 +979,14 @@ let ``should parse new restrictions && (>= net35) (< net40)``() =
     let lockFile = LockFileParser.Parse (toLines lockFileWithNewRestrictions)
     let main = lockFile.Head
     let packages = lockFile.Tail
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithNewRestrictions)
 
 let lockFileWithNewComplexRestrictions = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     AWSSDK.Core (3.1.5.3)
       Microsoft.Net.Http (>= 2.2.29) - restriction: && (< net45) (>= portable-net45+win8+wp8+wpa81)
       PCLStorage (>= 1.0.2) - restriction: && (< net45) (>= portable-net45+win8+wp8+wpa81)
@@ -991,13 +1007,14 @@ let ``should parse new restrictions || (&& (< net45) (>= portable-net45+win8+wp8
     let lockFile = LockFileParser.Parse (toLines lockFileWithNewComplexRestrictions)
     let main = lockFile.Head
     let packages = lockFile.Tail
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithNewComplexRestrictions)
 
 let lockFileWithMissingVersion = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Microsoft.Bcl (1.1.10) - restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21) - import_targets: false, restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
@@ -1012,13 +1029,14 @@ let ``should parse lockfile with missing version``() =
     let lockFile = LockFileParser.Parse (toLines lockFileWithMissingVersion)
     let main = lockFile.Head
     let packages = lockFile.Tail
-    
+
     LockFileSerializer.serializePackages main.Options (main.Packages |> List.map (fun p -> p.Name,p) |> Map.ofList)
     |> normalizeLineEndings
     |> shouldEqual (normalizeLineEndings lockFileWithMissingVersion)
 
 let lockFileWithCLiTool = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     Argu (2.1)
     Chessie (0.4)
       FSharp.Core
@@ -1027,11 +1045,11 @@ let lockFileWithCLiTool = """NUGET
     Newtonsoft.Json (8.0.3) - redirects: force"""
 
 [<Test>]
-let ``should parse lock file with cli tool``() = 
+let ``should parse lock file with cli tool``() =
     let lockFile = LockFileParser.Parse(toLines lockFileWithCLiTool)
     let main = lockFile.Head
     let packages = List.rev main.Packages
-    
+
     packages
     |> List.find (fun p -> p.Name = PackageName "dotnet-fable")
     |> fun p -> p.Kind |> shouldEqual Paket.PackageResolver.ResolvedPackageKind.DotnetCliTool

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -40,17 +40,17 @@ let ``should parse lock file``() =
     lockFile.Options.Settings.CopyLocal |> shouldEqual (Some false)
     lockFile.Options.Settings.ImportTargets |> shouldEqual None
 
-    packages.[0].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[0].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[0].Name |> shouldEqual (PackageName "Castle.Windsor")
     packages.[0].Version |> shouldEqual (SemVer.Parse "2.1")
     packages.[0].Dependencies |> shouldEqual Set.empty
 
-    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[1].Name |> shouldEqual (PackageName "Castle.Windsor-log4net")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.3")
     packages.[1].Dependencies |> shouldEqual (Set.ofList [PackageName "Castle.Windsor", VersionRequirement(Minimum(SemVer.Parse "2.0"), PreReleaseStatus.No), makeOrList []; PackageName "log4net", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), makeOrList []])
 
-    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
     packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), makeOrList []])
@@ -110,7 +110,7 @@ let ``should parse strict lock file``() =
     lockFile.Options.Settings.ImportTargets |> shouldEqual (Some false)
     lockFile.Options.Settings.CopyLocal |> shouldEqual None
 
-    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[5].Name |> shouldEqual (PackageName "log4net")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.1")
     packages.[5].Dependencies |> shouldEqual (Set.ofList [PackageName "log", VersionRequirement(Minimum(SemVer.Parse "1.0"), PreReleaseStatus.No), makeOrList []])
@@ -225,7 +225,7 @@ let ``should parse own lock file``() =
     packages.Length |> shouldEqual 16
     lockFile.Options.Strict |> shouldEqual false
 
-    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[1].Name |> shouldEqual (PackageName "FAKE")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.5.5")
     packages.[1].Settings.FrameworkRestrictions |> shouldEqual (makeOrList [])
@@ -276,7 +276,7 @@ let ``should parse own lock file2``() =
     packages.Length |> shouldEqual 16
     lockFile.Options.Strict |> shouldEqual false
 
-    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[1].Name |> shouldEqual (PackageName "FAKE")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.5.5")
     packages.[3].Settings.FrameworkRestrictions |> shouldEqual (makeOrList [])
@@ -315,7 +315,7 @@ let ``should parse framework restricted lock file``() =
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4)))
 
-    packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
     packages.[3].Settings.FrameworkRestrictions
@@ -335,7 +335,7 @@ let ``should parse framework restricted lock file``() =
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
                      FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4))] |> makeOrList |> getExplicitRestriction)
 
-    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[5].Name |> shouldEqual (PackageName "ReadOnlyCollectionInterfaces")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.0.0")
     packages.[5].Settings.FrameworkRestrictions
@@ -377,7 +377,7 @@ let ``should parse framework restricted lock file in new syntax``() =
 
     packages.[0].Settings.LicenseDownload |> shouldEqual (Some true)
 
-    packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
     packages.[3].Settings.CopyContentToOutputDirectory |> shouldEqual (Some CopyToOutputDirectorySettings.Never)
@@ -403,7 +403,7 @@ let ``should parse framework restricted lock file in new syntax``() =
                      FrameworkRestriction.Exactly(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V3_5))
                      FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V4))] |> makeOrList |> getExplicitRestriction)
 
-    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[5].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[5].Name |> shouldEqual (PackageName "ReadOnlyCollectionInterfaces")
     packages.[5].Version |> shouldEqual (SemVer.Parse "1.0.0")
     packages.[5].Settings.ImportTargets |> shouldEqual (Some false)

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -755,7 +755,7 @@ let ``should parse and serialize redirects lockfile``() =
 let autodetectLockFile = """REDIRECTS: ON
 FRAMEWORK: NET452, NET452
 NUGET
-  remote: http://api.nuget.org/v3/index.json
+  remote: https://api.nuget.org/v3/index.json
   specs:
     Autofac (3.5.2) - framework: net452
     Autofac.Extras.ServiceStack (2.0.2) - framework: net452

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -794,6 +794,7 @@ let ``should parse lock file from auto-detect settings``() =
 
 let lockFileWithManyFrameworksLegacy = """NUGET
   remote: https://www.nuget.org/api/v2
+  protocolVersion: 2
     CommonServiceLocator (1.3) - framework: >= net40, monoandroid, portable-net45+wp80+wpa81+win+monoandroid10+xamarinios10, xamarinios, winv4.5, winv4.5.1, wpv8.0, wpv8.1, sl50
     MvvmLightLibs (5.2)
       CommonServiceLocator (>= 1.0) - framework: net35, sl40

--- a/tests/Paket.Tests/Lockfile/ParserWithMultipleSourcesSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserWithMultipleSourcesSpecs.fs
@@ -25,11 +25,11 @@ let ``should parse lock file``() =
     packages.Length |> shouldEqual 6
     lockFile.Options.Strict |> shouldEqual false
 
-    packages.[0].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[0].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[0].Name |> shouldEqual (PackageName "Castle.Windsor")
     packages.[0].Version |> shouldEqual (SemVer.Parse "2.1")
 
-    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetSource
+    packages.[1].Source |> shouldEqual PackageSources.DefaultNuGetV2Source
     packages.[1].Name |> shouldEqual (PackageName "Castle.Windsor-log4net")
     packages.[1].Version |> shouldEqual (SemVer.Parse "3.3")
     

--- a/tests/Paket.Tests/Resolver/SimpleDependenciesSpecs.fs
+++ b/tests/Paket.Tests/Resolver/SimpleDependenciesSpecs.fs
@@ -39,7 +39,7 @@ let ``should resolve simple config1``() =
     getVersion resolved.[PackageName "Castle.Windsor"] |> shouldEqual "2.1"
     getVersion resolved.[PackageName "log4net"] |> shouldEqual "1.1"
     getVersion resolved.[PackageName "log"] |> shouldEqual "1.2"
-    getSource resolved.[PackageName "log"] |> shouldEqual PackageSources.DefaultNuGetSource
+    getSource resolved.[PackageName "log"] |> shouldEqual PackageSources.DefaultNuGetV2Source
 
 
 let config2 = """

--- a/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
@@ -89,3 +89,38 @@ let ``should parse protocol v2 even on wellknown nuget v3 source when protocolVe
     | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
         failwithf "%s should be parsed as a v2 protocol when protocolVersion explicitly specify v2" feed
     | e -> failwithf "%s %A" feed e
+
+
+[<TestCase("a")>]
+[<TestCase("")>]
+[<TestCase("          ")>]
+[<TestCase(".")>]
+[<TestCase("-1")>]
+let ``should not parse line if version for 'protocolVersion' is invalid or missing`` (invalidProtocolVersion: string) =
+    let line = sprintf "source https://api.nuget.org/v3/index.json protocolVersion: %s" invalidProtocolVersion
+
+    try
+        let _ = PackageSource.Parse(line)
+        failwith "expected error"
+    with
+    | e -> 
+        e.Message
+        |> shouldEqual (sprintf "Could not parse protocolVersion in \"%s\"" line)
+    |> ignore
+
+
+[<TestCase("0")>]
+[<TestCase("1")>]
+[<TestCase("4")>]
+let ``should not parse line if version for 'protocolVersion' is not a supported version`` (invalidProtocolVersion: string) =
+    let line = sprintf "source https://api.nuget.org/v3/index.json protocolVersion: %s" invalidProtocolVersion
+    
+    try
+        let _ = PackageSource.Parse(line)
+        failwith "expected error"
+    with
+    | e -> 
+        e.Message
+        |> shouldEqual (sprintf "Unsupported protocolVersion in \"%s\". Should be either 2 or 3" line)
+    |> ignore
+    

--- a/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
@@ -12,19 +12,19 @@ open Paket.PackageSources
 [<TestCase("http://my.domain/artifactory/api/nuget/nugetsource/")>]
 [<TestCase("http://my.domain/artifactory/api/nuget/nuget-local/")>]
 [<TestCase("http://my.domain/artifactory/api/nuget/nuget_proxy/")>]
-let ``should parse known nuget2 source``(feed : string) =
+let ``should parse known nuget2 source as v3 if nothing specified``(feed : string) =
     let line = sprintf "source %s" feed
     match PackageSource.Parse(line) with
-    | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+    | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
         let quoted = sprintf "source  \"%s\"" feed
         match PackageSource.Parse(quoted) with
-        | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
-            source |> shouldEqual qsource
         | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
-            failwithf "%s should be parsed as a v2 protocol when quoted" feed
+            source |> shouldEqual qsource
+        | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+            failwithf "%s should be parsed as a v3 protocol when quoted" feed
         | _ -> failwith quoted
-    | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
-        failwithf "%s should be parsed as a v2 protocol" feed
+    | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+        failwithf "%s should be parsed as a v3 protocol" feed
     | _ -> failwith feed
 
 [<TestCase("https://api.nuget.org/v3/index.json")>]

--- a/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PackageSourceSpecs.fs
@@ -46,3 +46,46 @@ let ``should parse known nuget3 source``(feed : string) =
     | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
         failwithf "%s should be parsed as a v3 protocol" feed
     | _ -> failwith feed
+
+[<TestCase("https://nuget.org/api/v2", 3)>]
+[<TestCase("https://nuget.org/api/v2/", 3)>]
+[<TestCase("https://www.myget.org/F/roslyn-tools/", 3)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nugetsource/", 3)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nuget-local/", 3)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/nuget_proxy/", 3)>]
+let ``should parse protocol v3 even on wellknown nuget v2 source when protocolVersion is explicit`` (feed: string, protocolVersion: int) =
+    let line = sprintf "source %s protocolVersion: %d" feed protocolVersion
+
+    match PackageSource.Parse(line) with
+    | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+        let quoted = sprintf "source  \"%s\" protocolVersion: %d" feed protocolVersion
+        match PackageSource.Parse(quoted) with
+        | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+            source |> shouldEqual qsource
+        | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+            failwithf "%s should be parsed as a v3 protocol when quoted and when protocolVersion explicitly specify v" feed
+        | _ -> failwith quoted
+    | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+        failwithf "%s should be parsed as a v3 protocol when protocolVersion explicitly specify v3" feed
+    | e -> failwithf "%s %A" feed e
+
+[<TestCase("https://api.nuget.org/v3/index.json", 2)>]
+[<TestCase("https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json", 2)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nugetsource/index.json", 2)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nuget-local/index.json", 2)>]
+[<TestCase("http://my.domain/artifactory/api/nuget/v3/nuget_proxy/index.json", 2)>]
+let ``should parse protocol v2 even on wellknown nuget v3 source when protocolVersion is explicit`` (feed: string, protocolVersion: int) =
+    let line = sprintf "source %s protocolVersion: %d" feed protocolVersion
+
+    match PackageSource.Parse(line) with
+    | NuGet { Url = source; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+        let quoted = sprintf "source  \"%s\" protocolVersion: %d" feed protocolVersion
+        match PackageSource.Parse(quoted) with
+        | NuGet { Url = qsource; Authentication = _; ProtocolVersion = ProtocolVersion2 } ->
+            source |> shouldEqual qsource
+        | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+            failwithf "%s should be parsed as a v2 protocol when quoted and when protocolVersion explicitly specify v2" feed
+        | _ -> failwith quoted
+    | NuGet { Url = _; Authentication = _; ProtocolVersion = ProtocolVersion3 } ->
+        failwithf "%s should be parsed as a v2 protocol when protocolVersion explicitly specify v2" feed
+    | e -> failwithf "%s %A" feed e


### PR DESCRIPTION
## Disclamer
Near to zero `FSharp` knowledge / experience
Near to zero `Paket` code background
Though, used paket for few years now on several C# solution (aside with `Fake` build and custom `Fake targets`)

## Descritpion
(it's suppose to address: #3842)
This PR intend to stop guessing the `protocolVersion` of a nuget source based on various `string.Contains`
* If nothing is specified `paket` will assume `Nuget protocolVersion 3`, no fallback to `protocolVersion 2`
* If a `protocolVersion` is specified, it will stick to it
* it should then persist that `protocolVersion` for that source in the `lockfile` to be able to also work during `paket restore`

## Target
Originally Merged and rollback from `v5.x` : https://github.com/fsprojects/Paket/pull/3844 because of "yet another specific source". I'll take a look at it later

For now, I'll try to aim the `v6.0` release first and if it's possible to also target `v5.x` later on (by keeping `protocolVersion2` as the default)

In order to make it to `v6` from the rolledback PR, here are review from `v5.x` PR about code to be deleted:
* https://github.com/tebeco/Paket/pull/2#discussion_r421271567
* https://github.com/tebeco/Paket/pull/2#discussion_r421273251
* https://github.com/tebeco/Paket/pull/2#discussion_r421330301
* https://github.com/tebeco/Paket/pull/2#discussion_r421361695

## Current state of the PR (will be edited to avoid scrolling if needed)
 - [x] parsing `paket.dependencies`
 - [x] Persists feed version in `paket.lock`
 - [x] parsing `paket.lock`
 - [x] Remove "smart guess" on URL if no `protocolVersion` specified => default to `v3`
 - [!] `NugetConvert`
    - [!] `NugetConvert` parsing proper handling : in fact `nuget.config` could already have a `protocolVersion="3"`)  <=== not this PR I think
- [x] Tests
  - [x] `paket.dependencies`
      - [x] Should read `protocolVersion`
      - [x] Should fail if no `version` specified after the token `protocolVersion:`
      - [x] Should fail if unsupported `version` specified after the token `protocolVersion:`
  - [x] `paket.lock`
    - [x] Should read back `paket.lock`
    - [x] Should add test specific to `protocolVersion: 3`

