### PR TITLE
Pick default project

### DIFF
--- a/src/Paket.Core/Common/Utils.fs
+++ b/src/Paket.Core/Common/Utils.fs
@@ -654,7 +654,7 @@ let parseKeyValuePairs (s:string) : Dictionary<string,string> =
         raise (Exception(sprintf "Could not parse '%s' as key/value pairs." s, exn))
 
 let saveFile (fileName : string) (contents : string) =
-    tracefn "Saving file %s" fileName
+    verbosefn "Saving file %s" fileName
     try
         File.WriteAllText (fileName, contents) |> ok
     with _ ->

--- a/src/Paket.Core/Installation/InstallProcess.fs
+++ b/src/Paket.Core/Installation/InstallProcess.fs
@@ -361,7 +361,7 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
             |> Seq.map (fun kv -> kv.Key)
         |> Set
 
-    tracefn "Created dependency graph (%d packages)." packagesToInstall.Count
+    tracefn "Created dependency graph (%d packages in total)" packagesToInstall.Count
     let root = Path.GetDirectoryName lockFile.FileName
     let model = CreateModel(options.AlternativeProjectRoot, root, options.Force, dependenciesFile, lockFile, packagesToInstall, updatedGroups) |> Map.ofArray
     let lookup = lockFile.GetDependencyLookupTable()
@@ -370,12 +370,13 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
     let prefix = dependenciesFile.Directory.Length + 1
     let norm (s:string) = (s.Substring prefix).Replace('\\', '/')
 
+
     if projectsAndReferences.Length > 0 then
-        tracefn " - Installing to %d projects" projectsAndReferences.Length
+        verbosefn " - Installing to %d projects" projectsAndReferences.Length
 
     for project, referenceFile in projectsAndReferences do
         let toolsVersion = project.GetToolsVersion()
-        tracefn "   - %s -> %s (MSBuild %O)" (norm referenceFile.FileName) (norm project.FileName) toolsVersion
+        verbosefn "   - %s -> %s (MSBuild %O)" (norm referenceFile.FileName) (norm project.FileName) toolsVersion
 
         let directDependencies, errorMessages =
             referenceFile.Groups
@@ -405,7 +406,6 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
                     (function Choice2Of2 errorMessage -> Some errorMessage | _ -> None)
             |> fun (resolvedPackages, dependencyErrors) ->
                     Map.ofSeq resolvedPackages, dependencyErrors
-
 
         let usedPackages, errorMessages =
             let mutable d = directDependencies
