### PR TITLE
Fixed issue when paket.dependencies has "copy_content_to_output_dir: preserve_newest"

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -68,7 +68,7 @@ module LockFileSerializer =
         match options.Settings.CopyContentToOutputDirectory with
         | Some CopyToOutputDirectorySettings.Always -> yield "COPY-CONTENT-TO-OUTPUT-DIR: ALWAYS"
         | Some CopyToOutputDirectorySettings.Never -> yield "COPY-CONTENT-TO-OUTPUT-DIR: NEVER"
-        | Some CopyToOutputDirectorySettings.PreserveNewest -> yield "COPY-CONTENT-TO-OUTPUT-DIR: PRESERVE-NEWEST"
+        | Some CopyToOutputDirectorySettings.PreserveNewest -> yield "COPY-CONTENT-TO-OUTPUT-DIR: PRESERVE_NEWEST"
         | None -> ()
 
         match options.Settings.ImportTargets with


### PR DESCRIPTION
Original bug: https://github.com/fsprojects/Paket/issues/4017

> When I put "copy_content_to_output_dir: preserve_newest" into my paket.dependencies file, an incorrect paket.lock is generated. paket.lock is incorrectly generated with "COPY-CONTENT-TO-OUTPUT-DIR: PRESERVE-NEWEST".