### PR TITLE
Change FSharp.Core dependency to be >= LOCKEDVERSION

### DIFF
--- a/src/Paket.Core/paket.template
+++ b/src/Paket.Core/paket.template
@@ -13,4 +13,6 @@ tags
 include-pdbs true
 dependencies
   framework: net461
+    FSharp.Core >= LOCKEDVERSION
   framework: netstandard2.0
+    FSharp.Core >= LOCKEDVERSION


### PR DESCRIPTION
Resolves #4034.

This allows downstream consumers to use FSharp.Core >= 5.0.0.