### PR TITLE
Added NoDefaultExcludes

### DIFF
--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -362,7 +362,9 @@
               PackageLicenseFile="$(PackageLicenseFile)"
               PackageLicenseExpression="$(PackageLicenseExpression)"
               PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)"
-              PackageReadmeFile="$(PackageReadmeFile)" />
+              PackageReadmeFile="$(PackageReadmeFile)"
+              NoDefaultExcludes="$(NoDefaultExcludes) "/>
+    
     <PackTask Condition="$(UseMSBuild16_0_Pack)"
               PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"
@@ -410,7 +412,8 @@
               NuspecProperties="$(NuspecProperties)"
               PackageLicenseFile="$(PackageLicenseFile)"
               PackageLicenseExpression="$(PackageLicenseExpression)"
-              PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)" />
+              PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)"
+              NoDefaultExcludes="$(NoDefaultExcludes)" />
 
     <PackTask Condition="$(UseMSBuild15_9_Pack)"
               PackItem="$(PackProjectInputFile)"


### PR DESCRIPTION
This is my very first PR, and I am scared and excited at the same time, 🙀 

When I was making templates for use with dotnet core, and these templates contained .files i.e. `.editorconfig`, etc, then these files would not be added to the package on executing dotnet pack. 

I would receive a warning stating that it was not going to add the .files to the package and to  specify `-NoDefaultExcludes` to the command line. So I would add it to the csproj instead and then noticed that this Paket.Restore.targets did not contain the option to pass on.

I am a little fresh to this project, so I haven't looked around in here much.
I have assumed that this is the correct place, to update this file as I believe this is where it comes from when a `paket restore` is executed.

I may also need a little help to work out what/where would be a good place to add a test for this? If there are tests around this already?

Also I started to try to make this change on a branch from `bugfix` but it seems there is something broken about that branch, I can't seem to run the ./build.sh as I receive TlsException: CertificateUnknown and when I go to the feed, it seems something is wrong.

I think I would like to be able to add this to bugfix and have a new 5.258.0 release maybe, (but again I am not sure on this process either)
