### PR TITLE
Fix dotnet pack on net5.0

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,6 @@ if errorlevel 1 (
 
 setlocal
 
-set MSBuild=%~dp0packages\build\RoslynTools.MSBuild\tools\msbuild
 
 packages\build\FAKE\tools\FAKE.exe build.fsx %*
 

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -171,7 +171,7 @@ type FrameworkVersion =
         | FrameworkVersion.V4_7_1 -> "471"
         | FrameworkVersion.V4_7_2 -> "472"
         | FrameworkVersion.V4_8 -> "48"
-        | FrameworkVersion.V5 -> "50"
+        | FrameworkVersion.V5 -> "5.0"
 
     static member TryParse s =
         match s with


### PR DESCRIPTION
This is a fix for dotnet paket pack on net5.0
This should solve #3980  and #3994 
The short version string for net5.0 is no 50 but 5.0

The rest of the tests seems to work and this is conform to net5.0 (inconsistent) versioning so it seems legit. 