### PR TITLE
use lazy initialization to fix UnauthorizedAccessException in Paket.C…

### DIFF
--- a/src/Paket.Core/Common/Constants.fs
+++ b/src/Paket.Core/Common/Constants.fs
@@ -131,7 +131,7 @@ let NuGetCacheFolder =
         let di = DirectoryInfo cachePath
         if not di.Exists then di.Create()
         Some di.FullName
-    ) |> Option.orElse (
+    ) |> Option.orElseWith (fun _ ->
         getEnvDir Environment.SpecialFolder.LocalApplicationData
         |> Option.bind (fun appData ->
             let di = DirectoryInfo (Path.Combine (appData, "Nuget", "Cache"))


### PR DESCRIPTION
Constants.NuGetCacheFolder can't be initialized without write access to:
Environment.SpecialFolder.LocalApplicationData

Setting "NuGetCachePath" does not help, Constants.NuGetCacheFolder still tries to create LocalApplicationData/Nuget/Cache directory:
_TypeInitializationException: The type initializer for 'Paket.Constants' threw exception.
UnauthorizedAccessException: Access to the path '***/Nuget/Cache' is denied_

Solution:
use Option.orElseWith (lazy initialization) instead of Option.orElse