### PR TITLE
Add paket.template "readme" file support.

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -110,6 +110,7 @@ field of the same name in the `.nupkg`.
 * `owners`
 * `releaseNotes`
 * `summary`
+* `readme`: This is a path to the readme file inside the package. It should be packaged in the `files` block (see below).
 * `language`
 * `projectUrl`
 * `iconUrl`

--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -110,7 +110,7 @@ field of the same name in the `.nupkg`.
 * `owners`
 * `releaseNotes`
 * `summary`
-* `readme`: This is a path to the readme file inside the package. It should be packaged in the `files` block (see below).
+* `readme`: This is a path to a readme file *in* the package. It should be added with the `files` block (see below).
 * `language`
 * `projectUrl`
 * `iconUrl`

--- a/src/Paket.Core/Packaging/NupkgWriter.fs
+++ b/src/Paket.Core/Packaging/NupkgWriter.fs
@@ -4,7 +4,6 @@ open System.IO
 open System.Xml.Linq
 open System.IO.Compression
 open Paket
-open Paket.Xml
 open System.Text
 open System.Text.RegularExpressions
 open System.Xml
@@ -191,6 +190,7 @@ module internal NupkgWriter =
             !! "requireLicenseAcceptance" "true"
         !! "description" core.Description
         (!!?) "summary" optional.Summary
+        (!!?) "readme" optional.Readme
         (!!?) "releaseNotes" optional.ReleaseNotes
         (!!?) "copyright" optional.Copyright
         (!!?) "language" optional.Language

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -2082,6 +2082,7 @@ type ProjectFile with
             Owners = propMap "Owners" [] splitString
             ReleaseNotes = prop "ReleaseNotes"
             Summary = prop "Summary"
+            Readme = prop "Readme"
             Language = prop "Langauge"
             ProjectUrl = prop "ProjectUrl"
             IconUrl = prop "IconUrl"

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -7,7 +7,6 @@ open System.Text.RegularExpressions
 open Chessie.ErrorHandling
 open Paket.Domain
 open Paket.InterprojectReferencesConstraint
-open Paket.Requirements
 
 module private TemplateParser =
     type private ParserState =
@@ -142,6 +141,7 @@ type OptionalPackagingInfo =
       Owners : string list
       ReleaseNotes : string option
       Summary : string option
+      Readme : string option
       Language : string option
       ProjectUrl : string option
       IconUrl : string option
@@ -173,6 +173,7 @@ type OptionalPackagingInfo =
           Owners = []
           ReleaseNotes = None
           Summary = None
+          Readme = None
           Language = None
           ProjectUrl = None
           LicenseExpression = None
@@ -538,6 +539,7 @@ module internal TemplateFile =
           Owners = owners
           ReleaseNotes = get "releaseNotes"
           Summary = get "summary"
+          Readme = get "readme"
           Language = get "language"
           ProjectUrl = get "projectUrl"
           IconUrl = get "iconUrl"

--- a/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
+++ b/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
@@ -1,13 +1,9 @@
 ﻿module Paket.NuspecWriterSpecs
 
-open System.IO
 open Paket
-open Chessie.ErrorHandling
 open FsUnit
 open NUnit.Framework
-open TestHelpers
 open Paket.Domain
-open Paket.Requirements
 
 [<Test>]
 let ``should serialize core info``() = 
@@ -369,6 +365,7 @@ let ``should not serialize all properties``() =
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>A description</description>
     <summary>summary</summary>
+    <readme>README.md</readme>
     <releaseNotes>A release notes
 second line</releaseNotes>
     <copyright>Paket owners 2015</copyright>
@@ -395,6 +392,7 @@ second line</releaseNotes>
               Owners = ["Steffen"; "Alex"]
               ReleaseNotes = Some"A release notes\r\nsecond line"
               Summary = Some "summary"
+              Readme = Some "README.md"
               Language = Some "en-US"
               ProjectUrl = Some "http://www.somewhere.com"
               LicenseExpression = Some "MIT"
@@ -404,7 +402,7 @@ second line</releaseNotes>
               References = ["file1.dll";"file2.dll"]
               Tags = ["aa"; "bb"]
               DevelopmentDependency = true }
-                       
+
     let doc = NupkgWriter.nuspecDoc (core, optional)
     doc.ToString()
     |> normalizeLineEndings

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -1,15 +1,12 @@
 ﻿module Paket.TemplateFile.Test
 
 open System.IO
-open System.IO
 open Paket
 open Chessie.ErrorHandling
 open FsUnit
 open NUnit.Framework
 open Paket.TestHelpers
 open Paket.Domain
-open Paket.Requirements
-open System.Text.RegularExpressions
 
 [<Literal>]
 let FileBasedShortDesc = """type file
@@ -168,6 +165,8 @@ packageTypes
     DotnetTool, Template
 summary
     Railway-oriented programming for .NET
+readme
+    README.md
 dependencies
      FSharp.Core 4.3.1
      My.OtherThing
@@ -198,6 +197,7 @@ let ``Optional fields are read`` (fileContent : string) =
     sut.Title |> shouldEqual (Some "Chessie.Rop")
     sut.Copyright |> shouldEqual (Some "Copyright 2015")
     sut.Summary |> shouldEqual (Some "Railway-oriented programming for .NET")
+    sut.Readme |> shouldEqual (Some "README.md")
     sut.IconUrl |> shouldEqual (Some "https://raw.githubusercontent.com/fsprojects/Chessie/master/docs/files/img/logo.png")
     sut.LicenseExpression |> shouldEqual (Some "Unlicense")
     sut.ProjectUrl |> shouldEqual (Some "http://github.com/fsprojects/Chessie")


### PR DESCRIPTION
This is another step towards closing https://github.com/fsprojects/Paket/issues/3710

Nuget added the ability to specify a path to a readme file within your package that will be displayed on nuget.org.
This adds the `readme` field to paket.template.