### PR TITLE
alleviate Warning FS0044 This construct is deprecated. Use PlatformMamtching.extractPlatforms instead

### DIFF
--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -5,6 +5,8 @@ open NUnit.Framework
 open Paket.IntegrationTests.TestHelpers
 open Paket
 
+#nowarn "0044" //  Warning FS0044 This construct is deprecated. Use PlatformMatching.extractPlatforms instead
+
 let makeScenarioPath scenario    = Path.Combine("loading-scripts", scenario)
 let paket command scenario       = paket command (makeScenarioPath scenario)
 let directPaket command scenario = directPaket command (makeScenarioPath scenario)

--- a/src/Paket.Core/Dependencies/Nuspec.fs
+++ b/src/Paket.Core/Dependencies/Nuspec.fs
@@ -51,7 +51,7 @@ module internal NuSpecParserHelper =
             [{ AssemblyName = name; FrameworkRestrictions = ExplicitRestriction FrameworkRestriction.NoRestriction }]
         | Some name, Some targetFrameworks ->
             targetFrameworks.Split([|','; ' '|],System.StringSplitOptions.RemoveEmptyEntries)
-            |> Array.choose FrameworkDetection.Extract
+            |> Array.choose FrameworkDetection.internalExtract
             |> Array.filter (fun x -> match x with Unsupported _ -> false | _ -> true)
             |> Array.map (fun fw -> 
                 { AssemblyName = name

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -774,7 +774,7 @@ let Restore(dependenciesFileName,projectFile:RestoreProjectOptions,force,group,i
             |> Option.map (fun s ->
                 s.Split([|';'|], StringSplitOptions.RemoveEmptyEntries)
                 |> Array.map (fun s -> s.Trim())
-                |> Array.choose FrameworkDetection.Extract
+                |> Array.choose FrameworkDetection.internalExtract
                 |> Array.filter (fun x -> match x with Unsupported _ -> false | _ -> true))
 
         let tasks =

--- a/src/Paket.Core/Installation/ScriptGeneration.fs
+++ b/src/Paket.Core/Installation/ScriptGeneration.fs
@@ -304,11 +304,11 @@ module ScriptGeneration =
             // specified frameworks are never considered default
             let targetFrameworkList = 
                 providedFrameworks 
-                |> List.choose FrameworkDetection.Extract
+                |> List.choose FrameworkDetection.internalExtract
                 |> List.filter (fun x -> match x with Unsupported _ -> false | _ -> true)
                 |> List.map (fun f -> f, false)
 
-            failOnMismatch providedFrameworks targetFrameworkList FrameworkDetection.Extract "Unrecognized Framework(s)"
+            failOnMismatch providedFrameworks targetFrameworkList FrameworkDetection.internalExtract "Unrecognized Framework(s)"
 
             if not (Seq.isEmpty targetFrameworkList) then 
                 targetFrameworkList :> seq<_>

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1114,7 +1114,7 @@ module ProjectFile =
 
                 | Some x -> [prefix() + (x.Replace("v",""))]
 
-            match frameworks |> List.choose (fun s -> FrameworkDetection.Extract s |> Option.map TargetProfile.SinglePlatform) |> List.filter (fun x -> match x with TargetProfile.SinglePlatform(Unsupported _) -> false | _ -> true)  with
+            match frameworks |> List.choose (fun s -> FrameworkDetection.internalExtract s |> Option.map TargetProfile.SinglePlatform) |> List.filter (fun x -> match x with TargetProfile.SinglePlatform(Unsupported _) -> false | _ -> true)  with
             | [] -> [TargetProfile.SinglePlatform (DotNetFramework FrameworkVersion.V4)]
             | xs -> xs
 

--- a/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
+++ b/src/Paket.Core/PaketConfigFiles/RuntimeGraph.fs
@@ -59,7 +59,7 @@ module RuntimeGraphParser =
             { Name = t.Key
               Supported =
                 [ for s in t.Value :?> JObject :> IEnumerable<KeyValuePair<string, JToken>> do
-                    match FrameworkDetection.Extract s.Key with
+                    match FrameworkDetection.internalExtract s.Key with
                     | Some (Unsupported _ ) -> ()
                     | Some fid ->
                         yield fid,

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -288,7 +288,7 @@ module internal TemplateFile =
     let private (|Framework|_|) (line:string) =
         match line.Trim()  with
         | String.RemovePrefix "framework:" trimmed ->
-            match FrameworkDetection.Extract trimmed with
+            match FrameworkDetection.internalExtract trimmed with
             | Some _ as fw -> Some fw
             | None ->
                 failwithf "Unable to identify a framework from '%s'" trimmed

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -810,9 +810,9 @@ module FrameworkDetection =
 
 
     open Logging
+
     /// parse a string to construct a Netframework, NetCore, NetStandard, or other dotnet identifier
-    [<Obsolete "Use PlatformMatching.extractPlatforms instead">]
-    let Extract =
+    let internal internalExtract =
         memoize
           (fun (path:string) ->
             let path = KnownAliases.normalizeFramework path
@@ -962,6 +962,10 @@ module FrameworkDetection =
                 | _ -> None
             result)
 
+    /// parse a string to construct a Netframework, NetCore, NetStandard, or other dotnet identifier
+    [<Obsolete "Use PlatformMatching.extractPlatforms instead">]
+    let Extract path = internalExtract path
+
     let DetectFromPath(path : string) : FrameworkIdentifier option =
         let path = path.Replace("\\", "/").ToLower()
         let fi = new FileInfo(path)
@@ -972,7 +976,7 @@ module FrameworkDetection =
             let endPos = path.LastIndexOf(fi.Name,StringComparison.OrdinalIgnoreCase)
             if startPos < 0 || endPos < 0 then None
             else
-                Extract(path.Substring(startPos + 4, endPos - startPos - 5))
+                internalExtract(path.Substring(startPos + 4, endPos - startPos - 5))
 
 
 type PortableProfileType =

--- a/src/Paket.Core/Versioning/PlatformMatching.fs
+++ b/src/Paket.Core/Versioning/PlatformMatching.fs
@@ -30,7 +30,7 @@ let private extractPlatformsPriv = memoize (fun path ->
     let splits = split path
     let platforms =
         splits
-        |> Array.choose FrameworkDetection.Extract
+        |> Array.choose FrameworkDetection.internalExtract
         |> Array.toList
 
     if platforms.Length = 0 then

--- a/src/Paket.Core/Versioning/Requirements.fs
+++ b/src/Paket.Core/Versioning/Requirements.fs
@@ -704,13 +704,13 @@ let parseRestrictionsLegacy failImmediatly (text:string) =
                     match fw2 with
                     | None ->
                         let handlers =
-                            [ FrameworkDetection.Extract >> Option.map FrameworkRestriction.AtLeast
+                            [ FrameworkDetection.internalExtract >> Option.map FrameworkRestriction.AtLeast
                               extractProfile >> Option.map FrameworkRestriction.AtLeastPlatform ]
 
                         tryParseFramework handlers fw1
 
                     | Some fw2 ->
-                        let tryParse = tryParseFramework [FrameworkDetection.Extract]
+                        let tryParse = tryParseFramework [FrameworkDetection.internalExtract]
 
                         match tryParse fw1, tryParse fw2 with
                         | Some x, Some y -> Some (FrameworkRestriction.Between (x, y))
@@ -722,7 +722,7 @@ let parseRestrictionsLegacy failImmediatly (text:string) =
                 let fw, remaining = frameworkToken (x.Substring 1)
 
                 let handlers =
-                    [ FrameworkDetection.Extract >> Option.map FrameworkRestriction.Exactly ]
+                    [ FrameworkDetection.internalExtract >> Option.map FrameworkRestriction.Exactly ]
 
                 tryParseFramework handlers fw, remaining
 
@@ -731,7 +731,7 @@ let parseRestrictionsLegacy failImmediatly (text:string) =
                 let fw, remaining = frameworkToken (x.Substring 2)
 
                 let handlers =
-                    [ FrameworkDetection.Extract >> Option.map FrameworkRestriction.Exactly ]
+                    [ FrameworkDetection.internalExtract >> Option.map FrameworkRestriction.Exactly ]
 
                 tryParseFramework handlers fw, remaining
 
@@ -739,7 +739,7 @@ let parseRestrictionsLegacy failImmediatly (text:string) =
                 let fw, remaining = frameworkToken x
 
                 let handlers =
-                    [ FrameworkDetection.Extract >> Option.map FrameworkRestriction.Exactly
+                    [ FrameworkDetection.internalExtract >> Option.map FrameworkRestriction.Exactly
                       extractProfile >> Option.map FrameworkRestriction.AtLeastPlatform ]
 
                 tryParseFramework handlers fw, remaining

--- a/tests/Paket.Tests/InstallModel/FrameworkIdentifierSpecs.fs
+++ b/tests/Paket.Tests/InstallModel/FrameworkIdentifierSpecs.fs
@@ -4,6 +4,8 @@ open Paket
 open NUnit.Framework
 open FsUnit
 
+#nowarn "0044" //  Warning FS0044 This construct is deprecated. Use PlatformMatching.extractPlatforms instead
+
 [<Test>]
 let ``should understand basic framework versions net20, net40, net45 ...``() = 
     FrameworkDetection.Extract("net20").Value |> shouldEqual (DotNetFramework(FrameworkVersion.V2))


### PR DESCRIPTION
Making it a bit less likely maintainer ignores the warnings altogether.