### PR TITLE
Update ReferenceLoading.PaketHandler.fs

### DIFF
--- a/src/FSharp.DependencyManager.Paket/ReferenceLoading.PaketHandler.fs
+++ b/src/FSharp.DependencyManager.Paket/ReferenceLoading.PaketHandler.fs
@@ -14,7 +14,7 @@ let userProfile =
 
 let tweakTargetFramework =
     function
-        | "netcoreapp5.0" -> "net5.0"
+        | "netcoreapp5.0" -> "net50"
         | targetFramework -> targetFramework
 
 let MakeDependencyManagerCommand scriptType packageManagerTargetFramework projectRootDirArgument = 


### PR DESCRIPTION
The framework moniker `"netcoreapp5.0"` should resolve to  `"net50"` instead of `"net5.0"` AFAICS, otherwise the path to load script is incorrect.