### PR TITLE
missing redirects: force for the fsi extension,

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -60,4 +60,4 @@ group Build
 
 group FSharpDepManagerExtension
   source https://nuget.org/api/v2
-  nuget FSharp.Core = 5.0.0
+  nuget FSharp.Core = 5.0.0 redirects: force

--- a/paket.lock
+++ b/paket.lock
@@ -868,7 +868,7 @@ GITHUB
 GROUP FSharpDepManagerExtension
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (5.0)
+    FSharp.Core (5.0) - redirects: force
 
 GROUP NetCoreTools
 STORAGE: NONE

--- a/src/FSharp.DependencyManager.Paket/FSharp.DependencyManager.Paket.fsproj
+++ b/src/FSharp.DependencyManager.Paket/FSharp.DependencyManager.Paket.fsproj
@@ -1,16 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>../../bin/</OutputPath>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="ReferenceLoading.PaketHandler.fs" />
     <Compile Include="PaketDependencyManager.fs" />
   </ItemGroup>
-
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
not sure if this address the wrong fsharp.core being referenced (still happening in the latest release)