### PR TITLE
Simplify or hide lots of log output.

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/DependenciesFile.fs
@@ -685,10 +685,11 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
             traceWarnfn "%s contains package %O in group %O already. ==> Ignored" fileName packageName groupName
             this
         else
-            if version = "" then
-                tracefn "Adding %O to %s into group %O" packageName fileName groupName
-            else
-                tracefn "Adding %O %s to %s into group %O" packageName version fileName groupName
+            match version, groupName.Name with
+            | "", "Main" -> tracefn "Adding package '%O'" packageName
+            | "", _ -> tracefn "Adding package '%O' into group %O" packageName groupName
+            | _, "Main" -> tracefn "Adding package '%O' %s" packageName version
+            | _, _ -> tracefn "Adding package '%O' %s into group %O" packageName version groupName
             this.AddAdditionalPackage(groupName, packageName,version,installSettings,kind)
 
     member this.AddGithub(groupName, repository) =
@@ -800,7 +801,7 @@ type DependenciesFile(fileName,groups:Map<GroupName,DependenciesGroup>, textRepr
 
     member this.Save() =
         File.WriteAllText(fileName, this.ToString())
-        tracefn "Dependencies files saved to %s" fileName
+        verbosefn "Dependencies files saved to %s" fileName
 
     static member FromSource(rootPath,source:string) : DependenciesFile =
         let source = source.Replace("\r\n","\n").Replace("\r","\n").Split('\n')

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -819,9 +819,9 @@ type LockFile (fileName:string, groups: Map<GroupName,LockFileGroup>) =
 
         if hasChanged then
             File.WriteAllText(fileName, output)
-            tracefn "Locked version resolution written to %s" fileName
+            verbosefn "Locked version resolution written to %s" fileName
         else
-            tracefn "%s is already up-to-date" fileName
+            verbosefn "%s is already up-to-date" fileName
         hasChanged
 
     /// Parses a paket.lock file from file

--- a/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
@@ -191,7 +191,7 @@ type ReferencesFile =
 
     member this.Save() =
         File.WriteAllText(this.FileName, this.ToString())
-        tracefn "References file saved to %s" this.FileName
+        verbosefn "References file saved to %s" this.FileName
 
     override this.ToString() =
         let printSourceFile (s:RemoteFileReference) =


### PR DESCRIPTION
This PR attempts to remove a lot of what is (IMHO) fluff that gets in the way during a "normal" paket add package when adding to the Main group (which I believe is by far the most common group use case).

Before:

```powershell
Paket version 5.242.2
Adding Saturn to C:\Users\Isaac\Source\Repos\Samples\paket.dependencies into group Main
Resolving packages for group Main:
 - Saturn 0.14.1
 - System.Threading.Tasks.Dataflow 5.0.0
 - FSharp.Core 5.0.0
 - Giraffe 4.1.0
 - Microsoft.AspNetCore.Authentication.JwtBearer 5.0.0
Could not detect any platforms from '.netcoreapp5.0' in 'C:\Users\Isaac\.nuget\packages\microsoft.aspnetcore.authentication.jwtbearer\5.0.0\Microsoft.AspNetCore.Authentication.JwtBearer.5.0.0.nupkg\Microsoft.AspNetCore.Authentication.JwtBearer.nuspec', please tell the package authors
Could not detect any platforms from '.NETCoreApp5.0' in 'C:\Users\Isaac\.nuget\packages\microsoft.aspnetcore.authentication.jwtbearer\5.0.0\Microsoft.AspNetCore.Authentication.JwtBearer.5.0.0.nupkg\Microsoft.AspNetCore.Authentication.JwtBearer.nuspec', please tell the package authors
 - FSharp.Control.Websockets 0.2.2
 - Newtonsoft.Json 12.0.3
 - TaskBuilder.fs 2.1.0
 - Utf8Json 1.3.7
 - Microsoft.IO.RecyclableMemoryStream 1.3.5
 - System.ValueTuple 4.5.0
 - System.Threading.Tasks.Extensions 4.5.4
 - System.Reflection.Emit 4.7.0
 - System.Reflection.Emit.Lightweight 4.7.0
 - NETStandard.Library 2.0.3
 - Microsoft.NETCore.Platforms 5.0.0
Locked version resolution written to C:\Users\Isaac\Source\Repos\Samples\paket.lock
Dependencies files saved to C:\Users\Isaac\Source\Repos\Samples\paket.dependencies
 - Creating model and downloading packages.
Could not detect any platforms from '.netcoreapp5.0' in 'C:\Users\Isaac\.nuget\packages\microsoft.aspnetcore.authentication.jwtbearer\5.0.0\microsoft.aspnetcore.authentication.jwtbearer.nuspec', please tell the package authors
Could not detect any platforms from '.NETCoreApp5.0' in 'C:\Users\Isaac\.nuget\packages\microsoft.aspnetcore.authentication.jwtbearer\5.0.0\microsoft.aspnetcore.authentication.jwtbearer.nuspec', please tell the package authors
Could not detect any platforms from 'net5.0' in 'C:\Users\Isaac\.nuget\packages\microsoft.aspnetcore.authentication.jwtbearer\5.0.0\lib\net5.0\Microsoft.AspNetCore.Authentication.JwtBearer.dll', please tell the package authors
 - Installing for projects
Performance:
 - Resolver: 4 seconds (1 runs)
    - Runtime: 343 milliseconds
    - Blocked (retrieving package details): 789 milliseconds (16 times)
    - Blocked (retrieving package versions): 3 seconds (6 times)
    - Not Blocked (retrieving package versions): 10 times
 - Disk IO: 67 milliseconds
 - Average Request Time: 161 milliseconds
 - Number of Requests: 17
 - Runtime: 5 seconds
Paket omitted 9 warnings similar to the ones above. You can see them in verbose mode.
```

After:

```powershell
Paket version 6.0.0-alpha055
Adding package 'Saturn'
Resolving dependency graph...
Created dependency graph (16 packages).
Total time taken: 6 seconds
```