@@ -508,8 +508,7 @@ let InstallIntoProjects(options : InstallerOptions, forceTouch, dependenciesFile
                 gitRemotePathPairs
                 |> Seq.map (fun (file,remoteFilePath) ->
                     let link = if file.Link = "." then Path.GetFileName file.Name else Path.Combine(file.Link, Path.GetFileName file.Name)
-                    if verbose then
-                        tracefn "FileName: %s " file.Name
+                    verbosefn "FileName: %s " file.Name
 
                     let linked = defaultArg file.Settings.Link true
                     let buildAction = project.DetermineBuildActionForRemoteItems file.Name

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -239,11 +239,10 @@ let extractRestoreTargets root =
             let (fileWritten, path) = extractElement root "Paket.Restore.targets"
             copiedElements := true
             if fileWritten then
-                if verbose then tracefn "Extracted Paket.Restore.targets to: %s (Can be disabled with PAKET_SKIP_RESTORE_TARGETS=true)" path
-                else tracefn "Extracted Paket.Restore.targets to: %s" path
+                verbosefn "Extracted Paket.Restore.targets to: %s (Can be disabled with PAKET_SKIP_RESTORE_TARGETS=true)" path
             path
     else
-        if verbose then tracefn "Skipping extraction of Paket.Restore.targets - if it was enabled, it would have been extracted to: %s (Can be re-enabled with PAKET_SKIP_RESTORE_TARGETS=false or deleting the environment variable to revert to default behavior)" path
+        verbosefn "Skipping extraction of Paket.Restore.targets - if it was enabled, it would have been extracted to: %s (Can be re-enabled with PAKET_SKIP_RESTORE_TARGETS=false or deleting the environment variable to revert to default behavior)" path
         path
 
 let CreateInstallModel(alternativeProjectRoot, root, groupName, sources, caches, force, package) =

--- a/src/Paket.Core/PackageManagement/AddProcess.fs
+++ b/src/Paket.Core/PackageManagement/AddProcess.fs
@@ -74,13 +74,15 @@ let private add installToProjects addToProjectsF dependenciesFileName groupName 
                 let forceTouch = hasChanged && options.TouchAffectedRefs
                 InstallProcess.Install(options, forceTouch, dependenciesFile, lockFile, updatedGroups)
                 GarbageCollection.CleanUp(dependenciesFile, lockFile)
-        
-        let resolutionForGroup = LockFile.LoadFrom(lockFileName.FullName).GetGroup(groupName).Resolution
-        match resolutionForGroup.TryFind package with
-        | Some resolved ->
-            tracefn "Resolved package '%s' to version %s" package.Name resolved.Version.AsString
-        | None ->
-            traceWarnfn "Could not find package %s in group %s" package.Name groupName.Name
+
+        lockFileName.Refresh()
+        if lockFileName.Exists then
+            let resolutionForGroup = LockFile.LoadFrom(lockFileName.FullName).GetGroup(groupName).Resolution
+            match resolutionForGroup.TryFind package with
+            | Some resolved ->
+                tracefn "Resolved package '%s' to version %s" package.Name resolved.Version.AsString
+            | None ->
+                traceWarnfn "Could not find package %s in group %s" package.Name groupName.Name
 
 // Add a package with the option to add it to a specified project.
 let AddToProject(dependenciesFileName, groupName, package, version, options : InstallerOptions, projectName, installAfter, runResolver, packageKind) =

--- a/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
@@ -153,7 +153,7 @@ type ReferencesFile =
 
         match this.Groups |> Map.tryFind groupName with
         | None ->
-                tracefn "Adding package %O to %s into new group %O" packageName this.FileName groupName
+                verbosefn "Adding package %O to %s into new group %O" packageName this.FileName groupName
 
                 let newGroup =
                     { Name = groupName
@@ -167,7 +167,7 @@ type ReferencesFile =
             if group.NugetPackages |> Seq.exists (fun p -> p.Name = packageName) then
                 this
             else
-                tracefn "Adding package %O to %s into group %O" packageName this.FileName groupName
+                verbosefn "Adding package %O to %s into group %O" packageName this.FileName groupName
 
                 let newGroup = { group with NugetPackages = group.NugetPackages @ [ package ] }
                 let newGroups = this.Groups |> Map.add newGroup.Name newGroup

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -231,21 +231,22 @@ let add (results : ParseResults<_>) =
             Dependencies.Init ()
             Dependencies.Locate ())
 
+    // If no project was supplied, check if there's a project in the current folder and if so, use that.
     let project =
-        let extensions = Set [ ".fsproj"; ".csproj" ]
         match project with
-        | Some _ -> project
+        | Some _ ->
+            project
         | None ->
-            Directory.GetCurrentDirectory()
-            |> Directory.EnumerateFiles
-            |> Seq.map Path.GetExtension
-            |> Seq.tryFind extensions.Contains
+            match Directory.GetCurrentDirectory() |> ProjectFile.FindAllProjects |> Array.toList with
+            | [] ->
+                None
+            | project :: _ ->
+                Some project.FileName
 
     match project with
     | Some projectName ->
         dependencies.AddToProject(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not, packageKind)
-    | None ->
-        
+    | None ->        
         let interactive = results.Contains AddArgs.Interactive
         dependencies.Add(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not, packageKind)
 

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -231,10 +231,21 @@ let add (results : ParseResults<_>) =
             Dependencies.Init ()
             Dependencies.Locate ())
 
+    let project =
+        let extensions = Set [ ".fsproj"; ".csproj" ]
+        match project with
+        | Some _ -> project
+        | None ->
+            Directory.GetCurrentDirectory()
+            |> Directory.EnumerateFiles
+            |> Seq.map Path.GetExtension
+            |> Seq.tryFind extensions.Contains
+
     match project with
     | Some projectName ->
         dependencies.AddToProject(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, projectName, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not, packageKind)
     | None ->
+        
         let interactive = results.Contains AddArgs.Interactive
         dependencies.Add(group, packageName, version, force, redirects, cleanBindingRedirects, createNewBindingFiles, interactive, noInstall |> not, semVerUpdateMode, touchAffectedRefs, noResolve |> not, packageKind)
 


### PR DESCRIPTION
@forki this is built on top of the **add-without-init** branch. It's totally the wrong way to do it, but if there's a way to identify any project in the "current" folder, then I think this approach would work. At least, testing locally it seems to do the right thing: you can go to an empty project, type `paket add Saturn` (assuming you have paket as a global tool) and everything will just work.