### PR TITLE
tweaks to build script to publish FSharp.DependencyManager.Paket

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -462,6 +462,15 @@ Target "NuGet" (fun _ ->
                   "/p:PackAsTool=true"]
             ToolPath = dotnetExePath
         })
+    DotNetCli.Pack (fun c ->
+        { c with
+            Project = "src/FSharp.DependencyManager.Paket/FSharp.DependencyManager.Paket.fsproj"
+            OutputPath = tempDir
+            AdditionalArgs =
+                [ sprintf "/p:Version=%s" release.NugetVersion
+                  sprintf "/p:PackageReleaseNotesFile=%s" releaseNotesPath ]
+            ToolPath = dotnetExePath
+        })
 )
 
 Target "PublishNuGet" (fun _ ->
@@ -666,10 +675,12 @@ Target "ReleaseGitHub" (fun _ ->
     |> createDraft gitOwner gitName release.NugetVersion (release.SemVer.PreRelease <> None) release.Notes
     |> uploadFile "./bin/merged/paket.exe"
     |> uploadFile "./bin/merged/paket-sha256.txt"
+    |> uploadFile "./bin/netstandard2.0/FSharp.DependencyManager.Paket.dll"
     |> uploadFile "./bin_bootstrapper/net461/paket.bootstrapper.exe"
     |> uploadFile ".paket/paket.targets"
     |> uploadFile ".paket/Paket.Restore.targets"
     |> uploadFile (tempDir </> sprintf "Paket.%s.nupkg" (release.NugetVersion))
+    |> uploadFile (tempDir </> sprintf "FSharp.DependencyManager.Paket.%s.nupkg" (release.NugetVersion))
     |> releaseDraft
     |> Async.RunSynchronously
 )

--- a/src/FSharp.DependencyManager.Paket/FSharp.DependencyManager.Paket.fsproj
+++ b/src/FSharp.DependencyManager.Paket/FSharp.DependencyManager.Paket.fsproj
@@ -4,6 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>../../bin/</OutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="ReferenceLoading.PaketHandler.fs" />
     <Compile Include="PaketDependencyManager.fs" />


### PR DESCRIPTION
Not 100% sure it is working, I expect those things:
* FSharp.DependencyManager.Paket.dll is part of github release artifacts
* FSharp.DependencyManager.Paket.{version}.nupkg is part of github release artifacts
* FSharp.DependencyManager.Paket is a nuget package published on nuget.org