### PR TITLE
Docs installation.md: Fix broken link to "Getting Started"

### DIFF
--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -122,4 +122,4 @@ often very useful to add some tools to your shell/IDE/Text Editor of choice.
 * [Editor support](editor-support.html)
 * [Shell completion](shell-completion.html)
 
-For next steps check out the [Getting Started](getting-started.html) section.
+For next steps check out the [Getting Started](get-started.html) section.


### PR DESCRIPTION
Just noticed this while reading the docs